### PR TITLE
Consistent Build Script Name

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "private": true,
   "dependencies": {},
   "scripts": {
-    "build": "calypso-build --config='./webpack.config.js'",
+    "build:webpack": "calypso-build --config='./webpack.config.js'",
     "clean": "rm -rf dist/",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This simply renames the build script from `build` to `build:webpack` to match https://github.com/Automattic/newspack-plugin for consistency's sake.

To test:

1. Check out this branch.
2. `npm ci && npm clean`
3. `npm run build:webpack`

Verify no errors and that `dist` directory has been created and populated.