### PR TITLE
Adds links to the featured images in the homepage article block.

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -52,7 +52,9 @@ class Edit extends Component {
 			<article className={ post.newspack_featured_image_src && 'post-has-image' } key={ post.id }>
 				{ showImage && post.newspack_featured_image_src && (
 					<div className="post-thumbnail" key="thumbnail">
-						<img src={ post.newspack_featured_image_src.large } />
+						<a href="#">
+							<img src={ post.newspack_featured_image_src.large } />
+						</a>
 					</div>
 				) }
 				<div className="entry-wrapper">

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -86,7 +86,9 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?>>
 					<?php if ( has_post_thumbnail() && $attributes['showImage'] ) : ?>
 						<div class="post-thumbnail">
-							<?php the_post_thumbnail( 'large' ); ?>
+							<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">
+								<?php the_post_thumbnail( 'large' ); ?>
+							</a>
 						</div><!-- .featured-image -->
 					<?php endif; ?>
 

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -86,7 +86,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?>>
 					<?php if ( has_post_thumbnail() && $attributes['showImage'] ) : ?>
 						<div class="post-thumbnail">
-							<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">
+							<a href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
 								<?php the_post_thumbnail( 'large' ); ?>
 							</a>
 						</div><!-- .featured-image -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a link to the featured image when shown in the Homepage Article block.

Closes #71.

### How to test the changes in this Pull Request:

1. Apply PR and run `npm run build:webpack`
2. Add a article block; make sure at least one of the articles has a featured image.
3. Confirm in the editor that the image is wrapped in a link, pointing to `#`.
4. Confirm on the front-end that the image is wrapped in a link, pointing to the full article.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
