### PR TITLE
Rework Columns Block with a more opinionated styles in our plugin

### DIFF
--- a/src/block-styles/core/columns/view.scss
+++ b/src/block-styles/core/columns/view.scss
@@ -2,14 +2,17 @@
 @import "../../../shared/sass/mixins";
 
 .wp-block-columns {
+
 	@include media( mobile ) {
+		flex-wrap: nowrap;
+		margin-left: -16px;
+		max-width: calc(100% + 32px);
+		width: calc(100% + 32px);
 
-		&[class*='is-style-first-col-to'] .wp-block-column {
-			margin-left: 32px;
-		}
-
-		&[class*='is-style-first-col-to'] .wp-block-column:nth-child( 2 ) {
-			margin-left: 0;
+		.wp-block-column {
+			margin-bottom: 0;
+			margin-left: 16px;
+			margin-right: 16px;
 		}
 
 		&.is-style-first-col-to-second .wp-block-column:nth-child( 2 ) {
@@ -22,45 +25,73 @@
 		}
 	}
 
+	@include media( tablet ) {
+		&.is-style-borders {
+			margin-left: -24px;
+			max-width: calc(100% + 48px);
+			width: calc(100% + 48px);
+
+			.wp-block-column {
+				margin-left: 24px;
+				margin-right: 24px;
+			}
+		}
+	}
+
+	@include media( desktop ) {
+		&.is-style-borders {
+			margin-left: -32px;
+			max-width: calc(100% + 64px);
+			width: calc(100% + 64px);
+
+			.wp-block-column {
+				margin-left: 32px;
+				margin-right: 32px;
+			}
+		}
+	}
+
 	&.is-style-borders {
 		.wp-block-column {
-			border-bottom: 1px solid $color__border;
 			position: relative;
 
-			&:last-child {
-				border-bottom: 0;
+			&:after {
+				border: 0 solid $color__border;
+				border-top-width: 1px;
+				bottom: -1em;
+				content: '';
+				left: 0;
+				position: absolute;
+				right: 0;
+			}
+
+			&:last-child:after {
+				display: none;
 			}
 
 			@include media( mobile ) {
-				border-bottom: 0;
-
-				&:not(:first-child) {
-					margin-left: 24px;
-				}
-
 				&:after {
-					border-right: 1px solid $color__border;
+					border-right-width: 1px;
+					border-top-width: 0;
 					bottom: 0;
-					content: '';
-					position: absolute;
-					right: -12px;
-					top: 0;
-				}
-
-				&:last-child:after {
-					display: none;
+					left: auto;
+					right: -16px;
+					top: 1em;
 				}
 			}
 
 			@include media( tablet ) {
-				&:not(:first-child) {
-					margin-left: 32px;
-				}
-
 				&:after {
-					right: -16px;
+					right: -24px;
+				}
+			}
+
+			@include media( desktop ) {
+				&:after {
+					right: -32px;
 				}
 			}
 		}
 	}
+
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

_This is an experiment_

This will allow our theme to lighten its CSS since most of the magic is now handled here.

I added a flex `nowrap` starting from mobile devices (600px) to make sure we overwrite Core. It also changes the behaviour of child elements by adding the same right/left margin to all of them.

I also tweaked the border style behaviour on smaller screens.

See: https://github.com/Automattic/newspack-theme/pull/493

### How to test the changes in this Pull Request:

1. Check out this branch and recompile the blocks
2. You will also need to [update the theme](https://github.com/Automattic/newspack-theme/pull/493)
3. Add different sizes of columns, does it work as expected?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
