### PR TITLE
Article Blocks: Add text colour picker

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -22,7 +22,6 @@ import {
 	RangeControl,
 	Toolbar,
 	ToggleControl,
-	withFallbackStyles,
 	Dashicon,
 	Placeholder,
 	Spinner,
@@ -38,16 +37,6 @@ const { decodeEntities } = wp.htmlEntities;
  * Module Constants
  */
 const MAX_POSTS_COLUMNS = 6;
-
-const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
-	const { textColor } = ownProps.attributes;
-	const editableNode = node.querySelector( '[contenteditable="true"]' );
-	//verify if editableNode is available, before using getComputedStyle.
-	const computedStyles = editableNode ? getComputedStyle( editableNode ) : null;
-	return {
-		fallbackTextColor: textColor || ! computedStyles ? undefined : computedStyles.color,
-	};
-} );
 
 class Edit extends Component {
 	renderPost = post => {
@@ -399,7 +388,6 @@ class Edit extends Component {
 
 export default compose( [
 	withColors( { textColor: 'color' } ),
-	applyFallbackStyles,
 	withSelect( ( select, props ) => {
 		const { postsToShow, author, categories, tags, single, singleMode } = props.attributes;
 		const { getAuthors, getEntityRecords } = select( 'core' );

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -114,7 +114,6 @@ class Edit extends Component {
 			latestPosts,
 			isSelected,
 			textColor,
-			customTextColor,
 			setTextColor,
 		} = this.props;
 		const hasPosts = Array.isArray( latestPosts ) && latestPosts.length;
@@ -285,7 +284,6 @@ class Edit extends Component {
 			hasPosts,
 			categoriesList,
 			textColor,
-			customTextColor,
 		} = this.props; // variables getting pulled out of props
 		const {
 			showExcerpt,
@@ -310,7 +308,7 @@ class Edit extends Component {
 			[ `type-scale${ typeScale }` ]: typeScale !== '5',
 			[ `image-align${ mediaPosition }` ]: showImage,
 			[ `image-scale${ imageScale }` ]: imageScale !== '1' && showImage,
-			'has-text-color': textColor || customTextColor,
+			'has-text-color': textColor,
 		} );
 
 		const blockControls = [
@@ -354,7 +352,7 @@ class Edit extends Component {
 				<div
 					className={ classes }
 					style={ {
-						color: textColor ? textColor.color : customTextColor,
+						color: textColor.color,
 					} }
 				>
 					{ latestPosts && ( ! RichText.isEmpty( sectionHeader ) || isSelected ) && (

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -29,7 +29,7 @@ import {
 import { withSelect } from '@wordpress/data';
 import { withState, compose } from '@wordpress/compose';
 
-import { PanelColorSettings, withColors, getColorClassName } from '@wordpress/block-editor';
+import { PanelColorSettings, withColors } from '@wordpress/block-editor';
 
 const { decodeEntities } = wp.htmlEntities;
 

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -40,7 +40,7 @@ const MAX_POSTS_COLUMNS = 6;
 
 class Edit extends Component {
 	renderPost = post => {
-		const { attributes, textColor } = this.props;
+		const { attributes } = this.props;
 		const {
 			showImage,
 			showCaption,

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -108,6 +108,10 @@ export const settings = {
 			type: 'boolean',
 			default: false,
 		},
+		textColor: {
+			type: 'string',
+			default: '',
+		},
 	},
 	supports: {
 		html: false,

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -112,6 +112,10 @@ export const settings = {
 			type: 'string',
 			default: '',
 		},
+		customTextColor: {
+			type: 'string',
+			default: '',
+		},
 	},
 	supports: {
 		html: false,

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -64,13 +64,27 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	if ( isset( $attributes['className'] ) ) {
 		$classes .= ' ' . $attributes['className'];
 	}
+
+	if ( isset( $attributes['textColor'] ) ) {
+		$classes .= ' has-text-color';
+		if ( '' !== $attributes['textColor'] ) {
+			$classes .= ' has-' . $attributes['textColor'] . '-color';
+		}
+	}
+
+	$styles = '';
+
+	if ( '' !== $attributes['customTextColor'] ) {
+		$styles = 'color: ' . $attributes['customTextColor'] . ';';
+	}
+
 	$post_counter = 0;
 
 	ob_start();
 
 	if ( $article_query->have_posts() ) :
 		?>
-		<div class="<?php echo esc_attr( $classes ); ?>">
+		<div class="<?php echo esc_attr( $classes ); ?>" style="<?php echo esc_attr( $styles ); ?>">
 
 			<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
 				<h2 class="article-section-title">
@@ -86,6 +100,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				$newspack_blocks_post_id[ get_the_ID() ] = true;
 				$post_counter++;
 				?>
+
 				<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?>>
 					<?php if ( has_post_thumbnail() && $attributes['showImage'] ) : ?>
 
@@ -252,6 +267,14 @@ function newspack_blocks_register_homepage_articles() {
 				'singleMode'    => array(
 					'type'    => 'boolean',
 					'default' => false,
+				),
+				'textColor'       => array(
+					'type'    => 'string',
+					'default' => '',
+				),
+				'customTextColor' => array(
+					'type'    => 'string',
+					'default' => '',
 				),
 			),
 			'render_callback' => 'newspack_blocks_render_block_homepage_articles',

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -153,6 +153,25 @@
 		display: block;
 		margin-right: 0.5em;
 	}
+
+	&.has-text-color {
+		.article-section-title,
+		.entry-title,
+		.entry-title a,
+		.entry-title a:visited,
+		.entry-meta,
+		.entry-meta a,
+		.entry-meta .byline a,
+		.entry-meta .byline a:visited {
+			color: inherit;
+		}
+	}
+
+	&.has-text-color {
+		.entry-meta span:not(.avatar) {
+			opacity: 0.9;
+		}
+	}
 }
 
 /* Some really rough font sizing */

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -169,7 +169,7 @@
 
 	&.has-text-color {
 		.entry-meta span:not(.avatar) {
-			opacity: 0.9;
+			opacity: 0.8;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a text colour picker to the Article Blocks; the purpose is to change the text to white or another light colour when the block is placed on something with a dark background, but it should allow you to change the text to any colour.

Note: For style packs that use the primary colour for the text in the header (Default, 3 and 4), if the primary colour in the theme is customized, it will override the block's setting in the editor.

It's more appropriate to fix this in the theme, so I'll tackle that in a separate PR. 

Closes #97.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`
2. Add an article block to a page, and switch it to a pre-defined colour from one of the first four spots (the primary and secondary colour); confirm it's applied.
3. Add a second block to the page, and pick a custom colour; confirm it's applied.
4. Save and publish; confirm the colours are applied on the front-end.
5. Navigate to Customize > Colours; switch the colour (primary or secondary) that you applied to the first block.
6. View that first block on the front-end and in the editor; confirm that the colour now used is your updated primary/secondary colour.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
