### PR TITLE
Increase posts list limit from 20 to 50.

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -372,7 +372,7 @@ export default withSelect( ( select, props ) => {
 		per_page: 100,
 	};
 	const postsListQuery = {
-		per_page: 20,
+		per_page: 50,
 	};
 	return {
 		latestPosts: getEntityRecords( 'postType', 'post', latestPostsQuery ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR ups the number of posts available in the 'Display Single Post' option in the block from 20 to 50. I'm finding 20 is not quite enough to find the posts I'm trying to find; this should still be low enough to not slow things down.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`
2. Add the block; confirm that there is now more than 20 posts appearing in the 'single post' dropdown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
