### PR TITLE
Article Blocks: Add additional font sizes

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -199,7 +199,7 @@ class Edit extends Component {
 						value={ typeScale }
 						onChange={ value => setAttributes( { typeScale: value } ) }
 						min={ 1 }
-						max={ 8 }
+						max={ 10 }
 						beforeIcon="editor-textcolor"
 						afterIcon="editor-textcolor"
 						required

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -169,9 +169,29 @@
 		}
 	}
 
-	&.type-scale8 article {
+	&.type-scale10 article {
 		.entry-title {
-			font-size: 2.2em;
+			font-size: 2.6em;
+		}
+		@include media(tablet) {
+			.entry-title {
+				font-size: 3.6em;
+			}
+			.avatar {
+				height: 2.4em;
+				width: 2.4em;
+			}
+		}
+		@include media(desktop) {
+			.entry-title {
+				font-size: 4.8em;
+			}
+		}
+	}
+
+	&.type-scale9 article {
+		.entry-title {
+			font-size: 2.4em;
 		}
 		@include media(tablet) {
 			.entry-title {
@@ -184,7 +204,27 @@
 		}
 		@include media(desktop) {
 			.entry-title {
-				font-size: 4em;
+				font-size: 4.4em;
+			}
+		}
+	}
+
+	&.type-scale8 article {
+		.entry-title {
+			font-size: 2.2em;
+		}
+		@include media(tablet) {
+			.entry-title {
+				font-size: 3.2em;
+			}
+			.avatar {
+				height: 2.4em;
+				width: 2.4em;
+			}
+		}
+		@include media(desktop) {
+			.entry-title {
+				font-size: 4.0em;
 			}
 		}
 	}
@@ -204,7 +244,7 @@
 		}
 		@include media(desktop) {
 			.entry-title {
-				font-size: 3.4em;
+				font-size: 3.6em;
 			}
 		}
 	}
@@ -240,6 +280,11 @@
 			.avatar {
 				height: 40px;
 				width: 40px;
+			}
+		}
+		@include media(desktop) {
+			.entry-title {
+				font-size: 2.4em;
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds two new font size options to the block, and adjusts the sizes throughout, to make them more consistently stepped, and have a more logical number of options (10 instead of 8).

Closes #113 .

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`
2. Copy-paste [this test content](https://cloudup.com/cyAELLSyDMb) into a post - it includes 10 blocks in ascending sizes.
3. Confirm that the blocks are visually different from one another, and seem like reasonable sizes, both on small screens and large screens.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
