### PR TITLE
Add left/rightblock alignment option to the group block

### DIFF
--- a/src/block-styles/core/group/editor.scss
+++ b/src/block-styles/core/group/editor.scss
@@ -1,0 +1,4 @@
+.block-editor-block-list__layout .block-editor-block-list__block[data-align="left"] .block-editor-block-list__block-edit .block-editor-block-list__block-edit,
+.block-editor-block-list__layout .block-editor-block-list__block[data-align="right"] .block-editor-block-list__block-edit .block-editor-block-list__block-edit {
+	float: none;
+}

--- a/src/block-styles/core/group/index.js
+++ b/src/block-styles/core/group/index.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import './editor.scss';
+addFilter( 'blocks.registerBlockType', 'newspack-blocks', ( settings, name ) => {
+	if ( name === 'core/group' ) {
+		const { supports } = settings;
+		const { align } = supports;
+		if ( align.indexOf( 'left' ) === -1 ) {
+			align.push( 'left' );
+		}
+		if ( align.indexOf( 'right' ) === -1 ) {
+			align.push( 'right' );
+		}
+	}
+	return settings;
+} );

--- a/src/setup/block-styles.js
+++ b/src/setup/block-styles.js
@@ -1,1 +1,2 @@
 import '../block-styles/core/columns';
+import '../block-styles/core/group';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR replaces #138, and adds align left and align right options to the block settings.

The appearance of these blocks will be improved in #465. 

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`
2. In the editor, add a Group block, and align it left:

![image](https://user-images.githubusercontent.com/177561/66333609-36279380-e8ec-11e9-8c07-ab33bfe5efdc.png)

3. Add  a second group block and align it right.
4. Confirm the block displays as expected in both the editor and on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?