### PR TITLE
Improves column plus borders behaviour

### DIFF
--- a/src/block-styles/core/columns/view.scss
+++ b/src/block-styles/core/columns/view.scss
@@ -34,17 +34,17 @@
 			@include media( mobile ) {
 				border-bottom: 0;
 
+				&:not(:first-child) {
+					margin-left: 24px;
+				}
+
 				&:after {
-					border-right: 1px solid transparent;
+					border-right: 1px solid $color__border;
 					bottom: 0;
 					content: '';
 					position: absolute;
-					right: -16px;
+					right: -12px;
 					top: 0;
-				}
-
-				&:nth-child(odd):after {
-					border-color: $color__border;
 				}
 
 				&:last-child:after {
@@ -53,8 +53,12 @@
 			}
 
 			@include media( tablet ) {
+				&:not(:first-child) {
+					margin-left: 32px;
+				}
+
 				&:after {
-					border-color: $color__border;
+					right: -16px;
 				}
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is a partial fix for an issue with the columns and the border styles.

Right now, the even width columns display the borders correctly at the tablet breakpoint, but the (fixed) custom width columns do not. All but the last set of columns have custom widths; the sets with two columns are okay, but the one with three is messed up:

![image](https://user-images.githubusercontent.com/177561/66443290-4f673780-e9f3-11e9-829d-8be6cce1820e.png)

This PR switches it so that the borders display correctly when you have custom column widths (but breaks the 'default' widths):

![image](https://user-images.githubusercontent.com/177561/66443327-732a7d80-e9f3-11e9-94bb-6ee84de4f299.png)

I'm not sure if there's a great way around this - perhaps if we extend the column block further to add a class if it uses custom block widths? I'd be very interested in getting some feedback on possible approaches.

In the meantime, if you want even-width columns, you can manually set them to even widths (50%, 50%, or 33.33%, 33.33%. 33.33%) and it "fix" the issue. 

(Style pack 3 will need an update based on what we choose to do here, since they have custom border styles. **Edited to add** PR added here: https://github.com/Automattic/newspack-theme/pull/483 Style 5 -- the other style pack that changes these borders -- does it in a smarter way, and doesn't need any changes). 

Closes #148.

### How to test the changes in this Pull Request:

1. Copy paste [this test content](https://cloudup.com/csJfug8JLsO) into the editor, or recreate the above by adding column blocks with 2-3 columns, setting them either at custom or default widths, and adding borders.
2. View on front-end; reduce the size of the browser window and note where the columns break/borders disappear.
3. Apply the PR and run `npm run build:webpack`
4. Confirm that you get something closer to the second screenshot; the column blocks using the default width will break kind of oddly, but the ones with custom widths will not.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
