### PR TITLE
Article Blocks: Adjust category styles a bit

### DIFF
--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -1,3 +1,5 @@
+@import "../../shared/sass/variables";
+
 .type-scale-slider,
 .image-scale-slider {
 	.dashicons-editor-textcolor,
@@ -13,6 +15,13 @@
 	}
 }
 
-.wp-block-newspack-blocks-homepage-articles .editor-rich-text {
-	width: 100%;
+.wp-block-newspack-blocks-homepage-articles {
+	.editor-rich-text {
+		width: 100%;
+	}
+
+	/* Article meta */
+	.cat-links {
+		font-size: $font__size-xs;
+	}
 }

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -153,7 +153,30 @@
 
 	/* Article meta */
 	.cat-links {
-		margin-bottom: 1em;
+		font-size: $font__size-xxs;
+		font-weight: bold;
+		margin: 0 0 0.5em;
+
+		a {
+			text-decoration: none;
+
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+
+	&.image-aligntop .post-has-image .cat-links {
+		background-color: #111;
+		left: 0;
+		padding: 0.3em 0.5em 0.25em;
+		position: absolute;
+		top: 0;
+
+		a {
+			color: #fff;
+			display: inline-block;
+		}
 	}
 
 	.entry-meta {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is part of a two-part process to update the newly added 'category styles.

On the block level, this PR updates the styles, making sure they mostly match on the front-end and in the editor, and that they're visible when you use the image-as-background option, and don't get in the way when you use the 'show image caption' option.

There will be a second PR on the theme side, to adjust some more style pack-specific issues. I'd recommend testing this with one of the style packs with limited styles on the `.cat-links`, like Style 2 or 4.


### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`
2. Add 5 article blocks; in all three, turn on 'Show Category'.
3. The blocks will need the following settings, at least one post in each will need an image:
a) One block with the default, images hidden:

**Before:**

![image](https://user-images.githubusercontent.com/177561/66512866-b259dc80-ea8e-11e9-8edc-107af284df1e.png)

**Before - Editor**

![image](https://user-images.githubusercontent.com/177561/66512965-f0570080-ea8e-11e9-81e7-d710dc9d6206.png)


**After:**

![image](https://user-images.githubusercontent.com/177561/66512370-9dc91480-ea8d-11e9-97a8-40306a237518.png)

b) One block with images displayed on top.

**Before:** 

![image](https://user-images.githubusercontent.com/177561/66512878-b8e85400-ea8e-11e9-9213-333716ca5006.png)

**Before - Editor**

![image](https://user-images.githubusercontent.com/177561/66512999-01a00d00-ea8f-11e9-88ea-9daaa8f84a3a.png)


**After:**

![image](https://user-images.githubusercontent.com/177561/66512382-a3265f00-ea8d-11e9-9c83-0fe60c6e20e3.png)

c) One block with images displayed on top + captions.

**Before:** 

![image](https://user-images.githubusercontent.com/177561/66512886-bede3500-ea8e-11e9-91cb-28d79dee9726.png)

**Before - Editor**
![image](https://user-images.githubusercontent.com/177561/66513011-0bc20b80-ea8f-11e9-9c9a-7ea99794a6b6.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/66512394-acafc700-ea8d-11e9-923a-720815a8ff1f.png)

d) One block with images displayed beside.

**Before:**

![image](https://user-images.githubusercontent.com/177561/66512910-ce5d7e00-ea8e-11e9-913d-53510324e0d4.png)

**Before - Editor**

![image](https://user-images.githubusercontent.com/177561/66513042-1a102780-ea8f-11e9-934f-6150778a916a.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/66512403-b3d6d500-ea8d-11e9-915a-6e2f1d5d3e9e.png)

e) One block with images displayed behind. 

**Before:**

![image](https://user-images.githubusercontent.com/177561/66512927-d87f7c80-ea8e-11e9-8396-ca9b4dab5f65.png)

**Before - Editor**

![image](https://user-images.githubusercontent.com/177561/66513077-26948000-ea8f-11e9-8b82-4e149c7650d3.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/66512414-ba654c80-ea8d-11e9-9e6d-4dc76cd77d21.png)

4. In each block option, we're looking for a) legibility and b) consistency between the front-end and the editor. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
