### PR TITLE
Standardize border styles in 'other' value input

### DIFF
--- a/src/blocks/donate/view.scss
+++ b/src/blocks/donate/view.scss
@@ -58,7 +58,6 @@ $primary_color: #2A7DE1;
 			position: absolute;
 			top: 10em;
 			left: 2em;
-			color: $muriel-gray-300;
 		}
 
 		input.other-input {
@@ -107,8 +106,14 @@ $primary_color: #2A7DE1;
 	position: relative;
 	max-width: 200px;
 	background-color: $muriel-white;
-	border: 2px solid $primary_color;
 	border-radius: 3px;
+	border: 1px solid $muriel-gray-200;
+
+	&:focus-within {
+		border-color: $muriel-gray-800;
+		outline: thin solid rgba( $muriel-gray-800, 0.15 );
+		outline-offset: -4px;
+	}
 
 	.currency {
 		font-size: 16px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes the default blue border from the 'Other' donation field.

It also adds a darker border when the field is in focus, and makes the 'Donation amount' text darker.

**Before:**

![image](https://user-images.githubusercontent.com/177561/65377590-eba6e580-dc62-11e9-8425-8e27304b0370.png)

**After**

![image](https://user-images.githubusercontent.com/177561/65377584-c7e39f80-dc62-11e9-8da1-3d1f4704a7a1.png)


Closes #111 


### How to test the changes in this Pull Request:

1. Add a donation block; note its appearance; click the 'Other' link to view the text input.
2. Apply the PR and run `npm run build:webpack`
3. Confirm that the blue border is no longer on the text input; focus on the input to confirm that it uses a darker grey.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
