### PR TITLE
Article Block: Increase spacing between articles on mobile

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -4,6 +4,7 @@
 .wp-block-newspack-blocks-homepage-articles {
 	article {
 		margin-bottom: 1.5em;
+		padding-bottom: 1.5em;
 		word-break: break-word;
 		overflow-wrap: break-word;
 	}
@@ -307,12 +308,8 @@
 	article {
 		border: solid rgba(0, 0, 0, 0.2);
 		border-width: 0 0 1px;
-		margin-bottom: 1em;
-		padding-bottom: 1em;
-
-		&:last-of-type {
-			border: 0;
-		}
+		margin-bottom: 2em;
+		padding-bottom: 2em;
 	}
 
 	@include media(tablet) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR increases the vertical space between the articles on mobile.

It also re-adds the bottom border on the last item; in isolation it makes sense, but when the blocks are stacked with other content, keeping the bottom border actually makes more sense. 

**Before:**

![image](https://user-images.githubusercontent.com/177561/65377365-c1075d80-dc5f-11e9-8c4e-c9ae53436f72.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/65377356-afbe5100-dc5f-11e9-8cd1-b9a2dc1a98ae.png)

Closes #112

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`
2. Add [this test content](https://cloudup.com/csBihgHGv1B) to a post to add the article block with or without borders, or build your own.
3. Shrink the browser window down to mobile size (note: there's an issue with the borders moving to the bottom before the columns are stacked; I'll tackle that in a seperate PR.
4. Confirm that the last item in the first block has a border.
5. Confirm that the vertical spacing is enough to visually separate the elements. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
