### PR TITLE
Tighten up layout of the article blocks

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -53,20 +53,19 @@ class Edit extends Component {
 					{ showExcerpt && <RawHTML key="excerpt">{ post.excerpt.rendered }</RawHTML> }
 
 					<div className="article-meta">
+						{ showAuthor && post.newspack_author_info.avatar && showAvatar && (
+							<span className="avatar author-avatar" key="author-avatar">
+								<RawHTML>{ post.newspack_author_info.avatar }</RawHTML>
+							</span>
+						) }
+
 						{ showAuthor && (
-							<span className="article-byline" key="byline">
-								{ post.newspack_author_info.avatar && showAvatar && (
-									<span className="avatar author-avatar" key="author-avatar">
-										<RawHTML>{ post.newspack_author_info.avatar }</RawHTML>
-									</span>
-								) }
-								<span className="author-name">
-									{ __( 'by' ) }{' '}
-									<span className="author vcard">
-										<a className="url fn n" href={ post.newspack_author_info.author_link }>
-											{ post.newspack_author_info.display_name }
-										</a>
-									</span>
+							<span className="author-name">
+								{ __( 'by' ) }{' '}
+								<span className="author vcard">
+									<a className="url fn n" href={ post.newspack_author_info.author_link }>
+										{ post.newspack_author_info.display_name }
+									</a>
 								</span>
 							</span>
 						) }

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -70,7 +70,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 						<?php the_title( '<h2 class="article-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' ); ?>
 
 						<?php if ( $attributes['showExcerpt'] ) : ?>
-							<p><?php the_excerpt(); ?></p>
+							<?php the_excerpt(); ?>
 						<?php endif; ?>
 
 						<?php if ( $attributes['showAuthor'] || $attributes['showDate'] ) : ?>
@@ -78,22 +78,20 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 							<div class="article-meta">
 
 								<?php if ( $attributes['showAuthor'] ) : ?>
-									<span class="article-byline">
+									<?php
+									if ( $attributes['showAvatar'] ) {
+										echo get_avatar( get_the_author_meta( 'ID' ) );
+									}
+									?>
+									<span class="author-name">
 										<?php
-										if ( $attributes['showAvatar'] ) {
-											echo get_avatar( get_the_author_meta( 'ID' ) );
-										}
+										printf(
+											/* translators: %s: post author. */
+											esc_html_x( 'by %s', 'post author', 'newspack-blocks' ),
+											'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
+										);
 										?>
-										<span class="author-name">
-											<?php
-											printf(
-												/* translators: %s: post author. */
-												esc_html_x( 'by %s', 'post author', 'newspack-blocks' ),
-												'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
-											);
-											?>
-										</span><!-- .author-name -->
-									</span><!-- .article-byline -->
+									</span><!-- .author-name -->
 									<?php
 								endif;
 

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -6,6 +6,10 @@
 		margin-bottom: 0.75em;
 		word-break: break-word;
 		overflow-wrap: break-word;
+
+		&:not(:last-child) {
+			margin-bottom: 1.5em;
+		}
 	}
 
 	/* Section header */
@@ -32,7 +36,7 @@
 	@include media(tablet) {
 		@for $i from 2 through 6 {
 			&.columns-#{ $i } article {
-				width: calc( ( 100% / #{$i} ) - 24px );
+				width: calc( ( 100% / #{$i} ) - 12px );
 			}
 		}
 	}
@@ -110,17 +114,23 @@
 	}
 
 	/* Article meta */
-	.avatar {
-		border-radius: 100%;
-		display: inline-block;
-		height: 36px;
-		margin-right: 0.25em;
-		width: 36px;
+	.article-meta {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		margin-top: 0.75em;
+
+		.author-name:not(:last-child) {
+			margin-right: 0.5em;
+		}
 	}
 
-	.article-byline {
-		align-items: center;
-		display: flex;
+	.avatar {
+		border-radius: 100%;
+		display: block;
+		height: 36px;
+		margin-right: 0.5em;
+		width: 36px;
 	}
 }
 

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -3,13 +3,9 @@
 
 .wp-block-newspack-blocks-homepage-articles {
 	article {
-		margin-bottom: 1em;
+		margin-bottom: 1.5em;
 		word-break: break-word;
 		overflow-wrap: break-word;
-
-		&:not(:last-child) {
-			margin-bottom: 1.5em;
-		}
 	}
 
 	/* Section header */
@@ -30,6 +26,10 @@
 
 		article {
 			width: 100%;
+
+			@include media(tablet) {
+				margin-bottom: 1em;
+			}
 		}
 	}
 

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -125,17 +125,6 @@
 		}
 	}
 
-	.article-meta {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: center;
-		margin-top: 0.75em;
-
-		.author-name:not(:last-child) {
-			margin-right: 0.5em;
-		}
-	}
-
 	.avatar {
 		border-radius: 100%;
 		display: block;

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -3,7 +3,7 @@
 
 .wp-block-newspack-blocks-homepage-articles {
 	article {
-		margin-bottom: 0.75em;
+		margin-bottom: 1em;
 		word-break: break-word;
 		overflow-wrap: break-word;
 
@@ -118,7 +118,7 @@
 		display: flex;
 		flex-wrap: wrap;
 		align-items: center;
-		margin-top: 0.75em;
+		margin-top: 0.5em;
 
 		.author-name:not(:last-child) {
 			margin-right: 0.5em;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is a bit of a mixed bag of changes, but they collectively tighten up the layout of the article blocks a bit: 

* Reduces the space between the columns when you've set the article block to display as grid.
* Gets the author avatar, name and published date on one line when there's room for it (the display when there isn't room for all three still needs work; the date sits below the avatar if it's there, which looks strange). 
* Adjusts the vertical space between articles, and with the post meta. 
* Removes an extra `<p>` tag from around `the_excerpt()`, and reworks the post meta markup a bit to allow for the current layout.

### How to test the changes in this Pull Request:

1. Set up a couple article blocks - one with multiple items displayed in one column, and second with the grid.
2. Check it over.
3. Apply the PR; confirm a few things:
   * That when there's space, the author avatar, name and published date appear on one line.
   * That the space between columns is reduced in the grid layout.
   * That the vertical space between articles when displayed in one column is increase. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
