### PR TITLE
Add small screen-specific font sizes

### DIFF
--- a/src/blocks/homepage-articles/sass/_mixins.scss
+++ b/src/blocks/homepage-articles/sass/_mixins.scss
@@ -1,0 +1,26 @@
+
+@mixin media( $res ) {
+	@if mobile == $res {
+		@media only screen and (min-width: $mobile_width) {
+			@content;
+		}
+	}
+
+	@if tablet == $res {
+		@media only screen and (min-width: $tablet_width) {
+			@content;
+		}
+	}
+
+	@if desktop == $res {
+		@media only screen and (min-width: $desktop_width) {
+			@content;
+		}
+	}
+
+	@if wide == $res {
+		@media only screen and (min-width: $wide_width) {
+			@content;
+		}
+	}
+}

--- a/src/blocks/homepage-articles/sass/_variables.scss
+++ b/src/blocks/homepage-articles/sass/_variables.scss
@@ -1,0 +1,4 @@
+$mobile_width: 600px;
+$tablet_width: 768px;
+$desktop_width: 1168px;
+$wide_width: 1379px;

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -123,16 +123,19 @@
 	article {
 		.article-title {
 			font-size: 24px;
-			@include media(tablet) {
-				font-size: 32px;
-			}
 		}
 		.article-meta {
 			font-size: 16px;
 		}
 		.avatar {
-			height: 28px;
-			width: 28px;
+			height: 36px;
+			width: 36px;
+		}
+
+		@include media(tablet) {
+			.article-title {
+				font-size: 32px;
+			}
 		}
 	}
 
@@ -223,13 +226,13 @@
 		.article-meta {
 			font-size: 14px;
 		}
+		.avatar {
+			height: 32px;
+			width: 32px;
+		}
 		@include media(tablet) {
 			.article-title {
 				font-size: 24px;
-			}
-			.avatar {
-				height: 32px;
-				width: 32px;
 			}
 		}
 	}

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -1,3 +1,6 @@
+@import "sass/variables";
+@import "sass/mixins";
+
 .wp-block-newspack-blocks-homepage-articles {
 	article {
 		margin-bottom: 16px;
@@ -18,7 +21,7 @@
 		}
 	}
 
-	@media ( min-width: 600px ) {
+	@include media(tablet) {
 		@for $i from 2 through 6 {
 			&.columns-#{ $i } article {
 				width: calc( ( 100% / #{$i} ) - 24px );
@@ -119,77 +122,92 @@
 	/* 'Normal' size */
 	article {
 		.article-title {
-			font-size: 32px;
-		}
-		.article-wrapper p {
-			font-size: 18px;
+			font-size: 24px;
+			@include media(tablet) {
+				font-size: 32px;
+			}
 		}
 		.article-meta {
 			font-size: 16px;
+		}
+		.avatar {
+			height: 28px;
+			width: 28px;
 		}
 	}
 
 	&.type-scale8 article {
 		.article-title {
-			font-size: 80px;
+			font-size: 44px;
 		}
-		.article-wrapper p {
-			font-size: 24px;
+		@include media(tablet) {
+			.article-title {
+				font-size: 68px;
+			}
+			.avatar {
+				height: 48px;
+				width: 48px;
+			}
 		}
-		.article-meta {
-			font-size: 20px;
-		}
-		.avatar {
-			height: 48px;
-			width: 48px;
+		@include media(desktop) {
+			.article-title {
+				font-size: 80px;
+			}
 		}
 	}
 
 	&.type-scale7 article {
 		.article-title {
-			font-size: 70px;
+			font-size: 40px;
 		}
-		.article-wrapper p {
-			font-size: 22px;
+		@include media( tablet) {
+			.article-title {
+				font-size: 56px;
+			}
+			.avatar {
+				height: 48px;
+				width: 48px;
+			}
 		}
-		.article-meta {
-			font-size: 18px;
-		}
-		.avatar {
-			height: 48px;
-			width: 48px;
+		@include media(desktop) {
+			.article-title {
+				font-size: 68px;
+			}
 		}
 	}
 
 	&.type-scale6 article {
 		.article-title {
-			font-size: 60px;
+			font-size: 36px;
 		}
-		.article-wrapper p {
-			font-size: 20px;
+		@include media(tablet) {
+			.article-title {
+				font-size: 48px;
+			}
+			.avatar {
+				height: 44px;
+				width: 44px;
+			}
 		}
-		.article-meta {
-			font-size: 18px;
-		}
-		.avatar {
-			height: 44px;
-			width: 44px;
+		@include media(desktop) {
+			.article-title {
+				font-size: 60px;
+			}
 		}
 	}
 
 	&.type-scale5 article {
 		.article-title {
-			font-size: 42px;
+			font-size: 28px;
 		}
-		.article-wrapper p {
-			font-size: 18px;
-		}
-		.article-meta {
-			font-size: 16px;
-		}
-		.avatar {
-			height: 40px;
-			width: 40px;
+		@include media(tablet) {
+			.article-title {
+				font-size: 44px;
+			}
+			.avatar {
+				height: 40px;
+				width: 40px;
+			}
 		}
 	}
 
@@ -197,7 +215,7 @@
 
 	&.type-scale3 article {
 		.article-title {
-			font-size: 24px;
+			font-size: 20px;
 		}
 		.article-wrapper p {
 			font-size: 16px;
@@ -205,15 +223,23 @@
 		.article-meta {
 			font-size: 14px;
 		}
-		.avatar {
-			height: 32px;
-			width: 32px;
+		@include media(tablet) {
+			.article-title {
+				font-size: 24px;
+			}
+			.avatar {
+				height: 32px;
+				width: 32px;
+			}
 		}
 	}
 
 	&.type-scale2 article {
 		.article-title {
-			font-size: 20px;
+			font-size: 18px;
+			@include media(tablet) {
+				font-size: 20px;
+			}
 		}
 		.article-wrapper p {
 			font-size: 16px;


### PR DESCRIPTION
This PR copies over some screen size variables and a `@media` mixin from the Newspack theme, and adjusts the font size for the block down depending on screen size. 

This is a partial fix for #16; the blocks still need some work on how the columns break down, to make sure that when they're multi-column, they don't get too crowded, _especially_ when they're nested inside of another block that creates column (like the default Columns block).

## To test

1. Add 8 test blocks to a page -- make each 1 article long, and give them each a different type scale value, ranging from 1 to 8. 
2. View the blocks on a desktop, tablet, and mobile sized screen.
3. Make sure the article title and avatar sizes are scaling up and down, and that nothing feels to overwhelmingly large on the smaller screens. 