### PR TITLE
Add toggle for displaying categories

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -50,7 +50,7 @@ class Newspack_Blocks_API {
 			'post',
 			'newspack_category_info',
 			array(
-				'get_callback'    => array( 'Newspack_Blocks_API', 'newspack_blocks_get_first_category' ),
+				'get_callback'    => array( 'Newspack_Blocks_API', 'newspack_blocks_get_primary_category' ),
 				'update_callback' => null,
 				'schema'          => null,
 			)
@@ -126,19 +126,34 @@ class Newspack_Blocks_API {
 	}
 
 	/**
-	 * Get first category for the rest field.
+	 * Get primary category for the rest field.
 	 *
 	 * @param Array $object  The object info.
 	 */
-	public static function newspack_blocks_get_first_category( $object ) {
-		$categories_list = get_the_category( $object['id'] );
-		$category_info   = '';
+	public static function newspack_blocks_get_primary_category( $object ) {
+		$category = false;
 
-		if ( ! empty( $categories_list ) ) {
-			$category_info = '<a href="' . get_category_link( $categories_list[0]->term_id ) . '">' . $categories_list[0]->name . '</a>';
+		// Use Yoast primary category if set.
+		if ( class_exists( 'WPSEO_Primary_Term' ) ) {
+			$primary_term = new WPSEO_Primary_Term( 'category', $object['id'] );
+			$category_id = $primary_term->get_primary_term();
+			if ( $category_id ) {
+				$category = get_term( $category_id );
+			}
 		}
 
-		return $category_info;
+		if ( ! $category ) {
+			$categories_list = get_the_category( $object['id'] );
+			if ( ! empty( $categories_list ) ) {
+				$category = $categories_list[0];
+			}
+		}
+
+		if ( ! $category ) {
+			return '';
+		}
+
+		return $category->name;
 	}
 
 }

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -48,6 +48,7 @@ class Edit extends Component {
 			showAuthor,
 			showAvatar,
 			showDate,
+			showCategory,
 			sectionHeader,
 		} = attributes;
 		return (
@@ -63,6 +64,11 @@ class Edit extends Component {
 					</figure>
 				) }
 				<div className="entry-wrapper">
+					{ showCategory && post.newspack_category_info.length && (
+						<div className="cat-links">
+							<a href='#'>{ post.newspack_category_info }</a>
+						</div>
+					) }
 					{ RichText.isEmpty( sectionHeader ) ? (
 						<h2 className="entry-title" key="title">
 							<a href="#">{ decodeEntities( post.title.rendered.trim() ) }</a>
@@ -132,6 +138,7 @@ class Edit extends Component {
 			showDate,
 			showAuthor,
 			showAvatar,
+			showCategory,
 			postLayout,
 			mediaPosition,
 			singleMode,
@@ -248,6 +255,13 @@ class Edit extends Component {
 							label={ __( 'Show Date' ) }
 							checked={ showDate }
 							onChange={ () => setAttributes( { showDate: ! showDate } ) }
+						/>
+					</PanelRow>
+					<PanelRow>
+						<ToggleControl
+							label={ __( 'Show Category' ) }
+							checked={ showCategory }
+							onChange={ () => setAttributes( { showCategory: ! showCategory } ) }
 						/>
 					</PanelRow>
 					<PanelRow>

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -64,6 +64,10 @@ export const settings = {
 			type: 'boolean',
 			default: true,
 		},
+		showCategory: {
+			type: 'boolean',
+			default: false,
+		},
 		postLayout: {
 			type: 'string',
 			default: 'list',

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -121,6 +121,38 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 					<div class="entry-wrapper">
 
+						<?php 
+						if ( $attributes['showCategory'] ) :
+							$category = false;
+
+							// Use Yoast primary category if set.
+							if ( class_exists( 'WPSEO_Primary_Term' ) ) {
+								$primary_term = new WPSEO_Primary_Term( 'category', get_the_ID() );
+								$category_id = $primary_term->get_primary_term();
+								if ( $category_id ) {
+									$category = get_term( $category_id );
+								}
+							}
+
+							if ( ! $category ) {
+								$categories_list = get_the_category();
+								if ( ! empty( $categories_list ) ) {
+									$category = $categories_list[0];
+								}
+							}
+
+							if ( $category ) :
+								?>
+								<div class='cat-links'>
+									<a href="<?php echo esc_url( get_category_link( $category->term_id ) ); ?>">
+										<?php echo esc_html( $category->name ); ?>
+									</a>
+								</div>
+								<?php
+							endif;
+						endif;
+						?>
+
 						<?php
 						if ( '' === $attributes['sectionHeader'] ) {
 							the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
@@ -223,6 +255,10 @@ function newspack_blocks_register_homepage_articles() {
 				'showAvatar'    => array(
 					'type'    => 'boolean',
 					'default' => true,
+				),
+				'showCategory'  => array(
+					'type'    => 'boolean',
+					'default' => false,
 				),
 				'content'       => array(
 					'type' => 'string',

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -8,6 +8,7 @@
 		margin-bottom: 1.5em;
 		word-break: break-word;
 		overflow-wrap: break-word;
+		position: relative;
 
 		&:last-of-type {
 			margin-bottom: 0;
@@ -143,6 +144,10 @@
 	}
 
 	/* Article meta */
+	.cat-links {
+		margin-bottom: 1em;
+	}
+
 	.entry-meta {
 		display: flex;
 		flex-wrap: wrap;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds a toggle for displaying categories on posts. I've used the theme's `cat-links` class for the category, so they should be more-or-less already styled just like other category links on the site. When possible, the block will pull the primary category from WPSEO instead of using whichever category it first sees.

If this looks good, I'll make a follow-up PR on the theme repo to add some handling on a couple of the alternate styles to make sure things look good. In general, they look pretty good out-of-the-box.

<img width="828" alt="Screen Shot 2019-10-07 at 12 14 27 PM" src="https://user-images.githubusercontent.com/7317227/66341825-db4a6800-e8fc-11e9-8670-1a98966ef185.png">

### How to test the changes in this Pull Request:

1. Activate WPSEO if it isn't already active. On a post that will be featured in the block, select 2+ categories. A dropdown should appear to let you select a primary category. Select a primary category different than the default:
<img width="201" alt="Screen Shot 2019-10-07 at 12 22 00 PM" src="https://user-images.githubusercontent.com/7317227/66341953-219fc700-e8fd-11e9-8462-07299608b6ef.png">

2. On your home page, insert an articles block. You should have a toggle available for displaying the category (default off). 
3. Toggle the category toggle on/off and verify it works correctly in the editor and on the frontend. 
4. Toggle WPSEO off and verify nothing breaks.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
