### PR TITLE
Add custom 'columns' block to fix issue on tablet-sized screens

### DIFF
--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -7,7 +7,7 @@
  * Author URI:      YOUR SITE HERE
  * Text Domain:     newspack-blocks
  * Domain Path:     /languages
- * Version:         1.0.0-alpha.5
+ * Version:         1.0.0-alpha.6
  *
  * @package         Newspack_Blocks
  */

--- a/src/blocks/custom-column/edit.js
+++ b/src/blocks/custom-column/edit.js
@@ -1,0 +1,122 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { forEach, find, difference } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	InnerBlocks,
+	BlockControls,
+	BlockVerticalAlignmentToolbar,
+	InspectorControls,
+} from '@wordpress/block-editor';
+import { PanelBody, RangeControl } from '@wordpress/components';
+import { withDispatch, withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	toWidthPrecision,
+	getTotalColumnsWidth,
+	getColumnWidths,
+	getAdjacentBlocks,
+	getRedistributedColumnWidths,
+} from '../custom-columns/utils';
+
+function ColumnEdit( { attributes, className, updateAlignment, updateWidth, hasChildBlocks } ) {
+	const { verticalAlignment, width } = attributes;
+
+	const classes = classnames( className, 'custom-columns', {
+		[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
+	} );
+
+	return (
+		<div className={ classes }>
+			<BlockControls>
+				<BlockVerticalAlignmentToolbar onChange={ updateAlignment } value={ verticalAlignment } />
+			</BlockControls>
+			<InspectorControls>
+				<PanelBody title={ __( 'Column Settings' ) }>
+					<RangeControl
+						label={ __( 'Percentage width' ) }
+						value={ width || '' }
+						onChange={ updateWidth }
+						min={ 0 }
+						max={ 100 }
+						required
+						allowReset
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<InnerBlocks
+				templateLock={ false }
+				renderAppender={ hasChildBlocks ? undefined : () => <InnerBlocks.ButtonBlockAppender /> }
+			/>
+		</div>
+	);
+}
+
+export default compose(
+	withSelect( ( select, ownProps ) => {
+		const { clientId } = ownProps;
+		const { getBlockOrder } = select( 'core/block-editor' );
+
+		return {
+			hasChildBlocks: getBlockOrder( clientId ).length > 0,
+		};
+	} ),
+	withDispatch( ( dispatch, ownProps, registry ) => {
+		return {
+			updateAlignment( verticalAlignment ) {
+				const { clientId, setAttributes } = ownProps;
+				const { updateBlockAttributes } = dispatch( 'core/block-editor' );
+				const { getBlockRootClientId } = registry.select( 'core/block-editor' );
+
+				// Update own alignment.
+				setAttributes( { verticalAlignment } );
+
+				// Reset Parent Columns Block
+				const rootClientId = getBlockRootClientId( clientId );
+				updateBlockAttributes( rootClientId, { verticalAlignment: null } );
+			},
+			updateWidth( width ) {
+				const { clientId } = ownProps;
+				const { updateBlockAttributes } = dispatch( 'core/block-editor' );
+				const { getBlockRootClientId, getBlocks } = registry.select( 'core/block-editor' );
+
+				// Constrain or expand siblings to account for gain or loss of
+				// total columns area.
+				const columns = getBlocks( getBlockRootClientId( clientId ) );
+				const adjacentColumns = getAdjacentBlocks( columns, clientId );
+
+				// The occupied width is calculated as the sum of the new width
+				// and the total width of blocks _not_ in the adjacent set.
+				const occupiedWidth =
+					width +
+					getTotalColumnsWidth(
+						difference( columns, [ find( columns, { clientId } ), ...adjacentColumns ] )
+					);
+
+				// Compute _all_ next column widths, in case the updated column
+				// is in the middle of a set of columns which don't yet have
+				// any explicit widths assigned (include updates to those not
+				// part of the adjacent blocks).
+				const nextColumnWidths = {
+					...getColumnWidths( columns, columns.length ),
+					[ clientId ]: toWidthPrecision( width ),
+					...getRedistributedColumnWidths( adjacentColumns, 100 - occupiedWidth, columns.length ),
+				};
+
+				forEach( nextColumnWidths, ( nextColumnWidth, columnClientId ) => {
+					updateBlockAttributes( columnClientId, { width: nextColumnWidth } );
+				} );
+			},
+		};
+	} )
+)( ColumnEdit );

--- a/src/blocks/custom-column/editor.js
+++ b/src/blocks/custom-column/editor.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { name, settings } from '.';
+
+registerBlockType( `newspack-blocks/${ name }`, settings );

--- a/src/blocks/custom-column/icon.js
+++ b/src/blocks/custom-column/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16zm0-11.47L17.74 9 12 13.47 6.26 9 12 4.53z" /></SVG>
+);

--- a/src/blocks/custom-column/index.js
+++ b/src/blocks/custom-column/index.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import icon from './icon';
+import save from './save';
+
+export const name = 'custom-column';
+export const title = __( 'Newspack Custom Column' );
+
+export const settings = {
+	title,
+	parent: [ 'custom-columns' ],
+	icon,
+	description: __( 'A single column within a columns block.' ),
+	category: 'newspack',
+	supports: {
+		inserter: false,
+		reusable: false,
+		html: false,
+	},
+	attributes: {
+		verticalAlignment: {
+			type: 'string',
+		},
+		width: {
+			type: 'number',
+			min: 0,
+			max: 100,
+		},
+	},
+
+	edit,
+	save,
+};

--- a/src/blocks/custom-column/index.js
+++ b/src/blocks/custom-column/index.js
@@ -34,7 +34,16 @@ export const settings = {
 			max: 100,
 		},
 	},
-
+	getEditWrapperProps( attributes ) {
+		const { width } = attributes;
+		if ( Number.isFinite( width ) ) {
+			return {
+				style: {
+					flexBasis: 'calc(' + width + '% - 16px)',
+				},
+			};
+		}
+	},
 	edit,
 	save,
 };

--- a/src/blocks/custom-column/save.js
+++ b/src/blocks/custom-column/save.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function save( { attributes } ) {
+	const { verticalAlignment, width } = attributes;
+
+	const wrapperClasses = classnames( {
+		[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
+	} );
+
+	let style;
+	if ( Number.isFinite( width ) ) {
+		style = { flexBasis: width + '%' };
+	}
+
+	return (
+		<div className={ wrapperClasses } style={ style }>
+			<InnerBlocks.Content />
+		</div>
+	);
+}

--- a/src/blocks/custom-column/save.js
+++ b/src/blocks/custom-column/save.js
@@ -17,7 +17,7 @@ export default function save( { attributes } ) {
 
 	let style;
 	if ( Number.isFinite( width ) ) {
-		style = { flexBasis: width + '%' };
+		style = { flexBasis: 'calc(' + width + '% - 16px)' };
 	}
 
 	return (

--- a/src/blocks/custom-columns/edit.js
+++ b/src/blocks/custom-columns/edit.js
@@ -1,0 +1,292 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { dropRight, times } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { PanelBody, RangeControl, SVG, Path } from '@wordpress/components';
+import {
+	InspectorControls,
+	InnerBlocks,
+	BlockControls,
+	BlockVerticalAlignmentToolbar,
+} from '@wordpress/block-editor';
+import { withDispatch, useSelect } from '@wordpress/data';
+import { createBlock } from '@wordpress/blocks';
+import { useState, useEffect, Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getColumnsTemplate,
+	hasExplicitColumnWidths,
+	getMappedColumnWidths,
+	getRedistributedColumnWidths,
+	toWidthPrecision,
+} from './utils';
+
+/**
+ * Allowed blocks constant is passed to InnerBlocks precisely as specified here.
+ * The contents of the array should never change.
+ * The array should contain the name of each block that is allowed.
+ * In columns block, the only block we allow is 'newspack/custom-column'.
+ *
+ * @constant
+ * @type {string[]}
+ */
+const ALLOWED_BLOCKS = [ 'newspack-blocks/custom-column' ];
+
+/**
+ * Template option choices for predefined columns layouts.
+ *
+ * @constant
+ * @type {Array}
+ */
+const TEMPLATE_OPTIONS = [
+	{
+		title: __( 'Two columns; equal split' ),
+		icon: (
+			<SVG width="48" height="48" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+				<Path
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M39 12C40.1046 12 41 12.8954 41 14V34C41 35.1046 40.1046 36 39 36H9C7.89543 36 7 35.1046 7 34V14C7 12.8954 7.89543 12 9 12H39ZM39 34V14H25V34H39ZM23 34H9V14H23V34Z"
+				/>
+			</SVG>
+		),
+		template: [ [ 'newspack-blocks/custom-column' ], [ 'newspack-blocks/custom-column' ] ],
+	},
+	{
+		title: __( 'Two columns; one-third, two-thirds split' ),
+		icon: (
+			<SVG width="48" height="48" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+				<Path
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M39 12C40.1046 12 41 12.8954 41 14V34C41 35.1046 40.1046 36 39 36H9C7.89543 36 7 35.1046 7 34V14C7 12.8954 7.89543 12 9 12H39ZM39 34V14H20V34H39ZM18 34H9V14H18V34Z"
+				/>
+			</SVG>
+		),
+		template: [
+			[ 'newspack-blocks/custom-column', { width: 33.33 } ],
+			[ 'newspack-blocks/custom-column', { width: 66.66 } ],
+		],
+	},
+	{
+		title: __( 'Two columns; two-thirds, one-third split' ),
+		icon: (
+			<SVG width="48" height="48" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+				<Path
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M39 12C40.1046 12 41 12.8954 41 14V34C41 35.1046 40.1046 36 39 36H9C7.89543 36 7 35.1046 7 34V14C7 12.8954 7.89543 12 9 12H39ZM39 34V14H30V34H39ZM28 34H9V14H28V34Z"
+				/>
+			</SVG>
+		),
+		template: [
+			[ 'newspack-blocks/custom-column', { width: 66.66 } ],
+			[ 'newspack-blocks/custom-column', { width: 33.33 } ],
+		],
+	},
+	{
+		title: __( 'Three columns; equal split' ),
+		icon: (
+			<SVG width="48" height="48" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+				<Path
+					fillRule="evenodd"
+					d="M41 14a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h30a2 2 0 0 0 2-2V14zM28.5 34h-9V14h9v20zm2 0V14H39v20h-8.5zm-13 0H9V14h8.5v20z"
+				/>
+			</SVG>
+		),
+		template: [
+			[ 'newspack-blocks/custom-column' ],
+			[ 'newspack-blocks/custom-column' ],
+			[ 'newspack-blocks/custom-column' ],
+		],
+	},
+	{
+		title: __( 'Three columns; wide center column' ),
+		icon: (
+			<SVG width="48" height="48" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+				<Path
+					fillRule="evenodd"
+					d="M41 14a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h30a2 2 0 0 0 2-2V14zM31 34H17V14h14v20zm2 0V14h6v20h-6zm-18 0H9V14h6v20z"
+				/>
+			</SVG>
+		),
+		template: [
+			[ 'newspack-blocks/custom-column', { width: 25 } ],
+			[ 'newspack-blocks/custom-column', { width: 50 } ],
+			[ 'newspack-blocks/custom-column', { width: 25 } ],
+		],
+	},
+];
+
+/**
+ * Number of columns to assume for template in case the user opts to skip
+ * template option selection.
+ *
+ * @type {number}
+ */
+const DEFAULT_COLUMNS = 2;
+
+export function ColumnsEdit( { attributes, className, updateAlignment, updateColumns, clientId } ) {
+	const { verticalAlignment } = attributes;
+
+	const { count } = useSelect( select => {
+		return {
+			count: select( 'core/block-editor' ).getBlockCount( clientId ),
+		};
+	} );
+	const [ template, setTemplate ] = useState( getColumnsTemplate( count ) );
+	const [ forceUseTemplate, setForceUseTemplate ] = useState( false );
+
+	// This is used to force the usage of the template even if the count doesn't match the template
+	// The count doesn't match the template once you use undo/redo (this is used to reset to the placeholder state).
+	useEffect(() => {
+		// Once the template is applied, reset it.
+		if ( forceUseTemplate ) {
+			setForceUseTemplate( false );
+		}
+	}, [ forceUseTemplate ]);
+
+	const classes = classnames( className, {
+		[ `are-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
+	} );
+
+	// The template selector is shown when we first insert the columns block (count === 0).
+	// or if there's no template available.
+	// The count === 0 trick is useful when you use undo/redo.
+	const showTemplateSelector = ( count === 0 && ! forceUseTemplate ) || ! template;
+
+	return (
+		<Fragment>
+			{ ! showTemplateSelector && (
+				<Fragment>
+					<InspectorControls>
+						<PanelBody>
+							<RangeControl
+								label={ __( 'Columns' ) }
+								value={ count }
+								onChange={ value => updateColumns( count, value ) }
+								min={ 2 }
+								max={ 6 }
+							/>
+						</PanelBody>
+					</InspectorControls>
+					<BlockControls>
+						<BlockVerticalAlignmentToolbar
+							onChange={ updateAlignment }
+							value={ verticalAlignment }
+						/>
+					</BlockControls>
+				</Fragment>
+			) }
+			<div className={ classes }>
+				<InnerBlocks
+					__experimentalTemplateOptions={ TEMPLATE_OPTIONS }
+					__experimentalOnSelectTemplateOption={ nextTemplate => {
+						if ( nextTemplate === undefined ) {
+							nextTemplate = getColumnsTemplate( DEFAULT_COLUMNS );
+						}
+
+						setTemplate( nextTemplate );
+						setForceUseTemplate( true );
+					} }
+					__experimentalAllowTemplateOptionSkip
+					template={ showTemplateSelector ? null : template }
+					templateLock="all"
+					allowedBlocks={ ALLOWED_BLOCKS }
+				/>
+			</div>
+		</Fragment>
+	);
+}
+
+export default withDispatch( ( dispatch, ownProps, registry ) => ( {
+	/**
+	 * Update all child Column blocks with a new vertical alignment setting
+	 * based on whatever alignment is passed in. This allows change to parent
+	 * to overide anything set on a individual column basis.
+	 *
+	 * @param {string} verticalAlignment the vertical alignment setting
+	 */
+	updateAlignment( verticalAlignment ) {
+		const { clientId, setAttributes } = ownProps;
+		const { updateBlockAttributes } = dispatch( 'core/block-editor' );
+		const { getBlockOrder } = registry.select( 'core/block-editor' );
+
+		// Update own alignment.
+		setAttributes( { verticalAlignment } );
+
+		// Update all child Column Blocks to match
+		const innerBlockClientIds = getBlockOrder( clientId );
+		innerBlockClientIds.forEach( innerBlockClientId => {
+			updateBlockAttributes( innerBlockClientId, {
+				verticalAlignment,
+			} );
+		} );
+	},
+
+	/**
+	 * Updates the column count, including necessary revisions to child Column
+	 * blocks to grant required or redistribute available space.
+	 *
+	 * @param {number} previousColumns Previous column count.
+	 * @param {number} newColumns      New column count.
+	 */
+	updateColumns( previousColumns, newColumns ) {
+		const { clientId } = ownProps;
+		const { replaceInnerBlocks } = dispatch( 'core/block-editor' );
+		const { getBlocks } = registry.select( 'core/block-editor' );
+
+		let innerBlocks = getBlocks( clientId );
+		const hasExplicitWidths = hasExplicitColumnWidths( innerBlocks );
+
+		// Redistribute available width for existing inner blocks.
+		const isAddingColumn = newColumns > previousColumns;
+
+		if ( isAddingColumn && hasExplicitWidths ) {
+			// If adding a new column, assign width to the new column equal to
+			// as if it were `1 / columns` of the total available space.
+			const newColumnWidth = toWidthPrecision( 100 / newColumns );
+
+			// Redistribute in consideration of pending block insertion as
+			// constraining the available working width.
+			const widths = getRedistributedColumnWidths( innerBlocks, 100 - newColumnWidth );
+
+			innerBlocks = [
+				...getMappedColumnWidths( innerBlocks, widths ),
+				...times( newColumns - previousColumns, () => {
+					return createBlock( 'newspack-blocks/custom-column', {
+						width: newColumnWidth,
+					} );
+				} ),
+			];
+		} else if ( isAddingColumn ) {
+			innerBlocks = [
+				...innerBlocks,
+				...times( newColumns - previousColumns, () => {
+					return createBlock( 'newspack-blocks/custom-column' );
+				} ),
+			];
+		} else {
+			// The removed column will be the last of the inner blocks.
+			innerBlocks = dropRight( innerBlocks, previousColumns - newColumns );
+
+			if ( hasExplicitWidths ) {
+				// Redistribute as if block is already removed.
+				const widths = getRedistributedColumnWidths( innerBlocks, 100 );
+
+				innerBlocks = getMappedColumnWidths( innerBlocks, widths );
+			}
+		}
+
+		replaceInnerBlocks( clientId, innerBlocks, false );
+	},
+} ) )( ColumnsEdit );

--- a/src/blocks/custom-columns/edit.js
+++ b/src/blocks/custom-columns/edit.js
@@ -263,7 +263,7 @@ export default withDispatch( ( dispatch, ownProps, registry ) => ( {
 			innerBlocks = [
 				...getMappedColumnWidths( innerBlocks, widths ),
 				...times( newColumns - previousColumns, () => {
-					return createBlock( 'newspack-blocks/custom-column', {
+					return createBlock( 'custom-column', {
 						width: newColumnWidth,
 					} );
 				} ),
@@ -272,7 +272,7 @@ export default withDispatch( ( dispatch, ownProps, registry ) => ( {
 			innerBlocks = [
 				...innerBlocks,
 				...times( newColumns - previousColumns, () => {
-					return createBlock( 'newspack-blocks/custom-column' );
+					return createBlock( 'custom-column' );
 				} ),
 			];
 		} else {

--- a/src/blocks/custom-columns/edit.js
+++ b/src/blocks/custom-columns/edit.js
@@ -263,7 +263,7 @@ export default withDispatch( ( dispatch, ownProps, registry ) => ( {
 			innerBlocks = [
 				...getMappedColumnWidths( innerBlocks, widths ),
 				...times( newColumns - previousColumns, () => {
-					return createBlock( 'custom-column', {
+					return createBlock( 'newspack-blocks/custom-column', {
 						width: newColumnWidth,
 					} );
 				} ),
@@ -272,7 +272,7 @@ export default withDispatch( ( dispatch, ownProps, registry ) => ( {
 			innerBlocks = [
 				...innerBlocks,
 				...times( newColumns - previousColumns, () => {
-					return createBlock( 'custom-column' );
+					return createBlock( 'newspack-blocks/custom-column' );
 				} ),
 			];
 		} else {

--- a/src/blocks/custom-columns/editor.js
+++ b/src/blocks/custom-columns/editor.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { name, settings } from '.';
+
+registerBlockType( `newspack-blocks/${ name }`, settings );

--- a/src/blocks/custom-columns/editor.scss
+++ b/src/blocks/custom-columns/editor.scss
@@ -1,0 +1,195 @@
+@import "../../shared/sass/variables";
+@import "../../shared/sass/mixins";
+
+// These margins make sure that nested blocks stack/overlay with the parent block chrome
+// This is sort of an experiment at making sure the editor looks as much like the end result as possible
+// Potentially the rules here can apply to all nested blocks and enable stacking, in which case it should be moved elsewhere
+// When using CSS grid, margins do not collapse on the container.
+.wp-block-newspack-blocks-custom-columns .editor-block-list__layout {
+	margin-left: 0;
+	margin-right: 0;
+
+	// This max-width is used to constrain the main editor column, it should not cascade into columns
+	.editor-block-list__block {
+		max-width: none;
+	}
+}
+
+// Fullwide: show margin left/right to ensure there's room for the side UI.
+// This is not a 1:1 preview with the front-end where these margins would presumably be zero.
+[data-type="newspack-blocks/custom-columns"][data-align="full"] .wp-block-newspack-blocks-custom-columns > .editor-inner-blocks {
+	padding-left: $block-padding;
+	padding-right: $block-padding;
+
+	@include break-small() {
+		padding-left: $block-container-side-padding;
+		padding-right: $block-container-side-padding;
+	}
+}
+
+.wp-block-newspack-blocks-custom-columns {
+	display: block;
+
+	> .editor-inner-blocks > .editor-block-list__layout {
+		display: flex;
+
+		// Responsiveness: Allow wrapping on mobile.
+		flex-wrap: wrap;
+
+		@include break-medium() {
+			flex-wrap: nowrap;
+		}
+		// Set full heights on Columns to enable vertical alignment preview
+		> [data-type="newspack-blocks/custom-column"],
+		> [data-type="newspack-blocks/custom-column"] > .editor-block-list__block-edit,
+		> [data-type="newspack-blocks/custom-column"] > .editor-block-list__block-edit > div[data-block],
+		> [data-type="newspack-blocks/custom-column"] > .editor-block-list__block-edit .block-custom-columns {
+			@include flex-full-height();
+		}
+		// Adjust the individual column block.
+		> [data-type="newspack-blocks/custom-column"] {
+
+			// On mobile, only a single column is shown, so match adjacent block paddings.
+			padding-left: 0;
+			padding-right: 0;
+			margin-left: -$block-padding;
+			margin-right: -$block-padding;
+
+			// Prevent the columns from growing wider than their distributed sizes.
+			min-width: 0;
+
+			// Prevent long unbroken words from overflowing.
+			word-break: break-word; // For back-compat.
+			overflow-wrap: break-word; // New standard.
+
+			// Responsiveness: Show at most one columns on mobile.
+			flex-basis: 100%;
+
+			// Beyond mobile, allow 2 columns.
+			@include break-small() {
+				flex-basis: calc(50% - (#{$grid-size-large} + #{$block-padding * 2}));
+				flex-grow: 0;
+				margin-left: $block-padding;
+				margin-right: $block-padding;
+			}
+
+			// Add space between columns. Themes can customize this if they wish to work differently.
+			// This has to match the same padding applied in style.scss.
+			// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
+			@include break-small() {
+				&:nth-child(even) {
+					margin-left: calc(#{$grid-size-large * 2} + #{$block-padding});
+				}
+			}
+
+			// When columns are in a single row, add space before all except the first.
+			@include break-medium() {
+				&:not(:first-child) {
+					margin-left: calc(#{$grid-size-large * 2} + #{$block-padding});
+				}
+			}
+
+			> .editor-block-list__block-edit {
+				margin-top: 0;
+				margin-bottom: 0;
+
+				// Remove Block "padding" so individual Column is flush with parent Columns
+				&::before {
+					left: 0;
+					right: 0;
+				}
+
+				> .editor-block-contextual-toolbar {
+					margin-left: -$border-width;
+				}
+
+				// Zero out margins.
+				> [data-block] {
+					margin-top: 0;
+					margin-bottom: 0;
+				}
+
+				// The Columns block is a flex-container, therefore it nullifies margin collapsing.
+				// Therefore, blocks inside this will appear to create a double margin.
+				// We compensate for this using negative margins.
+				> div > .wp-block-newspack-blocks-custom-columns > .editor-inner-blocks {
+					margin-top: -$default-block-margin;
+					margin-bottom: -$default-block-margin;
+				}
+			}
+		}
+	}
+}
+
+/**
+ * Columns act as as a "passthrough container"
+ * and therefore has its vertical margins/padding removed via negative margins
+ * therefore we need to compensate for this here by doubling the spacing on the
+ * vertical to ensure there is equal visual spacing around the inserter. Note there
+ * is no formal API for a "passthrough" Block so this is an edge case overide
+ */
+[data-type="newspack-blocks/custom-columns"] {
+
+	.block-list-appender {
+		margin-top: $block-padding*2;
+		margin-bottom: $block-padding*2;
+	}
+
+	// When the individual column block is selected, the nested padding overrules
+	// some of this margin. We need to adjust the appender spacing again as a result.
+	[data-type="newspack-blocks/custom-column"].is-selected .block-list-appender {
+		margin: $block-padding 0;
+	}
+}
+
+/**
+ * Vertical Alignment Preview
+ * note: specificity is important here to ensure individual
+ * * columns alignment is prioritised over parent column alignment
+ *
+ */
+.are-vertically-aligned-top .block-custom-columns,
+div.wp-block-newspack-blocks-custom-columns.is-vertically-aligned-top {
+	justify-content: flex-start;
+}
+
+.are-vertically-aligned-center .block-custom-columns,
+div.wp-block-newspack-blocks-custom-columns.is-vertically-aligned-center {
+	justify-content: center;
+}
+
+.are-vertically-aligned-bottom .block-custom-columns,
+div.wp-block-newspack-blocks-custom-columns.is-vertically-aligned-bottom {
+	justify-content: flex-end;
+}
+
+/**
+ * Fixes single Column breadcrumb position.
+ */
+[data-type="newspack-blocks/custom-column"] > .editor-block-list__block-edit > .editor-block-list__breadcrumb {
+	left: -$block-left-border-width;
+}
+
+/**
+ * Make single Column overlay not extend past boundaries of parent
+ */
+.wp-block-newspack-blocks-custom-columns > .block-editor-inner-blocks.has-overlay::after {
+	left: 0;
+	right: 0;
+}
+
+/**
+ * Add extra padding when the parent block is selected, for easier interaction.
+ */
+.block-editor-block-list__layout .block-editor-block-list__block[data-type="newspack-blocks/custom-columns"].is-selected > .block-editor-block-list__block-edit > [data-block] > div > .block-editor-inner-blocks,
+.block-editor-block-list__layout .block-editor-block-list__block[data-type="newspack-blocks/custom-columns"].has-child-selected > .block-editor-block-list__block-edit > [data-block] > div > .block-editor-inner-blocks,
+.block-editor-block-list__layout .block-editor-block-list__block[data-type="newspack-blocks/custom-column"].is-selected > .block-editor-block-list__block-edit > [data-block] > div > .block-editor-inner-blocks,
+.block-editor-block-list__layout .block-editor-block-list__block[data-type="newspack-blocks/custom-column"].has-child-selected > .block-editor-block-list__block-edit > [data-block] > div > .block-editor-inner-blocks {
+	padding: $block-padding;
+
+	// Negate this padding for the placeholder.
+	> .components-placeholder {
+		margin: -$block-padding;
+		width: calc(100% + #{$block-padding * 2});
+	}
+}

--- a/src/blocks/custom-columns/editor.scss
+++ b/src/blocks/custom-columns/editor.scss
@@ -5,7 +5,7 @@
 // This is sort of an experiment at making sure the editor looks as much like the end result as possible
 // Potentially the rules here can apply to all nested blocks and enable stacking, in which case it should be moved elsewhere
 // When using CSS grid, margins do not collapse on the container.
-.wp-block-newspack-blocks-custom-columns .editor-block-list__layout {
+[data-type="newspack-blocks/custom-columns"] .wp-block-newspack-blocks-custom-columns .editor-block-list__layout {
 	margin-left: 0;
 	margin-right: 0;
 
@@ -27,7 +27,7 @@
 	}
 }
 
-.wp-block-newspack-blocks-custom-columns {
+[data-type="newspack-blocks/custom-columns"] .wp-block-newspack-blocks-custom-columns {
 	display: block;
 
 	> .editor-inner-blocks > .editor-block-list__layout {

--- a/src/blocks/custom-columns/editor.scss
+++ b/src/blocks/custom-columns/editor.scss
@@ -5,7 +5,7 @@
 // This is sort of an experiment at making sure the editor looks as much like the end result as possible
 // Potentially the rules here can apply to all nested blocks and enable stacking, in which case it should be moved elsewhere
 // When using CSS grid, margins do not collapse on the container.
-[data-type="newspack-blocks/custom-columns"] .wp-block-newspack-blocks-custom-columns .editor-block-list__layout {
+.wp-block-newspack-blocks-custom-columns .editor-block-list__layout {
 	margin-left: 0;
 	margin-right: 0;
 
@@ -17,7 +17,7 @@
 
 // Fullwide: show margin left/right to ensure there's room for the side UI.
 // This is not a 1:1 preview with the front-end where these margins would presumably be zero.
-[data-type="newspack-blocks/custom-columns"][data-align="full"] .wp-block-newspack-blocks-custom-columns > .editor-inner-blocks {
+[data-align="full"] .wp-block-newspack-blocks-custom-columns > .editor-inner-blocks {
 	padding-left: $block-padding;
 	padding-right: $block-padding;
 
@@ -27,7 +27,7 @@
 	}
 }
 
-[data-type="newspack-blocks/custom-columns"] .wp-block-newspack-blocks-custom-columns {
+.wp-block-newspack-blocks-custom-columns {
 	display: block;
 
 	> .editor-inner-blocks > .editor-block-list__layout {

--- a/src/blocks/custom-columns/icon.js
+++ b/src/blocks/custom-columns/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { G, Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M4,4H20a2,2,0,0,1,2,2V18a2,2,0,0,1-2,2H4a2,2,0,0,1-2-2V6A2,2,0,0,1,4,4ZM4 6V18H8V6Zm6 0V18h4V6Zm6 0V18h4V6Z" /></G></SVG>
+);

--- a/src/blocks/custom-columns/index.js
+++ b/src/blocks/custom-columns/index.js
@@ -14,7 +14,6 @@ import save from './save';
  * Style dependencies - will load in editor
  */
 import './editor.scss';
-import './view.scss';
 
 export const name = 'custom-columns';
 export const title = __( 'Newspack Custom Columns' );

--- a/src/blocks/custom-columns/index.js
+++ b/src/blocks/custom-columns/index.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import icon from './icon';
+import save from './save';
+
+/**
+ * Style dependencies - will load in editor
+ */
+import './editor.scss';
+import './view.scss';
+
+export const name = 'custom-columns';
+export const title = __( 'Newspack Custom Columns' );
+
+export const settings = {
+	title,
+	icon,
+	description: __(
+		'Add a block that displays content in multiple columns, then add whatever content blocks you’d like.'
+	),
+	supports: {
+		align: [ 'wide', 'full' ],
+		html: false,
+	},
+	category: 'newspack',
+	attributes: {
+		verticalAlignment: {
+			type: 'string',
+		},
+	},
+	edit,
+	save,
+};

--- a/src/blocks/custom-columns/save.js
+++ b/src/blocks/custom-columns/save.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function save( { attributes } ) {
+	const { verticalAlignment } = attributes;
+
+	const wrapperClasses = classnames( {
+		[ `are-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
+	} );
+
+	return (
+		<div className={ wrapperClasses }>
+			<InnerBlocks.Content />
+		</div>
+	);
+}

--- a/src/blocks/custom-columns/utils.js
+++ b/src/blocks/custom-columns/utils.js
@@ -1,0 +1,149 @@
+/**
+ * External dependencies
+ */
+import memoize from 'memize';
+import { times, findIndex, sumBy, merge, mapValues } from 'lodash';
+
+/**
+ * Returns the layouts configuration for a given number of columns.
+ *
+ * @param {number} columns Number of columns.
+ *
+ * @return {Object[]} Columns layout configuration.
+ */
+export const getColumnsTemplate = memoize( columns => {
+	if ( columns === undefined ) {
+		return null;
+	}
+
+	return times( columns, () => [ 'newspack-blocks/custom-column' ] );
+} );
+
+/**
+ * Returns a column width attribute value rounded to standard precision.
+ * Returns `undefined` if the value is not a valid finite number.
+ *
+ * @param {?number} value Raw value.
+ *
+ * @return {number} Value rounded to standard precision.
+ */
+export const toWidthPrecision = value =>
+	Number.isFinite( value ) ? parseFloat( value.toFixed( 2 ) ) : undefined;
+
+/**
+ * Returns the considered adjacent to that of the specified `clientId` for
+ * resizing consideration. Adjacent blocks are those occurring after, except
+ * when the given block is the last block in the set. For the last block, the
+ * behavior is reversed.
+ *
+ * @param {WPBlock[]} blocks   Block objects.
+ * @param {string}    clientId Client ID to consider for adjacent blocks.
+ *
+ * @return {WPBlock[]} Adjacent block objects.
+ */
+export function getAdjacentBlocks( blocks, clientId ) {
+	const index = findIndex( blocks, { clientId } );
+	const isLastBlock = index === blocks.length - 1;
+
+	return isLastBlock ? blocks.slice( 0, index ) : blocks.slice( index + 1 );
+}
+
+/**
+ * Returns an effective width for a given block. An effective width is equal to
+ * its attribute value if set, or a computed value assuming equal distribution.
+ *
+ * @param {WPBlock} block           Block object.
+ * @param {number}  totalBlockCount Total number of blocks in Columns.
+ *
+ * @return {number} Effective column width.
+ */
+export function getEffectiveColumnWidth( block, totalBlockCount ) {
+	const { width = 100 / totalBlockCount } = block.attributes;
+	return toWidthPrecision( width );
+}
+
+/**
+ * Returns the total width occupied by the given set of column blocks.
+ *
+ * @param {WPBlock[]} blocks          Block objects.
+ * @param {?number}   totalBlockCount Total number of blocks in Columns.
+ *                                    Defaults to number of blocks passed.
+ *
+ * @return {number} Total width occupied by blocks.
+ */
+export function getTotalColumnsWidth( blocks, totalBlockCount = blocks.length ) {
+	return sumBy( blocks, block => getEffectiveColumnWidth( block, totalBlockCount ) );
+}
+
+/**
+ * Returns an object of `clientId` → `width` of effective column widths.
+ *
+ * @param {WPBlock[]} blocks          Block objects.
+ * @param {?number}   totalBlockCount Total number of blocks in Columns.
+ *                                    Defaults to number of blocks passed.
+ *
+ * @return {Object<string,number>} Column widths.
+ */
+export function getColumnWidths( blocks, totalBlockCount = blocks.length ) {
+	return blocks.reduce( ( result, block ) => {
+		const width = getEffectiveColumnWidth( block, totalBlockCount );
+		return Object.assign( result, { [ block.clientId ]: width } );
+	}, {} );
+}
+
+/**
+ * Returns an object of `clientId` → `width` of column widths as redistributed
+ * proportional to their current widths, constrained or expanded to fit within
+ * the given available width.
+ *
+ * @param {WPBlock[]} blocks          Block objects.
+ * @param {number}    availableWidth  Maximum width to fit within.
+ * @param {?number}   totalBlockCount Total number of blocks in Columns.
+ *                                    Defaults to number of blocks passed.
+ *
+ * @return {Object<string,number>} Redistributed column widths.
+ */
+export function getRedistributedColumnWidths(
+	blocks,
+	availableWidth,
+	totalBlockCount = blocks.length
+) {
+	const totalWidth = getTotalColumnsWidth( blocks, totalBlockCount );
+	const difference = availableWidth - totalWidth;
+	const adjustment = difference / blocks.length;
+
+	return mapValues( getColumnWidths( blocks, totalBlockCount ), width =>
+		toWidthPrecision( width + adjustment )
+	);
+}
+
+/**
+ * Returns true if column blocks within the provided set are assigned with
+ * explicit widths, or false otherwise.
+ *
+ * @param {WPBlock[]} blocks Block objects.
+ *
+ * @return {boolean} Whether columns have explicit widths.
+ */
+export function hasExplicitColumnWidths( blocks ) {
+	return blocks.some( block => Number.isFinite( block.attributes.width ) );
+}
+
+/**
+ * Returns a copy of the given set of blocks with new widths assigned from the
+ * provided object of redistributed column widths.
+ *
+ * @param {WPBlock[]}             blocks Block objects.
+ * @param {Object<string,number>} widths Redistributed column widths.
+ *
+ * @return {WPBlock[]} blocks Mapped block objects.
+ */
+export function getMappedColumnWidths( blocks, widths ) {
+	return blocks.map( block =>
+		merge( {}, block, {
+			attributes: {
+				width: widths[ block.clientId ],
+			},
+		} )
+	);
+}

--- a/src/blocks/custom-columns/view.js
+++ b/src/blocks/custom-columns/view.js
@@ -1,0 +1,1 @@
+import './view.scss';

--- a/src/blocks/custom-columns/view.scss
+++ b/src/blocks/custom-columns/view.scss
@@ -1,0 +1,87 @@
+@import "../../shared/sass/variables";
+@import "../../shared/sass/mixins";
+
+.wp-block-newspack-blocks-custom-columns {
+	display: flex;
+	margin-bottom: $default-block-margin;
+
+	// Responsiveness: Allow wrapping on mobile.
+	flex-wrap: wrap;
+
+	@include break-medium() {
+		flex-wrap: nowrap;
+	}
+}
+
+.wp-block-newspack-blocks-custom-column {
+	margin-bottom: 1em;
+	flex-grow: 1;
+
+	@media (max-width: #{ ($break-small - 1) }) {
+		// Responsiveness: Show at most one columns on mobile. This must be
+		// important since the Column assigns its own width as an inline style.
+		flex-basis: 100% !important;
+	}
+
+	// Prevent the columns from growing wider than their distributed sizes.
+	min-width: 0;
+
+	// Prevent long unbroken words from overflowing.
+	word-break: break-word; // For back-compat.
+	overflow-wrap: break-word; // New standard.
+
+	@include break-small() {
+
+		// Beyond mobile, allow 2 columns.
+		flex-basis: calc(50% - #{$grid-size-large});
+		flex-grow: 0;
+
+		// Add space between the multiple columns. Themes can customize this if they wish to work differently.
+		// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
+		&:nth-child(even) {
+			margin-left: $grid-size-large * 2;
+		}
+	}
+
+	@include break-medium() {
+
+		// When columns are in a single row, add space before all except the first.
+		&:not(:first-child) {
+			margin-left: $grid-size-large * 2;
+		}
+	}
+}
+
+/**
+ * All Columns Alignment
+ */
+.wp-block-newspack-blocks-custom-columns {
+	&.are-vertically-aligned-top {
+		align-items: flex-start;
+	}
+
+	&.are-vertically-aligned-center {
+		align-items: center;
+	}
+
+	&.are-vertically-aligned-bottom {
+		align-items: flex-end;
+	}
+}
+
+/**
+ * Individual Column Alignment
+ */
+.wp-block-newspack-blocks-custom-column {
+	&.is-vertically-aligned-top {
+		align-self: flex-start;
+	}
+
+	&.is-vertically-aligned-center {
+		align-self: center;
+	}
+
+	&.is-vertically-aligned-bottom {
+		align-self: flex-end;
+	}
+}

--- a/src/shared/sass/_mixins.scss
+++ b/src/shared/sass/_mixins.scss
@@ -24,3 +24,23 @@
 		}
 	}
 }
+
+// Mixins copied over from Gutenberg.
+@mixin break-small() {
+	@media (min-width: #{ ($break-small) }) {
+		@content;
+	}
+}
+
+@mixin break-medium() {
+	@media (min-width: #{ ($break-medium) }) {
+		@content;
+	}
+}
+
+
+@mixin flex-full-height() {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+}

--- a/src/shared/sass/_variables.scss
+++ b/src/shared/sass/_variables.scss
@@ -25,3 +25,18 @@ $font__line-height-heading: 1.2;
 $font__line-height-double: 2 * $font__line-height-heading;
 
 $color__border: #ccc;
+
+// Variables copied over from Gutenberg.
+
+$break-small: 600px;
+$break-medium: 782px;	// adminbar goes big
+
+$grid-size-large: 16px;
+$border-width: 1px;
+
+$block-padding: 14px; // Space between block footprint and focus boundaries. These are drawn outside the block footprint, and do not affect the size.
+$block-side-ui-width: 28px; // Width of the movers/drag handle UI.
+$block-side-ui-clearance: 2px; // Space between movers/drag handle UI, and block.
+$block-container-side-padding: $block-side-ui-width + $block-padding + 2 * $block-side-ui-clearance;
+$block-left-border-width: $border-width * 3;
+$default-block-margin: 28px; // This value provides a consistent, contiguous spacing between blocks (it's 2x $block-padding).


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR temporarily adds a copy of the Core Columns block, but with a wrapping issue fixed. It makes sure columns don't prematurely wrap on tablet-sized screens.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`
2. Confirm that you have a new block, Newspack Custom Columns.
3. Add the block to the editor; test out a variety of settings (column count, column width), and make sure they work as expected in the editor and on the front-end.
4. Create a block with uneven columns (one of the pre-defined ones will work fine, like the one that's two columns, 2/3 and 1/3 wide. Add a group block to each column and give it a background colour for easier testing.
5. On the front end, shrink down the browser window to less than 760px wide; confirm that the columns do not wrap.
6. Shrink down the browser window to less than 600px wide; confirm the columns do wrap. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?