### PR TITLE
Introduce utility method to check for AMP requests and do not enqueue JS if so

### DIFF
--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -97,6 +97,9 @@ class Newspack_Blocks {
 				NEWSPACK_BLOCKS__VERSION
 			);
 		}
+		if ( self::is_amp() ) {
+			return;
+		}
 		if ( file_exists( NEWSPACK_BLOCKS__PLUGIN_DIR . $script_path ) ) {
 			$dependencies = self::dependencies_from_path( NEWSPACK_BLOCKS__PLUGIN_DIR . "dist/{$type}/view.deps.json" );
 			wp_enqueue_script(
@@ -143,6 +146,15 @@ class Newspack_Blocks {
 			array_push( $classes, $attributes['className'] );
 		}
 		return implode( $classes, ' ' );
+	}
+
+	/**
+	 * Checks whether the current view is served in AMP context.
+	 *
+	 * @return bool True if AMP, false otherwise.
+	 */
+	public static function is_amp() {
+		return ! is_admin() && function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Introduce utility method to check if the current request is for AMP.
* If so, do not enqueue blocks JavaScript files in the frontend.

Closes #77  .

### How to test the changes in this Pull Request:

1. Follow the steps outlined in the issue, but in the end no validation errors should be reported.+