### PR TITLE
Upgrade calypso-build to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,17 +5,15 @@
   "requires": true,
   "dependencies": {
     "@automattic/calypso-build": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@automattic/calypso-build/-/calypso-build-1.0.0-rc.3.tgz",
-      "integrity": "sha512-W7tEgys5hm8ZOjaFgu+SVFJLaqZspj3AkPEdk7GrXe2u6zfRTVGZHRFnMHLeIX3E6xab8//gC23VQAvwUW7tlA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@automattic/calypso-build/-/calypso-build-2.0.0.tgz",
+      "integrity": "sha512-TZqoa+MHFyRHzqBrKgg0aQCmpEp8gpOgDFa2RIRBc2pbyJX6N1rDmQMgJb93FsSW68vlz60NhDZ0J7CkT8ZgBg==",
       "dev": true,
       "requires": {
         "@automattic/calypso-color-schemes": "^1.0.0",
         "@automattic/wordpress-external-dependencies-plugin": "^1.0.0",
         "@babel/core": "7.4.0",
         "@babel/plugin-proposal-class-properties": "7.4.0",
-        "@babel/plugin-proposal-export-default-from": "7.2.0",
-        "@babel/plugin-proposal-export-namespace-from": "7.2.0",
         "@babel/plugin-syntax-dynamic-import": "7.2.0",
         "@babel/plugin-transform-react-jsx": "7.3.0",
         "@babel/plugin-transform-runtime": "7.4.0",
@@ -677,26 +675,6 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/plugin-proposal-export-default-from": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.2.0.tgz",
-      "integrity": "sha512-NVfNe7F6nsasG1FnvcFxh2FN0l04ZNe75qTOAVOILWPam0tw9a63RtT/Dab8dPjedZa4fTQaQ83yMMywF9OSug==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-export-default-from": "^7.2.0"
-      }
-    },
-    "@babel/plugin-proposal-export-namespace-from": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.2.0.tgz",
-      "integrity": "sha512-DZUxbHYxQ5fUFIkMEnh75ogEdBLPfL+mQUqrO2hNY2LGm+tqFnxE924+mhAcCOh/8za8AaZsWHbq6bBoS3TAzA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-export-namespace-from": "^7.2.0"
-      }
-    },
     "@babel/plugin-proposal-json-strings": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
@@ -751,24 +729,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
       "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
-    "@babel/plugin-syntax-export-default-from": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.2.0.tgz",
-      "integrity": "sha512-c7nqUnNST97BWPtoe+Ssi+fJukc9P9/JMZ71IOMNQWza2E+Psrd46N6AEvtw6pqK+gt7ChjXyrw4SPDO79f3Lw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
-    "@babel/plugin-syntax-export-namespace-from": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.2.0.tgz",
-      "integrity": "sha512-1zGA3UNch6A+A11nIzBVEaE3DDJbjfB+eLIcf0GGOh/BJr/8NxL3546MGhV/r0RhH4xADFIEso39TKCfEMlsGA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -2495,9 +2455,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000966",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000966.tgz",
-      "integrity": "sha512-qqLQ/uYrpZmFhPY96VuBkMEo8NhVFBZ9y/Bh+KnvGzGJ5I8hvpIaWlF2pw5gqe4PLAL+ZjsPgMOvoXSpX21Keg==",
+      "version": "1.0.30000967",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000967.tgz",
+      "integrity": "sha512-rUBIbap+VJfxTzrM4akJ00lkvVb5/n5v3EGXfWzSH5zT8aJmGzjA8HWhJ4U6kCpzxozUSnB+yvAYDRPY6mRpgQ==",
       "dev": true
     },
     "caseless": {
@@ -3396,9 +3356,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.130",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.130.tgz",
-      "integrity": "sha512-UY2DI+gsnqGtQJqO8wXN0DnpJY+29FwJafACj0h18ZShn5besKnrRq6+lXWUbKzdxw92QQcnTqRLgNByOKXcUg==",
+      "version": "1.3.133",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.133.tgz",
+      "integrity": "sha512-lyoC8aoqbbDqsprb6aPdt9n3DpOZZzdz/T4IZKsR0/dkZIxnJVUjjcpOSwA66jPRIOyDAamCTAUqweU05kKNSg==",
       "dev": true
     },
     "elliptic": {
@@ -4202,8 +4162,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4224,14 +4183,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4246,20 +4203,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4376,8 +4330,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4389,7 +4342,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4404,7 +4356,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4412,14 +4363,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4438,7 +4387,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4519,8 +4467,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4532,7 +4479,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4618,8 +4564,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4655,7 +4600,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4675,7 +4619,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4719,14 +4662,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6524,9 +6465,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.17.tgz",
-      "integrity": "sha512-/SCjetyta1m7YXLgtACZGDYJdCSIBAWorDWkGCGZlydP2Ll7J48l7j/JxNYZ+xsgSPbWfdulVS/aY+GdjUsQ7Q==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.18.tgz",
+      "integrity": "sha512-/mnVgm6u/8OwlIsoyRXtTI0RfQcxZoAZbdwyXap0EeWwcOpDDymyCHM2/aR9XKmHXrvizHoPAOs0pcbiJ6RUaA==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -7059,9 +7000,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-      "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+      "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -9532,9 +9473,9 @@
       }
     },
     "vendors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.2.tgz",
-      "integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.3.tgz",
+      "integrity": "sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw==",
       "dev": true
     },
     "verror": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "Gruntfile.js",
   "author": "Automattic",
   "devDependencies": {
-    "@automattic/calypso-build": "^1.0.0-rc.3",
+    "@automattic/calypso-build": "^2.0.0",
     "@babel/core": "^7.4.0",
     "@wordpress/blocks": "^6.2.0",
     "@wordpress/element": "^2.3.0",


### PR DESCRIPTION
Just published latest version.

[Changelog](https://github.com/Automattic/wp-calypso/blob/master/packages/calypso-build/CHANGELOG.md)

> # 2.0.0
> 
> - Breaking change: Remove babel plugins incompatible with TypeScript. If your bundle continues to
>   compile without error, no changes are necessary. These babel plugins were removed:
> 
>   - [`@babel/plugin-proposal-export-default-from`](https://babeljs.io/docs/en/babel-plugin-proposal-export-default-from):
>     Code relying on this plugin will need to be modified for compatibility before it can be bundled
>     with `calypso-build`. For example:
> 
>     ```js
>     // Code relying on @babel/plugin-proposal-export-default-from
>     export someExportedName from 'some-module';
> 
>     // becomes
>     export { default as someExportedName } from 'some-module';
>     ```
> 
>   - [`@babel/plugin-proposal-export-namespace-from`](https://babeljs.io/docs/en/babel-plugin-proposal-export-namespace-from):
>     Code relying on this plugin will need to be modified for compatibility before it can be bundled
>     with `calypso-build`. For example:
> 
>     ```js
>     // Code relying on @babel/plugin-proposal-export-namespace-from
>     export * as someExportedName from 'some-module';
> 
>     // becomes
>     import * as someExportedName from 'some-module';
>     export { someExportedName };
>     ```
> 
> - Bugfix: Add ts and tsx extensions to webpack module resolution rules.
> 
> # 1.0.0
> 
> - Initial release
> 
