### PR TITLE
Remove 'more' button option from the article block.

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -39,15 +39,7 @@ const MAX_POSTS_COLUMNS = 6;
 class Edit extends Component {
 	renderPost = post => {
 		const { attributes } = this.props;
-		const {
-			showImage,
-			showExcerpt,
-			showAuthor,
-			showAvatar,
-			showDate,
-			sectionHeader,
-			moreLink,
-		} = attributes;
+		const { showImage, showExcerpt, showAuthor, showAvatar, showDate, sectionHeader } = attributes;
 		return (
 			<article className={ post.newspack_featured_image_src && 'post-has-image' } key={ post.id }>
 				{ showImage && post.newspack_featured_image_src && (
@@ -123,7 +115,6 @@ class Edit extends Component {
 			showAvatar,
 			postLayout,
 			mediaPosition,
-			moreLink,
 			singleMode,
 		} = attributes;
 		return (
@@ -162,13 +153,6 @@ class Edit extends Component {
 								! hasPosts ? MAX_POSTS_COLUMNS : Math.min( MAX_POSTS_COLUMNS, latestPosts.length )
 							}
 							required
-						/>
-					) }
-					{ ! singleMode && (
-						<ToggleControl
-							label={ __( 'Show "More" Link' ) }
-							checked={ moreLink }
-							onChange={ () => setAttributes( { moreLink: ! moreLink } ) }
 						/>
 					) }
 				</PanelBody>
@@ -270,7 +254,6 @@ class Edit extends Component {
 			typeScale,
 			imageScale,
 			sectionHeader,
-			moreLink,
 		} = attributes;
 
 		const classes = classNames( className, {
@@ -339,11 +322,6 @@ class Edit extends Component {
 						</Placeholder>
 					) }
 					{ latestPosts && latestPosts.map( post => this.renderPost( post ) ) }
-					{ latestPosts && moreLink && (
-						<a className="button" href="#">
-							{ __( 'More…' ) }
-						</a>
-					) }
 				</div>
 				<BlockControls>
 					<Toolbar controls={ blockControls } />

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -97,13 +97,9 @@ export const settings = {
 			type: 'string',
 			default: '',
 		},
-		moreLink: {
-			type: 'boolean',
-			default: false,
-		},
 		singleMode: {
 			type: 'boolean',
-			default: false
+			default: false,
 		},
 	},
 	supports: {

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -151,17 +151,6 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				<?php
 			endwhile;
 			?>
-
-			<?php
-			if ( $attributes['moreLink'] ) {
-				$more_url = get_permalink( get_option( 'page_for_posts' ) );
-				if ( $categories ) {
-					$more_url = get_category_link( $categories );
-				}
-				echo '<a class="button" href="' . esc_url( $more_url ) . '">' . esc_html__( 'More', 'newspack-blocks' ) . '</a>';
-			}
-			?>
-
 			<?php wp_reset_postdata(); ?>
 		</div>
 		<?php
@@ -241,10 +230,6 @@ function newspack_blocks_register_homepage_articles() {
 				'sectionHeader' => array(
 					'type'    => 'string',
 					'default' => '',
-				),
-				'moreLink'      => array(
-					'type'    => 'boolean',
-					'default' => false,
 				),
 				'singleMode'    => array(
 					'type'    => 'boolean',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Since it mostly duplicates the button block, but with less functionality and more complexity, we've opted to kill the in-block 'more' button. The recommended alternative is using the button link; if we find we need something 'smarter' (like automatically generating a link with an offset) we can approach that separately.

Closes #94.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`; confirm there are no errors.
2. Confirm that the 'more' button option is no longer there.
3. Double-check it's no longer referenced in the code. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
