### PR TITLE
Add class for when image is set to show in blocks

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -58,11 +58,11 @@ class Edit extends Component {
 				<div className="entry-wrapper">
 					{ RichText.isEmpty( sectionHeader ) ? (
 						<h2 className="entry-title" key="title">
-							<a href='#'>{ decodeEntities( post.title.rendered.trim() ) }</a>
+							<a href="#">{ decodeEntities( post.title.rendered.trim() ) }</a>
 						</h2>
 					) : (
 						<h3 className="entry-title" key="title">
-							<a href='#'>{ decodeEntities( post.title.rendered.trim() ) }</a>
+							<a href="#">{ decodeEntities( post.title.rendered.trim() ) }</a>
 						</h3>
 					) }
 					{ showExcerpt && <RawHTML key="excerpt">{ post.excerpt.rendered }</RawHTML> }
@@ -77,7 +77,7 @@ class Edit extends Component {
 							<span className="byline">
 								{ __( 'by' ) }{' '}
 								<span className="author vcard">
-									<a className="url fn n" href='#'>
+									<a className="url fn n" href="#">
 										{ post.newspack_author_info.display_name }
 									</a>
 								</span>
@@ -263,6 +263,7 @@ class Edit extends Component {
 
 		const classes = classNames( className, {
 			'is-grid': postLayout === 'grid',
+			'show-image': showImage,
 			[ `columns-${ columns }` ]: postLayout === 'grid',
 			[ `type-scale${ typeScale }` ]: typeScale !== '5',
 			[ `image-align${ mediaPosition }` ]: mediaPosition !== 'top' && showImage,

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -38,6 +38,9 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	if ( isset( $attributes['columns'] ) && 'grid' === $attributes['postLayout'] ) {
 		$classes .= ' columns-' . $attributes['columns'];
 	}
+	if ( $attributes['showImage'] ) {
+		$classes .= ' show-image';
+	}
 	if ( $attributes['showImage'] && isset( $attributes['mediaPosition'] ) && 'top' !== $attributes['mediaPosition'] ) {
 		$classes .= ' image-align' . $attributes['mediaPosition'];
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the class `show-image` to the containing `.wp-block-newspack-blocks-homepage-articles` element when the block is set to show the featured images for the posts that have them.

This, paired with the existing `.post-has-image` class is needed to achieve the overlap effect mocked up here: 

![image](https://user-images.githubusercontent.com/177561/62839643-3a636780-bc41-11e9-9320-ea6108e5a43a.png)

This PR also includes a change from `'` to `"` in a couple of the `href` values, due to a code cleanup extension I have in Sublime; it made the quote used match the other attributes, so I left it as is. 

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`.
2. Add a block and leave 'Show Featured Image' checked. 
3. Confirm that it has the class `show-image` on the containing .wp-block-newspack-blocks-homepage-articles` element in the editor, and on the front end.
4. Turn off 'Show Featured Image'.
5. Confirm that the class `show-image` is no longer on the containing element in the editor, or on the front end. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?