### PR TITLE
Article Block: Add image size options

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -94,6 +94,27 @@ class Newspack_Blocks_API {
 		);
 		$featured_image_set['full'] = $feat_img_array_full[0];
 
+		$feat_img_array_landscape        = wp_get_attachment_image_src(
+			$object['featured_media'],
+			'newspack-article-block-landscape',
+			false
+		);
+		$featured_image_set['landscape'] = $feat_img_array_landscape[0];
+
+		$feat_img_array_portrait        = wp_get_attachment_image_src(
+			$object['featured_media'],
+			'newspack-article-block-portrait',
+			false
+		);
+		$featured_image_set['portrait'] = $feat_img_array_portrait[0];
+
+		$feat_img_array_square        = wp_get_attachment_image_src(
+			$object['featured_media'],
+			'newspack-article-block-square',
+			false
+		);
+		$featured_image_set['square'] = $feat_img_array_square[0];
+
 		return $featured_image_set;
 	}
 

--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -66,54 +66,93 @@ class Newspack_Blocks_API {
 		if ( 0 === $object['featured_media'] ) {
 			return;
 		}
-		$feat_img_array_thumbnail        = wp_get_attachment_image_src(
-			$object['featured_media'],
-			'thumbnail',
-			false
-		);
-		$featured_image_set['thumbnail'] = $feat_img_array_thumbnail[0];
 
-		$feat_img_array_medium        = wp_get_attachment_image_src(
+		// Landscape image.
+		$feat_img_array_landscape_large        = wp_get_attachment_image_src(
 			$object['featured_media'],
-			'medium',
+			'newspack-article-block-landscape-large',
 			false
 		);
-		$featured_image_set['medium'] = $feat_img_array_medium[0];
+		$featured_image_set['landscape_large'] = $feat_img_array_landscape_large[0];
 
-		$feat_img_array_large        = wp_get_attachment_image_src(
+		$feat_img_array_landscape_medium        = wp_get_attachment_image_src(
 			$object['featured_media'],
-			'large',
+			'newspack-article-block-landscape-medium',
 			false
 		);
-		$featured_image_set['large'] = $feat_img_array_large[0];
+		$featured_image_set['landscape_medium'] = $feat_img_array_landscape_medium[0];
 
-		$feat_img_array_full        = wp_get_attachment_image_src(
+		$feat_img_array_landscape_small        = wp_get_attachment_image_src(
 			$object['featured_media'],
-			'full',
+			'newspack-article-block-landscape-small',
 			false
 		);
-		$featured_image_set['full'] = $feat_img_array_full[0];
+		$featured_image_set['landscape_small'] = $feat_img_array_landscape_small[0];
 
-		$feat_img_array_landscape        = wp_get_attachment_image_src(
+		$feat_img_array_landscape_tiny        = wp_get_attachment_image_src(
 			$object['featured_media'],
-			'newspack-article-block-landscape',
+			'newspack-article-block-landscape-tiny',
 			false
 		);
-		$featured_image_set['landscape'] = $feat_img_array_landscape[0];
+		$featured_image_set['landscape_tiny'] = $feat_img_array_landscape_tiny[0];
 
-		$feat_img_array_portrait        = wp_get_attachment_image_src(
+		// Portrait image.
+		$feat_img_array_portrait_large        = wp_get_attachment_image_src(
 			$object['featured_media'],
-			'newspack-article-block-portrait',
+			'newspack-article-block-portrait-large',
 			false
 		);
-		$featured_image_set['portrait'] = $feat_img_array_portrait[0];
+		$featured_image_set['portrait_large'] = $feat_img_array_portrait_large[0];
 
-		$feat_img_array_square        = wp_get_attachment_image_src(
+		$feat_img_array_portrait_medium        = wp_get_attachment_image_src(
 			$object['featured_media'],
-			'newspack-article-block-square',
+			'newspack-article-block-portrait-medium',
 			false
 		);
-		$featured_image_set['square'] = $feat_img_array_square[0];
+		$featured_image_set['portrait_medium'] = $feat_img_array_portrait_medium[0];
+
+		$feat_img_array_portrait_small        = wp_get_attachment_image_src(
+			$object['featured_media'],
+			'newspack-article-block-portrait-small',
+			false
+		);
+		$featured_image_set['portrait_small'] = $feat_img_array_portrait_small[0];
+
+		$feat_img_array_portrait_tiny        = wp_get_attachment_image_src(
+			$object['featured_media'],
+			'newspack-article-block-portrait-tiny',
+			false
+		);
+		$featured_image_set['portrait_tiny'] = $feat_img_array_portrait_tiny[0];
+
+		// Square image.
+		$feat_img_array_square_large        = wp_get_attachment_image_src(
+			$object['featured_media'],
+			'newspack-article-block-square-large',
+			false
+		);
+		$featured_image_set['square_large'] = $feat_img_array_square_large[0];
+
+		$feat_img_array_square_medium        = wp_get_attachment_image_src(
+			$object['featured_media'],
+			'newspack-article-block-square-medium',
+			false
+		);
+		$featured_image_set['square_medium'] = $feat_img_array_square_medium[0];
+
+		$feat_img_array_square_small        = wp_get_attachment_image_src(
+			$object['featured_media'],
+			'newspack-article-block-square-small',
+			false
+		);
+		$featured_image_set['square_small'] = $feat_img_array_square_small[0];
+
+		$feat_img_array_square_tiny        = wp_get_attachment_image_src(
+			$object['featured_media'],
+			'newspack-article-block-square-tiny',
+			false
+		);
+		$featured_image_set['square_tiny'] = $feat_img_array_square_tiny[0];
 
 		return $featured_image_set;
 	}

--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -68,91 +68,79 @@ class Newspack_Blocks_API {
 		}
 
 		// Landscape image.
-		$feat_img_array_landscape_large        = wp_get_attachment_image_src(
-			$object['featured_media'],
-			'newspack-article-block-landscape-large',
-			false
-		);
-		$featured_image_set['landscape_large'] = $feat_img_array_landscape_large[0];
+		$landscape_large  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-landscape-large' );
+		$landscape_medium = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-landscape-medium' );
+		$landscape_small  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-landscape-small' );
+		$landscape_size   = 'newspack-article-block-landscape-tiny';
 
-		$feat_img_array_landscape_medium        = wp_get_attachment_image_src(
-			$object['featured_media'],
-			'newspack-article-block-landscape-medium',
-			false
-		);
-		$featured_image_set['landscape_medium'] = $feat_img_array_landscape_medium[0];
+		if ( 400 === $landscape_small[1] && 300 === $landscape_small[2] ) {
+			$landscape_size = 'newspack-article-block-landscape-small';
+		}
 
-		$feat_img_array_landscape_small        = wp_get_attachment_image_src(
-			$object['featured_media'],
-			'newspack-article-block-landscape-small',
-			false
-		);
-		$featured_image_set['landscape_small'] = $feat_img_array_landscape_small[0];
+		if ( 800 === $landscape_medium[1] && 600 === $landscape_medium[2] ) {
+			$landscape_size = 'newspack-article-block-landscape-medium';
+		}
 
-		$feat_img_array_landscape_tiny        = wp_get_attachment_image_src(
+		if ( 1200 === $landscape_large[1] && 900 === $landscape_large[2] ) {
+			$landscape_size = 'newspack-article-block-landscape-large';
+		}
+
+		$feat_img_array_landscape        = wp_get_attachment_image_src(
 			$object['featured_media'],
-			'newspack-article-block-landscape-tiny',
+			$landscape_size,
 			false
 		);
-		$featured_image_set['landscape_tiny'] = $feat_img_array_landscape_tiny[0];
+		$featured_image_set['landscape'] = $feat_img_array_landscape[0];
 
 		// Portrait image.
-		$feat_img_array_portrait_large        = wp_get_attachment_image_src(
-			$object['featured_media'],
-			'newspack-article-block-portrait-large',
-			false
-		);
-		$featured_image_set['portrait_large'] = $feat_img_array_portrait_large[0];
+		$portrait_large  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-portrait-large' );
+		$portrait_medium = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-portrait-medium' );
+		$portrait_small  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-portrait-small' );
+		$portrait_size   = 'newspack-article-block-portrait-tiny';
 
-		$feat_img_array_portrait_medium        = wp_get_attachment_image_src(
-			$object['featured_media'],
-			'newspack-article-block-portrait-medium',
-			false
-		);
-		$featured_image_set['portrait_medium'] = $feat_img_array_portrait_medium[0];
+		if ( 300 === $portrait_small[1] && 400 === $portrait_small[2] ) {
+			$portrait_size = 'newspack-article-block-portrait-small';
+		}
 
-		$feat_img_array_portrait_small        = wp_get_attachment_image_src(
-			$object['featured_media'],
-			'newspack-article-block-portrait-small',
-			false
-		);
-		$featured_image_set['portrait_small'] = $feat_img_array_portrait_small[0];
+		if ( 600 === $portrait_medium[1] && 800 === $portrait_medium[2] ) {
+			$portrait_size = 'newspack-article-block-portrait-medium';
+		}
 
-		$feat_img_array_portrait_tiny        = wp_get_attachment_image_src(
+		if ( 900 === $portrait_large[1] && 1200 === $portrait_large[2] ) {
+			$portrait_size = 'newspack-article-block-portrait-large';
+		}
+
+		$feat_img_array_portrait        = wp_get_attachment_image_src(
 			$object['featured_media'],
-			'newspack-article-block-portrait-tiny',
+			$portrait_size,
 			false
 		);
-		$featured_image_set['portrait_tiny'] = $feat_img_array_portrait_tiny[0];
+		$featured_image_set['portrait'] = $feat_img_array_portrait[0];
 
 		// Square image.
-		$feat_img_array_square_large        = wp_get_attachment_image_src(
-			$object['featured_media'],
-			'newspack-article-block-square-large',
-			false
-		);
-		$featured_image_set['square_large'] = $feat_img_array_square_large[0];
+		$square_large  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-square-large' );
+		$square_medium = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-square-medium' );
+		$square_small  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-square-small' );
+		$square_size   = 'newspack-article-block-square-tiny';
 
-		$feat_img_array_square_medium        = wp_get_attachment_image_src(
-			$object['featured_media'],
-			'newspack-article-block-square-medium',
-			false
-		);
-		$featured_image_set['square_medium'] = $feat_img_array_square_medium[0];
+		if ( 400 === $square_small[1] && 400 === $square_small[2] ) {
+			$square_size = 'newspack-article-block-square-small';
+		}
 
-		$feat_img_array_square_small        = wp_get_attachment_image_src(
-			$object['featured_media'],
-			'newspack-article-block-square-small',
-			false
-		);
-		$featured_image_set['square_small'] = $feat_img_array_square_small[0];
+		if ( 800 === $square_medium[1] && 800 === $square_medium[2] ) {
+			$square_size = 'newspack-article-block-square-medium';
+		}
 
-		$feat_img_array_square_tiny        = wp_get_attachment_image_src(
+		if ( 1200 === $square_large[1] && 1200 === $square_large[2] ) {
+			$square_size = 'newspack-article-block-square-large';
+		}
+
+		$feat_img_array_square        = wp_get_attachment_image_src(
 			$object['featured_media'],
-			'newspack-article-block-square-tiny',
+			$square_size,
 			false
 		);
-		$featured_image_set['square_tiny'] = $feat_img_array_square_tiny[0];
+		$featured_image_set['square'] = $feat_img_array_square[0];
 
 		return $featured_image_set;
 	}
@@ -200,7 +188,6 @@ class Newspack_Blocks_API {
 
 		return $category_info;
 	}
-
 }
 
 add_action( 'rest_api_init', array( 'Newspack_Blocks_API', 'register_rest_fields' ) );

--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -68,22 +68,7 @@ class Newspack_Blocks_API {
 		}
 
 		// Landscape image.
-		$landscape_large  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-landscape-large' );
-		$landscape_medium = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-landscape-medium' );
-		$landscape_small  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-landscape-small' );
-		$landscape_size   = 'newspack-article-block-landscape-tiny';
-
-		if ( 400 === $landscape_small[1] && 300 === $landscape_small[2] ) {
-			$landscape_size = 'newspack-article-block-landscape-small';
-		}
-
-		if ( 800 === $landscape_medium[1] && 600 === $landscape_medium[2] ) {
-			$landscape_size = 'newspack-article-block-landscape-medium';
-		}
-
-		if ( 1200 === $landscape_large[1] && 900 === $landscape_large[2] ) {
-			$landscape_size = 'newspack-article-block-landscape-large';
-		}
+		$landscape_size = newspack_blocks_image_size_for_orientation( 'landscape' );
 
 		$feat_img_array_landscape        = wp_get_attachment_image_src(
 			$object['featured_media'],
@@ -93,22 +78,7 @@ class Newspack_Blocks_API {
 		$featured_image_set['landscape'] = $feat_img_array_landscape[0];
 
 		// Portrait image.
-		$portrait_large  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-portrait-large' );
-		$portrait_medium = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-portrait-medium' );
-		$portrait_small  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-portrait-small' );
-		$portrait_size   = 'newspack-article-block-portrait-tiny';
-
-		if ( 300 === $portrait_small[1] && 400 === $portrait_small[2] ) {
-			$portrait_size = 'newspack-article-block-portrait-small';
-		}
-
-		if ( 600 === $portrait_medium[1] && 800 === $portrait_medium[2] ) {
-			$portrait_size = 'newspack-article-block-portrait-medium';
-		}
-
-		if ( 900 === $portrait_large[1] && 1200 === $portrait_large[2] ) {
-			$portrait_size = 'newspack-article-block-portrait-large';
-		}
+		$portrait_size = newspack_blocks_image_size_for_orientation( 'portrait' );
 
 		$feat_img_array_portrait        = wp_get_attachment_image_src(
 			$object['featured_media'],
@@ -118,22 +88,7 @@ class Newspack_Blocks_API {
 		$featured_image_set['portrait'] = $feat_img_array_portrait[0];
 
 		// Square image.
-		$square_large  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-square-large' );
-		$square_medium = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-square-medium' );
-		$square_small  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-square-small' );
-		$square_size   = 'newspack-article-block-square-tiny';
-
-		if ( 400 === $square_small[1] && 400 === $square_small[2] ) {
-			$square_size = 'newspack-article-block-square-small';
-		}
-
-		if ( 800 === $square_medium[1] && 800 === $square_medium[2] ) {
-			$square_size = 'newspack-article-block-square-medium';
-		}
-
-		if ( 1200 === $square_large[1] && 1200 === $square_large[2] ) {
-			$square_size = 'newspack-article-block-square-large';
-		}
+		$square_size = newspack_blocks_image_size_for_orientation( 'square' );
 
 		$feat_img_array_square        = wp_get_attachment_image_src(
 			$object['featured_media'],

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -173,6 +173,16 @@ class Newspack_Blocks {
 	}
 }
 
+/**
+ * Add image sizes
+ */
+function newspack_blocks_image_sizes() {
+	add_image_size( 'newspack-article-block-landscape', 800, 600, true );
+	add_image_size( 'newspack-article-block-portrait', 600, 800, true );
+	add_image_size( 'newspack-article-block-square', 800, 800, true );
+}
+add_action( 'after_setup_theme', 'newspack_blocks_image_sizes' );
+
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'class-newspack-blocks-api.php';
 
 Newspack_Blocks::manage_view_scripts();

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -177,9 +177,21 @@ class Newspack_Blocks {
  * Add image sizes
  */
 function newspack_blocks_image_sizes() {
-	add_image_size( 'newspack-article-block-landscape', 800, 600, true );
-	add_image_size( 'newspack-article-block-portrait', 600, 800, true );
-	add_image_size( 'newspack-article-block-square', 800, 800, true );
+	add_image_size( 'newspack-article-block-landscape-large', 1200, 900, true );
+	add_image_size( 'newspack-article-block-portrait-large', 1500, 1200, true );
+	add_image_size( 'newspack-article-block-square-large', 1200, 1200, true );
+
+	add_image_size( 'newspack-article-block-landscape-medium', 800, 600, true );
+	add_image_size( 'newspack-article-block-portrait-medium', 600, 800, true );
+	add_image_size( 'newspack-article-block-square-medium', 800, 800, true );
+
+	add_image_size( 'newspack-article-block-landscape-small', 400, 300, true );
+	add_image_size( 'newspack-article-block-portrait-small', 300, 400, true );
+	add_image_size( 'newspack-article-block-square-small', 400, 400, true );
+
+	add_image_size( 'newspack-article-block-landscape-tiny', 200, 150, true );
+	add_image_size( 'newspack-article-block-portrait-tiny', 150, 200, true );
+	add_image_size( 'newspack-article-block-square-tiny', 200, 200, true );
 }
 add_action( 'after_setup_theme', 'newspack_blocks_image_sizes' );
 

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -195,6 +195,82 @@ function newspack_blocks_image_sizes() {
 }
 add_action( 'after_setup_theme', 'newspack_blocks_image_sizes' );
 
+/**
+ * Return the most appropriate thumbnail size to display.
+ *
+ * @param string $orientation The block's orientation settings: landscape|portrait|square.
+ *
+ * @return string Returns the thumbnail key to use.
+ */
+function newspack_blocks_image_size_for_orientation( $orientation = 'landscape' ) {
+	$sizes = array(
+		'landscape' => array(
+			'large'  => array(
+				1200,
+				900,
+			),
+			'medium' => array(
+				800,
+				600,
+			),
+			'small'  => array(
+				400,
+				300,
+			),
+			'tiny'   => array(
+				200,
+				150,
+			),
+		),
+		'portrait'  => array(
+			'large'  => array(
+				900,
+				1200,
+			),
+			'medium' => array(
+				600,
+				800,
+			),
+			'small'  => array(
+				300,
+				400,
+			),
+			'tiny'   => array(
+				150,
+				200,
+			),
+		),
+		'square'    => array(
+			'large'  => array(
+				1200,
+				1200,
+			),
+			'medium' => array(
+				800,
+				800,
+			),
+			'small'  => array(
+				400,
+				400,
+			),
+			'tiny'   => array(
+				200,
+				200,
+			),
+		),
+	);
+
+	foreach ( $sizes[ $orientation ] as $key => $dimensions ) {
+		$attachment = wp_get_attachment_image_src(
+			get_post_thumbnail_id( get_the_ID() ),
+			'newspack-article-block-' . $orientation . '-' . $key
+		);
+		if ( $dimensions[0] === $attachment[1] && $dimensions[1] === $attachment[2] ) {
+			return 'newspack-article-block-' . $orientation . '-' . $key;
+		}
+	}
+}
+
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'class-newspack-blocks-api.php';
 
 Newspack_Blocks::manage_view_scripts();

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -178,7 +178,7 @@ class Newspack_Blocks {
  */
 function newspack_blocks_image_sizes() {
 	add_image_size( 'newspack-article-block-landscape-large', 1200, 900, true );
-	add_image_size( 'newspack-article-block-portrait-large', 1500, 1200, true );
+	add_image_size( 'newspack-article-block-portrait-large', 900, 1200, true );
 	add_image_size( 'newspack-article-block-square-large', 1200, 1200, true );
 
 	add_image_size( 'newspack-article-block-landscape-medium', 800, 600, true );

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -322,7 +322,6 @@ class Edit extends Component {
 			showDate,
 			showImage,
 			imageShape,
-			imageFileSize,
 			showAuthor,
 			showAvatar,
 			postsToShow,
@@ -342,6 +341,7 @@ class Edit extends Component {
 			[ `type-scale${ typeScale }` ]: typeScale !== '5',
 			[ `image-align${ mediaPosition }` ]: showImage,
 			[ `image-scale${ imageScale }` ]: imageScale !== '1' && showImage,
+			[ `image-shape${ imageShape }` ]: imageShape !== 'landscape',
 			'has-text-color': textColor,
 		} );
 
@@ -402,27 +402,6 @@ class Edit extends Component {
 			},
 		];
 
-		const blockControlsImageFileSize = [
-			{
-				icon: landscapeIcon,
-				title: __( 'Large Image Size' ),
-				isActive: imageFileSize === 'large',
-				onClick: () => setAttributes( { imageFileSize: 'large' } ),
-			},
-			{
-				icon: portraitIcon,
-				title: __( 'Medium Image Size' ),
-				isActive: imageFileSize === 'medium',
-				onClick: () => setAttributes( { imageFileSize: 'medium' } ),
-			},
-			{
-				icon: squareIcon,
-				title: __( 'Small Image Size' ),
-				isActive: imageFileSize === 'small',
-				onClick: () => setAttributes( { imageFileSize: 'small' } ),
-			},
-		];
-
 		return (
 			<Fragment>
 				<div
@@ -454,7 +433,6 @@ class Edit extends Component {
 					<Toolbar controls={ blockControls } />
 					{ showImage && <Toolbar controls={ blockControlsImages } /> }
 					{ showImage && <Toolbar controls={ blockControlsImageShape } /> }
-					{ showImage && <Tollbar controls={ blockControlsImageFileSize } /> }
 				</BlockControls>
 				<InspectorControls>{ this.renderInspectorControls() }</InspectorControls>
 			</Fragment>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -68,6 +68,7 @@ class Edit extends Component {
 		const {
 			showImage,
 			imageShape,
+			imageFileSize,
 			showCaption,
 			showExcerpt,
 			showAuthor,
@@ -321,6 +322,7 @@ class Edit extends Component {
 			showDate,
 			showImage,
 			imageShape,
+			imageFileSize,
 			showAuthor,
 			showAvatar,
 			postsToShow,
@@ -400,6 +402,27 @@ class Edit extends Component {
 			},
 		];
 
+		const blockControlsImageFileSize = [
+			{
+				icon: landscapeIcon,
+				title: __( 'Large Image Size' ),
+				isActive: imageFileSize === 'large',
+				onClick: () => setAttributes( { imageFileSize: 'large' } ),
+			},
+			{
+				icon: portraitIcon,
+				title: __( 'Medium Image Size' ),
+				isActive: imageFileSize === 'medium',
+				onClick: () => setAttributes( { imageFileSize: 'medium' } ),
+			},
+			{
+				icon: squareIcon,
+				title: __( 'Small Image Size' ),
+				isActive: imageFileSize === 'small',
+				onClick: () => setAttributes( { imageFileSize: 'small' } ),
+			},
+		];
+
 		return (
 			<Fragment>
 				<div
@@ -431,6 +454,7 @@ class Edit extends Component {
 					<Toolbar controls={ blockControls } />
 					{ showImage && <Toolbar controls={ blockControlsImages } /> }
 					{ showImage && <Toolbar controls={ blockControlsImageShape } /> }
+					{ showImage && <Tollbar controls={ blockControlsImageFileSize } /> }
 				</BlockControls>
 				<InspectorControls>{ this.renderInspectorControls() }</InspectorControls>
 			</Fragment>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -21,10 +21,13 @@ import {
 	PanelRow,
 	RangeControl,
 	Toolbar,
+	DropdownMenu,
 	ToggleControl,
 	Dashicon,
 	Placeholder,
 	Spinner,
+	Path,
+	SVG,
 } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { withState, compose } from '@wordpress/compose';
@@ -38,11 +41,34 @@ const { decodeEntities } = wp.htmlEntities;
  */
 const MAX_POSTS_COLUMNS = 6;
 
+/* From https://material.io/tools/icons */
+const landscapeIcon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<Path d="M0 0h24v24H0z" fill="none" />
+		<Path d="M19 5H5c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 12H5V7h14v10z" />
+	</SVG>
+);
+
+const portraitIcon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<Path d="M0 0h24v24H0z" fill="none" />
+		<Path d="M17 3H7c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H7V5h10v14z" />
+	</SVG>
+);
+
+const squareIcon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<path d="M0 0h24v24H0z" fill="none" />
+		<path d="M18 4H6c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H6V6h12v12z" />
+	</SVG>
+);
+
 class Edit extends Component {
 	renderPost = post => {
 		const { attributes } = this.props;
 		const {
 			showImage,
+			imageShape,
 			showCaption,
 			showExcerpt,
 			showAuthor,
@@ -55,7 +81,13 @@ class Edit extends Component {
 				{ showImage && post.newspack_featured_image_src && (
 					<figure className="post-thumbnail" key="thumbnail">
 						<a href="#">
-							<img src={ post.newspack_featured_image_src.large } />
+							{ imageShape === 'landscape' && (
+								<img src={ post.newspack_featured_image_src.landscape } />
+							) }
+							{ imageShape === 'portrait' && (
+								<img src={ post.newspack_featured_image_src.portrait } />
+							) }
+							{ imageShape === 'square' && <img src={ post.newspack_featured_image_src.square } /> }
 						</a>
 						{ showCaption && '' !== post.newspack_featured_image_caption && (
 							<figcaption>{ post.newspack_featured_image_caption }</figcaption>
@@ -289,6 +321,7 @@ class Edit extends Component {
 			showExcerpt,
 			showDate,
 			showImage,
+			imageShape,
 			showAuthor,
 			showAvatar,
 			postsToShow,
@@ -347,6 +380,27 @@ class Edit extends Component {
 			},
 		];
 
+		const blockControlsImageShape = [
+			{
+				icon: landscapeIcon,
+				title: __( 'Landscape Image Shape' ),
+				isActive: imageShape === 'landscape',
+				onClick: () => setAttributes( { imageShape: 'landscape' } ),
+			},
+			{
+				icon: portraitIcon,
+				title: __( 'portrait Image Shape' ),
+				isActive: imageShape === 'portrait',
+				onClick: () => setAttributes( { imageShape: 'portrait' } ),
+			},
+			{
+				icon: squareIcon,
+				title: __( 'Square Image Shape' ),
+				isActive: imageShape === 'square',
+				onClick: () => setAttributes( { imageShape: 'square' } ),
+			},
+		];
+
 		return (
 			<Fragment>
 				<div
@@ -377,6 +431,7 @@ class Edit extends Component {
 				<BlockControls>
 					<Toolbar controls={ blockControls } />
 					{ showImage && <Toolbar controls={ blockControlsImages } /> }
+					{ showImage && <Toolbar controls={ blockControlsImageShape } /> }
 				</BlockControls>
 				<InspectorControls>{ this.renderInspectorControls() }</InspectorControls>
 			</Fragment>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -21,7 +21,6 @@ import {
 	PanelRow,
 	RangeControl,
 	Toolbar,
-	DropdownMenu,
 	ToggleControl,
 	Dashicon,
 	Placeholder,

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -56,6 +56,10 @@ export const settings = {
 			type: 'boolean',
 			default: false,
 		},
+		imageShape: {
+			type: 'string',
+			default: 'landscape',
+		},
 		showAuthor: {
 			type: 'boolean',
 			default: true,

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -60,6 +60,10 @@ export const settings = {
 			type: 'string',
 			default: 'landscape',
 		},
+		imageFileSize: {
+			type: 'string',
+			default: 'medium',
+		},
 		showAuthor: {
 			type: 'boolean',
 			default: true,

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -60,10 +60,6 @@ export const settings = {
 			type: 'string',
 			default: 'landscape',
 		},
-		imageFileSize: {
-			type: 'string',
-			default: 'medium',
-		},
 		showAuthor: {
 			type: 'boolean',
 			default: true,

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -102,18 +102,25 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				?>
 
 				<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?>>
-					<?php if ( has_post_thumbnail() && $attributes['showImage'] ) : ?>
 
+					<?php if ( has_post_thumbnail() && $attributes['showImage'] && $attributes['imageShape'] ) : ?>
 						<figure class="post-thumbnail">
 							<a href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
-								<?php the_post_thumbnail( 'large' ); ?>
+								<?php
+								if ( 'landscape' === $attributes['imageShape'] ) {
+									the_post_thumbnail( 'newspack-article-block-landscape' );
+								} elseif ( 'portrait' === $attributes['imageShape'] ) {
+									the_post_thumbnail( 'newspack-article-block-portrait' );
+								} else {
+									the_post_thumbnail( 'newspack-article-block-square' );
+								}
+								?>
 							</a>
 
 							<?php if ( $attributes['showCaption'] && '' !== get_the_post_thumbnail_caption() ) : ?>
 								<figcaption><?php the_post_thumbnail_caption(); ?>
 							<?php endif; ?>
 						</figure><!-- .featured-image -->
-
 					<?php endif; ?>
 
 					<div class="entry-wrapper">
@@ -259,6 +266,10 @@ function newspack_blocks_register_homepage_articles() {
 				'imageScale'    => array(
 					'type'    => 'integer',
 					'default' => 3,
+				),
+				'imageShape'    => array(
+					'type'    => 'string',
+					'default' => 'landscape',
 				),
 				'sectionHeader' => array(
 					'type'    => 'string',

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -112,53 +112,11 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 								$image_size = 'newspack-article-block-landscape-tiny';
 
 								if ( 'landscape' === $attributes['imageShape'] ) {
-									$landscape_large  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-landscape-large' );
-									$landscape_medium = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-landscape-medium' );
-									$landscape_small  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-landscape-small' );
-
-									// Don't use an image size unless it's actually fully cropped.
-									if ( 400 === $landscape_small[1] && 300 === $landscape_small[2] ) {
-										$image_size = 'newspack-article-block-landscape-small';
-									}
-									if ( 600 === $landscape_medium[1] && 800 === $landscape_medium[2] ) {
-										$image_size = 'newspack-article-block-landscape-medium';
-									}
-									if ( 1200 === $landscape_large[1] && 900 === $landscape_large[2] ) {
-										$image_size = 'newspack-article-block-landscape-large';
-									}
+									$image_size = newspack_blocks_image_size_for_orientation( 'landscape' );
 								} elseif ( 'portrait' === $attributes['imageShape'] ) {
-
-									$portrait_large  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-portrait-large' );
-									$portrait_medium = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-portrait-medium' );
-									$portrait_small  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-portrait-small' );
-									$image_size      = 'newspack-article-block-portrait-tiny';
-
-									// Don't use an image size unless it's actually fully cropped.
-									if ( 300 === $portrait_small[1] && 400 === $portrait_small[2] ) {
-										$image_size = 'newspack-article-block-portrait-small';
-									}
-									if ( 600 === $portrait_medium[1] && 800 === $portrait_medium[2] ) {
-										$image_size = 'newspack-article-block-portrait-medium';
-									}
-									if ( 900 === $portrait_large[1] && 1200 === $portrait_large[2] ) {
-										$image_size = 'newspack-article-block-portrait-large';
-									}
+									$image_size = newspack_blocks_image_size_for_orientation( 'portrait' );
 								} else {
-									$square_large  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-square-large' );
-									$square_medium = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-square-medium' );
-									$square_small  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-square-small' );
-									$image_size    = 'newspack-article-block-square-tiny';
-
-									// Don't use an image size unless it's actually fully cropped.
-									if ( 400 === $square_small[1] && 400 === $square_small[2] ) {
-										$image_size = 'newspack-article-block-square-small';
-									}
-									if ( 800 === $square_medium[1] && 800 === $square_medium[2] ) {
-										$image_size = 'newspack-article-block-square-medium';
-									}
-									if ( 1200 === $square_large[1] && 1200 === $square_large[2] ) {
-										$image_size = 'newspack-article-block-square-large';
-									}
+									$image_size = newspack_blocks_image_size_for_orientation( 'square' );
 								}
 								the_post_thumbnail( $image_size );
 								?>

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -104,16 +104,63 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?>>
 
 					<?php if ( has_post_thumbnail() && $attributes['showImage'] && $attributes['imageShape'] ) : ?>
+
 						<figure class="post-thumbnail">
 							<a href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
 								<?php
+
+								$image_size = 'newspack-article-block-landscape-tiny';
+
 								if ( 'landscape' === $attributes['imageShape'] ) {
-									the_post_thumbnail( 'newspack-article-block-landscape' );
+									$landscape_large  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-landscape-large' );
+									$landscape_medium = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-landscape-medium' );
+									$landscape_small  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-landscape-small' );
+
+									// Don't use an image size unless it's actually fully cropped.
+									if ( 400 === $landscape_small[1] && 300 === $landscape_small[2] ) {
+										$image_size = 'newspack-article-block-landscape-small';
+									}
+									if ( 600 === $landscape_medium[1] && 800 === $landscape_medium[2] ) {
+										$image_size = 'newspack-article-block-landscape-medium';
+									}
+									if ( 1200 === $landscape_large[1] && 900 === $landscape_large[2] ) {
+										$image_size = 'newspack-article-block-landscape-large';
+									}
 								} elseif ( 'portrait' === $attributes['imageShape'] ) {
-									the_post_thumbnail( 'newspack-article-block-portrait' );
+
+									$portrait_large  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-portrait-large' );
+									$portrait_medium = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-portrait-medium' );
+									$portrait_small  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-portrait-small' );
+									$image_size      = 'newspack-article-block-portrait-tiny';
+
+									// Don't use an image size unless it's actually fully cropped.
+									if ( 300 === $portrait_small[1] && 400 === $portrait_small[2] ) {
+										$image_size = 'newspack-article-block-portrait-small';
+									}
+									if ( 600 === $portrait_medium[1] && 800 === $portrait_medium[2] ) {
+										$image_size = 'newspack-article-block-portrait-medium';
+									}
+									if ( 900 === $portrait_large[1] && 1200 === $portrait_large[2] ) {
+										$image_size = 'newspack-article-block-portrait-large';
+									}
 								} else {
-									the_post_thumbnail( 'newspack-article-block-square' );
+									$square_large  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-square-large' );
+									$square_medium = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-square-medium' );
+									$square_small  = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'newspack-article-block-square-small' );
+									$image_size    = 'newspack-article-block-square-tiny';
+
+									// Don't use an image size unless it's actually fully cropped.
+									if ( 400 === $square_small[1] && 400 === $square_small[2] ) {
+										$image_size = 'newspack-article-block-square-small';
+									}
+									if ( 800 === $square_medium[1] && 800 === $square_medium[2] ) {
+										$image_size = 'newspack-article-block-square-medium';
+									}
+									if ( 1200 === $square_large[1] && 1200 === $square_large[2] ) {
+										$image_size = 'newspack-article-block-square-large';
+									}
 								}
+								the_post_thumbnail( $image_size );
 								?>
 							</a>
 

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -108,16 +108,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 						<figure class="post-thumbnail">
 							<a href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
 								<?php
-
-								$image_size = 'newspack-article-block-landscape-tiny';
-
-								if ( 'landscape' === $attributes['imageShape'] ) {
-									$image_size = newspack_blocks_image_size_for_orientation( 'landscape' );
-								} elseif ( 'portrait' === $attributes['imageShape'] ) {
-									$image_size = newspack_blocks_image_size_for_orientation( 'portrait' );
-								} else {
-									$image_size = newspack_blocks_image_size_for_orientation( 'square' );
-								}
+								$image_size = newspack_blocks_image_size_for_orientation( $attributes['imageShape'] );
 								the_post_thumbnail( $image_size );
 								?>
 							</a>

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -62,6 +62,11 @@
 
 	.post-thumbnail {
 		margin: 0;
+
+		img {
+			height: auto;
+			width: 100%;
+		}
 	}
 
 	figcaption {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds three fixed image sizes to the blocks plugin -- Landscape (800 x 600), Portrait (600 x 800) and Square (800 x 800). It's not a perfect solution to our image size issue (and I've outlined why below), but hopefully it's a good starting point towards a solid, useful fix. 

Some known issues:

* If the original image is smaller than the custom image size, it won't be cropped.
* The image sizes I've picked -- 800 x 600, 600 x 800 and 800 x 800 -- are a bit to small to fill the content space (1200); especially if we're talking about images for retina screens, where we'd ideally be starting with images twice as large as they need to be (so a minimum of 2400px).

These two images kind of push and pull each other: we need to make the image sizes smaller to work with small archive images (or small new images! Sometimes you just can't get a larger photo). But we also need to go larger to make them work in more layouts -- like a one column post -- and work better on a variety of screen sizes. 

One way around this might be to have different sizes of each shape (a small, medium, and large landscape image, for example); I'd be interested in getting some feedback on this overall, so we can land on a good way to approach it that isn't a big knotted mess. 

We also might want to incorporate the DropdownMenu for our block's Toolbar options, to turn some of these sets of buttons into a single dropdown of options (like how the block alignment is done).

See #96.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`
2. Install and run the [Regenerate Thumbnails](https://en-ca.wordpress.org/plugins/regenerate-thumbnails/) plugin.
3. Add an article block to a page; set it so it's showing images, and the posts in there actually have featured images. Ideally these image will be over 800px wide and over 800px tall to see the resizing in action, but having smaller images could also help you see how it doesn't work.
4. Clicking on the block, there should now be three new options in the Toolbar, for the different image shapes: 

![image](https://user-images.githubusercontent.com/177561/63892185-dc9e8180-c99b-11e9-947e-04f59617a5b5.png)

5. Try each of the sizing and confirm that your larger featured images switch between Landscape, Portrait, and Square.
6. Publish your post between each change, and confirm those image shapes are being used on the front end, when you have images large enough.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
