### PR TITLE
Adding 'more' link option to the Newspack blocks

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -35,7 +35,15 @@ const MAX_POSTS_COLUMNS = 6;
 class Edit extends Component {
 	renderPost = post => {
 		const { attributes } = this.props;
-		const { showImage, showExcerpt, showAuthor, showAvatar, showDate, sectionHeader } = attributes;
+		const {
+			showImage,
+			showExcerpt,
+			showAuthor,
+			showAvatar,
+			showDate,
+			sectionHeader,
+			moreLink,
+		} = attributes;
 		return (
 			<article
 				className={ post.newspack_featured_image_src && 'article-has-image' }
@@ -104,6 +112,7 @@ class Edit extends Component {
 			showAvatar,
 			postLayout,
 			mediaPosition,
+			moreLink,
 		} = attributes;
 		return (
 			<Fragment>
@@ -131,6 +140,11 @@ class Edit extends Component {
 							required
 						/>
 					) }
+					<ToggleControl
+						label={ __( 'Show "More" Link' ) }
+						checked={ moreLink }
+						onChange={ () => setAttributes( { moreLink: ! moreLink } ) }
+					/>
 				</PanelBody>
 				<PanelBody title={ __( 'Featured Image Settings' ) }>
 					<PanelRow>
@@ -142,7 +156,6 @@ class Edit extends Component {
 					</PanelRow>
 					{ showImage && mediaPosition !== 'top' && (
 						<RangeControl
-							className="image-scale-slider"
 							className="image-scale-slider"
 							label={ __( 'Featured Image Scale' ) }
 							value={ imageScale }
@@ -231,6 +244,7 @@ class Edit extends Component {
 			typeScale,
 			imageScale,
 			sectionHeader,
+			moreLink,
 		} = attributes;
 
 		const classes = classNames( className, {
@@ -298,6 +312,11 @@ class Edit extends Component {
 						</Placeholder>
 					) }
 					{ latestPosts && latestPosts.map( post => this.renderPost( post ) ) }
+					{ latestPosts && moreLink && (
+						<a className="button" href="#">
+							{ __( 'More…' ) }
+						</a>
+					) }
 				</div>
 				<BlockControls>
 					<Toolbar controls={ blockControls } />

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -87,6 +87,10 @@ export const settings = {
 			type: 'string',
 			default: '',
 		},
+		moreLink: {
+			type: 'boolean',
+			default: false,
+		},
 	},
 	supports: {
 		html: false,

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -126,8 +126,19 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				</article>
 				<?php
 			endwhile;
-			wp_reset_postdata();
 			?>
+
+			<?php
+			if ( $attributes['moreLink'] ) {
+				$more_url = get_permalink( get_option( 'page_for_posts' ) );
+				if ( $categories ) {
+					$more_url = get_category_link( $categories );
+				}
+				echo '<a class="button" href="' . esc_url( $more_url ) . '">' . esc_html( 'More', 'newspack-blocks' ) . '</a>';
+			}
+			?>
+
+			<?php wp_reset_postdata(); ?>
 		</div>
 		<?php
 		endif;
@@ -200,6 +211,10 @@ function newspack_blocks_register_homepage_articles() {
 				'sectionHeader' => array(
 					'type'    => 'string',
 					'default' => '',
+				),
+				'moreLink'      => array(
+					'type'    => 'boolean',
+					'default' => false,
 				),
 			),
 			'render_callback' => 'newspack_blocks_render_block_homepage_articles',

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -134,7 +134,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				if ( $categories ) {
 					$more_url = get_category_link( $categories );
 				}
-				echo '<a class="button" href="' . esc_url( $more_url ) . '">' . esc_html( 'More', 'newspack-blocks' ) . '</a>';
+				echo '<a class="button" href="' . esc_url( $more_url ) . '">' . esc_html__( 'More', 'newspack-blocks' ) . '</a>';
 			}
 			?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a 'More' link option to the block. When a block uses a specific category, the 'More' link leads to that Category's archive page. When a block uses 'All' categories, the link will go to the blog posts page. 

Known issues:

* In the editor, the 'More' link just links to `#`, rather than the correct link it uses on the front-end. The primary reason is complexity -- I got blocked trying to find a way to pull the current query's category's URL. I'm happy to circle back to this in a separate ticket, but it seems like it can be moved forward without. 
* The link has no styles included in the block; it uses the generic class `.button`, so it inherits the editor's button styles; on the front-end it successfully picks up the Newspack theme's styles for `.button`. My plan is to update the theme's styles to make sure it looks correct in the editor, and leave it as is for the default, but I'm open to feedback on that! 
* It's currently not possible to edit the button label; I think that will be a valuable enhancement down the road. 

See #24.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Add two Newspack blocks -- one with no specific category setting, and one with a specific category selected.
3. Turn on the 'More' links for both.
4. Verify that the 'More' link displays for each block.
5. Save and publish.
6. Verify that the 'More' link appears for both blocks on the front-end.
7. Click each 'More' link; verify that the one on the block with 'All' categories goes to your blog posts page, and the one on the block with a specific category leads to that category's archive page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
