### PR TITLE
Blocks: Make webpack.config.extensions.js extend calypso-build's

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "Gruntfile.js",
   "author": "Automattic",
   "devDependencies": {
-    "@automattic/calypso-build": "^1.0.0-alpha.0",
+    "@automattic/calypso-build": "^1.0.0-alpha.2",
     "@automattic/calypso-color-schemes": "^1.0.0-alpha.1",
     "@babel/core": "^7.4.0",
     "@babel/plugin-proposal-class-properties": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "classnames": "^2.2.6",
     "copy-webpack-plugin": "^5.0.2",
     "css-loader": "^2.1.1",
-    "duplicate-package-checker-webpack-plugin": "^3.0.0",
     "eslint": "^5.16.0",
     "file-loader": "^3.0.1",
     "grunt": "^0.4.5",

--- a/src/setup/blocks.json
+++ b/src/setup/blocks.json
@@ -1,3 +1,1 @@
-{
-  "production": ["example1-simple", "example2-attributes"]
-}
+["example1-simple", "example2-attributes"]

--- a/src/setup/blocks.json
+++ b/src/setup/blocks.json
@@ -1,1 +1,0 @@
-["example1-simple", "example2-attributes"]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,9 +6,7 @@
 /**
  * External dependencies
  */
-const _ = require( 'lodash' );
 const fs = require( 'fs' );
-const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
 const path = require( 'path' );
 
@@ -23,20 +21,16 @@ const path = require( 'path' );
 const editorSetup = path.join( __dirname, 'src', 'setup', 'editor' );
 const viewSetup = path.join( __dirname, 'src', 'setup', 'view' );
 
-function blockScripts( type, inputDir, presetBlocks ) {
-	return presetBlocks
+function blockScripts( type, inputDir, blocks ) {
+	return blocks
 		.map( block => path.join( inputDir, 'blocks', block, `${ type }.js` ) )
 		.filter( fs.existsSync );
 }
 
-const presetPath = path.join( __dirname, 'src', 'setup', 'blocks.json' );
-const presetIndex = require( presetPath );
-const presetBlocks = _.get( presetIndex, [ 'production' ], [] );
-const presetBetaBlocks = _.get( presetIndex, [ 'beta' ], [] );
-const allPresetBlocks = [ ...presetBlocks, ...presetBetaBlocks ];
+const blocks = require( path.join( __dirname, 'src', 'setup', 'blocks.json' ) );
 
 // Helps split up each block into its own folder view script
-const viewBlocksScripts = allPresetBlocks.reduce( ( viewBlocks, block ) => {
+const viewBlocksScripts = blocks.reduce( ( viewBlocks, block ) => {
 	const viewScriptPath = path.join( __dirname, 'src', 'blocks', block, 'view.js' );
 	if ( fs.existsSync( viewScriptPath ) ) {
 		viewBlocks[ block + '/view' ] = [ viewSetup, ...[ viewScriptPath ] ];
@@ -47,33 +41,15 @@ const viewBlocksScripts = allPresetBlocks.reduce( ( viewBlocks, block ) => {
 // Combines all the different blocks into one editor.js script
 const editorScript = [
 	editorSetup,
-	...blockScripts( 'editor', path.join( __dirname, 'src' ), presetBlocks ),
-];
-
-// Combines all the different blocks into one editor-beta.js script
-const editorBetaScript = [
-	editorSetup,
-	...blockScripts( 'editor', path.join( __dirname, 'src' ), allPresetBlocks ),
+	...blockScripts( 'editor', path.join( __dirname, 'src' ), blocks ),
 ];
 
 const webpackConfig = getBaseWebpackConfig( null, {
 	entry: {
 		editor: editorScript,
-		'editor-beta': editorBetaScript,
 		...viewBlocksScripts,
 	},
 	'output-path': path.join( __dirname, 'dist' ),
 } );
 
-module.exports = {
-	...webpackConfig,
-	plugins: [
-		...webpackConfig.plugins,
-		new CopyWebpackPlugin( [
-			{
-				from: presetPath,
-				to: 'index.json',
-			},
-		] ),
-	],
-};
+module.exports = webpackConfig;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,8 +65,10 @@ const webpackConfig = getBaseWebpackConfig( null, {
 	'output-path': path.join( __dirname, 'dist' ),
 } );
 
-module.exports = _.merge( {}, webpackConfig, {
+module.exports = {
+	...webpackConfig,
 	plugins: [
+		...webpackConfig.plugins,
 		new CopyWebpackPlugin( [
 			{
 				from: presetPath,
@@ -74,4 +76,4 @@ module.exports = _.merge( {}, webpackConfig, {
 			},
 		] ),
 	],
-} );
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,8 +20,8 @@ const path = require( 'path' );
 /**
  * Internal variables
  */
-const editorSetup = path.join( __dirname, 'extensions', 'setup', 'editor' );
-const viewSetup = path.join( __dirname, 'extensions', 'setup', 'view' );
+const editorSetup = path.join( __dirname, 'src', 'setup', 'editor' );
+const viewSetup = path.join( __dirname, 'src', 'setup', 'view' );
 
 function blockScripts( type, inputDir, presetBlocks ) {
 	return presetBlocks
@@ -29,7 +29,7 @@ function blockScripts( type, inputDir, presetBlocks ) {
 		.filter( fs.existsSync );
 }
 
-const presetPath = path.join( __dirname, 'extensions', 'setup', 'index.json' );
+const presetPath = path.join( __dirname, 'src', 'setup', 'blocks.json' );
 const presetIndex = require( presetPath );
 const presetBlocks = _.get( presetIndex, [ 'production' ], [] );
 const presetBetaBlocks = _.get( presetIndex, [ 'beta' ], [] );
@@ -37,7 +37,7 @@ const allPresetBlocks = [ ...presetBlocks, ...presetBetaBlocks ];
 
 // Helps split up each block into its own folder view script
 const viewBlocksScripts = allPresetBlocks.reduce( ( viewBlocks, block ) => {
-	const viewScriptPath = path.join( __dirname, 'extensions', 'blocks', block, 'view.js' );
+	const viewScriptPath = path.join( __dirname, 'src', 'blocks', block, 'view.js' );
 	if ( fs.existsSync( viewScriptPath ) ) {
 		viewBlocks[ block + '/view' ] = [ viewSetup, ...[ viewScriptPath ] ];
 	}
@@ -47,13 +47,13 @@ const viewBlocksScripts = allPresetBlocks.reduce( ( viewBlocks, block ) => {
 // Combines all the different blocks into one editor.js script
 const editorScript = [
 	editorSetup,
-	...blockScripts( 'editor', path.join( __dirname, 'extensions' ), presetBlocks ),
+	...blockScripts( 'editor', path.join( __dirname, 'src' ), presetBlocks ),
 ];
 
 // Combines all the different blocks into one editor-beta.js script
 const editorBetaScript = [
 	editorSetup,
-	...blockScripts( 'editor', path.join( __dirname, 'extensions' ), allPresetBlocks ),
+	...blockScripts( 'editor', path.join( __dirname, 'src' ), allPresetBlocks ),
 ];
 
 const webpackConfig = getBaseWebpackConfig( null, {
@@ -62,7 +62,7 @@ const webpackConfig = getBaseWebpackConfig( null, {
 		'editor-beta': editorBetaScript,
 		...viewBlocksScripts,
 	},
-	'output-path': path.join( __dirname, '_inc', 'blocks' ),
+	'output-path': path.join( __dirname, 'dist' ),
 } );
 
 module.exports = _.merge( {}, webpackConfig, {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,10 @@ function blockScripts( type, inputDir, blocks ) {
 		.filter( fs.existsSync );
 }
 
-const blocks = require( path.join( __dirname, 'src', 'setup', 'blocks.json' ) );
+const blocksDir = path.join( __dirname, 'src', 'blocks' );
+const blocks = fs
+  .readdirSync( blocksDir )
+  .filter( block => fs.existsSync( path.join( __dirname, 'src', 'blocks', block, 'editor.js' ) ) );
 
 // Helps split up each block into its own folder view script
 const viewBlocksScripts = blocks.reduce( ( viewBlocks, block ) => {


### PR DESCRIPTION
WIP. 

Inspired by https://github.com/Automattic/jetpack/pull/11802. The idea is to encapsulate complexity in `@automattic/calypso-build` and provide a nice enough interface to consumers.