### PR TITLE
Remove Live Links In Editor

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -54,11 +54,11 @@ class Edit extends Component {
 				<div className="entry-wrapper">
 					{ RichText.isEmpty( sectionHeader ) ? (
 						<h2 className="entry-title" key="title">
-							<a href={ post.link }>{ decodeEntities( post.title.rendered.trim() ) }</a>
+							<a href='#'>{ decodeEntities( post.title.rendered.trim() ) }</a>
 						</h2>
 					) : (
 						<h3 className="entry-title" key="title">
-							<a href={ post.link }>{ decodeEntities( post.title.rendered.trim() ) }</a>
+							<a href='#'>{ decodeEntities( post.title.rendered.trim() ) }</a>
 						</h3>
 					) }
 					{ showExcerpt && <RawHTML key="excerpt">{ post.excerpt.rendered }</RawHTML> }
@@ -73,7 +73,7 @@ class Edit extends Component {
 							<span className="byline">
 								{ __( 'by' ) }{' '}
 								<span className="author vcard">
-									<a className="url fn n" href={ post.newspack_author_info.author_link }>
+									<a className="url fn n" href='#'>
 										{ post.newspack_author_info.display_name }
 									</a>
 								</span>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR removes live links from the block in the editor. As noted in https://github.com/Automattic/newspack-blocks/issues/52 it's easy to accidentally click a link in the editor and be unexpectedly taken to another page. 

Closes #52

### How to test the changes in this Pull Request:

1. Add an instance of `Newspack Homepage Articles`, with `Show Author` checked.
2. Click on the title and author name, and verify no navigation occurs.
3. Test both with and without a block heading. This subtly alters the rendering of post titles.
4. Preview or publish the post, and verify that all links work as expected in the view.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
