### PR TITLE
Generate separate editor assets per each block

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,17 +32,22 @@ const blocks = fs
   .readdirSync( blocksDir )
   .filter( block => fs.existsSync( path.join( __dirname, 'src', 'blocks', block, 'editor.js' ) ) );
 
-// Helps split up each block into its own folder view script
-const viewBlocksScripts = blocks.reduce( ( viewBlocks, block ) => {
+// Helps split up each block into its own folder with view and editor scripts and styles.
+// Also creates a script one that combines all editor scripts for all blocks.
+const blocksScripts = blocks.reduce( ( scripts, block ) => {
 	const viewScriptPath = path.join( __dirname, 'src', 'blocks', block, 'view.js' );
 	if ( fs.existsSync( viewScriptPath ) ) {
-		viewBlocks[ block + '/view' ] = [ viewSetup, ...[ viewScriptPath ] ];
+		scripts[ block + '/view' ] = [ viewSetup, ...[ viewScriptPath ] ];
 	}
-	return viewBlocks;
+	const editorScriptPath = path.join( __dirname, 'src', 'blocks', block, 'editor.js' );
+	if ( fs.existsSync( editorScriptPath ) ) {
+		scripts[ block + '/editor' ] = [ editorSetup, ...[ editorScriptPath ] ];
+	}
+	return scripts;
 }, {} );
 
 // Combines all the different blocks into one editor.js script
-const editorScript = [
+const combinedEditorScript = [
 	editorSetup,
 	...blockScripts( 'editor', path.join( __dirname, 'src' ), blocks ),
 ];
@@ -55,9 +60,9 @@ const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },
 	{
 		entry: {
-			editor: editorScript,
+			editor: combinedEditorScript,
 			block_styles: blockStylesScript,
-			...viewBlocksScripts,
+			...blocksScripts,
 		},
 		'output-path': path.join( __dirname, 'dist' ),
 	}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Apart from the combined build of all the blocks together (current usage), this makes them also available as individual JS & CSS files.

This makes it easier to enqueue assets for a single block and a possibility to publish single blocks, as that currently looks like the future of blocks in WP.org block repo.

Closes # .

### How to test the changes in this Pull Request:

0. `npm install`
1. `npm run build:webpack`
2. Explore the `dist` folder generated
3. You show now see additional files - for example `dist/homepage-articles/editor.{js,css,rtl.css,deps.json}`

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
