### PR TITLE
Add 'border' styles to the blocks

### DIFF
--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -6,7 +6,7 @@ import { Path, SVG } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import edit from './edit';
 
 /**
@@ -32,6 +32,11 @@ export const settings = {
 	category: 'newspack',
 	keywords: [ __( 'posts' ), __( 'articles' ), __( 'latest' ) ],
 	description: __( 'A block for displaying homepage articles.' ),
+	styles: [
+		{ name: 'default', label: _x( 'Default', 'block style' ), isDefault: true },
+		{ name: 'background', label: _x( 'Background', 'block style' ) },
+		{ name: 'borders', label: _x( 'Borders', 'block style' ) },
+	],
 	attributes: {
 		className: {
 			type: 'string',

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -34,7 +34,6 @@ export const settings = {
 	description: __( 'A block for displaying homepage articles.' ),
 	styles: [
 		{ name: 'default', label: _x( 'Default', 'block style' ), isDefault: true },
-		{ name: 'background', label: _x( 'Background', 'block style' ) },
 		{ name: 'borders', label: _x( 'Borders', 'block style' ) },
 	],
 	attributes: {

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -286,22 +286,12 @@
 
 /* Block styles */
 
-.is-style-background {
-	article {
-		background: #fff;
-		border: 1px solid rgba(0, 0, 0, 0.2);
-	}
-
-	.entry-wrapper {
-		padding: 1.5em;
-	}
-}
-
 .is-style-borders {
 	article {
 		border: solid rgba(0, 0, 0, 0.2);
 		border-width: 0 0 1px;
-		padding-bottom: 1.5em;
+		margin-bottom: 1em;
+		padding-bottom: 1em;
 
 		&:last-of-type {
 			border: 0;

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -286,7 +286,7 @@
 
 /* Block styles */
 
-.is-style-borders {
+.wp-block-newspack-blocks-homepage-articles.is-style-borders {
 	article {
 		border: solid rgba(0, 0, 0, 0.2);
 		border-width: 0 0 1px;
@@ -299,10 +299,16 @@
 	}
 
 	@include media(tablet) {
+
+		@for $i from 2 through 6 {
+			&.columns-#{ $i } article {
+				padding-right: calc( ( 12px * #{$i} ) / ( #{$i} - 1 ) );
+			}
+		}
+
 		&.is-grid {
 			article {
 				border-width: 0 1px 0 0;
-				padding-right: 1.5em;
 			}
 		}
 

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -318,11 +318,11 @@
 
 		&.is-grid article:last-of-type,
 		&.columns-1 article,
-		&.columns-2 article:nth-child(2n),
-		&.columns-3 article:nth-child(3n),
-		&.columns-4 article:nth-child(4n),
-		&.columns-5 article:nth-child(5n),
-		&.columns-6 article:nth-child(6n) {
+		&.columns-2 article:nth-of-type(2n),
+		&.columns-3 article:nth-of-type(3n),
+		&.columns-4 article:nth-of-type(4n),
+		&.columns-5 article:nth-of-type(5n),
+		&.columns-6 article:nth-of-type(6n) {
 			border: 0;
 		}
 	}

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -283,3 +283,47 @@
 		}
 	}
 }
+
+/* Block styles */
+
+.is-style-background {
+	article {
+		background: #fff;
+		border: 1px solid rgba(0, 0, 0, 0.2);
+	}
+
+	.entry-wrapper {
+		padding: 1.5em;
+	}
+}
+
+.is-style-borders {
+	article {
+		border: solid rgba(0, 0, 0, 0.2);
+		border-width: 0 0 1px;
+		padding-bottom: 1.5em;
+
+		&:last-of-type {
+			border: 0;
+		}
+	}
+
+	@include media(tablet) {
+		&.is-grid {
+			article {
+				border-width: 0 1px 0 0;
+				padding-right: 1.5em;
+			}
+		}
+
+		&.is-grid article:last-of-type,
+		&.columns-1 article,
+		&.columns-2 article:nth-child(2n),
+		&.columns-3 article:nth-child(3n),
+		&.columns-4 article:nth-child(4n),
+		&.columns-5 article:nth-child(5n),
+		&.columns-6 article:nth-child(6n) {
+			border: 0;
+		}
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is a adaptation of #57, and adds an optional border style to the homepage blocks.

When the articles are in one column and there's more than one, the borders appear under each post but the last one:

![image](https://user-images.githubusercontent.com/177561/62992454-52d1ae80-be08-11e9-8c01-bc9f80788e08.png)

When they're set to display as a grid, the borders are displayed in-between vertically, switching to horizontal when viewed on smaller screens:

![image](https://user-images.githubusercontent.com/177561/62992462-5d8c4380-be08-11e9-8ecb-1504bfd97ce6.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`
2. In the editor, set up an article block with multiple articles, displayed in one column; add the 'Border' styles.
3. In the editor, set up an article block with multiple articles, displayed in a grid; add the 'Border' style.
4. Test the visuals on both the front-end and in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
