### PR TITLE
Fix article block tag API param

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -404,7 +404,7 @@ export default compose( [
 			per_page: 100,
 		};
 		const tagsListQuery = {
-			per_page: 1000,
+			per_page: 100,
 		};
 		const postsListQuery = {
 			per_page: 50,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR makes the `per_page` API param for the tags API call valid. Currently it always returns a 400 error, and no tags populate in the field:

<img width="622" alt="Screen Shot 2019-09-25 at 11 29 43 AM" src="https://user-images.githubusercontent.com/7317227/65629947-4739e180-df89-11e9-8cc0-04d84a1a9c9e.png">
<img width="576" alt="Screen Shot 2019-09-25 at 11 36 10 AM" src="https://user-images.githubusercontent.com/7317227/65629953-4bfe9580-df89-11e9-9ec1-578663989975.png">

This should solve the direct issue. However, virtually every site has >100 tags, so this isn't an ideal solution. I think an autocompleting remote search (e.g. https://select2.org/data-sources/ajax) is the best solution for the author/category/tag/etc. search in the block.

### How to test the changes in this Pull Request:

1. Attempt to filter an article block by a tag. Observe no tags are in the list.
2. Apply this PR.
3. Attempt to filter an article block by a tag. Observe it works correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
