### PR TITLE
Avoid Post Duplication (View Only)

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -13,10 +13,15 @@
  * @return string Returns the post content with latest posts added.
  */
 function newspack_blocks_render_block_homepage_articles( $attributes ) {
+	global $newspack_blocks_post_id;
+	if ( ! $newspack_blocks_post_id ) {
+		$newspack_blocks_post_id = array();
+	}
 	$author        = isset( $attributes['author'] ) ? $attributes['author'] : '';
 	$categories    = isset( $attributes['categories'] ) ? $attributes['categories'] : '';
+	$posts_to_show = intval( $attributes['postsToShow'] );
 	$args          = array(
-		'posts_per_page'      => $attributes['postsToShow'],
+		'posts_per_page'      => $posts_to_show + count( $newspack_blocks_post_id ),
 		'post_status'         => 'publish',
 		'suppress_filters'    => false,
 		'cat'                 => $categories,
@@ -45,6 +50,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	if ( isset( $attributes['className'] ) ) {
 		$classes .= ' ' . $attributes['className'];
 	}
+	$post_counter = 0;
 
 	ob_start();
 
@@ -60,6 +66,11 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 			endif;
 			while ( $article_query->have_posts() ) :
 				$article_query->the_post();
+				if ( isset( $newspack_blocks_post_id[ get_the_ID() ] ) || $post_counter > $posts_to_show ) {
+					continue;
+				}
+				$newspack_blocks_post_id[ get_the_ID() ] = true;
+				$post_counter++;
 				?>
 				<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?>>
 					<?php if ( has_post_thumbnail() && $attributes['showImage'] ) : ?>

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -66,7 +66,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 			endif;
 			while ( $article_query->have_posts() ) :
 				$article_query->the_post();
-				if ( isset( $newspack_blocks_post_id[ get_the_ID() ] ) || $post_counter > $posts_to_show ) {
+				if ( isset( $newspack_blocks_post_id[ get_the_ID() ] ) || $post_counter >= $posts_to_show ) {
 					continue;
 				}
 				$newspack_blocks_post_id[ get_the_ID() ] = true;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR is an attempt to ensure that multiple articles blocks on the same page will not show the same post more than once. Some questions and caveats:

- This PR only affects the view (preview/published content). In the editor there will still be duplicate posts. This will be addressed in a separate PR.
- Currently this logic will be applied to every instance of `Newspack Homepage Articles` block. Would we need the flexibility to exempt certain blocks from the logic? 
- Blocks will be processed in the order they appear on the page, with higher prioritized stories going to the first ones. It is possible that an unusual layout could be produced where the topmost block is not the visually dominant one, which could lead to unexpected distribution of posts.

This is a partial resolution of https://github.com/Automattic/newspack-blocks/issues/12

### How to test the changes in this Pull Request:

1. Add a few instances of the block to a post or page, with identical query settings.
2. Observe there are duplicate posts visible in the Editor.
3. Publish or preview. Observe that there is no duplication.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
