### PR TITLE
Group Block: Add styles to align block left and right

### DIFF
--- a/src/block-styles/core/group/editor.scss
+++ b/src/block-styles/core/group/editor.scss
@@ -1,0 +1,27 @@
+@import "../../../shared/sass/variables";
+@import "../../../shared/sass/mixins";
+
+@include media( tablet ) {
+	[data-type="core/group"]:not([data-align]) {
+		.wp-block-group {
+			position: relative;
+
+			&.is-style-alignleft,
+			&.is-style-alignright {
+				margin-bottom: 1em;
+				width: 50%;
+				z-index: 5;
+			}
+
+			&.is-style-alignleft {
+				float: left;
+				margin-right: 1em;
+			}
+
+			&.is-style-alignright {
+				float: right;
+				margin-left: 1em;
+			}
+		}
+	}
+}

--- a/src/block-styles/core/group/editor.scss
+++ b/src/block-styles/core/group/editor.scss
@@ -1,7 +1,7 @@
 @import "../../../shared/sass/variables";
 @import "../../../shared/sass/mixins";
 
-@include media( tablet ) {
+@include media( mobile ) {
 	[data-type="core/group"]:not([data-align]) {
 		.wp-block-group {
 			position: relative;

--- a/src/block-styles/core/group/index.js
+++ b/src/block-styles/core/group/index.js
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { registerBlockStyle } from '@wordpress/blocks';
+import './editor.scss';
+
+registerBlockStyle( 'core/group', {
+	name: 'alignleft',
+	label: 'Align Left',
+} );
+
+registerBlockStyle( 'core/group', {
+	name: 'alignright',
+	label: 'Align Right',
+} );

--- a/src/block-styles/core/group/view.scss
+++ b/src/block-styles/core/group/view.scss
@@ -1,7 +1,7 @@
 @import "../../../shared/sass/variables";
 @import "../../../shared/sass/mixins";
 
-@include media( tablet ) {
+@include media( mobile ) {
 	.wp-block-group:not(.alignwide):not(.alignfull) {
 		&.is-style-alignleft {
 			float: left;

--- a/src/block-styles/core/group/view.scss
+++ b/src/block-styles/core/group/view.scss
@@ -1,0 +1,18 @@
+@import "../../../shared/sass/variables";
+@import "../../../shared/sass/mixins";
+
+@include media( tablet ) {
+	.wp-block-group:not(.alignwide):not(.alignfull) {
+		&.is-style-alignleft {
+			float: left;
+			margin-right: 1em;
+			width: 50%;
+		}
+
+		&.is-style-alignright {
+			float: right;
+			margin-left: 1em;
+			width: 50%;
+		}
+	}
+}

--- a/src/block-styles/view.js
+++ b/src/block-styles/view.js
@@ -2,3 +2,4 @@
  * Internal dependencies
  */
 import './core/columns/view.scss';
+import './core/group/view.scss';

--- a/src/setup/block-styles.js
+++ b/src/setup/block-styles.js
@@ -1,1 +1,2 @@
 import '../block-styles/core/columns';
+import '../block-styles/core/group';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

By default, the group block has a default alignment, and lets you align it wide and full. This PR adds two block styles that also let you align it right and left.

![image](https://user-images.githubusercontent.com/177561/66231622-cd49dc80-e69b-11e9-97f4-9f82dc19572b.png)

Because we can't extend the core block to add proper alignments, this turned into a bit of a hacky work around, primarily in the editor:

1. **The options live in a different location than the typical alignment options:**

![image](https://user-images.githubusercontent.com/177561/66231670-e8b4e780-e69b-11e9-80f4-6a61f1ff88b9.png)

Because of that, you can apply both a 'wide' align and an 'align left' style. In this case, the 'wide' or 'full' align will override the left and right align styles -- you can only left or right align the block when it has the default width.

2. **We can't use the typical editor selectors:** When using the default alignments, the editor will place a `data-align` attribute on the top level element for the block. When using a style, the class is placed further inside of the block -- this means the styles we can add to align the block left and right can't "grab" all of the block pieces... meaning some of the Group block controls will not be part of the left or right alignment:

Aligned left:
![image](https://user-images.githubusercontent.com/177561/66231819-42b5ad00-e69c-11e9-8d57-8cc004e65117.png)

Aligned right:
![image](https://user-images.githubusercontent.com/177561/66231832-48ab8e00-e69c-11e9-9c37-cf8c49ed1953.png)

Hopefully this is minor enough not to be a problem; I'm not quite sure how we would work around it. 

I will make a separate PR in the theme to pull these blocks outside of the content area where appropriate. 

Closes #103.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`
2. Add a group block to the editor; click the styles and align it left. 
3. Save and publish; confirm it displays aligned left on the front end; scale down the browser window and confirm it turns full-width at the mobile breakpoint (600px).
4. Add a second block and align it right; repeat step 3 for this block.
5. Try setting each of these blocks align wide and align full; confirm that this completely overrides the left and right styles, and they display as normal wide and full alignments. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
