### PR TITLE
Block Exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,5 @@ To get started with a new block:
 - Add the block slug to the `production` array in `src/setup/blocks.json`
 - If the block requires server-side code add the slug to the `$newspack_blocks_blocks` array in `newspack-blocks.php`
 - Execute `npm run build`. If all went smoothly, you should see a Newspack category in the block picker, and your block should appear within it.
+
+If you wish to create a block which will not be included in release builds, add an empty file named `_development` to `/src/blocks/{BLOCKNAME}/`. The block will be built when running `npm run build:webpack` but will be ignored when running `npm run release:archive`.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build:webpack": "calypso-build --config='./webpack.config.js'",
     "clean": "rm -rf dist/",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "release:archive": "run-p \"clean\" && run-p \"build:webpack\" && mkdir -p assets/release && zip -r assets/release/newspack-blocks.zip . -x node_modules/\\* .git/\\* .github/\\* .gitignore .DS_Store vendor/\\*"
+    "release:archive": "run-p \"clean\" && NODE_ENV=production run-p \"build:webpack\" && mkdir -p assets/release && zip -r assets/release/newspack-blocks.zip . -x node_modules/\\* .git/\\* .github/\\* .gitignore .DS_Store vendor/\\*"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@
  * External dependencies
  */
 const fs = require( 'fs' );
+const isDevelopment = process.env.NODE_ENV !== 'production';
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
 const path = require( 'path' );
 
@@ -29,8 +30,13 @@ function blockScripts( type, inputDir, blocks ) {
 
 const blocksDir = path.join( __dirname, 'src', 'blocks' );
 const blocks = fs
-  .readdirSync( blocksDir )
-  .filter( block => fs.existsSync( path.join( __dirname, 'src', 'blocks', block, 'editor.js' ) ) );
+	.readdirSync( blocksDir )
+	.filter( block => fs.existsSync( path.join( __dirname, 'src', 'blocks', block, 'editor.js' ) ) )
+	.filter(
+		block =>
+			! fs.existsSync( path.join( __dirname, 'src', 'blocks', block, '_development' ) ) ||
+			isDevelopment
+	);
 
 // Helps split up each block into its own folder view script
 const viewBlocksScripts = blocks.reduce( ( viewBlocks, block ) => {
@@ -47,9 +53,7 @@ const editorScript = [
 	...blockScripts( 'editor', path.join( __dirname, 'src' ), blocks ),
 ];
 
-const blockStylesScript = [
-	path.join( __dirname, 'src', 'block-styles', 'view' ),
-];
+const blockStylesScript = [ path.join( __dirname, 'src', 'block-styles', 'view' ) ];
 
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Now that the plugin is in use in production environments, there will be situations where we will want to merge PRs with new blocks but exclude them from release builds. This PR approaches this by searching for an empty file named `_development` in the source directory for each block. If this file is present, the block won't be built if `NODE_ENV` is `production`. Executing the `release:archive` script now sets `NODE_ENV=production`, which has the added benefit of minifying Javascript and CSS.

### How to test the changes in this Pull Request:

1. Create a build using `npm run build:webpack` and a release with `npm run release:archive`.
2. Verify that all three blocks are available in both (Articles Carousel, Donate, Newspack Homepage Articles).  
3. Add an empty file named `_development` to `/src/blocks/carousel/`. 
4. Repeat step 1.
5. Verify that all three blocks are available in the normal build but Articles Carousel is excluded from the release.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
