### PR TITLE
Article block: Making sure showCaption is set to false by default everywhere.

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -211,7 +211,7 @@ function newspack_blocks_register_homepage_articles() {
 				),
 				'showCaption'   => array(
 					'type'    => 'boolean',
-					'default' => true,
+					'default' => false,
 				),
 				'showAuthor'    => array(
 					'type'    => 'boolean',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The 'Show Featured Image caption' option in the homepage block has mismatched default settings, so it always displays as 'on' on the front end, and can't be turned off there (it will preview as off in the editor)

This PR sets them both to 'off'.

### How to test the changes in this Pull Request:

1. Add an article block to a page; make sure at least one of the articles has a featured image with a caption.
2. View on front-end; note that the caption is visible.
3. Apply the PR and run `npm run build:webpack`.
4. Confirm that the caption is now hidden on the front end.
5. Turn the captions by turning on 'Show Featured Image Caption' in the editor.
6. Confirm that the captions correctly display when enabled. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
