### PR TITLE
Add a 'border' style for the columns block

### DIFF
--- a/src/block-styles/core/columns/editor.scss
+++ b/src/block-styles/core/columns/editor.scss
@@ -20,4 +20,42 @@
 			order: -1;
 		}
 	}
+
+	&.is-style-borders {
+		[data-type="core/column"] {
+			border-bottom: 1px solid $color__border;
+			position: relative;
+
+			&:last-child {
+				border-bottom: 0;
+			}
+
+			@include media( mobile ) {
+				border-bottom: 0;
+
+				&:after {
+					border-right: 1px solid transparent;
+					bottom: 0;
+					content: '';
+					position: absolute;
+					right: -30px;
+					top: 0;
+				}
+
+				&:nth-child(odd):after {
+					border-color: $color__border;
+				}
+
+				&:last-child:after {
+					display: none;
+				}
+			}
+
+			@include media( tablet ) {
+				&:after {
+					border-color: $color__border;
+				}
+			}
+		}
+	}
 }

--- a/src/block-styles/core/columns/index.js
+++ b/src/block-styles/core/columns/index.js
@@ -5,11 +5,16 @@ import { registerBlockStyle } from '@wordpress/blocks';
 import './editor.scss';
 
 registerBlockStyle( 'core/columns', {
-  name: 'first-col-to-second',
-  label: 'Move first column to second'
+	name: 'borders',
+	label: 'Borders',
 } );
 
 registerBlockStyle( 'core/columns', {
-  name: 'first-col-to-third',
-  label: 'Move first column to third'
+	name: 'first-col-to-second',
+	label: 'Move first column to second',
+} );
+
+registerBlockStyle( 'core/columns', {
+	name: 'first-col-to-third',
+	label: 'Move first column to third',
 } );

--- a/src/block-styles/core/columns/view.scss
+++ b/src/block-styles/core/columns/view.scss
@@ -3,7 +3,6 @@
 
 .wp-block-columns {
 	@include media( mobile ) {
-		flex-wrap: nowrap;
 
 		&[class*='is-style-first-col-to'] .wp-block-column {
 			margin-left: 32px;
@@ -20,6 +19,44 @@
 		&.is-style-first-col-to-third .wp-block-column:nth-child( 2 ),
 		&.is-style-first-col-to-third .wp-block-column:nth-child( 3 ) {
 			order: -1;
+		}
+	}
+
+	&.is-style-borders {
+		.wp-block-column {
+			border-bottom: 1px solid $color__border;
+			position: relative;
+
+			&:last-child {
+				border-bottom: 0;
+			}
+
+			@include media( mobile ) {
+				border-bottom: 0;
+
+				&:after {
+					border-right: 1px solid transparent;
+					bottom: 0;
+					content: '';
+					position: absolute;
+					right: -16px;
+					top: 0;
+				}
+
+				&:nth-child(odd):after {
+					border-color: $color__border;
+				}
+
+				&:last-child:after {
+					display: none;
+				}
+			}
+
+			@include media( tablet ) {
+				&:after {
+					border-color: $color__border;
+				}
+			}
 		}
 	}
 }

--- a/src/shared/sass/_variables.scss
+++ b/src/shared/sass/_variables.scss
@@ -23,3 +23,5 @@ $font__line-height-body: 1.6;
 $font__line-height-pre: 1.6;
 $font__line-height-heading: 1.2;
 $font__line-height-double: 2 * $font__line-height-heading;
+
+$color__border: #ccc;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a 'border' style to the column block.

It also removes an unneeded style from the re-ordering styles (`flex-wrap: nowrap`).

This PR does need a couple adjustments to the theme, as far as when the columns break -- the theme overrides the Gutenberg default for some reason, so you get some odd column spacing as you shrink the browser window down. I've added a fix for this in https://github.com/Automattic/newspack-theme/pull/314; that PR will need to be applied to the theme to get the same results as some of the screenshots below.

I realize this is a pretty odd approach -- I couldn't find a good way to use `border-right` and maintain the even column spacing, and I wanted to mess with the main styles of the block (like left and right margins) as little as possible. I'm open to suggestions for other approaches, though!

Closes #81

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`.
2. Copy-paste [this test content into the code editor](https://cloudup.com/cIOddZlCYVb); to best test the spacing of each column, it has an image in each so you can see exactly where they are.
3. Switch the column style to use the 'Borders' style:

![image](https://user-images.githubusercontent.com/177561/63549520-7d48f900-c4e5-11e9-8d13-95f1b1de5316.png)

4. Confirm that a border appears between each block, evenly spaced:

![image](https://user-images.githubusercontent.com/177561/63549589-8fc33280-c4e5-11e9-889d-bdafe998844f.png)

5. Shrink down the window and confirm that when the columns start displaying in two columns, the border does not appear next to the end of each row (PR https://github.com/Automattic/newspack-theme/pull/314 needs to be applied to see this; otherwise the second and third block will be on the same line, with no space between):

![image](https://user-images.githubusercontent.com/177561/63549778-f8121400-c4e5-11e9-9d82-136f9722bd44.png)

6. Shrink down the browser window further and confirm that the border appears under each column once they're down to one column, excluding the last one:

![image](https://user-images.githubusercontent.com/177561/63549942-5dfe9b80-c4e6-11e9-82be-4e0560fb7e33.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

