### PR TITLE
Article Block: Improve breakpoints for smaller screens

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -44,7 +44,7 @@
 			flex-basis: calc( 50% - 16px);
 		}
 
-		&.columns-5 article:last-of-type {
+		&.columns-5 article:last-of-type:nth-child(odd) {
 			flex-grow: 1;
 		}
 	}

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -24,7 +24,7 @@
 		list-style: none;
 
 		article {
-			width: 100%;
+			flex-basis: 100%;
 
 			@include media(tablet) {
 				margin-bottom: 1em;
@@ -32,10 +32,27 @@
 		}
 	}
 
+	@include media(mobile) {
+		&.columns-3 article,
+		&.columns-6 article {
+			flex-basis: calc( 33.333% - 16px );
+		}
+
+		&.columns-2 article,
+		&.columns-4 article,
+		&.columns-5 article {
+			flex-basis: calc( 50% - 16px);
+		}
+
+		&.columns-5 article:last-of-type {
+			flex-grow: 1;
+		}
+	}
+
 	@include media(tablet) {
 		@for $i from 2 through 6 {
 			&.columns-#{ $i } article {
-				width: calc( ( 100% / #{$i} ) - 12px );
+				flex-basis: calc( ( 100% / #{$i} ) - 16px );
 			}
 		}
 	}
@@ -302,7 +319,7 @@
 
 		@for $i from 2 through 6 {
 			&.columns-#{ $i } article {
-				padding-right: calc( ( 12px * #{$i} ) / ( #{$i} - 1 ) );
+				padding-right: calc( ( 16px * #{$i} ) / ( #{$i} - 1 ) );
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes some improvements to the article block breakpoints, when using it on smaller screens. It looks like:

```
Desktop:     1 col     2 col     3 col     4 col     5 col     6 col
Tablet:      1 col     2 col     3 col     2 col     2 col*    3 col
Mobile:      1 col     1 col     1 col     1 col     1 col     1 col

* The five column block splits into two rows of two, and one row of one, if it's an uneven number. 
```

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`
2. Copy-paste [this test content](https://cloudup.com/cRUjc4KWHpk) into the code editor; it adds six blocks, one of each column width.
3. Confirm the correct column counts are showing for the desktop size screen.
4. Scale down the browser window to less than 768px but more than 600px -- to emulate a tablet-sized screen. Confirm the column arrangements reflect what's listed above.
5. Scale down the browser window to less than 600px to emulate a mobile-sized screen - confirm that each of the blocks is displaying in one column.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
