### PR TITLE
Refactor Plugin PHP as a Class

### DIFF
--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -84,7 +84,7 @@ class Newspack_Blocks {
 	/**
 	 * Enqueue view scripts and styles for a single block.
 	 *
-	 * @param string $type The block's slug.
+	 * @param string $type The block's type.
 	 */
 	public static function enqueue_view_assets( $type ) {
 		$style_path  = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css';

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -124,6 +124,26 @@ class Newspack_Blocks {
 		$dependencies[] = 'wp-polyfill';
 		return $dependencies;
 	}
+
+	/**
+	 * Utility to assemble the class for a server-side rendered bloc
+	 *
+	 * @param string $type The block type.
+	 * @param array  $attributes Block attributes.
+	 *
+	 * @return string Class list separated by spaces.
+	 */
+	public static function block_classes( $type, $attributes = array() ) {
+		$align   = isset( $attributes['align'] ) ? $attributes['align'] : 'center';
+		$classes = array(
+			"wp-block-newspack-blocks-{$type}",
+			"align{$align}",
+		);
+		if ( isset( $attributes['className'] ) ) {
+			array_push( $classes, $attributes['className'] );
+		}
+		return implode( $classes, ' ' );
+	}
 }
 Newspack_Blocks::manage_view_scripts();
 add_action( 'enqueue_block_editor_assets', array( 'Newspack_Blocks', 'enqueue_block_editor_assets' ) );

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -15,92 +15,51 @@
 define( 'NEWSPACK_BLOCKS__BLOCKS_DIRECTORY', 'dist/' );
 define( 'NEWSPACK_BLOCKS__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'NEWSPACK_BLOCKS__VERSION', '0.1.0' );
-
 /**
- * Enqueue block scripts and styles for the editor.
+ * Newspack blocks functionality
  */
-function newspack_blocks_enqueue_block_editor_assets() {
-	$editor_script = plugins_url( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'editor.js', __FILE__ );
-	$editor_style  = plugins_url( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'editor.css', __FILE__ );
-	$dependencies  = array(
-		'lodash',
-		'wp-api-fetch',
-		'wp-blob',
-		'wp-blocks',
-		'wp-components',
-		'wp-compose',
-		'wp-data',
-		'wp-date',
-		'wp-edit-post',
-		'wp-editor',
-		'wp-element',
-		'wp-escape-html',
-		'wp-hooks',
-		'wp-i18n',
-		'wp-keycodes',
-		'wp-plugins',
-		'wp-polyfill',
-		'wp-rich-text',
-		'wp-token-list',
-		'wp-url',
-	);
-	wp_enqueue_script(
-		'newspack-blocks-editor',
-		$editor_script,
-		$dependencies,
-		NEWSPACK_BLOCKS__VERSION,
-		true
-	);
-	wp_enqueue_style(
-		'newspack-blocks-editor',
-		$editor_style,
-		array(),
-		NEWSPACK_BLOCKS__VERSION
-	);
-}
-
-/**
- * Enqueue view scripts and styles for a single block.
- *
- * @param string $type The block's slug.
- * @param array  $dependencies An array of script dependencies.
- */
-function newspack_blocks_enqueue_view_assets( $type, $dependencies = array() ) {
-	if ( is_admin() ) {
-		// A block's view assets will not be required in wp-admin.
-		return;
-	}
-	$style_path  = BLOCKS_DIRECTORY . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css';
-	$script_path = BLOCKS_DIRECTORY . $type . '/view.js';
-
-	if ( file_exists( NEWSPACK__PLUGIN_DIR . $style_path ) ) {
-		wp_enqueue_style(
-			"newspack-block-{$type}",
-			plugins_url( $style_path, __FILE__ ),
-			array(),
-			NEWSPACK_BLOCKS__VERSION
+class Newspack_Blocks {
+	/**
+	 * Enqueue block scripts and styles for editor.
+	 */
+	public static function enqueue_block_editor_assets() {
+		$editor_script = plugins_url( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'editor.js', __FILE__ );
+		$editor_style  = plugins_url( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'editor.css', __FILE__ );
+		$dependencies  = array(
+			'lodash',
+			'wp-api-fetch',
+			'wp-blob',
+			'wp-blocks',
+			'wp-components',
+			'wp-compose',
+			'wp-data',
+			'wp-date',
+			'wp-edit-post',
+			'wp-editor',
+			'wp-element',
+			'wp-escape-html',
+			'wp-hooks',
+			'wp-i18n',
+			'wp-keycodes',
+			'wp-plugins',
+			'wp-polyfill',
+			'wp-rich-text',
+			'wp-token-list',
+			'wp-url',
 		);
-	}
-
-	if ( file_exists( NEWSPACK__PLUGIN_DIR . $script_path ) ) {
 		wp_enqueue_script(
-			"newspack-block-{$type}",
-			plugins_url( $script_path, __FILE__ ),
+			'newspack-blocks-editor',
+			$editor_script,
 			$dependencies,
+			NEWSPACK_BLOCKS__VERSION,
+			true
+		);
+		wp_enqueue_style(
+			'newspack-blocks-editor',
+			$editor_style,
 			array(),
 			NEWSPACK_BLOCKS__VERSION
 		);
 	}
 }
-
-/* An array of slugs for the blocks that require server-side handling (rendering, or asset loading) */
-$newspack_blocks_blocks = array();
-
-foreach ( $newspack_blocks_blocks as $newspack_blocks_block ) {
-	$newspack_blocks_view_path = NEWSPACK__PLUGIN_DIR . 'src/blocks/' . $newspack_blocks_block . '/view.php';
-	if ( file_exists( $newspack_blocks_view_path ) ) {
-		include_once $newspack_blocks_view_path;
-	}
-}
-
-add_action( 'enqueue_block_editor_assets', 'newspack_blocks_enqueue_block_editor_assets' );
+add_action( 'enqueue_block_editor_assets', array( 'Newspack_Blocks', 'enqueue_block_editor_assets' ) );

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -25,28 +25,7 @@ class Newspack_Blocks {
 	public static function enqueue_block_editor_assets() {
 		$editor_script = plugins_url( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'editor.js', __FILE__ );
 		$editor_style  = plugins_url( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'editor.css', __FILE__ );
-		$dependencies  = array(
-			'lodash',
-			'wp-api-fetch',
-			'wp-blob',
-			'wp-blocks',
-			'wp-components',
-			'wp-compose',
-			'wp-data',
-			'wp-date',
-			'wp-edit-post',
-			'wp-editor',
-			'wp-element',
-			'wp-escape-html',
-			'wp-hooks',
-			'wp-i18n',
-			'wp-keycodes',
-			'wp-plugins',
-			'wp-polyfill',
-			'wp-rich-text',
-			'wp-token-list',
-			'wp-url',
-		);
+		$dependencies  = self::dependencies_from_path( NEWSPACK_BLOCKS__PLUGIN_DIR . 'dist/editor.deps.json' );
 		wp_enqueue_script(
 			'newspack-blocks-editor',
 			$editor_script,
@@ -60,6 +39,22 @@ class Newspack_Blocks {
 			array(),
 			NEWSPACK_BLOCKS__VERSION
 		);
+	}
+
+	/**
+	 * Parse generated .deps.json file and return array of dependencies to be enqueued.
+	 *
+	 * @param string $path Path to the generated dependencies file.
+	 *
+	 * @return array Array of dependencides.
+	 */
+	public static function dependencies_from_path( $path ) {
+		$dependencies = file_exists( $path )
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			? json_decode( file_get_contents( $path ) )
+			: array();
+		$dependencies[] = 'wp-polyfill';
+		return $dependencies;
 	}
 }
 add_action( 'enqueue_block_editor_assets', array( 'Newspack_Blocks', 'enqueue_block_editor_assets' ) );

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -58,14 +58,14 @@ class Newspack_Blocks {
 			}
 			$type = $block_directory->getFilename();
 
-			/* If index.php is found, include it and use for block rendering. */
-			$view_php_path = $src_directory . $type . '/index.php';
+			/* If view.php is found, include it and use for block rendering. */
+			$view_php_path = $src_directory . $type . '/view.php';
 			if ( file_exists( $view_php_path ) ) {
 				include_once $view_php_path;
 				continue;
 			}
 
-			/* If index.php is missing but view Javascript file is found, do generic view asset loading. */
+			/* If view.php is missing but view Javascript file is found, do generic view asset loading. */
 			$view_js_path = $dist_directory . $type . '/view.js';
 			if ( file_exists( $view_js_path ) ) {
 				register_block_type(

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -87,7 +87,7 @@ class Newspack_Blocks {
 	 * @param string $type The block's slug.
 	 * @param array  $dependencies An array of script dependencies.
 	 */
-	public static function enqueue_view_assets( $type, $dependencies = array() ) {
+	public static function enqueue_view_assets( $type ) {
 		$style_path  = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css';
 		$script_path = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view.js';
 		if ( file_exists( NEWSPACK_BLOCKS__PLUGIN_DIR . $style_path ) ) {
@@ -99,6 +99,7 @@ class Newspack_Blocks {
 			);
 		}
 		if ( file_exists( NEWSPACK_BLOCKS__PLUGIN_DIR . $script_path ) ) {
+			$dependencies = self::dependencies_from_path( NEWSPACK_BLOCKS__PLUGIN_DIR . "dist/{$type}/view.deps.json" );
 			wp_enqueue_script(
 				"newspack-blocks-{$type}",
 				plugins_url( $script_path, __FILE__ ),

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -85,7 +85,6 @@ class Newspack_Blocks {
 	 * Enqueue view scripts and styles for a single block.
 	 *
 	 * @param string $type The block's slug.
-	 * @param array  $dependencies An array of script dependencies.
 	 */
 	public static function enqueue_view_assets( $type ) {
 		$style_path  = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css';

--- a/src/blocks/example2-attributes/style.scss
+++ b/src/blocks/example2-attributes/style.scss
@@ -1,0 +1,3 @@
+.wp-block-newspack-blocks-example2-attributes {
+	border: 3px solid blue;
+}

--- a/src/blocks/example2-attributes/view.js
+++ b/src/blocks/example2-attributes/view.js
@@ -1,0 +1,1 @@
+import './style.scss';

--- a/src/blocks/example3-ssr/edit.js
+++ b/src/blocks/example3-ssr/edit.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
+import { Component } from '@wordpress/element';
+
+import { icon, title } from './';
+
+class Edit extends Component {
+	render() {
+		const { attributes, className } = this.props;
+		const { align } = attributes;
+		const classes = classNames( className, `align${ align }` );
+		return (
+			<div className={ classes }>
+				<p>Newspack SSR Example. In View, today's date will be displayed.</p>
+			</div>
+		);
+	}
+}
+export default Edit;

--- a/src/blocks/example3-ssr/editor.js
+++ b/src/blocks/example3-ssr/editor.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { name, settings } from '.';
+
+registerBlockType( `newspack-blocks/${ name }`, settings );

--- a/src/blocks/example3-ssr/index.js
+++ b/src/blocks/example3-ssr/index.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import edit from './edit';
+
+export const name = 'example3-ssr';
+export const title = __( 'Newspack SSR Example' );
+
+/* From https://material.io/tools/icons */
+export const icon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<Path fill="none" d="M0 0h24v24H0z" />
+		<Path d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z" />
+	</SVG>
+);
+
+export const settings = {
+	title,
+	icon,
+	category: 'newspack',
+	keywords: [ __( 'news' ) ],
+	description: __( 'Example of a block with server-side rendering.' ),
+	attributes: {
+		align: {
+			type: 'string',
+			default: 'center',
+		},
+	},
+	supports: {
+		html: false,
+		align: true,
+	},
+	edit,
+	save: () => null,
+};

--- a/src/blocks/example3-ssr/style.scss
+++ b/src/blocks/example3-ssr/style.scss
@@ -1,0 +1,3 @@
+.wp-block-newspack-blocks-example3-ssr {
+	background: beige;
+}

--- a/src/blocks/example3-ssr/view.js
+++ b/src/blocks/example3-ssr/view.js
@@ -1,0 +1,1 @@
+import './style.scss';

--- a/src/blocks/example3-ssr/view.php
+++ b/src/blocks/example3-ssr/view.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Server-side rendering of the `newspack-blocks/example2-attributes` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `newspack-blocks/example2-attributes` block on server.
+ *
+ * @param array  $attributes The block attributes.
+ * @param string $content The block content.
+ *
+ * @return string Returns the post content with latest posts added.
+ */
+function newspack_blocks_render_block_example3_ssr( $attributes, $content ) {
+	$classes = Newspack_Blocks::block_classes( 'example3-ssr', $attributes );
+	$today   = date( 'm/d/Y h:i:s a', time() );
+	ob_start();
+	?>
+	<div class="<?php echo esc_attr( $classes ); ?>">
+		<p><?php echo wp_kses_post( $today ); ?></p>
+	</div>
+	<?php
+	$content = ob_get_clean();
+
+	Newspack_Blocks::enqueue_view_assets( 'example3-ssr' );
+	return $content;
+}
+
+/**
+ * Registers the `newspack-blocks/homepage-articles` block on server.
+ */
+register_block_type(
+	'newspack-blocks/example3-ssr',
+	array(
+		'render_callback' => 'newspack_blocks_render_block_example3_ssr',
+	)
+);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,7 +47,7 @@ const editorScript = [
 	...blockScripts( 'editor', path.join( __dirname, 'src' ), blocks ),
 ];
 
-const webpackConfig = getBaseWebpackConfig( null, {
+const webpackConfig = getBaseWebpackConfig( { WP: true }, {
 	entry: {
 		editor: editorScript,
 		...viewBlocksScripts,


### PR DESCRIPTION
This PR brings in a few improvements to the plugin:

1) The main plugin PHP file is refactored as a class: `Newspack_Blocks`
2) View-side block registration and asset loading is more sophisticated. If a block directory contains a `view.php` file, this will be included and used for block registration and rendering. If there is a `view.js` file but no `view.php` then a generic block registration is created which simply enqueues `view.js` & `view.css`.
3) All script enqueuing now relies on generated dependency lists created by `@automattic/wordpress-external-dependencies-plugin`, rather than requiring manual dependency management.
4) Introduces a new example block which demonstrates server-side rendering.

To test:

- Run `npm ci && npm install && npm run clean && NODE_ENV=production npm run build`
- Install/Activate the plugin
- Create a post, open the block picker, verify there is a Newspack category and there are three blocks within it.
- Verify the three blocks work as expected.