### PR TITLE
Article Block: Make sure captions inherit custom text colour

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -163,7 +163,8 @@
 		.entry-meta,
 		.entry-meta a,
 		.entry-meta .byline a,
-		.entry-meta .byline a:visited {
+		.entry-meta .byline a:visited,
+		figcaption {
 			color: inherit;
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure the captions that can be shown in the Articles Block will inherit the custom text colours that you set.

### How to test the changes in this Pull Request:

1. Add an article block to a page; make sure at least one post has a featured image, and that featured image has a caption.
2. In the block settings, enable 'Show Featured Image Caption'
3. In the block settings, pick a custom colour.
4. Note that the caption is not using the colour, in the editor or on the front-end:

![image](https://user-images.githubusercontent.com/177561/65537974-2dca6400-debb-11e9-8835-8971b5f6e84a.png)

5. Apply the PR and run `npm run build:webpack`
6. Confirm that the caption text colour now matches your custom colour selection, in the editor and on the front-end:

![image](https://user-images.githubusercontent.com/177561/65538229-bd701280-debb-11e9-957d-58f2a1385434.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
