### PR TITLE
Article Block: Fix issue where has-text-color class was always being applied

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -177,7 +177,7 @@ class Edit extends Component {
 			url,
 		} = attributes;
 
-		const fetchAuthorSuggestions = ( search ) => {
+		const fetchAuthorSuggestions = search => {
 			return apiFetch( {
 				path: addQueryArgs( '/wp/v2/users', {
 					search,
@@ -185,27 +185,27 @@ class Edit extends Component {
 					_fields: 'id,name',
 				} ),
 			} ).then( function( users ) {
-				return users.map( user => ( { 
+				return users.map( user => ( {
 					value: user.id,
 					label: decodeEntities( user.name ) || __( '(no name)' ),
 				} ) );
 			} );
 		};
-		const fetchSavedAuthors = ( userIDs ) => {
+		const fetchSavedAuthors = userIDs => {
 			return apiFetch( {
 				path: addQueryArgs( '/wp/v2/users', {
 					per_page: 100,
-					include: userIDs.join(','),
+					include: userIDs.join( ',' ),
 				} ),
 			} ).then( function( users ) {
-				return users.map( user => ( { 
+				return users.map( user => ( {
 					value: user.id,
 					label: decodeEntities( user.name ) || __( '(no name)' ),
 				} ) );
 			} );
 		};
 
-		const fetchCategorySuggestions = ( search ) => {
+		const fetchCategorySuggestions = search => {
 			return apiFetch( {
 				path: addQueryArgs( '/wp/v2/categories', {
 					search,
@@ -215,28 +215,28 @@ class Edit extends Component {
 					order: 'desc',
 				} ),
 			} ).then( function( categories ) {
-				return categories.map( category => ( { 
+				return categories.map( category => ( {
 					value: category.id,
 					label: decodeEntities( category.name ) || __( '(no title)' ),
 				} ) );
 			} );
 		};
-		const fetchSavedCategories = ( categoryIDs ) => {
+		const fetchSavedCategories = categoryIDs => {
 			return apiFetch( {
 				path: addQueryArgs( '/wp/v2/categories', {
 					per_page: 100,
 					_fields: 'id,name',
-					include: categoryIDs.join(','),
+					include: categoryIDs.join( ',' ),
 				} ),
 			} ).then( function( categories ) {
-				return categories.map( category => ( { 
+				return categories.map( category => ( {
 					value: category.id,
 					label: decodeEntities( category.name ) || __( '(no title)' ),
 				} ) );
 			} );
 		};
 
-		const fetchTagSuggestions = ( search ) => {
+		const fetchTagSuggestions = search => {
 			return apiFetch( {
 				path: addQueryArgs( '/wp/v2/tags', {
 					search,
@@ -252,12 +252,12 @@ class Edit extends Component {
 				} ) );
 			} );
 		};
-		const fetchSavedTags = ( tagIDs ) => {
+		const fetchSavedTags = tagIDs => {
 			return apiFetch( {
 				path: addQueryArgs( '/wp/v2/tags', {
 					per_page: 100,
 					_fields: 'id,name',
-					include: tagIDs.join(','),
+					include: tagIDs.join( ',' ),
 				} ),
 			} ).then( function( tags ) {
 				return tags.map( tag => ( {
@@ -288,7 +288,7 @@ class Edit extends Component {
 									<BaseControl>
 										<AutocompleteTokenField
 											tokens={ authors || [] }
-											onChange={ ( tokens ) => setAttributes( { authors: tokens } ) }
+											onChange={ tokens => setAttributes( { authors: tokens } ) }
 											fetchSuggestions={ fetchAuthorSuggestions }
 											fetchSavedInfo={ fetchSavedAuthors }
 											label={ __( 'Author' ) }
@@ -297,7 +297,7 @@ class Edit extends Component {
 									<BaseControl>
 										<AutocompleteTokenField
 											tokens={ categories || [] }
-											onChange={ ( tokens ) => setAttributes( { categories: tokens } ) }
+											onChange={ tokens => setAttributes( { categories: tokens } ) }
 											fetchSuggestions={ fetchCategorySuggestions }
 											fetchSavedInfo={ fetchSavedCategories }
 											label={ __( 'Category' ) }
@@ -306,7 +306,7 @@ class Edit extends Component {
 									<BaseControl>
 										<AutocompleteTokenField
 											tokens={ tags || [] }
-											onChange={ ( tokens ) => setAttributes( { tags: tokens } ) }
+											onChange={ tokens => setAttributes( { tags: tokens } ) }
 											fetchSuggestions={ fetchTagSuggestions }
 											fetchSavedInfo={ fetchSavedTags }
 											label={ __( 'Tag' ) }
@@ -468,7 +468,7 @@ class Edit extends Component {
 			[ `image-align${ mediaPosition }` ]: showImage,
 			[ `image-scale${ imageScale }` ]: imageScale !== '1' && showImage,
 			[ `image-shape${ imageShape }` ]: imageShape !== 'landscape',
-			'has-text-color': textColor,
+			'has-text-color': textColor.color !== '',
 			'show-caption': showCaption,
 		} );
 

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -71,11 +71,11 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 		$classes .= ' ' . $attributes['className'];
 	}
 
-	if ( isset( $attributes['textColor'] ) ) {
+	if ( '' !== $attributes['textColor'] || '' !== $attributes['customTextColor'] ) {
 		$classes .= ' has-text-color';
-		if ( '' !== $attributes['textColor'] ) {
+	}
+	if ( '' !== $attributes['textColor'] ) {
 			$classes .= ' has-' . $attributes['textColor'] . '-color';
-		}
 	}
 
 	$styles = '';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, the `.has-text-color` class is always applied to the article block, which is causing some colour issues with the 'section header'.

This PR fixes the class issue and visual issues on the front-end; an incoming theme PR, paired with this PR, will fix the remaining preview issues in the editor.

Closes #137.

### How to test the changes in this Pull Request:

1. Add a couple article blocks to the editor, and give each of them a 'section header'.
2. Leave one block as-is, select a colour from the colour palette for the second one, and a custom colour for the third. 
3. Note the appearance of each block on the front end. With style packs default, 3 and 4, the text should match the primary colour; for 1 and 2, it should be grey. In the block using default colours, though, it will always look black:

**Default:**
![image](https://user-images.githubusercontent.com/177561/66276610-b943dd80-e849-11e9-83f9-69311c2d5b41.png)

**Style 1**
![image](https://user-images.githubusercontent.com/177561/66276616-c3fe7280-e849-11e9-962a-df970bce5924.png)

**Style 2**
![image](https://user-images.githubusercontent.com/177561/66276619-cd87da80-e849-11e9-8228-3a8fb2d9c7f7.png)

**Style 3**
![image](https://user-images.githubusercontent.com/177561/66276625-d7114280-e849-11e9-86ac-9c13f982a3ea.png)

**Style 4**
![image](https://user-images.githubusercontent.com/177561/66276631-e2646e00-e849-11e9-92f7-7082643d5293.png)

4. Apply the PR and run `npm run build:webpack`.
5. Cycle through all of the style packs again; for the default, 3 and 4, the 'section title' should use the primary colour, but be overridden by any block-based custom colours. For 1 and 2, the section title should be dark grey (rather than black). 

**Default:**
![image](https://user-images.githubusercontent.com/177561/66276656-0922a480-e84a-11e9-9be3-0165e93e3c25.png)

**Style 1:**
![image](https://user-images.githubusercontent.com/177561/66276661-15a6fd00-e84a-11e9-9906-c9e8d7295329.png)

**Style 2:**
![image](https://user-images.githubusercontent.com/177561/66276665-20fa2880-e84a-11e9-98f0-0dea16807d6d.png)

**Style 3:**
![image](https://user-images.githubusercontent.com/177561/66276668-2b1c2700-e84a-11e9-9a0a-a64a47b2f8f7.png)

**Style 4:**
![image](https://user-images.githubusercontent.com/177561/66276672-353e2580-e84a-11e9-81ed-b6a4f8747b1c.png)



### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
