### PR TITLE
Article Block: Reduce vertical spacing within articles

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -303,6 +303,9 @@
 	&.type-scale10,
 	&.type-scale9,
 	&.type-scale8 {
+		.entry-title {
+			line-height: 1.1em;
+		}
 		@include media(tablet) {
 			article .avatar {
 				height: 2.4em;

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -83,7 +83,11 @@
 	}
 
 	&.image-aligntop .post-thumbnail {
-		margin-bottom: 1em;
+		margin-bottom: 0.25em;
+
+		figcaption {
+			margin-bottom: 0.5em;
+		}
 	}
 
 	&.image-alignleft,
@@ -194,6 +198,10 @@
 		border-radius: 100%;
 		display: block;
 		margin-right: 0.5em;
+	}
+
+	p {
+		margin-top: 0.5em;
 	}
 
 	&.has-text-color {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR tightens up the vertical spacing within the articles in the article block, as an attempt to make them become more visually distinct from each other without increasing space between each article (though we can do that, too, if needed).

### How to test the changes in this Pull Request:

1. Add some article blocks to a page with different settings (with/without images, font sizes).
2. View the articles on large and small screen sizes; note the vertical spacing between photos, titles, content and post meta.

![image](https://user-images.githubusercontent.com/177561/66721398-4b9f3080-edb8-11e9-847e-1f5e714366a7.png)

![image](https://user-images.githubusercontent.com/177561/66721380-3fb36e80-edb8-11e9-8c4c-12b2c7d6f170.png)

3. Apply the PR and run `npm run build:webpack`
4. View the articles again; confirm that the spacing is reduced, and things look better (as opposed to worse - no one wants that!).

![image](https://user-images.githubusercontent.com/177561/66721295-1561b100-edb8-11e9-9d8d-acec42746d20.png)

![image](https://user-images.githubusercontent.com/177561/66721312-214d7300-edb8-11e9-8886-a6f5d48653c4.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
