### PR TITLE
Adds optional image caption to the homepage article blocks.

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -103,13 +103,7 @@ class Newspack_Blocks_API {
 	 * @param Array $object  The object info.
 	 */
 	public static function newspack_blocks_get_image_caption( $object ) {
-		if ( 0 === $object['featured_media'] ) {
-			return;
-		}
-
-		$featured_image_caption = wp_get_attachment_caption( $object['featured_media'] );
-
-		return $featured_image_caption;
+		return (int) $object['featured_media'] > 0 ? trim( wp_get_attachment_caption( $object['featured_media'] ) ) : null;
 	}
 
 	/**

--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -24,6 +24,16 @@ class Newspack_Blocks_API {
 			)
 		);
 
+		register_rest_field(
+			array( 'post', 'page' ),
+			'newspack_featured_image_caption',
+			array(
+				'get_callback'    => array( 'Newspack_Blocks_API', 'newspack_blocks_get_image_caption' ),
+				'update_callback' => null,
+				'schema'          => null,
+			)
+		);
+
 		/* Add author info source */
 		register_rest_field(
 			'post',
@@ -85,6 +95,21 @@ class Newspack_Blocks_API {
 		$featured_image_set['full'] = $feat_img_array_full[0];
 
 		return $featured_image_set;
+	}
+
+	/**
+	 * Get thumbnail featured image captions for the rest field.
+	 *
+	 * @param Array $object  The object info.
+	 */
+	public static function newspack_blocks_get_image_caption( $object ) {
+		if ( 0 === $object['featured_media'] ) {
+			return;
+		}
+
+		$featured_image_caption = wp_get_attachment_caption( $object['featured_media'] );
+
+		return $featured_image_caption;
 	}
 
 	/**

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -39,15 +39,26 @@ const MAX_POSTS_COLUMNS = 6;
 class Edit extends Component {
 	renderPost = post => {
 		const { attributes } = this.props;
-		const { showImage, showExcerpt, showAuthor, showAvatar, showDate, sectionHeader } = attributes;
+		const {
+			showImage,
+			showCaption,
+			showExcerpt,
+			showAuthor,
+			showAvatar,
+			showDate,
+			sectionHeader,
+		} = attributes;
 		return (
 			<article className={ post.newspack_featured_image_src && 'post-has-image' } key={ post.id }>
 				{ showImage && post.newspack_featured_image_src && (
-					<div className="post-thumbnail" key="thumbnail">
+					<figure className="post-thumbnail" key="thumbnail">
 						<a href="#">
 							<img src={ post.newspack_featured_image_src.large } />
 						</a>
-					</div>
+						{ showCaption && '' !== post.newspack_featured_image_caption && (
+							<figcaption>{ post.newspack_featured_image_caption }</figcaption>
+						) }
+					</figure>
 				) }
 				<div className="entry-wrapper">
 					{ RichText.isEmpty( sectionHeader ) ? (
@@ -110,6 +121,7 @@ class Edit extends Component {
 			sectionHeader,
 			columns,
 			showImage,
+			showCaption,
 			imageScale,
 			showExcerpt,
 			typeScale,
@@ -171,6 +183,16 @@ class Edit extends Component {
 							onChange={ () => setAttributes( { showImage: ! showImage } ) }
 						/>
 					</PanelRow>
+					{ showImage && (
+						<PanelRow>
+							<ToggleControl
+								label={ __( 'Show Featured Image Caption' ) }
+								checked={ showCaption }
+								onChange={ () => setAttributes( { showCaption: ! showCaption } ) }
+							/>
+						</PanelRow>
+					) }
+
 					{ showImage && mediaPosition !== 'top' && (
 						<RangeControl
 							className="image-scale-slider"

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -290,7 +290,7 @@ class Edit extends Component {
 			'show-image': showImage,
 			[ `columns-${ columns }` ]: postLayout === 'grid',
 			[ `type-scale${ typeScale }` ]: typeScale !== '5',
-			[ `image-align${ mediaPosition }` ]: mediaPosition !== 'top' && showImage,
+			[ `image-align${ mediaPosition }` ]: showImage,
 			[ `image-scale${ imageScale }` ]: imageScale !== '1' && showImage,
 		} );
 

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -54,7 +54,7 @@ export const settings = {
 		},
 		showCaption: {
 			type: 'boolean',
-			default: true,
+			default: false,
 		},
 		showAuthor: {
 			type: 'boolean',

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -52,6 +52,10 @@ export const settings = {
 			type: 'boolean',
 			default: true,
 		},
+		showCaption: {
+			type: 'boolean',
+			default: true,
+		},
 		showAuthor: {
 			type: 'boolean',
 			default: true,

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -88,11 +88,17 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				?>
 				<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?>>
 					<?php if ( has_post_thumbnail() && $attributes['showImage'] ) : ?>
-						<div class="post-thumbnail">
+
+						<figure class="post-thumbnail">
 							<a href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
 								<?php the_post_thumbnail( 'large' ); ?>
 							</a>
-						</div><!-- .featured-image -->
+
+							<?php if ( $attributes['showCaption'] && '' !== get_the_post_thumbnail_caption() ) : ?>
+								<figcaption><?php the_post_thumbnail_caption(); ?>
+							<?php endif; ?>
+						</figure><!-- .featured-image -->
+
 					<?php endif; ?>
 
 					<div class="entry-wrapper">
@@ -185,6 +191,10 @@ function newspack_blocks_register_homepage_articles() {
 					'default' => true,
 				),
 				'showImage'     => array(
+					'type'    => 'boolean',
+					'default' => true,
+				),
+				'showCaption'   => array(
 					'type'    => 'boolean',
 					'default' => true,
 				),

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -52,7 +52,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	if ( $attributes['showImage'] ) {
 		$classes .= ' show-image';
 	}
-	if ( $attributes['showImage'] && isset( $attributes['mediaPosition'] ) && 'top' !== $attributes['mediaPosition'] ) {
+	if ( $attributes['showImage'] && isset( $attributes['mediaPosition'] ) ) {
 		$classes .= ' image-align' . $attributes['mediaPosition'];
 	}
 	if ( isset( $attributes['typeScale'] ) ) {

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -63,6 +63,14 @@
 		margin: 0;
 	}
 
+	figcaption {
+		font-size: $font__size-xxs;
+	}
+
+	&.image-aligntop .post-thumbnail {
+		margin-bottom: 1em;
+	}
+
 	&.image-alignleft,
 	&.image-alignright {
 		.post-has-image {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the option to show the image caption for the featured image in the Homepage Article Block.

It uses a very standard tag -- `figcaption` -- that right now is styled too specifically in the theme, so it's not being applied. I'm hoping to clean that up in a separate PR for the theme; ~~I may need to circle back and make adjustments for the font-scaling in the block after that, but for the time being, there are no styles for the caption in the block (so it looks a bit blah).~~ 

Edited to add: I did make some size and spacing adjustments for the block in 63bbae8, but tried to keep them in line with the level of styles added to the block so far.

I updated the markup used for the featured image to a `<figure>` tag, which is more standard with what's used for the image block.

I set the caption to show by default, but I'm wondering if we should set it to 'off' by default instead -- would be interested in feedback on that!

![image](https://user-images.githubusercontent.com/177561/63640922-d8e8c300-c65a-11e9-8952-34a12f0e415e.png)

![image](https://user-images.githubusercontent.com/177561/63640923-ddad7700-c65a-11e9-8fb5-bcefad4d5152.png)

Closes #46.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`.
2. Add a article block with a featured image and a caption. 
3. Confirm that the toggle 'Show Featured Image Caption' shows/hides the caption in the editor and on the front-end.
4. Confirm that that toggle disappears when the featured image is hidden.
5. Confirm that when an image doesn't have a caption, the `<figcaption></figcaption>` is not output, even when it's set to show a caption.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
<!-- Mark completed items with an [x] -->
