### PR TITLE
Make avatar sizes more consistent on small screens

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -280,14 +280,20 @@
 		.entry-meta {
 			font-size: 0.8em;
 		}
+
 		.avatar {
-			height: 1.8em;
-			width: 1.8em;
+			height: 25px;
+			width: 25px;
 		}
 
 		@include media(tablet) {
 			.entry-title {
 				font-size: 1.6em;
+			}
+
+			.avatar {
+				height: 40px;
+				width: 40px;
 			}
 		}
 	}
@@ -417,9 +423,6 @@
 	&.type-scale3 article {
 		.entry-title {
 			font-size: 1.0em;
-			@include media( tablet ) {
-				font-size: 1.2em
-			}
 		}
 		.entry-wrapper p {
 			font-size: 0.8em;
@@ -427,26 +430,36 @@
 		.entry-meta {
 			font-size: 0.7em;
 		}
-		.avatar {
-			height: 32px;
-			width: 32px;
+		@include media( tablet ) {
+			.entry-title {
+				font-size: 1.2em
+			}
+
+			.avatar {
+				height: 32px;
+				width: 32px;
+			}
 		}
 	}
 
 	&.type-scale2 article {
 		.entry-title {
 			font-size: 0.8em;
-			@include media( tablet ) {
-				font-size: 0.9em
-			}
 		}
 		.entry-wrapper p,
 		.entry-meta {
 			font-size: 0.7em;
 		}
-		.avatar {
-			height: 28px;
-			width: 28px;
+
+		@include media( tablet ) {
+			.entry-title {
+				font-size: 0.9em;
+			}
+
+			.avatar {
+				height: 28px;
+				width: 28px;
+			}
 		}
 	}
 
@@ -458,9 +471,11 @@
 		.entry-meta {
 			font-size: 0.6em;
 		}
-		.avatar {
-			height: 24px;
-			width: 24px;
+		@include media( tablet ) {
+			.avatar {
+				height: 24px;
+				width: 24px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In reviewing sites, I noticed the varying avatar sizes looks a bit odd on smaller screens.

It changes based on the type scale, but when you get down to a certain point, the fonts are all pretty small -- it makes more sense to get the avatars consistent, too.

### How to test the changes in this Pull Request:

1. Set up a page with multiple blocks of different sizes, or [copy paste my test content.](https://cloudup.com/cyohq3mASrd)
2. View on the front end; scale down the browser window to a smaller size, and note the variation in avatars -- it's subtle, but they're all slightly different sizes:

![image](https://user-images.githubusercontent.com/177561/66610668-2ec4ec00-eb71-11e9-8532-f796e34aec16.png)

![image](https://user-images.githubusercontent.com/177561/66610657-21a7fd00-eb71-11e9-8db1-added3d230cc.png)

3. Apply the PR and run `npm run build:webpack`.
4. Confirm that the avatars are now all the same size on screens tablet-sized and smaller:

![image](https://user-images.githubusercontent.com/177561/66610779-82cfd080-eb71-11e9-8c46-3039e00aeb77.png)

Their sizes will still vary on screens larger than that.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
