### PR TITLE
Alternate Approach To AMP Compatibility

### DIFF
--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -97,7 +97,7 @@ class Newspack_Blocks {
 				NEWSPACK_BLOCKS__VERSION
 			);
 		}
-		if ( file_exists( NEWSPACK_BLOCKS__PLUGIN_DIR . $script_path ) ) {
+		if ( ! self::is_amp_request() && file_exists( NEWSPACK_BLOCKS__PLUGIN_DIR . $script_path ) ) {
 			$dependencies = self::dependencies_from_path( NEWSPACK_BLOCKS__PLUGIN_DIR . "dist/{$type}/view.deps.json" );
 			wp_enqueue_script(
 				"newspack-blocks-{$type}",
@@ -143,6 +143,15 @@ class Newspack_Blocks {
 			array_push( $classes, $attributes['className'] );
 		}
 		return implode( $classes, ' ' );
+	}
+
+	/**
+	 * Does the page return AMP content.
+	 *
+	 * @return bool $is_amp_request Are we on am AMP view.
+	 */
+	public static function is_amp_request() {
+		return ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() );
 	}
 }
 


### PR DESCRIPTION
This is an alternate approach to https://github.com/Automattic/newspack-blocks/pull/19, in which rather than removing `view.js` entirely we enqueue is only when not in an AMP request. This approach keeps open the possibility of blocks with view-side scripts, which may be used in AMP & non-AMP environments.

Testing Instructions:

1) Install AMP plugin on test site along running Newspack plugin, so to Native mode.
2) Add Newspack Homepage Articles block to a Post or Page and publish.
3) Review AMP errors. There should be none related to `view.js` or `wp-polyfill`.