### PR TITLE
Article Blocks: Remove bottom border of last item

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -502,6 +502,10 @@
 
 		&:last-of-type {
 			margin-bottom: 0;
+
+			&:not(:first-of-type) {
+				border-bottom: 0;
+			}
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In an attempt to create some predictable behaviour, I changed the article block to include a border under the last item. Unfortunately, this leads to a lot of doubled borders, especially on smaller screens, or at the very bottom of the page.

I think it ultimately makes more sense to remove the bottom border from the last item; the only time it seems to make sense to keep it is if you only have the block set to show one article; if it doesn't show on the last article in that case, it won't show at all.

### How to test the changes in this Pull Request:

1. Set up three article blocks: one with one article, one with several articles displayed as a list.
2. Apply the 'borders' style to all three.
3. Confirm that the last article in each block does not have a bottom border, unless it is the block only displaying one article. 

Note: I noticed some screwy behaviour with the borders and grid styles when testing this change -- the borders move to the bottom of the articles before they actually break into separate columns. I can look at resolving this in a separate PR; it could also change again down the road, depending on what we go with for #106. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
