### PR TITLE
Article Block: Add class when captions are enabled

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -299,6 +299,7 @@ class Edit extends Component {
 			typeScale,
 			imageScale,
 			sectionHeader,
+			showCaption,
 		} = attributes;
 
 		const classes = classNames( className, {
@@ -309,6 +310,7 @@ class Edit extends Component {
 			[ `image-align${ mediaPosition }` ]: showImage,
 			[ `image-scale${ imageScale }` ]: imageScale !== '1' && showImage,
 			'has-text-color': textColor,
+			'show-caption': showCaption,
 		} );
 
 		const blockControls = [

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -61,6 +61,9 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	if ( $attributes['showImage'] && isset( $attributes['imageScale'] ) ) {
 		$classes .= ' image-scale' . $attributes['imageScale'];
 	}
+	if ( $attributes['showCaption'] ) {
+		$classes .= ' show-caption';
+	}
 	if ( isset( $attributes['className'] ) ) {
 		$classes .= ' ' . $attributes['className'];
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a class to the article block when the captions are set to show; it can then be used to help iron out any styles that may need to be changed in this case (there are some visual issues with Style 3's title overlap when captions are enabled). 

Note: this is probably best to test after #125 is merged.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`
2. Add an article block to a post or page; turn on 'Show Featured Image Captions'
3. Make sure the class `show-caption` appears on the main article container in the editor.
4. Save and publish.
5. Make sure the class `show-caption` also appears on the front end.
6. Turn off 'Show Featured Image Captions' in the editor.
7. Confirm that the class `show-caption` no longer appears in the editor or front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
