### PR TITLE
Specify Single Post

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -17,11 +17,11 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment, RawHTML } from '@wordpress/element';
 import { InspectorControls, RichText, BlockControls } from '@wordpress/editor';
 import {
-	ToggleControl,
 	PanelBody,
 	PanelRow,
 	RangeControl,
 	Toolbar,
+	ToggleControl,
 	Dashicon,
 	Placeholder,
 	Spinner,
@@ -124,6 +124,7 @@ class Edit extends Component {
 			postLayout,
 			mediaPosition,
 			moreLink,
+			singleMode,
 		} = attributes;
 		return (
 			<Fragment>
@@ -134,6 +135,7 @@ class Edit extends Component {
 							onNumberOfItemsChange={ value => setAttributes( { postsToShow: value } ) }
 							authorList={ authorList }
 							postList={ postList }
+							singleMode={ singleMode }
 							categoriesList={ categoriesList }
 							selectedCategoryId={ categories }
 							selectedAuthorId={ author }
@@ -147,6 +149,7 @@ class Edit extends Component {
 							onSingleChange={ value =>
 								setAttributes( { single: '' !== value ? value : undefined } )
 							}
+							onSingleModeChange={ value => setAttributes( { singleMode: value } ) }
 						/>
 					) }
 					{ postLayout === 'grid' && (
@@ -161,11 +164,13 @@ class Edit extends Component {
 							required
 						/>
 					) }
-					<ToggleControl
-						label={ __( 'Show "More" Link' ) }
-						checked={ moreLink }
-						onChange={ () => setAttributes( { moreLink: ! moreLink } ) }
-					/>
+					{ ! singleMode && (
+						<ToggleControl
+							label={ __( 'Show "More" Link' ) }
+							checked={ moreLink }
+							onChange={ () => setAttributes( { moreLink: ! moreLink } ) }
+						/>
+					) }
 				</PanelBody>
 				<PanelBody title={ __( 'Featured Image Settings' ) }>
 					<PanelRow>
@@ -350,10 +355,10 @@ class Edit extends Component {
 }
 
 export default withSelect( ( select, props ) => {
-	const { postsToShow, author, categories, single } = props.attributes;
+	const { postsToShow, author, categories, single, singleMode } = props.attributes;
 	const { getAuthors, getEntityRecords } = select( 'core' );
 	const latestPostsQuery = pickBy(
-		single
+		singleMode
 			? { include: single }
 			: {
 					per_page: postsToShow,

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -58,11 +58,11 @@ class Edit extends Component {
 				<div className="entry-wrapper">
 					{ RichText.isEmpty( sectionHeader ) ? (
 						<h2 className="entry-title" key="title">
-							<a href='#'>{ decodeEntities( post.title.rendered.trim() ) }</a>
+							<a href="#">{ decodeEntities( post.title.rendered.trim() ) }</a>
 						</h2>
 					) : (
 						<h3 className="entry-title" key="title">
-							<a href='#'>{ decodeEntities( post.title.rendered.trim() ) }</a>
+							<a href="#">{ decodeEntities( post.title.rendered.trim() ) }</a>
 						</h3>
 					) }
 					{ showExcerpt && <RawHTML key="excerpt">{ post.excerpt.rendered }</RawHTML> }
@@ -77,7 +77,7 @@ class Edit extends Component {
 							<span className="byline">
 								{ __( 'by' ) }{' '}
 								<span className="author vcard">
-									<a className="url fn n" href='#'>
+									<a className="url fn n" href="#">
 										{ post.newspack_author_info.display_name }
 									</a>
 								</span>
@@ -101,6 +101,7 @@ class Edit extends Component {
 			attributes,
 			authorList,
 			categoriesList,
+			postList,
 			setAttributes,
 			latestPosts,
 			isSelected,
@@ -108,6 +109,7 @@ class Edit extends Component {
 		const hasPosts = Array.isArray( latestPosts ) && latestPosts.length;
 		const {
 			author,
+			single,
 			postsToShow,
 			categories,
 			sectionHeader,
@@ -131,14 +133,19 @@ class Edit extends Component {
 							numberOfItems={ postsToShow }
 							onNumberOfItemsChange={ value => setAttributes( { postsToShow: value } ) }
 							authorList={ authorList }
+							postList={ postList }
 							categoriesList={ categoriesList }
 							selectedCategoryId={ categories }
 							selectedAuthorId={ author }
+							selectedSingleId={ single }
 							onCategoryChange={ value =>
 								setAttributes( { categories: '' !== value ? value : undefined } )
 							}
 							onAuthorChange={ value =>
 								setAttributes( { author: '' !== value ? value : undefined } )
+							}
+							onSingleChange={ value =>
+								setAttributes( { single: '' !== value ? value : undefined } )
 							}
 						/>
 					) }
@@ -343,23 +350,28 @@ class Edit extends Component {
 }
 
 export default withSelect( ( select, props ) => {
-	const { postsToShow, author, categories } = props.attributes;
+	const { postsToShow, author, categories, single } = props.attributes;
 	const { getAuthors, getEntityRecords } = select( 'core' );
 	const latestPostsQuery = pickBy(
-		{
-			per_page: postsToShow,
-			categories,
-			author,
-		},
+		single
+			? { include: single }
+			: {
+					per_page: postsToShow,
+					categories,
+					author,
+			  },
 		value => ! isUndefined( value )
 	);
-
 	const categoriesListQuery = {
 		per_page: 100,
+	};
+	const postsListQuery = {
+		per_page: 20,
 	};
 	return {
 		latestPosts: getEntityRecords( 'postType', 'post', latestPostsQuery ),
 		categoriesList: getEntityRecords( 'taxonomy', 'category', categoriesListQuery ),
 		authorList: getAuthors(),
+		postList: getEntityRecords( 'postType', 'post', postsListQuery ),
 	};
 } )( Edit );

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -97,6 +97,10 @@ export const settings = {
 			type: 'boolean',
 			default: false,
 		},
+		singleMode: {
+			type: 'boolean',
+			default: false
+		},
 	},
 	supports: {
 		html: false,

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -78,6 +78,9 @@ export const settings = {
 		categories: {
 			type: 'string',
 		},
+		single: {
+			type: 'string',
+		},
 		typeScale: {
 			type: 'integer',
 			default: 4,

--- a/src/blocks/homepage-articles/query-controls/index.js
+++ b/src/blocks/homepage-articles/query-controls/index.js
@@ -3,13 +3,27 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { QueryControls as BaseControl, SelectControl } from '@wordpress/components';
+import { QueryControls as BaseControl, SelectControl, ToggleControl } from '@wordpress/components';
 
 class QueryControls extends Component {
 	render = () => {
-		const { authorList, postList, onAuthorChange, onSingleChange, selectedSingleId, selectedAuthorId } = this.props;
+		const {
+			authorList,
+			postList,
+			onAuthorChange,
+			onSingleChange,
+			selectedSingleId,
+			selectedAuthorId,
+			singleMode,
+			onSingleModeChange,
+		} = this.props;
 		return [
-			onSingleChange && (
+			<ToggleControl
+				checked={ singleMode }
+				onChange={ onSingleModeChange }
+				label={ __( 'Choose specific story' ) }
+			/>,
+			singleMode && (
 				<SelectControl
 					key="query-controls-single-post-select"
 					label={ __( 'Display One Specific Post' ) }
@@ -21,8 +35,8 @@ class QueryControls extends Component {
 					onChange={ onSingleChange }
 				/>
 			),
-			! selectedSingleId && <BaseControl { ...this.props } />,
-			! selectedSingleId && onAuthorChange && (
+			! singleMode && <BaseControl { ...this.props } />,
+			! singleMode && onAuthorChange && (
 				<SelectControl
 					key="query-controls-author-select"
 					label={ __( 'Author' ) }
@@ -37,5 +51,10 @@ class QueryControls extends Component {
 		];
 	};
 }
+
+QueryControls.defaultProps = {
+	authorList: [],
+	postList: [],
+};
 
 export default QueryControls;

--- a/src/blocks/homepage-articles/query-controls/index.js
+++ b/src/blocks/homepage-articles/query-controls/index.js
@@ -7,10 +7,22 @@ import { QueryControls as BaseControl, SelectControl } from '@wordpress/componen
 
 class QueryControls extends Component {
 	render = () => {
-		const { authorList, onAuthorChange, selectedAuthorId } = this.props;
+		const { authorList, postList, onAuthorChange, onSingleChange, selectedSingleId, selectedAuthorId } = this.props;
 		return [
-			<BaseControl { ...this.props } />,
-			onAuthorChange && (
+			onSingleChange && (
+				<SelectControl
+					key="query-controls-single-post-select"
+					label={ __( 'Display One Specific Post' ) }
+					value={ selectedSingleId }
+					options={ [
+						{ label: __( '-- Select Post --' ), value: '' },
+						...postList.map( post => ( { label: post.title.rendered, value: post.id } ) ),
+					] }
+					onChange={ onSingleChange }
+				/>
+			),
+			! selectedSingleId && <BaseControl { ...this.props } />,
+			! selectedSingleId && onAuthorChange && (
 				<SelectControl
 					key="query-controls-author-select"
 					label={ __( 'Author' ) }

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -19,6 +19,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	}
 	$author        = isset( $attributes['author'] ) ? $attributes['author'] : '';
 	$categories    = isset( $attributes['categories'] ) ? $attributes['categories'] : '';
+	$single        = isset( $attributes['single'] ) ? $attributes['single'] : '';
 	$posts_to_show = intval( $attributes['postsToShow'] );
 	$args          = array(
 		'posts_per_page'      => $posts_to_show + count( $newspack_blocks_post_id ),
@@ -28,6 +29,12 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 		'author'              => $author,
 		'ignore_sticky_posts' => true,
 	);
+	if ( $single ) {
+		$args['p'] = $single;
+	} else {
+		$args['cat']    = $categories;
+		$args['author'] = $author;
+	}
 	$article_query = new WP_Query( $args );
 
 	$classes = Newspack_Blocks::block_classes( 'homepage-articles', $attributes );
@@ -214,6 +221,9 @@ function newspack_blocks_register_homepage_articles() {
 					'type' => 'string',
 				),
 				'categories'    => array(
+					'type' => 'string',
+				),
+				'single'        => array(
 					'type' => 'string',
 				),
 				'typeScale'     => array(

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -21,6 +21,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	$categories    = isset( $attributes['categories'] ) ? $attributes['categories'] : '';
 	$single        = isset( $attributes['single'] ) ? $attributes['single'] : '';
 	$posts_to_show = intval( $attributes['postsToShow'] );
+	$single_mode   = intval( $attributes['singleMode'] );
 	$args          = array(
 		'posts_per_page'      => $posts_to_show + count( $newspack_blocks_post_id ),
 		'post_status'         => 'publish',
@@ -29,7 +30,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 		'author'              => $author,
 		'ignore_sticky_posts' => true,
 	);
-	if ( $single ) {
+	if ( $single_mode ) {
 		$args['p'] = $single;
 	} else {
 		$args['cat']    = $categories;
@@ -239,6 +240,10 @@ function newspack_blocks_register_homepage_articles() {
 					'default' => '',
 				),
 				'moreLink'      => array(
+					'type'    => 'boolean',
+					'default' => false,
+				),
+				'singleMode'    => array(
 					'type'    => 'boolean',
 					'default' => false,
 				),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a Select to the top of the **Display Settings** Panel for selecting a specific post. If a selection is made, only this post will be shown, and any category, author, or limit settings will be ignored. In the sidebar, the category/author/limit will actually be hidden if a post selection has been made to avoid confusion. 

Big caveat! A select control is definitely not the right UI for this because of the potentially huge number of posts. A select is used in the customizer for setting the homepage Page so I opted to go this way at first, but it will need to be replaced. The Select will only display the 20 most recent posts, so the current version is not yet as flexible as it needs to be. I propose we consider this PR as-is so that the basic functionality is addressed, then consider alternate UI in a new PR (cc: @sonjaleix).

<img width="281" alt="Screen Shot 2019-07-25 at 8 35 04 AM" src="https://user-images.githubusercontent.com/1477002/61875145-03a6f680-aeb8-11e9-9279-509c8674d730.png">

This partially resolved https://github.com/Automattic/newspack-blocks/issues/41

### How to test the changes in this Pull Request:

1. Check out this branch, run `npm run build:webpack`
2. Add a block. Observe **Display One Specific Post** `SelectControl` at the top of the sidebar. 
3. Select a post. 
4. Observe that only that post is displayed in the block. 
5. Observe that **Category**, **Author**, and **Number of Items** UI are hidden.
6. Preview the post and verify that only the select post is shown.
7. In the editor, set the `SelectControl` back to `-- Select Post --` and observe that all UI fields are revealed again and the posts shown return to normal.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
