### PR TITLE
Add field for a block section header

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -284,7 +284,7 @@ class Edit extends Component {
 				<div className={ classes }>
 					{ sectionHeader && (
 						<div className="article-section-title" key="article-section-title">
-							{ sectionHeader }
+							<span>{ sectionHeader }</span>
 						</div>
 					) }
 

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -21,6 +21,7 @@ import {
 	Dashicon,
 	Placeholder,
 	Spinner,
+	TextControl,
 } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { withState } from '@wordpress/compose';
@@ -89,6 +90,7 @@ class Edit extends Component {
 		const {
 			postsToShow,
 			categories,
+			sectionHeader,
 			columns,
 			showImage,
 			imageScale,
@@ -126,6 +128,12 @@ class Edit extends Component {
 							required
 						/>
 					) }
+					<TextControl
+						label={ __( 'Block Section Header' ) }
+						value={ sectionHeader }
+						onChange={ value => setAttributes( { sectionHeader: value } ) }
+						help={ __( 'Displays an optional header above the article blocks.' ) }
+					/>
 				</PanelBody>
 				<PanelBody title={ __( 'Featured Image Settings' ) }>
 					<PanelRow>
@@ -224,6 +232,7 @@ class Edit extends Component {
 			categories,
 			typeScale,
 			imageScale,
+			sectionHeader,
 		} = attributes;
 
 		const classes = classNames( className, {
@@ -273,6 +282,12 @@ class Edit extends Component {
 		return (
 			<Fragment>
 				<div className={ classes }>
+					{ sectionHeader && (
+						<div className="article-section-title" key="article-section-title">
+							{ sectionHeader }
+						</div>
+					) }
+
 					{ latestPosts && ! latestPosts.length && (
 						<Placeholder>{ __( 'Sorry, no posts were found.' ) }</Placeholder>
 					) }

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -277,15 +277,13 @@ class Edit extends Component {
 			<Fragment>
 				<div className={ classes }>
 					{ latestPosts && ( ! RichText.isEmpty( sectionHeader ) || isSelected ) && (
-						<div className="article-section-title">
-							<span>
-								<RichText
-									onChange={ value => setAttributes( { sectionHeader: value } ) }
-									placeholder={ __( 'Write header…' ) }
-									value={ sectionHeader }
-								/>
-							</span>
-						</div>
+						<RichText
+							onChange={ value => setAttributes( { sectionHeader: value } ) }
+							placeholder={ __( 'Write header…' ) }
+							value={ sectionHeader }
+							tagName="div"
+							className="article-section-title"
+						/>
 					) }
 					{ latestPosts && ! latestPosts.length && (
 						<Placeholder>{ __( 'Sorry, no posts were found.' ) }</Placeholder>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -276,14 +276,6 @@ class Edit extends Component {
 		return (
 			<Fragment>
 				<div className={ classes }>
-					{ latestPosts && ! latestPosts.length && (
-						<Placeholder>{ __( 'Sorry, no posts were found.' ) }</Placeholder>
-					) }
-					{ ! latestPosts && (
-						<Placeholder>
-							<Spinner />
-						</Placeholder>
-					) }
 					{ latestPosts && ( ! RichText.isEmpty( sectionHeader ) || isSelected ) && (
 						<div className="article-section-title">
 							<span>
@@ -294,6 +286,14 @@ class Edit extends Component {
 								/>
 							</span>
 						</div>
+					) }
+					{ latestPosts && ! latestPosts.length && (
+						<Placeholder>{ __( 'Sorry, no posts were found.' ) }</Placeholder>
+					) }
+					{ ! latestPosts && (
+						<Placeholder>
+							<Spinner />
+						</Placeholder>
 					) }
 					{ latestPosts && latestPosts.map( post => this.renderPost( post ) ) }
 				</div>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -21,7 +21,6 @@ import {
 	Dashicon,
 	Placeholder,
 	Spinner,
-	TextControl,
 } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { withState } from '@wordpress/compose';
@@ -85,7 +84,7 @@ class Edit extends Component {
 	};
 
 	renderInspectorControls = () => {
-		const { attributes, categoriesList, setAttributes, latestPosts } = this.props;
+		const { attributes, categoriesList, setAttributes, latestPosts, isSelected } = this.props;
 		const hasPosts = Array.isArray( latestPosts ) && latestPosts.length;
 		const {
 			postsToShow,
@@ -128,12 +127,6 @@ class Edit extends Component {
 							required
 						/>
 					) }
-					<TextControl
-						label={ __( 'Block Section Header' ) }
-						value={ sectionHeader }
-						onChange={ value => setAttributes( { sectionHeader: value } ) }
-						help={ __( 'Displays an optional header above the article blocks.' ) }
-					/>
 				</PanelBody>
 				<PanelBody title={ __( 'Featured Image Settings' ) }>
 					<PanelRow>
@@ -215,6 +208,7 @@ class Edit extends Component {
 			attributes,
 			className,
 			setAttributes,
+			isSelected,
 			latestPosts,
 			hasPosts,
 			categoriesList,
@@ -282,12 +276,6 @@ class Edit extends Component {
 		return (
 			<Fragment>
 				<div className={ classes }>
-					{ sectionHeader && (
-						<div className="article-section-title" key="article-section-title">
-							<span>{ sectionHeader }</span>
-						</div>
-					) }
-
 					{ latestPosts && ! latestPosts.length && (
 						<Placeholder>{ __( 'Sorry, no posts were found.' ) }</Placeholder>
 					) }
@@ -295,6 +283,17 @@ class Edit extends Component {
 						<Placeholder>
 							<Spinner />
 						</Placeholder>
+					) }
+					{ latestPosts && ( ! RichText.isEmpty( sectionHeader ) || isSelected ) && (
+						<div className="article-section-title">
+							<span>
+								<RichText
+									onChange={ value => setAttributes( { sectionHeader: value } ) }
+									placeholder={ __( 'Write header…' ) }
+									value={ sectionHeader }
+								/>
+							</span>
+						</div>
 					) }
 					{ latestPosts && latestPosts.map( post => this.renderPost( post ) ) }
 				</div>

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -12,3 +12,7 @@
 		width: 16px;
 	}
 }
+
+.wp-block-newspack-blocks-homepage-articles .editor-rich-text {
+	width: 100%;
+}

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -83,6 +83,10 @@ export const settings = {
 			type: 'integer',
 			default: 3,
 		},
+		sectionHeader: {
+			type: 'string',
+			default: '',
+		},
 	},
 	supports: {
 		html: false,

--- a/src/blocks/homepage-articles/sass/_mixins.scss
+++ b/src/blocks/homepage-articles/sass/_mixins.scss
@@ -1,0 +1,26 @@
+
+@mixin media( $res ) {
+	@if mobile == $res {
+		@media only screen and (min-width: $mobile_width) {
+			@content;
+		}
+	}
+
+	@if tablet == $res {
+		@media only screen and (min-width: $tablet_width) {
+			@content;
+		}
+	}
+
+	@if desktop == $res {
+		@media only screen and (min-width: $desktop_width) {
+			@content;
+		}
+	}
+
+	@if wide == $res {
+		@media only screen and (min-width: $wide_width) {
+			@content;
+		}
+	}
+}

--- a/src/blocks/homepage-articles/sass/_variables.scss
+++ b/src/blocks/homepage-articles/sass/_variables.scss
@@ -1,0 +1,4 @@
+$mobile_width: 600px;
+$tablet_width: 768px;
+$desktop_width: 1168px;
+$wide_width: 1379px;

--- a/src/blocks/homepage-articles/sass/_variables.scss
+++ b/src/blocks/homepage-articles/sass/_variables.scss
@@ -2,3 +2,21 @@ $mobile_width: 600px;
 $tablet_width: 768px;
 $desktop_width: 1168px;
 $wide_width: 1379px;
+
+$font__size_base: 20px;
+$font__size-ratio: 1.125;
+
+$font__size-xxs: 1em / ( 1.5 * $font__size-ratio );
+$font__size-xs: 1em / ( 1.25 * $font__size-ratio );
+$font__size-sm: 1em / ( 1 * $font__size-ratio );
+$font__size-md: 1em * ( 1 * $font__size-ratio );
+$font__size-lg: 1em * ( 1.25 * $font__size-ratio );
+$font__size-xl: 1em * ( 1.5 * $font__size-ratio );
+$font__size-xxl: 1em * ( 2 * $font__size-ratio );
+$font__size-xxxl: 1em * ( 2.5 * $font__size-ratio );
+$font__size-xxxxl: 1em * ( 2.75 * $font__size-ratio );
+
+$font__line-height-body: 1.6;
+$font__line-height-pre: 1.6;
+$font__line-height-heading: 1.2;
+$font__line-height-double: 2 * $font__line-height-heading;

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -51,7 +51,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 			<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
 				<div class="article-section-title">
-					<span><?php echo esc_html( $attributes['sectionHeader'] ); ?></span>
+					<span><?php echo wp_kses_post( $attributes['sectionHeader'] ); ?></span>
 				</div>
 			<?php
 			endif;

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -51,7 +51,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 			<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
 				<div class="article-section-title">
-					<?php echo esc_html( $attributes['sectionHeader'] ); ?>
+					<span><?php echo esc_html( $attributes['sectionHeader'] ); ?></span>
 				</div>
 			<?php
 			endif;

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -48,7 +48,13 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	if ( $article_query->have_posts() ) :
 		?>
 		<div class="<?php echo esc_attr( $classes ); ?>">
+
+			<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
+				<div class="article-section-title">
+					<?php echo esc_html( $attributes['sectionHeader'] ); ?>
+				</div>
 			<?php
+			endif;
 			while ( $article_query->have_posts() ) :
 				$article_query->the_post();
 				?>
@@ -185,6 +191,10 @@ function newspack_blocks_register_homepage_articles() {
 				'imageScale'    => array(
 					'type'    => 'integer',
 					'default' => 3,
+				),
+				'sectionHeader' => array(
+					'type'    => 'string',
+					'default' => '',
 				),
 			),
 			'render_callback' => 'newspack_blocks_render_block_homepage_articles',

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -1,4 +1,3 @@
-
 @import "sass/variables";
 @import "sass/mixins";
 
@@ -111,6 +110,10 @@
 	}
 
 	/* Article meta */
+<<<<<<< HEAD
+=======
+
+>>>>>>> Remove specific font families from styles, so the blocks inherit styles from the theme more easily.
 	.avatar {
 		border-radius: 100%;
 		display: inline-block;

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -31,7 +31,7 @@ $font__line-height-double: 2 * $font__line-height-heading;
 	/* Section header */
 	.article-section-title {
 		font-family: $font__sans-serif;
-		font-size: $font__size-xxs;
+		font-size: $font__size-sm;
 		font-weight: bold;
 		margin-bottom: 0.5em;
 		width: 100%; // make sure this isn't caught up in the flex styles.

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -123,16 +123,19 @@
 	article {
 		.article-title {
 			font-size: 24px;
-			@include media(tablet) {
-				font-size: 32px;
-			}
 		}
 		.article-meta {
 			font-size: 16px;
 		}
 		.avatar {
-			height: 28px;
-			width: 28px;
+			height: 36px;
+			width: 36px;
+		}
+
+		@include media(tablet) {
+			.article-title {
+				font-size: 32px;
+			}
 		}
 	}
 
@@ -223,13 +226,13 @@
 		.article-meta {
 			font-size: 14px;
 		}
+		.avatar {
+			height: 32px;
+			width: 32px;
+		}
 		@include media(tablet) {
 			.article-title {
 				font-size: 24px;
-			}
-			.avatar {
-				height: 32px;
-				width: 32px;
 			}
 		}
 	}

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -110,10 +110,6 @@
 	}
 
 	/* Article meta */
-<<<<<<< HEAD
-=======
-
->>>>>>> Remove specific font families from styles, so the blocks inherit styles from the theme more easily.
 	.avatar {
 		border-radius: 100%;
 		display: inline-block;

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -1,8 +1,3 @@
-/* Variables */
-$font__sans-serif: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
-	'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
-$font__serif: Georgia, Garamond, 'Times New Roman', serif;
-
 $font__size_base: 20px;
 $font__size-ratio: 1.125;
 
@@ -30,7 +25,6 @@ $font__line-height-double: 2 * $font__line-height-heading;
 
 	/* Section header */
 	.article-section-title {
-		font-family: $font__sans-serif;
 		font-size: $font__size-sm;
 		font-weight: bold;
 		margin-bottom: 0.5em;
@@ -119,7 +113,6 @@ $font__line-height-double: 2 * $font__line-height-heading;
 	/* Headings */
 	// This may be removeable, depending on the theme sizing.
 	.article-title {
-		font-family: $font__sans-serif;
 		margin: 0;
 		a {
 			color: inherit;
@@ -132,10 +125,6 @@ $font__line-height-double: 2 * $font__line-height-heading;
 	}
 
 	/* Article meta */
-
-	.article-meta {
-		font-family: $font__sans-serif;
-	}
 
 	.avatar {
 		border-radius: 100%;

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -1,3 +1,6 @@
+@import "sass/variables";
+@import "sass/mixins";
+
 .wp-block-newspack-blocks-homepage-articles {
 	article {
 		margin-bottom: 16px;
@@ -18,7 +21,7 @@
 		}
 	}
 
-	@media ( min-width: 600px ) {
+	@include media(tablet) {
 		@for $i from 2 through 6 {
 			&.columns-#{ $i } article {
 				width: calc( ( 100% / #{$i} ) - 24px );
@@ -119,77 +122,92 @@
 	/* 'Normal' size */
 	article {
 		.article-title {
-			font-size: 32px;
-		}
-		.article-wrapper p {
-			font-size: 18px;
+			font-size: 24px;
+			@include media(tablet) {
+				font-size: 32px;
+			}
 		}
 		.article-meta {
 			font-size: 16px;
+		}
+		.avatar {
+			height: 28px;
+			width: 28px;
 		}
 	}
 
 	&.type-scale8 article {
 		.article-title {
-			font-size: 80px;
+			font-size: 44px;
 		}
-		.article-wrapper p {
-			font-size: 24px;
+		@include media(tablet) {
+			.article-title {
+				font-size: 68px;
+			}
+			.avatar {
+				height: 48px;
+				width: 48px;
+			}
 		}
-		.article-meta {
-			font-size: 20px;
-		}
-		.avatar {
-			height: 48px;
-			width: 48px;
+		@include media(desktop) {
+			.article-title {
+				font-size: 80px;
+			}
 		}
 	}
 
 	&.type-scale7 article {
 		.article-title {
-			font-size: 70px;
+			font-size: 40px;
 		}
-		.article-wrapper p {
-			font-size: 22px;
+		@include media( tablet) {
+			.article-title {
+				font-size: 56px;
+			}
+			.avatar {
+				height: 48px;
+				width: 48px;
+			}
 		}
-		.article-meta {
-			font-size: 18px;
-		}
-		.avatar {
-			height: 48px;
-			width: 48px;
+		@include media(desktop) {
+			.article-title {
+				font-size: 68px;
+			}
 		}
 	}
 
 	&.type-scale6 article {
 		.article-title {
-			font-size: 60px;
+			font-size: 36px;
 		}
-		.article-wrapper p {
-			font-size: 20px;
+		@include media(tablet) {
+			.article-title {
+				font-size: 48px;
+			}
+			.avatar {
+				height: 44px;
+				width: 44px;
+			}
 		}
-		.article-meta {
-			font-size: 18px;
-		}
-		.avatar {
-			height: 44px;
-			width: 44px;
+		@include media(desktop) {
+			.article-title {
+				font-size: 60px;
+			}
 		}
 	}
 
 	&.type-scale5 article {
 		.article-title {
-			font-size: 42px;
+			font-size: 28px;
 		}
-		.article-wrapper p {
-			font-size: 18px;
-		}
-		.article-meta {
-			font-size: 16px;
-		}
-		.avatar {
-			height: 40px;
-			width: 40px;
+		@include media(tablet) {
+			.article-title {
+				font-size: 44px;
+			}
+			.avatar {
+				height: 40px;
+				width: 40px;
+			}
 		}
 	}
 
@@ -197,7 +215,7 @@
 
 	&.type-scale3 article {
 		.article-title {
-			font-size: 24px;
+			font-size: 20px;
 		}
 		.article-wrapper p {
 			font-size: 16px;
@@ -205,15 +223,23 @@
 		.article-meta {
 			font-size: 14px;
 		}
-		.avatar {
-			height: 32px;
-			width: 32px;
+		@include media(tablet) {
+			.article-title {
+				font-size: 24px;
+			}
+			.avatar {
+				height: 32px;
+				width: 32px;
+			}
 		}
 	}
 
 	&.type-scale2 article {
 		.article-title {
-			font-size: 20px;
+			font-size: 18px;
+			@include media(tablet) {
+				font-size: 20px;
+			}
 		}
 		.article-wrapper p {
 			font-size: 16px;

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -1,11 +1,20 @@
+
 @import "sass/variables";
 @import "sass/mixins";
 
 .wp-block-newspack-blocks-homepage-articles {
 	article {
-		margin-bottom: 16px;
+		margin-bottom: 0.75em;
 		word-break: break-word;
 		overflow-wrap: break-word;
+	}
+
+	/* Section header */
+	.article-section-title {
+		font-size: $font__size-sm;
+		font-weight: bold;
+		margin-bottom: 0.5em;
+		width: 100%; // make sure this isn't caught up in the flex styles.
 	}
 
 	/* Column styles */
@@ -102,7 +111,6 @@
 	}
 
 	/* Article meta */
-
 	.avatar {
 		border-radius: 100%;
 		display: inline-block;

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -1,8 +1,40 @@
+/* Variables */
+$font__sans-serif: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+	'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+$font__serif: Georgia, Garamond, 'Times New Roman', serif;
+
+$font__size_base: 20px;
+$font__size-ratio: 1.125;
+
+$font__size-xxs: 1em / ( 1.5 * $font__size-ratio );
+$font__size-xs: 1em / ( 1.25 * $font__size-ratio );
+$font__size-sm: 1em / ( 1 * $font__size-ratio );
+$font__size-md: 1em * ( 1 * $font__size-ratio );
+$font__size-lg: 1em * ( 1.25 * $font__size-ratio );
+$font__size-xl: 1em * ( 1.5 * $font__size-ratio );
+$font__size-xxl: 1em * ( 2 * $font__size-ratio );
+$font__size-xxxl: 1em * ( 2.5 * $font__size-ratio );
+$font__size-xxxxl: 1em * ( 2.75 * $font__size-ratio );
+
+$font__line-height-body: 1.6;
+$font__line-height-pre: 1.6;
+$font__line-height-heading: 1.2;
+$font__line-height-double: 2 * $font__line-height-heading;
+
 .wp-block-newspack-blocks-homepage-articles {
 	article {
-		margin-bottom: 16px;
+		margin-bottom: 0.75em;
 		word-break: break-word;
 		overflow-wrap: break-word;
+	}
+
+	/* Section header */
+	.article-section-title {
+		font-family: $font__sans-serif;
+		font-size: $font__size-xxs;
+		font-weight: bold;
+		margin-bottom: 0.5em;
+		width: 100%; // make sure this isn't caught up in the flex styles.
 	}
 
 	/* Column styles */
@@ -87,6 +119,7 @@
 	/* Headings */
 	// This may be removeable, depending on the theme sizing.
 	.article-title {
+		font-family: $font__sans-serif;
 		margin: 0;
 		a {
 			color: inherit;
@@ -99,6 +132,10 @@
 	}
 
 	/* Article meta */
+
+	.article-meta {
+		font-family: $font__sans-serif;
+	}
 
 	.avatar {
 		border-radius: 100%;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a basic section heading to the homepage block -- it's an optional string of text that appears above the articles in the block, to help differentiate the different areas on the homepage.

With this PR I've also included some font-related variables, to be used in this block to make it easier to assign throughout; it can be moved to a more central location once we have more blocks to use it with.  

Fixes #23.

### How to test the changes in this Pull Request:

1. Apply patch.
2. Add a Homepage block to a page. 
3. Under 'Display Settings', there should now be a field labelled "Block Section Header".
4. Confirm that adding text here appears in the editor.
5. Save and publish and confirm that the text appears on the front end. 
6. Check out some other settings and make sure you don't see any weirdness (a good one is switching the block to a grid). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?