### PR TITLE
Add transforms to and from core/latest-posts

### DIFF
--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { Path, SVG } from '@wordpress/components';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -139,4 +140,37 @@ export const settings = {
 	},
 	edit,
 	save: () => null, // to use view.php
+	transforms: {
+		from: [
+			{
+				type: 'block',
+				blocks: [ 'core/latest-posts' ],
+				transform: ( { displayPostContent, displayPostDate, postLayout, columns, postsToShow } ) => {
+					return createBlock( 'newspack-blocks/homepage-articles', {
+						showExcerpt: displayPostContent,
+						showDate: displayPostDate,
+						postLayout,
+						columns,
+						postsToShow,
+						showAuthor: false,
+					} );
+				},
+			},
+		],
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'core/latest-posts' ],
+				transform: ( { showExcerpt, showDate, postLayout, columns, postsToShow } ) => {
+					return createBlock( 'core/latest-posts', {
+						displayPostContent: showExcerpt,
+						displayPostDate: showDate,
+						postLayout,
+						columns,
+						postsToShow,
+					} );
+				},
+			},
+		],
+	},
 };

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -145,7 +145,7 @@ export const settings = {
 			{
 				type: 'block',
 				blocks: [ 'core/latest-posts' ],
-				transform: ( { displayPostContent, displayPostDate, postLayout, columns, postsToShow } ) => {
+				transform: ( { displayPostContent, displayPostDate, postLayout, columns, postsToShow, categories } ) => {
 					return createBlock( 'newspack-blocks/homepage-articles', {
 						showExcerpt: displayPostContent,
 						showDate: displayPostDate,
@@ -153,6 +153,7 @@ export const settings = {
 						columns,
 						postsToShow,
 						showAuthor: false,
+						categories: categories ? [ categories ] : [],
 					} );
 				},
 			},
@@ -161,13 +162,14 @@ export const settings = {
 			{
 				type: 'block',
 				blocks: [ 'core/latest-posts' ],
-				transform: ( { showExcerpt, showDate, postLayout, columns, postsToShow } ) => {
+				transform: ( { showExcerpt, showDate, postLayout, columns, postsToShow, categories } ) => {
 					return createBlock( 'core/latest-posts', {
 						displayPostContent: showExcerpt,
 						displayPostDate: showDate,
 						postLayout,
 						columns,
 						postsToShow,
+						categories: categories[0] || '',
 					} );
 				},
 			},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This makes it easy for users to switch to Newspack Homepage Articles if they were already using the core block for showing latest posts. It transforms all configuration attributes that are shared between the two blocks.

It also provides a transformation for the opposite direction. Due to Newspack having much more options for configuration, the way back is not lossless. Things like specific styling, filtering categories/authors/tags will be lost on the way because it's just not supported on the other side.

Shared options: number of posts to show, layouts (list/grid), number of grid columns, showing a date, and showing an excerpt.

### How to test the changes in this Pull Request:

1. Start a new page and insert "Latest Posts" block from the core.
2. Configure the block in different ways and always try to transform it into Newspack Homepage Articles and back to latest posts.
3. Confirm there are no errors coming from the transformation and it always succeeds. 
4. Undo button should undo the transformation in a single click.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?