### PR TITLE
First pass at adding a 'post meta' (author and date) block

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -35,6 +35,17 @@ class Newspack_Blocks_API {
 			)
 		);
 
+		/* Add published date source. */
+		register_rest_field(
+			'post',
+			'newspack_published_date',
+			array(
+				'get_callback'    => array( 'Newspack_Blocks_API', 'newspack_blocks_get_published_date' ),
+				'update_callback' => null,
+				'schema'          => null,
+			)
+		);
+
 		/* Add first category source */
 		register_rest_field(
 			'post',
@@ -104,6 +115,18 @@ class Newspack_Blocks_API {
 
 		/* Return the author data */
 		return $author_data;
+	}
+
+	/**
+	 * Get date published info for the rest field.
+	 *
+	 * @param Array $object  The object info.
+	 */
+	public static function newspack_blocks_get_published_date( $object ) {
+		$published_date = get_the_date( '', $object['id'] );
+
+		/* Return the published date */
+		return $published_date;
 	}
 
 	/**

--- a/src/blocks/post-meta/edit.js
+++ b/src/blocks/post-meta/edit.js
@@ -7,15 +7,39 @@ import classNames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component, Fragment, RawHTML } from '@wordpress/element';
+
+const { decodeEntities } = wp.htmlEntities;
 
 class Edit extends Component {
+	renderPost = post => {
+		const { attributes } = this.props;
+		return (
+			<div className="entry-meta">
+				<span className="author-avatar">
+					<RawHTML>{ post.newspack_author_info.avatar }</RawHTML>
+				</span>
+				<span className="byline">
+					<span>{ __( 'by' ) }</span>{' '}
+					<span className="author vcard">
+						<a className="url fn n" href="#">
+							{ post.newspack_author_info.display_name }
+						</a>
+					</span>
+				</span>
+				<span className="posted-on">
+					<time className="entry-date published">{ post.newspack_published_date }</time>
+				</span>
+			</div>
+		);
+	};
 	render() {
-		const { className, author } = this.props; // variables getting pulled out of props
+		const { className } = this.props; // variables getting pulled out of props
+		const post = wp.data.select( 'core/editor' ).getCurrentPost();
 		return (
 			<Fragment>
 				<div className={ className }>
-					<h2>{ __( 'This is the author.', 'newspack' ) }</h2>
+					<div>{ this.renderPost( post ) }</div>
 				</div>
 			</Fragment>
 		);

--- a/src/blocks/post-meta/edit.js
+++ b/src/blocks/post-meta/edit.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+
+class Edit extends Component {
+	render() {
+		const { className, author } = this.props; // variables getting pulled out of props
+		return (
+			<Fragment>
+				<div className={ className }>
+					<h2>{ __( 'This is the author.', 'newspack' ) }</h2>
+				</div>
+			</Fragment>
+		);
+	}
+}
+
+export default Edit;

--- a/src/blocks/post-meta/editor.js
+++ b/src/blocks/post-meta/editor.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { name, settings } from '.';
+
+registerBlockType( `newspack-blocks/${ name }`, settings );

--- a/src/blocks/post-meta/index.js
+++ b/src/blocks/post-meta/index.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import edit from './edit';
+
+/**
+ * Style dependencies - will load in editor
+ */
+import './editor.scss';
+import './view.scss';
+
+export const name = 'post-meta';
+export const title = __( 'Newspack Post Meta' );
+
+/* From https://material.io/tools/icons */
+export const icon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<Path d="M0 0h24v24H0z" fill="none" />
+		<Path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z" />
+	</SVG>
+);
+
+export const settings = {
+	title,
+	icon,
+	category: 'newspack',
+	keywords: [ __( 'posts' ), __( 'meta' ), __( 'author' ) ],
+	description: __( 'A block for displaying article post meta.' ),
+	attributes: {
+		className: {
+			type: 'string',
+		},
+		author: {
+			type: 'string',
+			source: 'meta',
+			meta: 'author',
+		},
+	},
+	supports: {
+		html: false,
+		align: false,
+	},
+	edit,
+	save: () => null, // to use view.php
+};

--- a/src/blocks/post-meta/view.js
+++ b/src/blocks/post-meta/view.js
@@ -1,0 +1,7 @@
+//alert( "hello!");
+
+/**
+ * Style dependencies
+ */
+
+import './view.scss';

--- a/src/blocks/post-meta/view.php
+++ b/src/blocks/post-meta/view.php
@@ -59,8 +59,7 @@ function newspack_blocks_render_block_post_meta( $attributes ) {
 			);
 
 			printf(
-				'<span class="posted-on"><a href="%1$s" rel="bookmark">%2$s</a></span>',
-				esc_url( get_permalink() ),
+				'<span class="posted-on">%1$s</span>',
 				wp_kses(
 					$time_string,
 					array(

--- a/src/blocks/post-meta/view.php
+++ b/src/blocks/post-meta/view.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Server-side rendering of the `newspack-blocks/author-bio` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `newspack-blocks/author-bio` block on server.
+ *
+ * @param array $attributes The block attributes.
+ *
+ * @return string Returns the post content with latest posts added.
+ */
+function newspack_blocks_render_block_post_meta( $attributes ) {
+	$classes = Newspack_Blocks::block_classes( 'post-meta', $attributes );
+
+	ob_start();
+	?>
+
+		<div class="entry-meta">
+
+			<?php
+
+			// Author name and avatar.
+			printf(
+				/* translators: 1: Author avatar. 2: post author, only visible to screen readers. 3: author link. */
+				'<span class="author-avatar">%1$s</span><span class="byline"><span>%2$s</span> <span class="author vcard"><a class="url fn n" href="%3$s">%4$s</a></span></span>',
+				wp_kses(
+					get_avatar( get_the_author_meta( 'ID' ) ),
+					array(
+						'img' => array(
+							'alt'    => array(),
+							'src'    => array(),
+							'srcset' => array(),
+							'class'  => array(),
+							'width'  => array(),
+							'height' => array(),
+						),
+					)
+				),
+				esc_html__( 'by', 'newspack-blocks' ),
+				esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
+				esc_html( get_the_author() )
+			);
+
+			$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
+			if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
+				$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
+			}
+
+			// Publish date.
+			$time_string = sprintf(
+				$time_string,
+				esc_attr( get_the_date( DATE_W3C ) ),
+				esc_html( get_the_date() ),
+				esc_attr( get_the_modified_date( DATE_W3C ) ),
+				esc_html( get_the_modified_date() )
+			);
+
+			printf(
+				'<span class="posted-on"><a href="%1$s" rel="bookmark">%2$s</a></span>',
+				esc_url( get_permalink() ),
+				wp_kses(
+					$time_string,
+					array(
+						'time' => array(
+							'class'    => array(),
+							'datetime' => array(),
+						),
+					)
+				)
+			);
+
+			?>
+		</div><!-- .entry-meta -->
+
+		<?php
+		$content = ob_get_clean();
+		Newspack_Blocks::enqueue_view_assets( 'post-meta' );
+		return $content;
+}
+
+/**
+ * Registers the `newspack-blocks/post-meta` block on server.
+ */
+function newspack_blocks_register_post_meta() {
+	register_block_type(
+		'newspack-blocks/post-meta',
+		array(
+			'attributes'      => array(
+				'className' => array(
+					'type' => 'string',
+				),
+			),
+			'render_callback' => 'newspack_blocks_render_block_post_meta',
+		)
+	);
+}
+add_action( 'init', 'newspack_blocks_register_post_meta' );

--- a/src/blocks/post-meta/view.scss
+++ b/src/blocks/post-meta/view.scss
@@ -1,0 +1,6 @@
+.wp-block-newspack-blocks-post-meta {
+	.entry-meta {
+		font-size: calc( 1em * 0.8 );
+		font-weight: normal;
+	}
+}

--- a/src/blocks/post-meta/view.scss
+++ b/src/blocks/post-meta/view.scss
@@ -1,6 +1,0 @@
-.wp-block-newspack-blocks-post-meta {
-	.entry-meta {
-		font-size: calc( 1em * 0.8 );
-		font-weight: normal;
-	}
-}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR creates a first pass at a block that displays the post's author and publish date. It's _very_ rough -- there aren't really editor styles -- but it's a start.

This is what the block currently outputs in the editor: 

![image](https://user-images.githubusercontent.com/177561/62233403-60555600-b37d-11e9-9f24-a2a6bd9b38a6.png)

... and on the front-end: 

![image](https://user-images.githubusercontent.com/177561/62233545-a6aab500-b37d-11e9-87cb-b194b7041d42.png)

(It currently uses the same markup as the theme, so it's inheriting the styles on the front-end).

One thing I was wondering was should we put _everything_ together -- author, date and share icons -- or create individual blocks for each? 

I can see benefits to both -- if we keep them separate, it will be more flexible for layout and choosing what's shown. However, it could make it harder to achieve layouts like the one currently in the theme:

![image](https://user-images.githubusercontent.com/177561/62233093-ae1d8e80-b37c-11e9-8a22-44035dc56edd.png)

You could use a column block and align the text to the right on the column with the share icons... but that's not going to look great on mobile since the share icons will still be right aligned.

Bundled together, it limits the layout/options, but we might be able to offer some pre-set choices, similar to the columns:

![image](https://user-images.githubusercontent.com/177561/62233348-41ef5a80-b37d-11e9-82ff-ff252cadcc3c.png)

We also need to consider how we get something like this working with multi-author?

I also expect this block needs a new name; what it is will depend on our approach.

There might also be other things I'm not considering -- any thoughts are welcome!

### How to test the changes in this Pull Request:

1. Add the 'Post Meta' block to a post.
2. Confirm that the correct author and published date are displaying relative to the current post. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
