### PR TITLE
Update classes to match "standard" theme classes

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -37,27 +37,24 @@ class Edit extends Component {
 		const { attributes } = this.props;
 		const { showImage, showExcerpt, showAuthor, showAvatar, showDate, sectionHeader } = attributes;
 		return (
-			<article
-				className={ post.newspack_featured_image_src && 'article-has-image' }
-				key={ post.id }
-			>
+			<article className={ post.newspack_featured_image_src && 'post-has-image' } key={ post.id }>
 				{ showImage && post.newspack_featured_image_src && (
-					<div className="article-thumbnail" key="thumbnail">
+					<div className="post-thumbnail" key="thumbnail">
 						<img src={ post.newspack_featured_image_src.large } />
 					</div>
 				) }
-				<div className="article-wrapper">
+				<div className="entry-wrapper">
 					{ RichText.isEmpty( sectionHeader ) ? (
-						<h2 className="article-title" key="title">
+						<h2 className="entry-title" key="title">
 							<a href={ post.link }>{ decodeEntities( post.title.rendered.trim() ) }</a>
 						</h2>
 					) : (
-						<h3 className="article-title" key="title">
+						<h3 className="entry-title" key="title">
 							<a href={ post.link }>{ decodeEntities( post.title.rendered.trim() ) }</a>
 						</h3>
 					) }
 					{ showExcerpt && <RawHTML key="excerpt">{ post.excerpt.rendered }</RawHTML> }
-					<div className="article-meta use-header-font">
+					<div className="entry-meta">
 						{ showAuthor && post.newspack_author_info.avatar && showAvatar && (
 							<span className="avatar author-avatar" key="author-avatar">
 								<RawHTML>{ post.newspack_author_info.avatar }</RawHTML>
@@ -65,7 +62,7 @@ class Edit extends Component {
 						) }
 
 						{ showAuthor && (
-							<span className="author-name">
+							<span className="byline">
 								{ __( 'by' ) }{' '}
 								<span className="author vcard">
 									<a className="url fn n" href={ post.newspack_author_info.author_link }>
@@ -75,7 +72,7 @@ class Edit extends Component {
 							</span>
 						) }
 						{ showDate && (
-							<time className="article-date published" key="pub-date">
+							<time className="entry-date published" key="pub-date">
 								{ moment( post.date_gmt )
 									.local()
 									.format( 'MMMM DD, Y' ) }

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -59,20 +59,20 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 			while ( $article_query->have_posts() ) :
 				$article_query->the_post();
 				?>
-				<article <?php echo has_post_thumbnail() ? 'class="article-has-image"' : ''; ?>>
+				<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?>>
 					<?php if ( has_post_thumbnail() && $attributes['showImage'] ) : ?>
-						<div class="article-thumbnail">
+						<div class="post-thumbnail">
 							<?php the_post_thumbnail( 'large' ); ?>
 						</div><!-- .featured-image -->
 					<?php endif; ?>
 
-					<div class="article-wrapper">
+					<div class="entry-wrapper">
 
 						<?php
 						if ( '' === $attributes['sectionHeader'] ) {
-							the_title( '<h2 class="article-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
+							the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
 						} else {
-							the_title( '<h3 class="article-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h3>' );
+							the_title( '<h3 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h3>' );
 						}
 						?>
 
@@ -82,7 +82,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 						<?php if ( $attributes['showAuthor'] || $attributes['showDate'] ) : ?>
 
-							<div class="article-meta use-header-font">
+							<div class="entry-meta">
 
 								<?php if ( $attributes['showAuthor'] ) : ?>
 									<?php
@@ -90,7 +90,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 										echo get_avatar( get_the_author_meta( 'ID' ) );
 									}
 									?>
-									<span class="author-name">
+									<span class="byline">
 										<?php
 										printf(
 											/* translators: %s: post author. */
@@ -106,7 +106,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 									$time_string = '<time class="article-date published updated" datetime="%1$s">%2$s</time>';
 
 									if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
-										$time_string = '<time class="article-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
+										$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
 									}
 
 									$time_string = sprintf(
@@ -120,9 +120,9 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 									echo $time_string; // WPCS: XSS OK.
 								}
 								?>
-							</div><!-- .article-meta -->
+							</div><!-- .entry-meta -->
 						<?php endif; ?>
-					</div><!-- .article-wrapper -->
+					</div><!-- .entry-wrapper -->
 				</article>
 				<?php
 			endwhile;

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -103,7 +103,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 								endif;
 
 								if ( $attributes['showDate'] ) {
-									$time_string = '<time class="article-date published updated" datetime="%1$s">%2$s</time>';
+									$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
 
 									if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
 										$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -42,22 +42,26 @@
 
 	/* Image styles */
 
+	.post-thumbnail {
+		margin: 0;
+	}
+
 	&.image-alignleft,
 	&.image-alignright {
-		.article-has-image {
+		.post-has-image {
 			display: flex;
 
-			.article-thumbnail,
-			.article-wrapper {
+			.post-thumbnail,
+			.entry-wrapper {
 				flex-basis: 50%;
 			}
 		}
 
 		&.image-scale4 {
-			.article-thumbnail {
+			.post-thumbnail {
 				flex-basis: 75%;
 			}
-			.article-wrapper {
+			.entry-wrapper {
 				flex-basis: 25%;
 			}
 		}
@@ -65,62 +69,55 @@
 		// .image-scale3 is the default - 50%
 
 		&.image-scale2 {
-			.article-thumbnail {
+			.post-thumbnail {
 				flex-basis: 33%;
 			}
-			.article-wrapper {
+			.entry-wrapper {
 				flex-basis: 67%;
 			}
 		}
 
 		&.image-scale1 {
-			.article-thumbnail {
+			.post-thumbnail {
 				flex-basis: 25%;
 			}
-			.article-wrapper {
+			.entry-wrapper {
 				flex-basis: 75%;
 			}
 		}
 	}
 
 	&.image-alignleft {
-		.article-thumbnail {
-			margin-right: 16px;
+		.post-thumbnail {
+			margin-right: 1em;
 		}
 	}
 
 	&.image-alignright {
-		.article-thumbnail {
-			margin-left: 16px;
+		.post-thumbnail {
+			margin-left: 1em;
 		}
-		.article-wrapper {
+		.entry-wrapper {
 			order: -1;
 		}
 	}
 
 	/* Headings */
-	// This may be removeable, depending on the theme sizing.
-	.article-title {
-		margin: 0;
+	.entry-title {
 		a {
-			color: inherit;
 			text-decoration: none;
-
-			&:hover {
-				color: inherit;
-			}
 		}
 	}
 
 	/* Article meta */
-	.article-meta {
+	.entry-meta {
 		display: flex;
 		flex-wrap: wrap;
 		align-items: center;
 		margin-top: 0.5em;
 
-		.author-name:not(:last-child) {
-			margin-right: 0.5em;
+		.byline:not(:last-child) {
+			margin-right: 1.5em;
 		}
 	}
 
@@ -137,10 +134,10 @@
 .wp-block-newspack-blocks-homepage-articles {
 	/* 'Normal' size */
 	article {
-		.article-title {
+		.entry-title {
 			font-size: 24px;
 		}
-		.article-meta {
+		.entry-meta {
 			font-size: 16px;
 		}
 		.avatar {
@@ -149,18 +146,18 @@
 		}
 
 		@include media(tablet) {
-			.article-title {
+			.entry-title {
 				font-size: 32px;
 			}
 		}
 	}
 
 	&.type-scale8 article {
-		.article-title {
+		.entry-title {
 			font-size: 44px;
 		}
 		@include media(tablet) {
-			.article-title {
+			.entry-title {
 				font-size: 68px;
 			}
 			.avatar {
@@ -169,18 +166,18 @@
 			}
 		}
 		@include media(desktop) {
-			.article-title {
+			.entry-title {
 				font-size: 80px;
 			}
 		}
 	}
 
 	&.type-scale7 article {
-		.article-title {
+		.entry-title {
 			font-size: 40px;
 		}
 		@include media( tablet) {
-			.article-title {
+			.entry-title {
 				font-size: 56px;
 			}
 			.avatar {
@@ -189,18 +186,18 @@
 			}
 		}
 		@include media(desktop) {
-			.article-title {
+			.entry-title {
 				font-size: 68px;
 			}
 		}
 	}
 
 	&.type-scale6 article {
-		.article-title {
+		.entry-title {
 			font-size: 36px;
 		}
 		@include media(tablet) {
-			.article-title {
+			.entry-title {
 				font-size: 48px;
 			}
 			.avatar {
@@ -209,18 +206,18 @@
 			}
 		}
 		@include media(desktop) {
-			.article-title {
+			.entry-title {
 				font-size: 60px;
 			}
 		}
 	}
 
 	&.type-scale5 article {
-		.article-title {
+		.entry-title {
 			font-size: 28px;
 		}
 		@include media(tablet) {
-			.article-title {
+			.entry-title {
 				font-size: 44px;
 			}
 			.avatar {
@@ -233,13 +230,13 @@
 	/* Type Scale 4: default */
 
 	&.type-scale3 article {
-		.article-title {
+		.entry-title {
 			font-size: 20px;
 		}
-		.article-wrapper p {
+		.entry-wrapper p {
 			font-size: 16px;
 		}
-		.article-meta {
+		.entry-meta {
 			font-size: 14px;
 		}
 		.avatar {
@@ -247,23 +244,23 @@
 			width: 32px;
 		}
 		@include media(tablet) {
-			.article-title {
+			.entry-title {
 				font-size: 24px;
 			}
 		}
 	}
 
 	&.type-scale2 article {
-		.article-title {
+		.entry-title {
 			font-size: 18px;
 			@include media(tablet) {
 				font-size: 20px;
 			}
 		}
-		.article-wrapper p {
+		.entry-wrapper p {
 			font-size: 16px;
 		}
-		.article-meta {
+		.entry-meta {
 			font-size: 14px;
 		}
 		.avatar {
@@ -273,11 +270,11 @@
 	}
 
 	&.type-scale1 article {
-		.article-title {
+		.entry-title {
 			font-size: 16px;
 		}
-		.article-wrapper p,
-		.article-meta {
+		.entry-wrapper p,
+		.entry-meta {
 			font-size: 14px;
 		}
 		.avatar {

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -104,7 +104,9 @@
 
 	/* Headings */
 	.entry-title {
+		margin: 0;
 		a {
+			color: inherit;
 			text-decoration: none;
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the `.article-*` classes used in the block to the more standard `.entry-*` classes used for posts in many themes (thanks to them being used in default themes and _s). 

The hope is that this will help the blocks inherit the theme's styles with minimal interference, though right now it may cause some visual breakage (for example, the theme will have to pass its .entry-meta styles to the editor for them to look right; this isn't standard at the moment -- post meta doesn't appear in the editor yet -- but I expect it will be down the road. 

### How to test the changes in this Pull Request:

1. Visually review the block.
2. Apply the PR.
3. Make sure it looks _mostly_ the same. As noted, some adjustments will be needed in the theme, so the post meta will not use the correct font in the editor, but the other fonts used (post header and excerpt) and the sizes should match the front-end. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->
