### PR TITLE
Carousel Block

### DIFF
--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -159,7 +159,7 @@ class Newspack_Blocks {
 	 *
 	 * @return string Class list separated by spaces.
 	 */
-	public static function block_classes( $type, $attributes = array() ) {
+	public static function block_classes( $type, $attributes = array(), $extra = array() ) {
 		$align   = isset( $attributes['align'] ) ? $attributes['align'] : 'center';
 		$classes = array(
 			"wp-block-newspack-blocks-{$type}",
@@ -167,6 +167,9 @@ class Newspack_Blocks {
 		);
 		if ( isset( $attributes['className'] ) ) {
 			array_push( $classes, $attributes['className'] );
+		}
+		if ( is_array( $extra ) && ! empty( $extra ) ) {
+			$classes = array_merge( $classes, $extra );
 		}
 		return implode( $classes, ' ' );
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3290,6 +3290,14 @@
         "entities": "^1.1.1"
       }
     },
+    "dom7": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-2.1.3.tgz",
+      "integrity": "sha512-QTxHHDox+M6ZFz1zHPAHZKI3JOHY5iY4i9BK2uctlggxKQwRhO3q3HHFq1BKsT25Bm/ySSj70K6Wk/G4bs9rMQ==",
+      "requires": {
+        "ssr-window": "^1.0.1"
+      }
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -8823,6 +8831,11 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "ssr-window": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-1.0.1.tgz",
+      "integrity": "sha512-dgFqB+f00LJTEgb6UXhx0h+SrG50LJvti2yMKMqAgzfUmUXZrLSv2fjULF7AWGwK25EXu8+smLR3jYsJQChPsg=="
+    },
     "ssri": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
@@ -9030,6 +9043,15 @@
         "stable": "^0.1.8",
         "unquote": "~1.1.1",
         "util.promisify": "~1.0.0"
+      }
+    },
+    "swiper": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-4.5.1.tgz",
+      "integrity": "sha512-se6I7PWWu950NAMXXT+ENtF/6SVb8mPyO+bTfNxbQBILSeLqsYp3Ndap+YOA0EczOIUlea274PKejT6gKZDseA==",
+      "requires": {
+        "dom7": "^2.1.3",
+        "ssr-window": "^1.0.1"
       }
     },
     "symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "test": "tests"
   },
   "private": true,
-  "dependencies": {},
+  "dependencies": {
+    "swiper": "4.5.1"
+  },
   "scripts": {
     "build:webpack": "calypso-build --config='./webpack.config.js'",
     "clean": "rm -rf dist/",

--- a/src/blocks/carousel/create-swiper.js
+++ b/src/blocks/carousel/create-swiper.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { mapValues, merge } from 'lodash';
+import Swiper from 'Swiper';
+import '../../../node_modules/swiper/dist/css/swiper.css';
+
+export default function createSwiper(
+	container = '.swiper-container',
+	params = {},
+	callbacks = {}
+) {
+	const defaultParams = {
+		effect: 'slide',
+		grabCursor: true,
+		init: true,
+		initialSlide: 0,
+		navigation: {
+			nextEl: '.swiper-button-next',
+			prevEl: '.swiper-button-prev',
+		},
+		pagination: {
+			bulletElement: 'button',
+			clickable: true,
+			el: '.swiper-pagination',
+			type: 'bullets',
+		},
+		preventClicksPropagation: false /* Necessary for normal block interactions */,
+		releaseFormElements: false,
+		setWrapperSize: true,
+		touchStartPreventDefault: false,
+	};
+	// const [ { default: Swiper } ] = await Promise.all( [
+	// 	import( /* webpackChunkName: "swiper" */ 'swiper' ),
+	// ] );
+	return new Swiper( container, merge( {}, defaultParams, params ) );
+}

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -4,6 +4,7 @@
 import QueryControls from '../homepage-articles/query-controls';
 import createSwiper from './create-swiper';
 import classnames from 'classnames';
+import AutocompleteTokenField from '../homepage-articles/components/autocomplete-tokenfield.js';
 
 /**
  * External dependencies
@@ -25,13 +26,15 @@ import {
 	RangeControl,
 	Spinner,
 	ToggleControl,
+	BaseControl,
 } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { withState, compose } from '@wordpress/compose';
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import { decodeEntities } from '@wordpress/html-entities';
 
 import { PanelColorSettings, withColors } from '@wordpress/block-editor';
-
-const { decodeEntities } = wp.htmlEntities;
 
 class Edit extends Component {
 	constructor( props ) {
@@ -87,13 +90,10 @@ class Edit extends Component {
 			isSelected,
 			latestPosts,
 			hasPosts,
-			authorList,
-			categoriesList,
-			tagsList,
 		} = this.props;
 		const { autoPlayState } = this.state;
 		const {
-			author,
+			authors,
 			autoplay,
 			categories,
 			delay,
@@ -109,6 +109,97 @@ class Edit extends Component {
 			'swiper-container',
 			autoplay && autoPlayState && 'wp-block-newspack-blocks-carousel__autoplay-playing'
 		);
+
+		const fetchAuthorSuggestions = search => {
+			return apiFetch( {
+				path: addQueryArgs( '/wp/v2/users', {
+					search,
+					per_page: 20,
+					_fields: 'id,name',
+				} ),
+			} ).then( function( users ) {
+				return users.map( user => ( {
+					value: user.id,
+					label: decodeEntities( user.name ) || __( '(no name)', 'newspack-blocks' ),
+				} ) );
+			} );
+		};
+		const fetchSavedAuthors = userIDs => {
+			return apiFetch( {
+				path: addQueryArgs( '/wp/v2/users', {
+					per_page: 100,
+					include: userIDs.join( ',' ),
+				} ),
+			} ).then( function( users ) {
+				return users.map( user => ( {
+					value: user.id,
+					label: decodeEntities( user.name ) || __( '(no name)', 'newspack-blocks' ),
+				} ) );
+			} );
+		};
+
+		const fetchCategorySuggestions = search => {
+			return apiFetch( {
+				path: addQueryArgs( '/wp/v2/categories', {
+					search,
+					per_page: 20,
+					_fields: 'id,name',
+					orderby: 'count',
+					order: 'desc',
+				} ),
+			} ).then( function( categories ) {
+				return categories.map( category => ( {
+					value: category.id,
+					label: decodeEntities( category.name ) || __( '(no title)', 'newspack-blocks' ),
+				} ) );
+			} );
+		};
+		const fetchSavedCategories = categoryIDs => {
+			return apiFetch( {
+				path: addQueryArgs( '/wp/v2/categories', {
+					per_page: 100,
+					_fields: 'id,name',
+					include: categoryIDs.join( ',' ),
+				} ),
+			} ).then( function( categories ) {
+				return categories.map( category => ( {
+					value: category.id,
+					label: decodeEntities( category.name ) || __( '(no title)', 'newspack-blocks' ),
+				} ) );
+			} );
+		};
+
+		const fetchTagSuggestions = search => {
+			return apiFetch( {
+				path: addQueryArgs( '/wp/v2/tags', {
+					search,
+					per_page: 20,
+					_fields: 'id,name',
+					orderby: 'count',
+					order: 'desc',
+				} ),
+			} ).then( function( tags ) {
+				return tags.map( tag => ( {
+					value: tag.id,
+					label: decodeEntities( tag.name ) || __( '(no title)', 'newspack-blocks' ),
+				} ) );
+			} );
+		};
+		const fetchSavedTags = tagIDs => {
+			return apiFetch( {
+				path: addQueryArgs( '/wp/v2/tags', {
+					per_page: 100,
+					_fields: 'id,name',
+					include: tagIDs.join( ',' ),
+				} ),
+			} ).then( function( tags ) {
+				return tags.map( tag => ( {
+					value: tag.id,
+					label: decodeEntities( tag.name ) || __( '(no title)', 'newspack-blocks' ),
+				} ) );
+			} );
+		};
+
 		return (
 			<Fragment>
 				<div className={ classes } ref={ this.carouselRef }>
@@ -208,29 +299,45 @@ class Edit extends Component {
 				</div>
 				<InspectorControls>
 					<PanelBody title={ __( 'Display Settings' ) } initialOpen={ true }>
-						{ postsToShow && categoriesList && (
-							<QueryControls
-								enableSingle={ false }
-								numberOfItems={ postsToShow }
-								onNumberOfItemsChange={ value => setAttributes( { postsToShow: value } ) }
-								authorList={ authorList }
-								tagsList={ tagsList }
-								categoriesList={ categoriesList }
-								selectedCategoryId={ categories }
-								selectedAuthorId={ author }
-								selectedTagId={ tags }
-								onCategoryChange={ value =>
-									setAttributes( { categories: '' !== value ? value : undefined } )
-								}
-								onTagChange={ value => setAttributes( { tags: '' !== value ? value : undefined } ) }
-								onAuthorChange={ value =>
-									setAttributes( { author: '' !== value ? value : undefined } )
-								}
-								onSingleChange={ value =>
-									setAttributes( { single: '' !== value ? value : undefined } )
-								}
-								onSingleModeChange={ value => setAttributes( { singleMode: value } ) }
-							/>
+						{ postsToShow && (
+							<Fragment>
+								<QueryControls
+									enableSingle={ false }
+									numberOfItems={ postsToShow }
+									onNumberOfItemsChange={ value => setAttributes( { postsToShow: value } ) }
+									onSingleChange={ value =>
+										setAttributes( { single: '' !== value ? value : undefined } )
+									}
+									onSingleModeChange={ value => setAttributes( { singleMode: value } ) }
+								/>
+								<BaseControl>
+									<AutocompleteTokenField
+										tokens={ authors || [] }
+										onChange={ tokens => setAttributes( { authors: tokens } ) }
+										fetchSuggestions={ fetchAuthorSuggestions }
+										fetchSavedInfo={ fetchSavedAuthors }
+										label={ __( 'Author', 'newspack-blocks' ) }
+									/>
+								</BaseControl>
+								<BaseControl>
+									<AutocompleteTokenField
+										tokens={ categories || [] }
+										onChange={ tokens => setAttributes( { categories: tokens } ) }
+										fetchSuggestions={ fetchCategorySuggestions }
+										fetchSavedInfo={ fetchSavedCategories }
+										label={ __( 'Category', 'newspack-blocks' ) }
+									/>
+								</BaseControl>
+								<BaseControl>
+									<AutocompleteTokenField
+										tokens={ tags || [] }
+										onChange={ tokens => setAttributes( { tags: tokens } ) }
+										fetchSuggestions={ fetchTagSuggestions }
+										fetchSavedInfo={ fetchSavedTags }
+										label={ __( 'Tag', 'newspack-blocks' ) }
+									/>
+								</BaseControl>
+							</Fragment>
 						) }
 					</PanelBody>
 					<PanelBody title={ __( 'Slideshow Settings' ) } initialOpen={ true }>
@@ -294,28 +401,19 @@ class Edit extends Component {
 
 export default compose( [
 	withSelect( ( select, props ) => {
-		const { postsToShow, author, categories, tags } = props.attributes;
-		const { getAuthors, getEntityRecords } = select( 'core' );
+		const { postsToShow, authors, categories, tags } = props.attributes;
+		const { getEntityRecords } = select( 'core' );
 		const latestPostsQuery = pickBy(
 			{
 				per_page: postsToShow,
 				categories,
-				author,
+				author: authors,
 				tags,
 			},
 			value => ! isUndefined( value )
 		);
-		const categoriesListQuery = {
-			per_page: 100,
-		};
-		const tagsListQuery = {
-			per_page: 100,
-		};
 		return {
 			latestPosts: getEntityRecords( 'postType', 'post', latestPostsQuery ),
-			categoriesList: getEntityRecords( 'taxonomy', 'category', categoriesListQuery ),
-			tagsList: getEntityRecords( 'taxonomy', 'post_tag', tagsListQuery ),
-			authorList: getAuthors(),
 		};
 	} ),
 ] )( Edit );

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -138,6 +138,11 @@ class Edit extends Component {
 														</a>
 													</span>
 												</span>
+												{ post.newspack_category_info.length && (
+													<div>
+														<a href="#">{ post.newspack_category_info }</a>
+													</div>
+												) }
 												<time className="entry-date published" key="pub-date">
 													{ moment( post.date_gmt )
 														.local()

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -122,7 +122,7 @@ class Edit extends Component {
 					) }
 					{ latestPosts && (
 						<Fragment>
-							<div class="swiper-wrapper">
+							<div className="swiper-wrapper">
 								{ latestPosts.map( post => (
 									<article className="post-has-image swiper-slide" key={ post.id }>
 										<figure className="post-thumbnail">
@@ -134,7 +134,7 @@ class Edit extends Component {
 										</figure>
 										<div className="entry-wrapper">
 											{ showCategory && post.newspack_category_info.length && (
-												<div class="cat-links">
+												<div className="cat-links">
 													<a href="#">{ post.newspack_category_info }</a>
 												</div>
 											) }

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -18,13 +18,10 @@ import { Component, Fragment, RawHTML } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/editor';
 import {
 	PanelBody,
-	Toolbar,
-	ToggleControl,
-	Dashicon,
 	Placeholder,
+	RangeControl,
 	Spinner,
-	Path,
-	SVG,
+	ToggleControl,
 } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { withState, compose } from '@wordpress/compose';
@@ -46,7 +43,7 @@ class Edit extends Component {
 			categoriesList,
 			tagsList,
 		} = this.props; // variables getting pulled out of props
-		const { author, categories, postsToShow, tags } = attributes;
+		const { author, autoplay, categories, delay, postsToShow, tags } = attributes;
 		return (
 			<Fragment>
 				<div className={ className }>
@@ -86,6 +83,27 @@ class Edit extends Component {
 									setAttributes( { single: '' !== value ? value : undefined } )
 								}
 								onSingleModeChange={ value => setAttributes( { singleMode: value } ) }
+							/>
+						) }
+					</PanelBody>
+					<PanelBody title={ __( 'Slideshow Settings' ) } initialOpen={ true }>
+						<ToggleControl
+							label={ __( 'Autoplay' ) }
+							help={ __( 'Autoplay between slides' ) }
+							checked={ autoplay }
+							onChange={ autoplay => {
+								setAttributes( { autoplay } );
+							} }
+						/>
+						{ autoplay && (
+							<RangeControl
+								label={ __( 'Delay between transitions (in seconds)' ) }
+								value={ delay }
+								onChange={ delay => {
+									setAttributes( { delay } );
+								} }
+								min={ 1 }
+								max={ 5 }
 							/>
 						) }
 					</PanelBody>

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -154,9 +154,9 @@ class Edit extends Component {
 													</span>
 												) }
 												{ showCategory && post.newspack_category_info.length && (
-													<div>
+													<span class="cat-links">
 														<a href="#">{ post.newspack_category_info }</a>
-													</div>
+													</span>
 												) }
 												{ showDate && (
 													<time className="entry-date published" key="pub-date">

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -123,7 +123,7 @@ class Edit extends Component {
 					{ latestPosts && (
 						<Fragment>
 							<div className="swiper-wrapper">
-								{ latestPosts.map( post => (
+								{ latestPosts.map( post => post.newspack_featured_image_src && (
 									<article className="post-has-image swiper-slide" key={ post.id }>
 										<figure className="post-thumbnail">
 											{ post.newspack_featured_image_src && (

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -133,6 +133,11 @@ class Edit extends Component {
 											) }
 										</figure>
 										<div className="entry-wrapper">
+											{ showCategory && post.newspack_category_info.length && (
+												<div class="cat-links">
+													<a href="#">{ post.newspack_category_info }</a>
+												</div>
+											) }
 											<h3 className="entry-title">
 												<a href="#">{ decodeEntities( post.title.rendered.trim() ) }</a>
 											</h3>
@@ -142,7 +147,6 @@ class Edit extends Component {
 														<RawHTML>{ post.newspack_author_info.avatar }</RawHTML>
 													</span>
 												) }
-
 												{ showAuthor && (
 													<span className="byline">
 														{ __( 'by' ) }{' '}
@@ -151,11 +155,6 @@ class Edit extends Component {
 																{ post.newspack_author_info.display_name }
 															</a>
 														</span>
-													</span>
-												) }
-												{ showCategory && post.newspack_category_info.length && (
-													<span class="cat-links">
-														<a href="#">{ post.newspack_category_info }</a>
 													</span>
 												) }
 												{ showDate && (

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -1,0 +1,124 @@
+/**
+ * Internal dependencies
+ */
+import QueryControls from '../homepage-articles/query-controls';
+
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import { isUndefined, pickBy } from 'lodash';
+import moment from 'moment';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment, RawHTML } from '@wordpress/element';
+import { InspectorControls } from '@wordpress/editor';
+import {
+	PanelBody,
+	Toolbar,
+	ToggleControl,
+	Dashicon,
+	Placeholder,
+	Spinner,
+	Path,
+	SVG,
+} from '@wordpress/components';
+import { withSelect } from '@wordpress/data';
+import { withState, compose } from '@wordpress/compose';
+
+import { PanelColorSettings, withColors } from '@wordpress/block-editor';
+
+const { decodeEntities } = wp.htmlEntities;
+
+class Edit extends Component {
+	render() {
+		const {
+			attributes,
+			className,
+			setAttributes,
+			isSelected,
+			latestPosts,
+			hasPosts,
+			authorList,
+			categoriesList,
+			tagsList,
+		} = this.props; // variables getting pulled out of props
+		const { author, categories, postsToShow, tags } = attributes;
+		return (
+			<Fragment>
+				<div className={ className }>
+					{ latestPosts && ! latestPosts.length && (
+						<Placeholder>{ __( 'Sorry, no posts were found.' ) }</Placeholder>
+					) }
+					{ ! latestPosts && (
+						<Placeholder>
+							<Spinner />
+						</Placeholder>
+					) }
+					{ latestPosts && (
+						<Placeholder>{ __( 'Carousel Display has no rendering in the editor.' ) }</Placeholder>
+					) }
+				</div>
+				<InspectorControls>
+					<PanelBody title={ __( 'Display Settings' ) } initialOpen={ true }>
+						{ postsToShow && categoriesList && (
+							<QueryControls
+								enableSingle={ false }
+								numberOfItems={ postsToShow }
+								onNumberOfItemsChange={ value => setAttributes( { postsToShow: value } ) }
+								authorList={ authorList }
+								tagsList={ tagsList }
+								categoriesList={ categoriesList }
+								selectedCategoryId={ categories }
+								selectedAuthorId={ author }
+								selectedTagId={ tags }
+								onCategoryChange={ value =>
+									setAttributes( { categories: '' !== value ? value : undefined } )
+								}
+								onTagChange={ value => setAttributes( { tags: '' !== value ? value : undefined } ) }
+								onAuthorChange={ value =>
+									setAttributes( { author: '' !== value ? value : undefined } )
+								}
+								onSingleChange={ value =>
+									setAttributes( { single: '' !== value ? value : undefined } )
+								}
+								onSingleModeChange={ value => setAttributes( { singleMode: value } ) }
+							/>
+						) }
+					</PanelBody>
+				</InspectorControls>
+			</Fragment>
+		);
+	}
+}
+
+export default compose( [
+	withSelect( ( select, props ) => {
+		const { postsToShow, author, categories, tags } = props.attributes;
+		const { getAuthors, getEntityRecords } = select( 'core' );
+		const latestPostsQuery = pickBy(
+			{
+				per_page: postsToShow,
+				categories,
+				author,
+				tags,
+			},
+			value => ! isUndefined( value )
+		);
+		const categoriesListQuery = {
+			per_page: 100,
+		};
+		const tagsListQuery = {
+			per_page: 100,
+		};
+		return {
+			latestPosts: getEntityRecords( 'postType', 'post', latestPostsQuery ),
+			categoriesList: getEntityRecords( 'taxonomy', 'category', categoriesListQuery ),
+			tagsList: getEntityRecords( 'taxonomy', 'post_tag', tagsListQuery ),
+			authorList: getAuthors(),
+		};
+	} ),
+] )( Edit );

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -103,7 +103,7 @@ class Edit extends Component {
 									setAttributes( { delay } );
 								} }
 								min={ 1 }
-								max={ 5 }
+								max={ 20 }
 							/>
 						) }
 					</PanelBody>

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -59,7 +59,7 @@ class Edit extends Component {
 						</Placeholder>
 					) }
 					{ latestPosts && (
-						<Placeholder>{ __( 'Carousel Display has no rendering in the editor.' ) }</Placeholder>
+						<Placeholder>{ __( 'Editor rendering of Carousel to come.' ) }</Placeholder>
 					) }
 				</div>
 				<InspectorControls>

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -20,6 +20,7 @@ import { Component, createRef, Fragment, RawHTML } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/editor';
 import {
 	PanelBody,
+	PanelRow,
 	Placeholder,
 	RangeControl,
 	Spinner,
@@ -55,12 +56,13 @@ class Edit extends Component {
 		this.swiperInstance = createSwiper(
 			this.carouselRef.current,
 			{
-				autoplay: autoplay && autoPlayState
-					? {
-							delay: delay * 1000,
-							disableOnInteraction: false,
-					  }
-					: false,
+				autoplay:
+					autoplay && autoPlayState
+						? {
+								delay: delay * 1000,
+								disableOnInteraction: false,
+						  }
+						: false,
 				effect: 'slide',
 				initialSlide: realIndex,
 				loop: true,
@@ -90,7 +92,18 @@ class Edit extends Component {
 			tagsList,
 		} = this.props;
 		const { autoPlayState } = this.state;
-		const { author, autoplay, categories, delay, postsToShow, tags } = attributes;
+		const {
+			author,
+			autoplay,
+			categories,
+			delay,
+			postsToShow,
+			showCategory,
+			showDate,
+			showAuthor,
+			showAvatar,
+			tags,
+		} = attributes;
 		const classes = classnames(
 			className,
 			'swiper-container',
@@ -124,30 +137,34 @@ class Edit extends Component {
 												<a href="#">{ decodeEntities( post.title.rendered.trim() ) }</a>
 											</h3>
 											<div className="entry-meta">
-												{ post.newspack_author_info.avatar && (
+												{ showAuthor && showAvatar && post.newspack_author_info.avatar && (
 													<span className="avatar author-avatar" key="author-avatar">
 														<RawHTML>{ post.newspack_author_info.avatar }</RawHTML>
 													</span>
 												) }
 
-												<span className="byline">
-													{ __( 'by' ) }{' '}
-													<span className="author vcard">
-														<a className="url fn n" href="#">
-															{ post.newspack_author_info.display_name }
-														</a>
+												{ showAuthor && (
+													<span className="byline">
+														{ __( 'by' ) }{' '}
+														<span className="author vcard">
+															<a className="url fn n" href="#">
+																{ post.newspack_author_info.display_name }
+															</a>
+														</span>
 													</span>
-												</span>
-												{ post.newspack_category_info.length && (
+												) }
+												{ showCategory && post.newspack_category_info.length && (
 													<div>
 														<a href="#">{ post.newspack_category_info }</a>
 													</div>
 												) }
-												<time className="entry-date published" key="pub-date">
-													{ moment( post.date_gmt )
-														.local()
-														.format( 'MMMM DD, Y' ) }
-												</time>
+												{ showDate && (
+													<time className="entry-date published" key="pub-date">
+														{ moment( post.date_gmt )
+															.local()
+															.format( 'MMMM DD, Y' ) }
+													</time>
+												) }
 											</div>
 										</div>
 									</article>
@@ -236,6 +253,38 @@ class Edit extends Component {
 								min={ 1 }
 								max={ 20 }
 							/>
+						) }
+					</PanelBody>
+					<PanelBody title={ __( 'Article Meta Settings', 'newspack-blocks' ) }>
+						<PanelRow>
+							<ToggleControl
+								label={ __( 'Show Date', 'newspack-blocks' ) }
+								checked={ showDate }
+								onChange={ () => setAttributes( { showDate: ! showDate } ) }
+							/>
+						</PanelRow>
+						<PanelRow>
+							<ToggleControl
+								label={ __( 'Show Category', 'newspack-blocks' ) }
+								checked={ showCategory }
+								onChange={ () => setAttributes( { showCategory: ! showCategory } ) }
+							/>
+						</PanelRow>
+						<PanelRow>
+							<ToggleControl
+								label={ __( 'Show Author', 'newspack-blocks' ) }
+								checked={ showAuthor }
+								onChange={ () => setAttributes( { showAuthor: ! showAuthor } ) }
+							/>
+						</PanelRow>
+						{ showAuthor && (
+							<PanelRow>
+								<ToggleControl
+									label={ __( 'Show Author Avatar', 'newspack-blocks' ) }
+									checked={ showAvatar }
+									onChange={ () => setAttributes( { showAvatar: ! showAvatar } ) }
+								/>
+							</PanelRow>
 						) }
 					</PanelBody>
 				</InspectorControls>

--- a/src/blocks/carousel/editor.js
+++ b/src/blocks/carousel/editor.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { name, settings } from '.';
+
+registerBlockType( `newspack-blocks/${ name }`, settings );

--- a/src/blocks/carousel/editor.scss
+++ b/src/blocks/carousel/editor.scss
@@ -2,13 +2,25 @@
 	.entry-title {
 		color: white;
 	}
+	.post-thumbnail img {
+		display: block;
+	}
 	.swiper-pagination-bullet.swiper-pagination-bullet-active {
 		opacity: 1;
 		transform: scale( 1 );
 	}
-	.amp-carousel-button.amp-carousel-button-prev,
-	.amp-carousel-button.amp-carousel-button-next {
-		margin-top: -24px;
+	.amp-carousel-button {
+		&.amp-carousel-button-next,
+		&.amp-carousel-button-prev {
+			left: 16px;
+			margin-top: -18px; // bullets height / 2
+			transform: translateY(-50%);
+		}
+
+		&.amp-carousel-button-next {
+			left: auto;
+			right: 16px;
+		}
 	}
 }
 .editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-carousel .entry-title a {

--- a/src/blocks/carousel/editor.scss
+++ b/src/blocks/carousel/editor.scss
@@ -1,0 +1,16 @@
+.wp-block-newspack-blocks-carousel {
+	.entry-title {
+		color: white;
+	}
+	.swiper-pagination-bullet.swiper-pagination-bullet-active {
+		opacity: 1;
+		transform: scale( 1 );
+	}
+	.amp-carousel-button.amp-carousel-button-prev,
+	.amp-carousel-button.amp-carousel-button-next {
+		margin-top: -24px;
+	}
+}
+.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-carousel .entry-title a {
+	color: inherit;
+}

--- a/src/blocks/carousel/editor.scss
+++ b/src/blocks/carousel/editor.scss
@@ -2,6 +2,15 @@
 	.entry-title {
 		color: white;
 	}
+	a {
+		color: inherit;
+
+		&:active,
+		&:focus,
+		&:hover {
+			color: rgba( 255, 255, 255, 0.75 );
+		}
+	}
 	.post-thumbnail img {
 		display: block;
 	}
@@ -23,6 +32,7 @@
 		}
 	}
 }
-.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-carousel .entry-title a {
+.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-carousel .entry-title a,
+.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-carousel .entry-meta .byline a {
 	color: inherit;
 }

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -36,6 +36,14 @@ export const settings = {
 		className: {
 			type: 'string',
 		},
+		autoplay: {
+			type: 'boolean',
+			default: false,
+		},
+		delay: {
+			type: 'number',
+			default: 3,
+		},
 		postsToShow: {
 			type: 'integer',
 			default: 3,

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+import edit from './edit';
+
+/**
+ * Style dependencies - will load in editor
+ */
+import './editor.scss';
+import './view.scss';
+
+export const name = 'carousel';
+export const title = __( 'Articles Carousel' );
+
+/* From https://material.io/tools/icons */
+export const icon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<Path d="M0 0h24v24H0z" fill="none" />
+		<Path d="M3 13h8V3H3v10zm0 8h8v-6H3v6zm10 0h8V11h-8v10zm0-18v6h8V3h-8z" />
+	</SVG>
+);
+
+export const settings = {
+	title,
+	icon,
+	category: 'newspack',
+	keywords: [ __( 'posts' ), __( 'slideshow' ), __( 'carousel' ) ],
+	description: __( 'A carousel of articles.' ),
+	attributes: {
+		className: {
+			type: 'string',
+		},
+		postsToShow: {
+			type: 'integer',
+			default: 3,
+		},
+		author: {
+			type: 'string',
+		},
+		categories: {
+			type: 'string',
+		},
+		tags: {
+			type: 'string',
+		},
+	},
+	supports: {
+		html: false,
+		align: false,
+	},
+	edit,
+	save: () => null, // to use view.php
+};

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -12,8 +12,8 @@ import edit from './edit';
 /**
  * Style dependencies - will load in editor
  */
-import './editor.scss';
 import './view.scss';
+import './editor.scss';
 
 export const name = 'carousel';
 export const title = __( 'Articles Carousel' );

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -22,7 +22,7 @@ export const title = __( 'Articles Carousel' );
 export const icon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 		<Path d="M0 0h24v24H0z" fill="none" />
-		<Path d="M3 13h8V3H3v10zm0 8h8v-6H3v6zm10 0h8V11h-8v10zm0-18v6h8V3h-8z" />
+		<Path d="M7 19h10V4H7v15zm-5-2h4V6H2v11zM18 6v11h4V6h-4z" />
 	</SVG>
 );
 

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -42,7 +42,7 @@ export const settings = {
 		},
 		delay: {
 			type: 'number',
-			default: 3,
+			default: 5,
 		},
 		postsToShow: {
 			type: 'integer',

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -57,6 +57,22 @@ export const settings = {
 		tags: {
 			type: 'string',
 		},
+		showDate: {
+			type: 'boolean',
+			default: true,
+		},
+		showAuthor: {
+			type: 'boolean',
+			default: true,
+		},
+		showAvatar: {
+			type: 'boolean',
+			default: true,
+		},
+		showCategory: {
+			type: 'boolean',
+			default: false,
+		},
 	},
 	supports: {
 		html: false,

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -48,14 +48,14 @@ export const settings = {
 			type: 'integer',
 			default: 3,
 		},
-		author: {
-			type: 'string',
+		authors: {
+			type: 'array',
 		},
 		categories: {
-			type: 'string',
+			type: 'array',
 		},
 		tags: {
-			type: 'string',
+			type: 'array',
 		},
 		showDate: {
 			type: 'boolean',

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -1,0 +1,7 @@
+//alert( "hello!");
+
+/**
+ * Style dependencies
+ */
+
+import './view.scss';

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -142,11 +142,11 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 
 							if ( $attributes['showCategory'] && $category ) :
 								?>
-								<div>
+								<span class="cat-links">
 									<a href="<?php echo esc_url( get_category_link( $category->term_id ) ); ?>">
 										<?php echo esc_html( $category->name ); ?>
 									</a>
-								</div>
+								</span>
 								<?php
 							endif;
 							?>

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -101,6 +101,36 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 				<div class="entry-wrapper">
 
 					<?php
+					$category = false;
+
+					// Use Yoast primary category if set.
+					if ( class_exists( 'WPSEO_Primary_Term' ) ) {
+						$primary_term = new WPSEO_Primary_Term( 'category', get_the_ID() );
+						$category_id  = $primary_term->get_primary_term();
+						if ( $category_id ) {
+							$category = get_term( $category_id );
+						}
+					}
+
+					if ( ! $category ) {
+						$categories_list = get_the_category();
+						if ( ! empty( $categories_list ) ) {
+							$category = $categories_list[0];
+						}
+					}
+
+					if ( $attributes['showCategory'] && $category ) :
+						?>
+						<div class="cat-links">
+							<a href="<?php echo esc_url( get_category_link( $category->term_id ) ); ?>">
+								<?php echo esc_html( $category->name ); ?>
+							</a>
+						</div>
+						<?php
+					endif;
+					?>
+
+					<?php
 						the_title( '<h3 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h3>' );
 					?>
 
@@ -120,37 +150,9 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 								);
 								?>
 							</span><!-- .author-name -->
-						<?php endif; ?>
 							<?php
-							$category = false;
-
-							// Use Yoast primary category if set.
-							if ( class_exists( 'WPSEO_Primary_Term' ) ) {
-								$primary_term = new WPSEO_Primary_Term( 'category', get_the_ID() );
-								$category_id  = $primary_term->get_primary_term();
-								if ( $category_id ) {
-									$category = get_term( $category_id );
-								}
-							}
-
-							if ( ! $category ) {
-								$categories_list = get_the_category();
-								if ( ! empty( $categories_list ) ) {
-									$category = $categories_list[0];
-								}
-							}
-
-							if ( $attributes['showCategory'] && $category ) :
-								?>
-								<span class="cat-links">
-									<a href="<?php echo esc_url( get_category_link( $category->term_id ) ); ?>">
-										<?php echo esc_html( $category->name ); ?>
-									</a>
-								</span>
-								<?php
 							endif;
-							?>
-							<?php
+
 							if ( $attributes['showDate'] ) {
 								$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
 								if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -117,6 +117,35 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 								?>
 							</span><!-- .author-name -->
 							<?php
+							$category = false;
+
+							// Use Yoast primary category if set.
+							if ( class_exists( 'WPSEO_Primary_Term' ) ) {
+								$primary_term = new WPSEO_Primary_Term( 'category', get_the_ID() );
+								$category_id  = $primary_term->get_primary_term();
+								if ( $category_id ) {
+									$category = get_term( $category_id );
+								}
+							}
+
+							if ( ! $category ) {
+								$categories_list = get_the_category();
+								if ( ! empty( $categories_list ) ) {
+									$category = $categories_list[0];
+								}
+							}
+
+							if ( $category ) :
+								?>
+								<div>
+									<a href="<?php echo esc_url( get_category_link( $category->term_id ) ); ?>">
+										<?php echo esc_html( $category->name ); ?>
+									</a>
+								</div>
+								<?php
+							endif;
+							?>
+							<?php
 							$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
 							if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
 								$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -13,22 +13,39 @@
  * @return string Returns the post content with latest posts added.
  */
 function newspack_blocks_render_block_carousel( $attributes ) {
-	if ( ! Newspack_Blocks::is_amp() ) {
-		wp_enqueue_script(
-			'amp-carousel',
-			'https://cdn.ampproject.org/v0/amp-carousel-0.1.js',
+	if ( ! wp_script_is( 'amp-runtime', 'registered' ) ) {
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+		wp_register_script(
+			'amp-runtime',
+			'https://cdn.ampproject.org/v0.js',
 			null,
-			NEWSPACK_BLOCKS__VERSION,
-			true
-		);
-		wp_enqueue_script(
-			'amp-selector',
-			'https://cdn.ampproject.org/v0/amp-selector-0.1.js',
 			null,
-			NEWSPACK_BLOCKS__VERSION,
 			true
 		);
 	}
+	if ( ! wp_script_is( 'amp-carousel', 'registered' ) ) {
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+		wp_register_script(
+			'amp-carousel',
+			'https://cdn.ampproject.org/v0/amp-carousel-latest.js',
+			array( 'amp-runtime' ),
+			null,
+			true
+		);
+	}
+	if ( ! wp_script_is( 'amp-selector', 'registered' ) ) {
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+		wp_register_script(
+			'amp-selector',
+			'https://cdn.ampproject.org/v0/amp-selector-latest.js',
+			array( 'amp-runtime' ),
+			null,
+			true
+		);
+	}
+
+	wp_enqueue_script( 'amp-carousel' );
+	wp_enqueue_script( 'amp-selector' );
 	static $newspack_blocks_carousel_id = 0;
 	$newspack_blocks_carousel_id++;
 	$autoplay      = isset( $attributes['autoplay'] ) ? $attributes['autoplay'] : false;

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -31,13 +31,19 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 	}
 	static $newspack_blocks_carousel_id = 0;
 	$newspack_blocks_carousel_id++;
-	$classes       = Newspack_Blocks::block_classes( 'carousel', $attributes );
 	$autoplay      = isset( $attributes['autoplay'] ) ? $attributes['autoplay'] : false;
 	$author        = isset( $attributes['author'] ) ? $attributes['author'] : '';
 	$categories    = isset( $attributes['categories'] ) ? $attributes['categories'] : '';
 	$delay         = isset( $attributes['delay'] ) ? absint( $attributes['delay'] ) : 3;
 	$tags          = isset( $attributes['tags'] ) ? $attributes['tags'] : '';
 	$posts_to_show = intval( $attributes['postsToShow'] );
+
+	$other = array();
+	if ( $autoplay ) {
+		$other[] = 'wp-block-newspack-blocks-carousel__autoplay-playing';
+	}
+	$classes = Newspack_Blocks::block_classes( 'carousel', $attributes, $other );
+
 	$args          = array(
 		'posts_per_page'      => $posts_to_show,
 		'post_status'         => 'publish',
@@ -148,9 +154,40 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 		esc_attr( $classes ),
 		absint( $newspack_blocks_carousel_id ),
 		$carousel,
-		'',
+		$autoplay ? newspack_blocks_carousel_block_autoplay_ui( $newspack_blocks_carousel_id ) : '',
 		$selector
 	);
+}
+
+/**
+ * Generate autoplay play/pause UI.
+ *
+ * @param int $block_ordinal The ordinal number of the block, used in unique ID.
+ *
+ * @return string Autoplay UI markup.
+ */
+function newspack_blocks_carousel_block_autoplay_ui( $block_ordinal = 0 ) {
+	$block_id        = sprintf(
+		'wp-block-newspack-carousel__%d',
+		absint( $block_ordinal )
+	);
+	$amp_carousel_id = sprintf(
+		'wp-block-newspack-carousel__amp-carousel__%d',
+		absint( $block_ordinal )
+	);
+	$autoplay_pause  = sprintf(
+		'<a aria-label="%s" class="amp-carousel-button-pause amp-carousel-button" role="button" on="tap:%s.toggleAutoplay(toggleOn=false),%s.toggleClass(class=wp-block-newspack-blocks-carousel__autoplay-playing,force=false)"></a>',
+		esc_attr__( 'Pause Slideshow', 'newspack-blocks' ),
+		esc_attr( $amp_carousel_id ),
+		esc_attr( $block_id )
+	);
+	$autoplay_play   = sprintf(
+		'<a aria-label="%s" class="amp-carousel-button-play amp-carousel-button" role="button" on="tap:%s.toggleAutoplay(toggleOn=true),%s.toggleClass(class=wp-block-newspack-blocks-carousel__autoplay-playing,force=true)"></a>',
+		esc_attr__( 'Play Slideshow', 'newspack-blocks' ),
+		esc_attr( $amp_carousel_id ),
+		esc_attr( $block_id )
+	);
+	return $autoplay_pause . $autoplay_play;
 }
 
 /**

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -49,11 +49,11 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 	static $newspack_blocks_carousel_id = 0;
 	$newspack_blocks_carousel_id++;
 	$autoplay      = isset( $attributes['autoplay'] ) ? $attributes['autoplay'] : false;
-	$author        = isset( $attributes['author'] ) ? $attributes['author'] : '';
-	$categories    = isset( $attributes['categories'] ) ? $attributes['categories'] : '';
 	$delay         = isset( $attributes['delay'] ) ? absint( $attributes['delay'] ) : 3;
-	$tags          = isset( $attributes['tags'] ) ? $attributes['tags'] : '';
 	$posts_to_show = intval( $attributes['postsToShow'] );
+	$authors       = isset( $attributes['authors'] ) ? $attributes['authors'] : array();
+	$categories    = isset( $attributes['categories'] ) ? $attributes['categories'] : array();
+	$tags          = isset( $attributes['tags'] ) ? $attributes['tags'] : array();
 
 	$other = array();
 	if ( $autoplay ) {
@@ -65,16 +65,22 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 		'posts_per_page'      => $posts_to_show,
 		'post_status'         => 'publish',
 		'suppress_filters'    => false,
-		'cat'                 => $categories,
-		'tag_id'              => $tags,
-		'author'              => $author,
 		'ignore_sticky_posts' => true,
-		'cat'                 => $categories,
-		'author'              => $author,
 		'meta_key'            => '_thumbnail_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 		'meta_value_num'      => 0,
 		'meta_compare'        => '>',
 	);
+
+	if ( $authors ) {
+		$args['author__in'] = $authors;
+	}
+	if ( $categories ) {
+		$args['category__in'] = $categories;
+	}
+	if ( $tags ) {
+		$args['tag__in'] = $tags;
+	}
+
 	$article_query = new WP_Query( $args );
 	$counter       = 0;
 	ob_start();
@@ -263,22 +269,34 @@ function newspack_blocks_register_carousel() {
 					'type'    => 'integer',
 					'default' => 3,
 				),
-				'author'       => array(
-					'type' => 'string',
+				'authors'      => array(
+					'type'    => 'array',
+					'default' => array(),
+					'items'   => array(
+						'type' => 'integer',
+					),
+				),
+				'categories'   => array(
+					'type'    => 'array',
+					'default' => array(),
+					'items'   => array(
+						'type' => 'integer',
+					),
+				),
+				'tags'         => array(
+					'type'    => 'array',
+					'default' => array(),
+					'items'   => array(
+						'type' => 'integer',
+					),
 				),
 				'autoplay'     => array(
 					'type'    => 'boolean',
 					'default' => false,
 				),
-				'categories'   => array(
-					'type' => 'string',
-				),
 				'delay'        => array(
 					'type'    => 'integer',
 					'default' => 5,
-				),
-				'tags'         => array(
-					'type' => 'string',
 				),
 				'showAuthor'   => array(
 					'type'    => 'boolean',

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -217,7 +217,7 @@ function newspack_blocks_register_carousel() {
 				),
 				'delay'       => array(
 					'type'    => 'integer',
-					'default' => 4,
+					'default' => 5,
 				),
 				'tags'        => array(
 					'type' => 'string',

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Server-side rendering of the `newspack-blocks/carousel` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `newspack-blocks/carousel` block on server.
+ *
+ * @param array $attributes The block attributes.
+ *
+ * @return string Returns the post content with latest posts added.
+ */
+function newspack_blocks_render_block_carousel( $attributes ) {
+	if ( ! Newspack_Blocks::is_amp() ) {
+		wp_enqueue_script(
+			'amp-carousel',
+			'https://cdn.ampproject.org/v0/amp-carousel-0.1.js',
+			null,
+			NEWSPACK_BLOCKS__VERSION,
+			true
+		);
+		wp_enqueue_script(
+			'amp-selector',
+			'https://cdn.ampproject.org/v0/amp-selector-0.1.js',
+			null,
+			NEWSPACK_BLOCKS__VERSION,
+			true
+		);
+	}
+	static $newspack_blocks_carousel_id = 0;
+	$newspack_blocks_carousel_id++;
+	$classes       = Newspack_Blocks::block_classes( 'carousel', $attributes );
+	$author        = isset( $attributes['author'] ) ? $attributes['author'] : '';
+	$categories    = isset( $attributes['categories'] ) ? $attributes['categories'] : '';
+	$tags          = isset( $attributes['tags'] ) ? $attributes['tags'] : '';
+	$posts_to_show = intval( $attributes['postsToShow'] );
+	$args          = array(
+		'posts_per_page'      => $posts_to_show,
+		'post_status'         => 'publish',
+		'suppress_filters'    => false,
+		'cat'                 => $categories,
+		'tag_id'              => $tags,
+		'author'              => $author,
+		'ignore_sticky_posts' => true,
+		'cat'                 => $categories,
+		'author'              => $author,
+	);
+	$article_query = new WP_Query( $args );
+	$counter       = 0;
+	ob_start();
+	if ( $article_query->have_posts() ) :
+		while ( $article_query->have_posts() ) :
+			$article_query->the_post();
+			if ( ! has_post_thumbnail() ) {
+				continue;
+			}
+			$counter++;
+			?>
+
+			<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?>>
+				<figure class="post-thumbnail">
+					<a href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
+						<?php
+							the_post_thumbnail(
+								'large',
+								array(
+									'object-fit' => 'cover',
+									'layout'     => 'fill',
+								)
+							);
+						?>
+					</a>
+				</figure>
+				<div class="entry-wrapper">
+
+					<?php
+						the_title( '<h3 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h3>' );
+					?>
+
+					<div class="entry-meta">
+
+							<?php echo get_avatar( get_the_author_meta( 'ID' ) ); ?>
+							<span class="byline">
+								<?php
+								printf(
+									/* translators: %s: post author. */
+									esc_html_x( 'by %s', 'post author', 'newspack-blocks' ),
+									'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
+								);
+								?>
+							</span><!-- .author-name -->
+							<?php
+							$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
+							if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
+								$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
+							}
+							$time_string = sprintf(
+								$time_string,
+								esc_attr( get_the_date( DATE_W3C ) ),
+								esc_html( get_the_date() ),
+								esc_attr( get_the_modified_date( DATE_W3C ) ),
+								esc_html( get_the_modified_date() )
+							);
+							echo $time_string; // WPCS: XSS OK.
+							?>
+					</div><!-- .entry-meta -->
+				</div><!-- .entry-wrapper -->
+			</article>
+			<?php
+		endwhile;
+		endif;
+		wp_reset_postdata();
+	$slides  = ob_get_clean();
+	$buttons = array();
+	for ( $x = 0; $x < $counter; $x++ ) {
+		$aria_label = sprintf(
+			/* translators: %d: Slide number. */
+			__( 'Go to slide %d', 'newspack-blocks' ),
+			absint( $x + 1 )
+		);
+		$buttons[] = sprintf(
+			'<button option="%d" class="swiper-pagination-bullet" tabindex="0" role="button" aria-label="%s" %s></button>',
+			absint( $x ),
+			esc_attr( $aria_label ),
+			0 === $x ? 'selected' : ''
+		);
+	}
+	$selector = sprintf(
+		'<amp-selector id="wp-block-newspack-carousel__amp-pagination__%1$d" class="swiper-pagination-bullets amp-pagination" on="select:wp-block-newspack-carousel__amp-carousel__%1$d.goToSlide(index=event.targetOption)" layout="container">%2$s</amp-selector>',
+		absint( $newspack_blocks_carousel_id ),
+		implode( '', $buttons )
+	);
+	$delay    = 3;
+	$autoplay = true;
+	$carousel = sprintf(
+		'<amp-carousel width="4" height="3" layout="responsive" type="slides" data-next-button-aria-label="%1$s" data-prev-button-aria-label="%2$s" controls loop %3$s id="wp-block-newspack-carousel__amp-carousel__%4$s" on="slideChange:wp-block-newspack-carousel__amp-pagination__%4$s.toggle(index=event.index, value=true)">%5$s</amp-carousel>',
+		esc_attr__( 'Next Slide', 'newspack-blocks' ),
+		esc_attr__( 'Previous Slide', 'newspack-blocks' ),
+		$autoplay ? 'autoplay delay=' . esc_attr( $delay * 1000 ) : '',
+		absint( $newspack_blocks_carousel_id ),
+		$slides
+	);
+	Newspack_Blocks::enqueue_view_assets( 'carousel' );
+	return sprintf(
+		'<div class="%1$s" id="wp-block-newspack-carousel__%2$d">%3$s%4$s%5$s</div>',
+		esc_attr( $classes ),
+		absint( $newspack_blocks_carousel_id ),
+		$carousel,
+		'',
+		$selector
+	);
+}
+
+/**
+ * Registers the `newspack-blocks/carousel` block on server.
+ */
+function newspack_blocks_register_carousel() {
+	register_block_type(
+		'newspack-blocks/carousel',
+		array(
+			'attributes'      => array(
+				'className'   => array(
+					'type' => 'string',
+				),
+				'postsToShow' => array(
+					'type'    => 'integer',
+					'default' => 3,
+				),
+				'author'      => array(
+					'type' => 'string',
+				),
+				'categories'  => array(
+					'type' => 'string',
+				),
+				'tags'        => array(
+					'type' => 'string',
+				),
+			),
+			'render_callback' => 'newspack_blocks_render_block_carousel',
+		)
+	);
+}
+add_action( 'init', 'newspack_blocks_register_carousel' );

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -71,6 +71,9 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 		'ignore_sticky_posts' => true,
 		'cat'                 => $categories,
 		'author'              => $author,
+		'meta_key'            => '_thumbnail_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		'meta_value_num'      => 0,
+		'meta_compare'        => '>',
 	);
 	$article_query = new WP_Query( $args );
 	$counter       = 0;
@@ -84,7 +87,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 			$counter++;
 			?>
 
-			<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?>>
+			<article class="post-has-image">
 				<figure class="post-thumbnail">
 					<a href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
 						<?php

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -32,8 +32,10 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 	static $newspack_blocks_carousel_id = 0;
 	$newspack_blocks_carousel_id++;
 	$classes       = Newspack_Blocks::block_classes( 'carousel', $attributes );
+	$autoplay      = isset( $attributes['autoplay'] ) ? $attributes['autoplay'] : false;
 	$author        = isset( $attributes['author'] ) ? $attributes['author'] : '';
 	$categories    = isset( $attributes['categories'] ) ? $attributes['categories'] : '';
+	$delay         = isset( $attributes['delay'] ) ? absint( $attributes['delay'] ) : 3;
 	$tags          = isset( $attributes['tags'] ) ? $attributes['tags'] : '';
 	$posts_to_show = intval( $attributes['postsToShow'] );
 	$args          = array(
@@ -132,8 +134,6 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 		absint( $newspack_blocks_carousel_id ),
 		implode( '', $buttons )
 	);
-	$delay    = 3;
-	$autoplay = true;
 	$carousel = sprintf(
 		'<amp-carousel width="4" height="3" layout="responsive" type="slides" data-next-button-aria-label="%1$s" data-prev-button-aria-label="%2$s" controls loop %3$s id="wp-block-newspack-carousel__amp-carousel__%4$s" on="slideChange:wp-block-newspack-carousel__amp-pagination__%4$s.toggle(index=event.index, value=true)">%5$s</amp-carousel>',
 		esc_attr__( 'Next Slide', 'newspack-blocks' ),
@@ -171,8 +171,16 @@ function newspack_blocks_register_carousel() {
 				'author'      => array(
 					'type' => 'string',
 				),
+				'autoplay'    => array(
+					'type'    => 'boolean',
+					'default' => false,
+				),
 				'categories'  => array(
 					'type' => 'string',
+				),
+				'delay'       => array(
+					'type'    => 'integer',
+					'default' => 4,
 				),
 				'tags'        => array(
 					'type' => 'string',

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -105,8 +105,12 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 					?>
 
 					<div class="entry-meta">
-
-							<?php echo get_avatar( get_the_author_meta( 'ID' ) ); ?>
+						<?php if ( $attributes['showAuthor'] ) : ?>
+							<?php
+							if ( $attributes['showAvatar'] ) {
+								echo get_avatar( get_the_author_meta( 'ID' ) );
+							}
+							?>
 							<span class="byline">
 								<?php
 								printf(
@@ -116,6 +120,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 								);
 								?>
 							</span><!-- .author-name -->
+						<?php endif; ?>
 							<?php
 							$category = false;
 
@@ -135,7 +140,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 								}
 							}
 
-							if ( $category ) :
+							if ( $attributes['showCategory'] && $category ) :
 								?>
 								<div>
 									<a href="<?php echo esc_url( get_category_link( $category->term_id ) ); ?>">
@@ -146,18 +151,20 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 							endif;
 							?>
 							<?php
-							$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
-							if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
-								$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
+							if ( $attributes['showDate'] ) {
+								$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
+								if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
+									$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
+								}
+								$time_string = sprintf(
+									$time_string,
+									esc_attr( get_the_date( DATE_W3C ) ),
+									esc_html( get_the_date() ),
+									esc_attr( get_the_modified_date( DATE_W3C ) ),
+									esc_html( get_the_modified_date() )
+								);
+								echo $time_string; // WPCS: XSS OK.
 							}
-							$time_string = sprintf(
-								$time_string,
-								esc_attr( get_the_date( DATE_W3C ) ),
-								esc_html( get_the_date() ),
-								esc_attr( get_the_modified_date( DATE_W3C ) ),
-								esc_html( get_the_modified_date() )
-							);
-							echo $time_string; // WPCS: XSS OK.
 							?>
 					</div><!-- .entry-meta -->
 				</div><!-- .entry-wrapper -->
@@ -244,29 +251,45 @@ function newspack_blocks_register_carousel() {
 		'newspack-blocks/carousel',
 		array(
 			'attributes'      => array(
-				'className'   => array(
+				'className'    => array(
 					'type' => 'string',
 				),
-				'postsToShow' => array(
+				'postsToShow'  => array(
 					'type'    => 'integer',
 					'default' => 3,
 				),
-				'author'      => array(
+				'author'       => array(
 					'type' => 'string',
 				),
-				'autoplay'    => array(
+				'autoplay'     => array(
 					'type'    => 'boolean',
 					'default' => false,
 				),
-				'categories'  => array(
+				'categories'   => array(
 					'type' => 'string',
 				),
-				'delay'       => array(
+				'delay'        => array(
 					'type'    => 'integer',
 					'default' => 5,
 				),
-				'tags'        => array(
+				'tags'         => array(
 					'type' => 'string',
+				),
+				'showAuthor'   => array(
+					'type'    => 'boolean',
+					'default' => true,
+				),
+				'showAvatar'   => array(
+					'type'    => 'boolean',
+					'default' => true,
+				),
+				'showCategory' => array(
+					'type'    => 'boolean',
+					'default' => false,
+				),
+				'showDate'     => array(
+					'type'    => 'boolean',
+					'default' => true,
 				),
 			),
 			'render_callback' => 'newspack_blocks_render_block_carousel',

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -2,6 +2,8 @@
 @import '../../shared/sass/mixins';
 
 .wp-block-newspack-blocks-carousel {
+	position: relative;
+	margin-top: 0;
 	article {
 		max-width: 100%;
 		padding: 0;
@@ -129,6 +131,21 @@
 		cursor: pointer;
 	}
 
+	.amp-carousel-button-play,
+	.amp-carousel-button-pause {
+		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M6%2019h4V5H6v14zm8-14v14h4V5h-4z'%20fill='white'/%3E%3Cpath%20d='M0%200h24v24H0z'%20fill='none'/%3E%3C/svg%3E" );
+		display: none;
+		margin-top: 0;
+		position: absolute;
+		left: 0;
+		top: 0;
+		z-index: 1;
+	}
+
+	.amp-carousel-button-play {
+		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M8%205v14l11-7z'%20fill='white'/%3E%3Cpath%20d='M0 0h24v24H0z'%20fill='none'/%3E%3C/svg%3E" );
+	}
+
 	/* Image styles */
 
 	figcaption {
@@ -160,5 +177,13 @@
 		border-radius: 100%;
 		display: block;
 		margin-right: 0.5em;
+	}
+	&.wp-block-newspack-blocks-carousel__autoplay-playing .amp-carousel-button-pause,
+	.amp-carousel-button-play {
+		display: block;
+	}
+	&.wp-block-newspack-blocks-carousel__autoplay-playing .amp-carousel-button-play,
+	.amp-carousel-button-pause {
+		display: none;
 	}
 }

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -11,6 +11,14 @@
 		overflow-wrap: break-word;
 		.entry-title {
 			font-size: 1.2em;
+
+			a {
+				&:active,
+				&:focus,
+				&:hover {
+					color: rgba( 255, 255, 255, 0.75 );
+				}
+			}
 		}
 		.entry-meta {
 			font-size: 0.8em;
@@ -30,12 +38,27 @@
 			}
 		}
 		.entry-wrapper {
-			position: absolute;
 			bottom: 0;
-			width: 100%;
 			background-color: rgba( 0, 0, 0, 0.5 );
 			color: white;
-			padding: 1em;
+			left: 0;
+			padding: 1.5em;
+			position: absolute;
+			right: 0;
+		}
+		.entry-meta {
+			color: inherit;
+			margin-bottom: 0;
+
+			a {
+				color: inherit;
+
+				&:active,
+				&:focus,
+				&:hover {
+					color: rgba( 255, 255, 255, 0.75 );
+				}
+			}
 		}
 	}
 	figure.post-thumbnail {
@@ -99,9 +122,11 @@
 	}
 	.amp-carousel-button-next {
 		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M5.88%204.12L13.76%2012l-7.88%207.88L8%2022l10-10L8%202z'%20fill='white'/%3E%3Cpath%20fill='none'%20d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
+		cursor: pointer;
 	}
 	.amp-carousel-button-prev {
 		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M18%204.12L10.12%2012%2018%2019.88%2015.88%2022l-10-10%2010-10z'%20fill='white'/%3E%3Cpath%20fill='none'%20d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
+		cursor: pointer;
 	}
 
 	/* Image styles */

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -132,13 +132,20 @@
 			outline-offset: -4px;
 		}
 	}
+	.amp-carousel-button-next,
+	.amp-carousel-button-prev {
+		display: none;
+
+		@include media( mobile ) {
+			display: block;
+		}
+	}
 	.amp-carousel-button-next {
 		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M5.88%204.12L13.76%2012l-7.88%207.88L8%2022l10-10L8%202z'%20fill='white'/%3E%3Cpath%20fill='none'%20d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
 	}
 	.amp-carousel-button-prev {
 		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M18%204.12L10.12%2012%2018%2019.88%2015.88%2022l-10-10%2010-10z'%20fill='white'/%3E%3Cpath%20fill='none'%20d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
 	}
-
 	.amp-carousel-button-play,
 	.amp-carousel-button-pause {
 		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M6%2019h4V5H6v14zm8-14v14h4V5h-4z'%20fill='white'/%3E%3Cpath%20d='M0%200h24v24H0z'%20fill='none'/%3E%3C/svg%3E" );
@@ -150,13 +157,11 @@
 		transform: none;
 		z-index: 1;
 	}
-
 	.amp-carousel-button-play {
 		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M8%205v14l11-7z'%20fill='white'/%3E%3Cpath%20d='M0 0h24v24H0z'%20fill='none'/%3E%3C/svg%3E" );
 	}
 
 	/* Image styles */
-
 	figcaption {
 		font-size: $font__size-xxs;
 	}

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -137,7 +137,8 @@
 		margin-top: 0;
 		position: absolute;
 		right: 16px;
-		top: 40px;
+		top: 16px;
+		transform: none;
 		z-index: 1;
 	}
 

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -15,6 +15,15 @@
 			font-size: 1.2em;
 
 			a {
+				/* autoprefixer: off */
+				-webkit-box-orient: vertical;
+				/* autoprefixer: on */
+				display: -webkit-box;
+				-webkit-line-clamp: 3;
+				max-height: 3.5625em;
+				overflow: hidden;
+				text-overflow: ellipsis;
+
 				&:active,
 				&:focus,
 				&:hover {

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -108,6 +108,7 @@
 		border: 0;
 		border-radius: 4px;
 		box-shadow: none;
+		cursor: pointer;
 		height: 48px;
 		margin: 0;
 		padding: 0;
@@ -124,11 +125,9 @@
 	}
 	.amp-carousel-button-next {
 		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M5.88%204.12L13.76%2012l-7.88%207.88L8%2022l10-10L8%202z'%20fill='white'/%3E%3Cpath%20fill='none'%20d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
-		cursor: pointer;
 	}
 	.amp-carousel-button-prev {
 		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M18%204.12L10.12%2012%2018%2019.88%2015.88%2022l-10-10%2010-10z'%20fill='white'/%3E%3Cpath%20fill='none'%20d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
-		cursor: pointer;
 	}
 
 	.amp-carousel-button-play,
@@ -137,8 +136,8 @@
 		display: none;
 		margin-top: 0;
 		position: absolute;
-		left: 0;
-		top: 0;
+		right: 16px;
+		top: 40px;
 		z-index: 1;
 	}
 

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -24,6 +24,10 @@
 			.entry-title {
 				font-size: 1.6em;
 			}
+			.avatar {
+				height: 40px;
+				width: 40px;
+			}
 		}
 		.entry-wrapper {
 			position: absolute;

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -8,7 +8,7 @@
 		max-width: 100%;
 		padding: 0;
 		position: relative;
-		margin-bottom: 1.5em;
+		margin-bottom: 0;
 		word-break: break-word;
 		overflow-wrap: break-word;
 		.entry-title {

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -63,6 +63,8 @@
 
 			a {
 				color: inherit;
+				font-weight: bold;
+				text-decoration: none;
 
 				&:active,
 				&:focus,
@@ -182,7 +184,8 @@
 		align-items: center;
 		margin-top: 0.5em;
 
-		.byline:not( :last-child ) {
+		.byline:not( :last-child ),
+		.byline + div:not( :last-child ) {
 			margin-right: 1.5em;
 		}
 	}

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -1,0 +1,135 @@
+@import '../../shared/sass/variables';
+@import '../../shared/sass/mixins';
+
+.wp-block-newspack-blocks-carousel {
+	article {
+		max-width: 100%;
+		padding: 0;
+		position: relative;
+		margin-bottom: 1.5em;
+		word-break: break-word;
+		overflow-wrap: break-word;
+		.entry-title {
+			font-size: 1.2em;
+		}
+		.entry-meta {
+			font-size: 0.8em;
+		}
+		.avatar {
+			height: 1.8em;
+			width: 1.8em;
+		}
+
+		@include media( tablet ) {
+			.entry-title {
+				font-size: 1.6em;
+			}
+		}
+		.entry-wrapper {
+			position: absolute;
+			bottom: 0;
+			width: 100%;
+			background-color: rgba( 0, 0, 0, 0.5 );
+			color: white;
+			padding: 1em;
+		}
+	}
+	figure.post-thumbnail {
+		margin: 0;
+		height: 100%;
+		padding: 0;
+		img {
+			height: auto;
+			width: 100%;
+			height: 100%;
+		}
+	}
+	p {
+		white-space: normal;
+	}
+	.swiper-pagination-bullets {
+		bottom: 0;
+		line-height: 24px;
+		padding: 10px 0 2px;
+		position: relative;
+		text-align: center;
+	}
+	.swiper-pagination-bullet {
+		background: black;
+		display: inline-block;
+		height: 16px;
+		opacity: 0.5;
+		transform: scale( 0.75 );
+		transition: opacity 250ms, transform 250ms;
+		width: 16px;
+		border-radius: 100%;
+		padding: 0;
+		margin: 0 4px;
+		&[selected] {
+			opacity: 1;
+			transform: scale( 1 );
+		}
+	}
+
+	.amp-carousel-button {
+		background-color: rgba( 0, 0, 0, 0.5 );
+		background-position: center;
+		background-repeat: no-repeat;
+		background-size: 24px;
+		border: 0;
+		border-radius: 4px;
+		box-shadow: none;
+		height: 48px;
+		margin: 0;
+		padding: 0;
+		transition: background-color 250ms;
+		width: 48px;
+		&:focus,
+		&:hover {
+			background-color: rgba( 0, 0, 0, 0.75 );
+		}
+		&:focus {
+			outline: thin dotted white;
+			outline-offset: -4px;
+		}
+	}
+	.amp-carousel-button-next {
+		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M5.88%204.12L13.76%2012l-7.88%207.88L8%2022l10-10L8%202z'%20fill='white'/%3E%3Cpath%20fill='none'%20d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
+	}
+	.amp-carousel-button-prev {
+		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M18%204.12L10.12%2012%2018%2019.88%2015.88%2022l-10-10%2010-10z'%20fill='white'/%3E%3Cpath%20fill='none'%20d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
+	}
+
+	/* Image styles */
+
+	figcaption {
+		font-size: $font__size-xxs;
+	}
+
+	/* Headings */
+	.entry-title {
+		margin: 0 0 0.25em;
+		a {
+			color: inherit;
+			text-decoration: none;
+		}
+	}
+
+	/* Article meta */
+	.entry-meta {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		margin-top: 0.5em;
+
+		.byline:not( :last-child ) {
+			margin-right: 1.5em;
+		}
+	}
+
+	.avatar {
+		border-radius: 100%;
+		display: block;
+		margin-right: 0.5em;
+	}
+}

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -185,8 +185,14 @@
 		margin-top: 0.5em;
 
 		.byline:not( :last-child ),
-		.byline + div:not( :last-child ) {
+		.cat-links:not( :last-child ) {
 			margin-right: 1.5em;
+		}
+
+		.cat-links {
+			font-size: inherit;
+			margin-bottom: 0;
+			margin-top: 0;
 		}
 	}
 

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -11,6 +11,16 @@
 		margin-bottom: 0;
 		word-break: break-word;
 		overflow-wrap: break-word;
+
+		a {
+			color: inherit;
+
+			&:active,
+			&:focus,
+			&:hover {
+				color: rgba( 255, 255, 255, 0.75 );
+			}
+		}
 		.entry-title {
 			font-size: 1.2em;
 
@@ -23,12 +33,6 @@
 				max-height: 3.5625em;
 				overflow: hidden;
 				text-overflow: ellipsis;
-
-				&:active,
-				&:focus,
-				&:hover {
-					color: rgba( 255, 255, 255, 0.75 );
-				}
 			}
 		}
 		.entry-meta {
@@ -171,6 +175,7 @@
 	/* Headings */
 	.entry-title {
 		margin: 0 0 0.25em;
+
 		a {
 			color: inherit;
 			text-decoration: none;
@@ -184,15 +189,19 @@
 		align-items: center;
 		margin-top: 0.5em;
 
-		.byline:not( :last-child ),
-		.cat-links:not( :last-child ) {
+		.byline:not( :last-child ) {
 			margin-right: 1.5em;
 		}
+	}
 
-		.cat-links {
-			font-size: inherit;
-			margin-bottom: 0;
-			margin-top: 0;
+	.cat-links {
+		color: inherit;
+		font-size: 0.6em;
+		font-weight: bold;
+		margin: 0 0 0.5em;
+
+		a {
+			text-decoration: none;
 		}
 	}
 

--- a/src/blocks/homepage-articles/query-controls/index.js
+++ b/src/blocks/homepage-articles/query-controls/index.js
@@ -19,13 +19,16 @@ class QueryControls extends Component {
 			selectedTagId,
 			singleMode,
 			onSingleModeChange,
+			enableSingle,
 		} = this.props;
 		return [
-			<ToggleControl
-				checked={ singleMode }
-				onChange={ onSingleModeChange }
-				label={ __( 'Choose specific story' ) }
-			/>,
+			enableSingle && (
+				<ToggleControl
+					checked={ singleMode }
+					onChange={ onSingleModeChange }
+					label={ __( 'Choose specific story' ) }
+				/>
+			),
 			singleMode && (
 				<SelectControl
 					key="query-controls-single-post-select"
@@ -71,6 +74,7 @@ QueryControls.defaultProps = {
 	authorList: [],
 	postList: [],
 	tagsList: [],
+	enableSingle: true,
 };
 
 export default QueryControls;


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a Carousel block that uses `amp-carousel` to display posts.  `amp-carousel` cannot currently be used in the editor because it does not support DOM mutation after page load, which occurs whenever the array of posts to be displayed changes. Eventually Bento AMP will resolve this, but until this is available we will use the Swiper library to make the block functional in the editor. Currently, there is only a placeholder in the editor.

<img width="857" alt="Screen Shot 2019-10-08 at 12 18 29 AM" src="https://user-images.githubusercontent.com/1477002/66367198-344be780-e961-11e9-818e-b2d64c8f3d4a.png">

Closes https://github.com/Automattic/newspack-blocks/issues/48.

### How to test the changes in this Pull Request:

1. Check out the branch and execute `npm run build:webpack`
2. Add Articles Carousel block to a post.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
