### PR TITLE
Columns Style: Fix editor preview of column reordering

### DIFF
--- a/src/block-styles/core/columns/editor.scss
+++ b/src/block-styles/core/columns/editor.scss
@@ -1,7 +1,7 @@
 @import "../../../shared/sass/variables";
 @import "../../../shared/sass/mixins";
 
-.wp-block-columns {
+.wp-block .wp-block-columns {
 	@include media(mobile) {
 		&[class*='is-style-first-col-to'] [data-type="core/column"] {
 			margin-left: 46px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

There appears to have been a change in the core column block styles, so the editor preview of our 'reordering' block style was overlapping a bit.

This PR fixes that by making the selector a bit more specific.

### How to test the changes in this Pull Request:

1. Make sure you're running the latest version of the Gutenberg plugin.
2. Add a columns block to a page, and change the style to the 'Move first column to second' style.

![image](https://user-images.githubusercontent.com/177561/65650957-c21eee80-dfc1-11e9-9bf1-7a871ccff134.png)

3. Note the appearance in the editor -- the first and second columns should be kind of overlapping:

![image](https://user-images.githubusercontent.com/177561/65651149-6739c700-dfc2-11e9-8628-ff465f1613ce.png)

4. Apply the PR and run `npm run build:webpack`
5. Confirm that the issue is resolved.

![image](https://user-images.githubusercontent.com/177561/65651073-1de97780-dfc2-11e9-8acf-b65a40d06333.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
