### PR TITLE
Update font sizing to use ems

### DIFF
--- a/src/blocks/homepage-articles/sass/_variables.scss
+++ b/src/blocks/homepage-articles/sass/_variables.scss
@@ -6,15 +6,18 @@ $wide_width: 1379px;
 $font__size_base: 20px;
 $font__size-ratio: 1.125;
 
-$font__size-xxs: 1em / ( 1.5 * $font__size-ratio );
-$font__size-xs: 1em / ( 1.25 * $font__size-ratio );
-$font__size-sm: 1em / ( 1 * $font__size-ratio );
-$font__size-md: 1em * ( 1 * $font__size-ratio );
-$font__size-lg: 1em * ( 1.25 * $font__size-ratio );
-$font__size-xl: 1em * ( 1.5 * $font__size-ratio );
-$font__size-xxl: 1em * ( 2 * $font__size-ratio );
-$font__size-xxxl: 1em * ( 2.5 * $font__size-ratio );
-$font__size-xxxxl: 1em * ( 2.75 * $font__size-ratio );
+$font__size-xxxs:  1em * 0.5; // 10px
+$font__size-xxs:   1em * 0.6; // 12px
+$font__size-xs:    1em * 0.7; // 14px
+$font__size-sm:    1em * 0.8; // 16px
+// $font__size_base: 1em * 1; // 20px
+$font__size-md:    1em * 1.2; // 24px
+$font__size-lg:    1em * 1.4; // 28px
+$font__size-xl:    1em * 1.8; // 36px
+$font__size-xxl:   1em * 2.2; // 44px
+$font__size-xxxl:  1em * 2.8; // 56px
+$font__size-xxxxl: 1em * 3.2; // 64px
+
 
 $font__line-height-body: 1.6;
 $font__line-height-pre: 1.6;

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -126,9 +126,7 @@
 	.avatar {
 		border-radius: 100%;
 		display: block;
-		height: 36px;
 		margin-right: 0.5em;
-		width: 36px;
 	}
 }
 
@@ -137,50 +135,50 @@
 	/* 'Normal' size */
 	article {
 		.entry-title {
-			font-size: 24px;
+			font-size: 1.2em;
 		}
 		.entry-meta {
-			font-size: 16px;
+			font-size: 0.8em;
 		}
 		.avatar {
-			height: 36px;
-			width: 36px;
+			height: 1.8em;
+			width: 1.8em;
 		}
 
 		@include media(tablet) {
 			.entry-title {
-				font-size: 32px;
+				font-size: 1.6em;
 			}
 		}
 	}
 
 	&.type-scale8 article {
 		.entry-title {
-			font-size: 44px;
+			font-size: 2.2em;
 		}
 		@include media(tablet) {
 			.entry-title {
-				font-size: 68px;
+				font-size: 3.4em;
 			}
 			.avatar {
-				height: 48px;
-				width: 48px;
+				height: 2.4em;
+				width: 2.4em;
 			}
 		}
 		@include media(desktop) {
 			.entry-title {
-				font-size: 80px;
+				font-size: 4em;
 			}
 		}
 	}
 
 	&.type-scale7 article {
 		.entry-title {
-			font-size: 40px;
+			font-size: 2em;
 		}
 		@include media( tablet) {
 			.entry-title {
-				font-size: 56px;
+				font-size: 2.8em;
 			}
 			.avatar {
 				height: 48px;
@@ -189,18 +187,18 @@
 		}
 		@include media(desktop) {
 			.entry-title {
-				font-size: 68px;
+				font-size: 3.4em;
 			}
 		}
 	}
 
 	&.type-scale6 article {
 		.entry-title {
-			font-size: 36px;
+			font-size: 1.8em;
 		}
 		@include media(tablet) {
 			.entry-title {
-				font-size: 48px;
+				font-size: 2.4em;
 			}
 			.avatar {
 				height: 44px;
@@ -209,18 +207,18 @@
 		}
 		@include media(desktop) {
 			.entry-title {
-				font-size: 60px;
+				font-size: 3em;
 			}
 		}
 	}
 
 	&.type-scale5 article {
 		.entry-title {
-			font-size: 28px;
+			font-size: 1.4em;
 		}
 		@include media(tablet) {
 			.entry-title {
-				font-size: 44px;
+				font-size: 2.2em;
 			}
 			.avatar {
 				height: 40px;
@@ -233,13 +231,13 @@
 
 	&.type-scale3 article {
 		.entry-title {
-			font-size: 20px;
+			font-size: 1em;
 		}
 		.entry-wrapper p {
-			font-size: 16px;
+			font-size: 0.8em;
 		}
 		.entry-meta {
-			font-size: 14px;
+			font-size: 0.7em;
 		}
 		.avatar {
 			height: 32px;
@@ -247,23 +245,23 @@
 		}
 		@include media(tablet) {
 			.entry-title {
-				font-size: 24px;
+				font-size: 1.2em;
 			}
 		}
 	}
 
 	&.type-scale2 article {
 		.entry-title {
-			font-size: 18px;
+			font-size: 0.9em;
 			@include media(tablet) {
-				font-size: 20px;
+				font-size: 1em;
 			}
 		}
 		.entry-wrapper p {
-			font-size: 16px;
+			font-size: 0.8em;
 		}
 		.entry-meta {
-			font-size: 14px;
+			font-size: 0.7em;
 		}
 		.avatar {
 			height: 28px;
@@ -273,11 +271,11 @@
 
 	&.type-scale1 article {
 		.entry-title {
-			font-size: 16px;
+			font-size: 0.8em;
 		}
 		.entry-wrapper p,
 		.entry-meta {
-			font-size: 14px;
+			font-size: 0.7em;
 		}
 		.avatar {
 			height: 24px;

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -104,7 +104,7 @@
 
 	/* Headings */
 	.entry-title {
-		margin: 0;
+		margin: 0 0 0.25em;
 		a {
 			color: inherit;
 			text-decoration: none;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the homepage block's font sizing to switch it from pixels to ems, so it inherits the general font sizing from the theme using it.

It also updates the font size variables to match sizing used in the theme; they're not used in the homepage article blocks, but I left them in place in case we need them for another block. If it turns out we don't, and we stick with using ems, they can be removed. 

### How to test the changes in this Pull Request:

1. Set up the homepage block using the different sizes, or copy-paste this example into the code view of the block editor: https://cloudup.com/cKNYeV2Gil3
2. Apply the PR and run `npm run build`.
3. Confirm that the font sizing hasn't really changed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
