### PR TITLE
Update 'section' header markup to make it use a h2 tag

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -57,7 +57,7 @@ class Edit extends Component {
 						</h3>
 					) }
 					{ showExcerpt && <RawHTML key="excerpt">{ post.excerpt.rendered }</RawHTML> }
-					<div className="article-meta">
+					<div className="article-meta use-header-font">
 						{ showAuthor && post.newspack_author_info.avatar && showAvatar && (
 							<span className="avatar author-avatar" key="author-avatar">
 								<RawHTML>{ post.newspack_author_info.avatar }</RawHTML>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -35,7 +35,7 @@ const MAX_POSTS_COLUMNS = 6;
 class Edit extends Component {
 	renderPost = post => {
 		const { attributes } = this.props;
-		const { showImage, showExcerpt, showAuthor, showAvatar, showDate } = attributes;
+		const { showImage, showExcerpt, showAuthor, showAvatar, showDate, sectionHeader } = attributes;
 		return (
 			<article
 				className={ post.newspack_featured_image_src && 'article-has-image' }
@@ -47,11 +47,16 @@ class Edit extends Component {
 					</div>
 				) }
 				<div className="article-wrapper">
-					<h2 className="article-title" key="title">
-						<a href={ post.link }>{ decodeEntities( post.title.rendered.trim() ) }</a>
-					</h2>
+					{ RichText.isEmpty( sectionHeader ) ? (
+						<h2 className="article-title" key="title">
+							<a href={ post.link }>{ decodeEntities( post.title.rendered.trim() ) }</a>
+						</h2>
+					) : (
+						<h3 className="article-title" key="title">
+							<a href={ post.link }>{ decodeEntities( post.title.rendered.trim() ) }</a>
+						</h3>
+					) }
 					{ showExcerpt && <RawHTML key="excerpt">{ post.excerpt.rendered }</RawHTML> }
-
 					<div className="article-meta">
 						{ showAuthor && post.newspack_author_info.avatar && showAvatar && (
 							<span className="avatar author-avatar" key="author-avatar">
@@ -280,7 +285,7 @@ class Edit extends Component {
 							onChange={ value => setAttributes( { sectionHeader: value } ) }
 							placeholder={ __( 'Write header…' ) }
 							value={ sectionHeader }
-							tagName="div"
+							tagName="h2"
 							className="article-section-title"
 						/>
 					) }

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -81,7 +81,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 						<?php if ( $attributes['showAuthor'] || $attributes['showDate'] ) : ?>
 
-							<div class="article-meta">
+							<div class="article-meta use-header-font">
 
 								<?php if ( $attributes['showAuthor'] ) : ?>
 									<?php

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -50,9 +50,9 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 		<div class="<?php echo esc_attr( $classes ); ?>">
 
 			<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
-				<div class="article-section-title">
+				<h2 class="article-section-title">
 					<span><?php echo wp_kses_post( $attributes['sectionHeader'] ); ?></span>
-				</div>
+				</h2>
 			<?php
 			endif;
 			while ( $article_query->have_posts() ) :
@@ -67,7 +67,13 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 					<div class="article-wrapper">
 
-						<?php the_title( '<h2 class="article-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' ); ?>
+						<?php
+						if ( '' === $attributes['sectionHeader'] ) {
+							the_title( '<h2 class="article-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
+						} else {
+							the_title( '<h3 class="article-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h3>' );
+						}
+						?>
 
 						<?php if ( $attributes['showExcerpt'] ) : ?>
 							<?php the_excerpt(); ?>

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -11,7 +11,6 @@
 	/* Section header */
 	.article-section-title {
 		font-size: $font__size-sm;
-		font-weight: bold;
 		margin-bottom: 0.5em;
 		width: 100%; // make sure this isn't caught up in the flex styles.
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the section header to use an `h2` tag, so it will inherit the theme's heading styles.

It also conditionally switches the tag used on the article titles, from `<h3>` when there is a section header, and `<h2>` when there is not. 

I also added a `.use-header-font` class to the post meta, so the font doesn't have to be explicitly set in the theme. 

Related to discussion here: https://github.com/Automattic/newspack-theme/pull/49#pullrequestreview-246552526

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Set up an article block without a section header; publish and check the markup.
3. Add a section header.
4. Confirm that the markup of the section header uses an `<h2>`, and that the article title goes from `<h2>` to `<h3>`.
5. Try a couple different font scale values, and make sure the font size of the article title is the same, regardless what header it uses. 
6. Confirm that the `.article-meta` div now also has the class `.use-header-font`. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
