### PR TITLE
Attempt at adding text colour picker for the Article Block

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -26,6 +26,7 @@ import {
 	Placeholder,
 	Spinner,
 } from '@wordpress/components';
+import { PanelColorSettings } from '@wordpress/block-editor';
 import { withSelect } from '@wordpress/data';
 import { withState } from '@wordpress/compose';
 
@@ -47,6 +48,8 @@ class Edit extends Component {
 			showDate,
 			sectionHeader,
 			moreLink,
+			textColor,
+			setTextColor,
 		} = attributes;
 		return (
 			<article className={ post.newspack_featured_image_src && 'post-has-image' } key={ post.id }>
@@ -125,6 +128,8 @@ class Edit extends Component {
 			mediaPosition,
 			moreLink,
 			singleMode,
+			textColor,
+			setTextColor,
 		} = attributes;
 		return (
 			<Fragment>
@@ -239,6 +244,16 @@ class Edit extends Component {
 						</PanelRow>
 					) }
 				</PanelBody>
+				<PanelColorSettings
+					title={ __( 'Color Settings' ) }
+					colorSettings={ [
+						{
+							value: textColor.color,
+							onChange: setTextColor,
+							label: __( 'Text Color' ),
+						},
+					] }
+				/>
 			</Fragment>
 		);
 	};
@@ -280,6 +295,8 @@ class Edit extends Component {
 			[ `type-scale${ typeScale }` ]: typeScale !== '5',
 			[ `image-align${ mediaPosition }` ]: mediaPosition !== 'top' && showImage,
 			[ `image-scale${ imageScale }` ]: imageScale !== '1' && showImage,
+			'has-text-color': textColor.color,
+			[ textColor.class ]: textColor.class,
 		} );
 
 		const blockControls = [
@@ -320,7 +337,12 @@ class Edit extends Component {
 
 		return (
 			<Fragment>
-				<div className={ classes }>
+				<div
+					className={ classes }
+					style={ {
+						color: textColor.color,
+					} }
+				>
 					{ latestPosts && ( ! RichText.isEmpty( sectionHeader ) || isSelected ) && (
 						<RichText
 							onChange={ value => setAttributes( { sectionHeader: value } ) }

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -15,14 +15,8 @@ import moment from 'moment';
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment, RawHTML } from '@wordpress/element';
-import {
-	InspectorControls,
-	RichText,
-	BlockControls,
-	PanelColorSettings,
-	withColors,
-	getColorClass,
-} from '@wordpress/editor';
+import { InspectorControls, RichText, BlockControls } from '@wordpress/editor';
+import { PanelColorSettings, withColors, getColorClass } from '@wordpress/block-editor';
 import {
 	PanelBody,
 	PanelRow,
@@ -54,9 +48,9 @@ const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
 	};
 } );
 
-class Edit extends Component {
+class articleBlock extends Component {
 	renderPost = post => {
-		const { attributes } = this.props;
+		const { attributes, textColor, fallbackTextColor } = this.props;
 		const {
 			showImage,
 			showExcerpt,
@@ -65,9 +59,6 @@ class Edit extends Component {
 			showDate,
 			sectionHeader,
 			moreLink,
-			textColor,
-			backgroundColor,
-			setTextColor,
 		} = attributes;
 		return (
 			<article className={ post.newspack_featured_image_src && 'post-has-image' } key={ post.id }>
@@ -126,6 +117,8 @@ class Edit extends Component {
 			setAttributes,
 			latestPosts,
 			isSelected,
+			textColor,
+			fallbackTextColor,
 		} = this.props;
 		const hasPosts = Array.isArray( latestPosts ) && latestPosts.length;
 		const {
@@ -146,9 +139,8 @@ class Edit extends Component {
 			mediaPosition,
 			moreLink,
 			singleMode,
-			textColor,
-			setTextColor,
 		} = attributes;
+		const setTextColor = value => setAttributes( { textColor: value } );
 		return (
 			<Fragment>
 				<PanelBody title={ __( 'Display Settings' ) } initialOpen={ true }>
@@ -288,6 +280,8 @@ class Edit extends Component {
 			latestPosts,
 			hasPosts,
 			categoriesList,
+			textColor,
+			fallbackTextColor,
 		} = this.props; // variables getting pulled out of props
 		const {
 			showExcerpt,
@@ -304,7 +298,6 @@ class Edit extends Component {
 			imageScale,
 			sectionHeader,
 			moreLink,
-			textColor,
 		} = attributes;
 
 		const classes = classNames( className, {
@@ -425,6 +418,6 @@ const articleBlockEdit = compose( [
 			postList: getEntityRecords( 'postType', 'post', postsListQuery ),
 		};
 	} ),
-] )( Edit );
+] )( articleBlock );
 
 export default articleBlockEdit;

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -103,7 +103,11 @@ export const settings = {
 		},
 		singleMode: {
 			type: 'boolean',
-			default: false
+			default: false,
+		},
+		textColor: {
+			type: 'string',
+			default: '',
 		},
 	},
 	supports: {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I well and truly hit a wall with this one, so pushing up to get a second set of eyes on what went wrong.

So far I managed to get the colour picker displaying; at one point picking a colour would fire an `i is not defined` JavaScript error, but now it's just failing silently. 

When complete it will close #97.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
