### PR TITLE
In progress: add control for excerpt length

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -38,6 +38,7 @@ class Edit extends Component {
 		const {
 			showImage,
 			showExcerpt,
+			excerptLength,
 			showAuthor,
 			showAvatar,
 			showDate,
@@ -61,7 +62,14 @@ class Edit extends Component {
 							<a href={ post.link }>{ decodeEntities( post.title.rendered.trim() ) }</a>
 						</h3>
 					) }
-					{ showExcerpt && <RawHTML key="excerpt">{ post.excerpt.rendered }</RawHTML> }
+					{ showExcerpt && (
+						<RawHTML key="excerpt">
+							{ post.excerpt.rendered
+								.trim()
+								.split( ' ', excerptLength )
+								.join( ' ' ) + ' [&hellip;]' }
+						</RawHTML>
+					) }
 					<div className="entry-meta">
 						{ showAuthor && post.newspack_author_info.avatar && showAvatar && (
 							<span className="avatar author-avatar" key="author-avatar">
@@ -103,6 +111,7 @@ class Edit extends Component {
 			showImage,
 			imageScale,
 			showExcerpt,
+			excerptLength,
 			typeScale,
 			showDate,
 			showAuthor,
@@ -173,6 +182,15 @@ class Edit extends Component {
 							onChange={ () => setAttributes( { showExcerpt: ! showExcerpt } ) }
 						/>
 					</PanelRow>
+					{ showExcerpt && (
+						<RangeControl
+							label={ __( 'Maximum words in excerpt.' ) }
+							value={ excerptLength }
+							onChange={ value => setAttributes( { excerptLength: value } ) }
+							min={ 1 }
+							max={ 100 }
+						/>
+					) }
 					<RangeControl
 						className="type-scale-slider"
 						label={ __( 'Type Scale' ) }
@@ -229,6 +247,7 @@ class Edit extends Component {
 		} = this.props; // variables getting pulled out of props
 		const {
 			showExcerpt,
+			excerptLength,
 			showDate,
 			showImage,
 			showAuthor,

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -40,6 +40,10 @@ export const settings = {
 			type: 'boolean',
 			default: true,
 		},
+		excerptLength: {
+			type: 'integer',
+			default: 55,
+		},
 		showDate: {
 			type: 'boolean',
 			default: true,

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -77,7 +77,11 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 						?>
 
 						<?php if ( $attributes['showExcerpt'] ) : ?>
-							<?php the_excerpt(); ?>
+							<?php
+								$excerpt_length = $attributes['excerptLength'];
+								$post_excerpt = get_the_excerpt();
+
+								echo esc_html( wp_trim_words( $post_excerpt, $excerpt_length, ' [&hellip;] ' ) ); ?>
 						<?php endif; ?>
 
 						<?php if ( $attributes['showAuthor'] || $attributes['showDate'] ) : ?>
@@ -161,6 +165,10 @@ function newspack_blocks_register_homepage_articles() {
 				'showExcerpt'   => array(
 					'type'    => 'boolean',
 					'default' => true,
+				),
+				'excerptLength' => array(
+					'type'    => 'integer',
+					'default' => 55,
 				),
 				'showDate'      => array(
 					'type'    => 'boolean',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a slider that controls the excerpt length, allowing a range from 1 to 100 words.

Note that it currently depends on limitations otherwise set by WordPress. WordPress sets the default excerpt length to 55; this can be changed using a filter in a theme or plugin:

```
function custom_excerpt_length( $length ) {
     return 100;
}
add_filter( 'excerpt_length', 'custom_excerpt_length' );
```

I think, ideally this control would pick up the default length -- whether it's 55 or customized -- and set that as the maximum length. That part still needs work.

See #22 

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`.
2. Add a homepage block.
3. Make sure the excerpt length control only displays when the excerpt displays, and is hidden if the excerpt is hidden.
4. Make sure it allows you to reduce the length of the excerpt.
5. Make sure the updated length appears on the front-end. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
