### PR TITLE
Simplify babel.config.js

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,51 +1,5 @@
-const config = {
-	presets: [
-		[
-			'@babel/env',
-			{
-				useBuiltIns: 'entry',
-				corejs: 2,
-				// Exclude transforms that make all code slower, see https://github.com/facebook/create-react-app/pull/5278
-				exclude: [ 'transform-typeof-symbol' ],
-			},
-		],
-		'@babel/react',
-	],
-	plugins: [
-		'@babel/plugin-proposal-class-properties',
-		'@babel/plugin-proposal-export-default-from',
-		'@babel/plugin-proposal-export-namespace-from',
-		'@babel/plugin-syntax-dynamic-import',
-		[
-			'@babel/transform-runtime',
-			{
-				corejs: false, // we polyfill so we don't need core-js
-				helpers: true,
-				regenerator: false,
-				useESModules: false,
-			},
-		],
-		[
-			'@wordpress/import-jsx-pragma',
-			{
-				scopeVariable: 'createElement',
-				source: '@wordpress/element',
-				isDefault: false,
-			},
-		],
-		[
-			'@babel/transform-react-jsx',
-			{
-				pragma: 'createElement',
-			},
-		],
-	],
-	env: {
-		test: {
-			presets: [ [ '@babel/env', { targets: { node: 'current' } } ] ],
-			plugins: [ 'add-module-exports', 'babel-plugin-dynamic-import-node' ],
-		},
-	},
-};
+module.exports = {
+	extends: require.resolve( '@automattic/calypso-build/babel.config.js' ),
+	presets: [ require( '@automattic/calypso-build/babel/wordpress-element' ) ],
 
-module.exports = config;
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "Gruntfile.js",
   "author": "Automattic",
   "devDependencies": {
-    "@automattic/calypso-build": "^1.0.0-alpha.2",
+    "@automattic/calypso-build": "^1.0.0-alpha.4",
     "@automattic/calypso-color-schemes": "^1.0.0-alpha.1",
     "@babel/core": "^7.4.0",
     "@babel/plugin-proposal-class-properties": "^7.4.0",


### PR DESCRIPTION
Verify that blocks still build fine.

---

I'll clean up babel plugin deps in a follow-up PR. That will require some work on the Calypso side (https://github.com/Automattic/wp-calypso/pull/32144) (and a new release of `calypso-build`) first.

I also plan to file a separate PR to simplify the webpack config. Thought it might be fine to keep things small and separate.