### PR TITLE
Reduce size of smallest type scale options

### DIFF
--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -7,7 +7,7 @@
  * Author URI:      YOUR SITE HERE
  * Text Domain:     newspack-blocks
  * Domain Path:     /languages
- * Version:         1.0.0-alpha.5
+ * Version:         1.0.0-alpha.6
  *
  * @package         Newspack_Blocks
  */

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -198,6 +198,18 @@
 		}
 	}
 
+	&.type-scale10,
+	&.type-scale9,
+	&.type-scale8 {
+		@include media(tablet) {
+			article .avatar {
+				height: 2.4em;
+				width: 2.4em;
+			}
+		}
+
+	}
+
 	&.type-scale10 article {
 		.entry-title {
 			font-size: 2.6em;
@@ -205,10 +217,6 @@
 		@include media(tablet) {
 			.entry-title {
 				font-size: 3.6em;
-			}
-			.avatar {
-				height: 2.4em;
-				width: 2.4em;
 			}
 		}
 		@include media(desktop) {
@@ -226,14 +234,10 @@
 			.entry-title {
 				font-size: 3.4em;
 			}
-			.avatar {
-				height: 2.4em;
-				width: 2.4em;
-			}
 		}
 		@include media(desktop) {
 			.entry-title {
-				font-size: 4.4em;
+				font-size: 4.2em;
 			}
 		}
 	}
@@ -244,16 +248,12 @@
 		}
 		@include media(tablet) {
 			.entry-title {
-				font-size: 3.2em;
-			}
-			.avatar {
-				height: 2.4em;
-				width: 2.4em;
+				font-size: 3.0em;
 			}
 		}
 		@include media(desktop) {
 			.entry-title {
-				font-size: 4.0em;
+				font-size: 3.6em;
 			}
 		}
 	}
@@ -264,7 +264,7 @@
 		}
 		@include media( tablet) {
 			.entry-title {
-				font-size: 2.8em;
+				font-size: 2.4em;
 			}
 			.avatar {
 				height: 48px;
@@ -273,18 +273,18 @@
 		}
 		@include media(desktop) {
 			.entry-title {
-				font-size: 3.6em;
+				font-size: 3em;
 			}
 		}
 	}
 
 	&.type-scale6 article {
 		.entry-title {
-			font-size: 1.8em;
+			font-size: 1.7em;
 		}
 		@include media(tablet) {
 			.entry-title {
-				font-size: 2.4em;
+				font-size: 2.0em;
 			}
 			.avatar {
 				height: 44px;
@@ -293,7 +293,7 @@
 		}
 		@include media(desktop) {
 			.entry-title {
-				font-size: 3em;
+				font-size: 2.4em;
 			}
 		}
 	}
@@ -304,7 +304,7 @@
 		}
 		@include media(tablet) {
 			.entry-title {
-				font-size: 2.2em;
+				font-size: 1.8em;
 			}
 			.avatar {
 				height: 40px;
@@ -313,7 +313,7 @@
 		}
 		@include media(desktop) {
 			.entry-title {
-				font-size: 2.4em;
+				font-size: 2.0em;
 			}
 		}
 	}
@@ -322,7 +322,10 @@
 
 	&.type-scale3 article {
 		.entry-title {
-			font-size: 1em;
+			font-size: 1.0em;
+			@include media( tablet ) {
+				font-size: 1.2em
+			}
 		}
 		.entry-wrapper p {
 			font-size: 0.8em;
@@ -334,23 +337,16 @@
 			height: 32px;
 			width: 32px;
 		}
-		@include media(tablet) {
-			.entry-title {
-				font-size: 1.2em;
-			}
-		}
 	}
 
 	&.type-scale2 article {
 		.entry-title {
-			font-size: 0.9em;
-			@include media(tablet) {
-				font-size: 1em;
+			font-size: 0.8em;
+			@include media( tablet ) {
+				font-size: 0.9em
 			}
 		}
-		.entry-wrapper p {
-			font-size: 0.8em;
-		}
+		.entry-wrapper p,
 		.entry-meta {
 			font-size: 0.7em;
 		}
@@ -361,12 +357,16 @@
 	}
 
 	&.type-scale1 article {
-		.entry-title {
-			font-size: 0.8em;
-		}
-		.entry-wrapper p,
-		.entry-meta {
+		.entry-title,
+		.entry-wrapper p {
 			font-size: 0.7em;
+		}
+		.entry-meta {
+			font-size: 0.6em;
+
+			@include media( tablet ) {
+				font-size: 0.7em;
+			}
 		}
 		.avatar {
 			height: 24px;

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -363,10 +363,6 @@
 		}
 		.entry-meta {
 			font-size: 0.6em;
-
-			@include media( tablet ) {
-				font-size: 0.7em;
-			}
 		}
 		.avatar {
 			height: 24px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR reduces the size of the smallest type scale option for the block (based on feedback), and refines the differences between different sizes a bit.

Closes #130.

### How to test the changes in this Pull Request:

1. Copy-paste [this test content](https://cloudup.com/comkHU8FNUj) into a post or page; it has a copy of the article block in each size. 
2. Note its appearance.
3. Apply the PR and run `npm run build:webpack`
4. Confirm that the smallest size is now smaller (14px); also confirm that the difference between each of the different sizes seems fairly consistent, and they're noticeably different from each other. 

(And just let me know if anything is "off"!). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

(I messed something up with the version bump PR, causing the commit to show up here -- master should already have it set to '6'). 