### PR TITLE
Update breakpoint for block styles to match Gutenberg's

### DIFF
--- a/src/shared/sass/_variables.scss
+++ b/src/shared/sass/_variables.scss
@@ -1,5 +1,5 @@
 $mobile_width: 600px;
-$tablet_width: 768px;
+$tablet_width: 782px;
 $desktop_width: 1168px;
 $wide_width: 1379px;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the block styles breakpoint for tablet-sized screens to match Gutenberg's, so we don't have odd moments at different screen sizes. 

A related fix is included in the theme in https://github.com/Automattic/newspack-theme/pull/334.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`
2. Add a homepage article block and set it to display as a grid.
3. Confirm that the columns change to display as one column at screen sizes smaller than 782px, rather than 768px.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
