### PR TITLE
Update the Primary Color to use Newspack new blue: `#36f`

### DIFF
--- a/src/blocks/donate/editor.scss
+++ b/src/blocks/donate/editor.scss
@@ -1,5 +1,7 @@
+$primary_color: #36f;
+
 .wp-block-newspack-blocks-donate button[type='submit'] {
-	background: #2A7DE1;
+	background: $primary_color;
 	border: none;
 	border-radius: 5px;
 	box-sizing: border-box;

--- a/src/blocks/donate/view.scss
+++ b/src/blocks/donate/view.scss
@@ -1,4 +1,4 @@
-$primary_color: #2A7DE1;
+$primary_color: #36f;
 
 .wp-block-newspack-blocks-donate {
 	position: relative;

--- a/src/setup/newspack-logo.js
+++ b/src/setup/newspack-logo.js
@@ -1,20 +1,17 @@
 /**
  * External dependencies
  */
-import { G, Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/components';
 import classNames from 'classnames';
 
 export default ( { size = 24, className } ) => (
 	<SVG
-		className={ classNames( 'jetpack-logo', className ) }
+		className={ classNames( 'newspack-logo', className ) }
 		width={ size }
 		height={ size }
 		viewBox="0 0 32 32"
 	>
-		<G stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-			<G fill="#2A7DE1" fillRule="nonzero">
-				<Path d="M16,0 C24.8365823,0 32,7.16345853 32,16.0000911 C32,24.8367237 24.8365823,32 16,32 C7.16341774,32 0,24.8367237 0,16.0000911 C0,7.16345853 7.16341774,0 16,0 Z M9.00970874,8.85436893 L9.00970874,13.6011058 L9.076,13.669 L9.00970874,13.6699029 L9.00970874,23.0938511 L12.4789644,23.0938511 L12.478,17.134 L18.3297326,23.0938511 L22.9902913,23.0938511 L9.00970874,8.85436893 Z M22.9902913,15.4822006 L20.1423948,15.4822006 L21.2545041,16.6213592 L22.9902913,16.6213592 L22.9902913,15.4822006 Z M22.9902913,12.1682848 L16.9320388,12.1682848 L18.0321512,13.3074434 L22.9902913,13.3074434 L22.9902913,12.1682848 Z M22.9902913,8.85436893 L13.6699029,8.85436893 L14.7723242,9.99352751 L22.9902913,9.99352751 L22.9902913,8.85436893 Z" id="Combined-Shape-Copy" fill="#2A7DE1" />
-			</G>
-		</G>
+		<Path d="M16 32c8.836 0 16-7.164 16-16S24.836 0 16 0 0 7.164 0 16s7.163 16 16 16z" fill="#36F" />
+		<Path d="M22.988 16.622h-1.72l-1.103-1.124h2.823v1.124zm0-3.31H18.02l-1.102-1.124h6.071v1.124zm0-3.31h-8.217l-1.103-1.125h9.32v1.125zm0 13.12L9.012 8.878v4.749l.069.071h-.07v9.426h3.451v-5.98l5.867 5.98h4.66z" fill="#fff" />
 	</SVG>
 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

* Update the `$primary_color` variable
* Adjust the Newspack logo

### How to test the changes in this Pull Request:

1. Check out the branch and execute `npm run build:webpack`
2. Test the blocks and see if any of the old blue is still appearing

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
