### PR TITLE
Do not overlap the category over the image.

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -170,19 +170,6 @@
 		}
 	}
 
-	&.image-aligntop .post-has-image .cat-links {
-		background-color: #111;
-		left: 0;
-		padding: 0.3em 0.5em 0.25em;
-		position: absolute;
-		top: 0;
-
-		a {
-			color: #fff;
-			display: inline-block;
-		}
-	}
-
 	.entry-meta {
 		display: flex;
 		flex-wrap: wrap;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes the styles that place the category on top of the image, when you opt to display it on blocks. 

We've had two requests to move it so far; I suggested adding an option to move it in #164, but if we do it seems like having it below the image by default would be preferable. 

I'm starting that process here, but recognize this is something pretty distinct that is now available on staging sites. So I'd be open to discussing how to approach this further, what the 'default' should be and if we should make something changeable on the block. 

### How to test the changes in this Pull Request:

1. Add a an article block to a page; make sure at least one of the articles displayed has an image.
2. Set the block to display categories.
3. View on the front-end; note the category placement is different:

![image](https://user-images.githubusercontent.com/177561/67243070-a7e2ff80-f40b-11e9-9921-363daf1efd61.png)

4. Apply the PR and run `npm run build:webpack`
5. Confirm that the category now displays in the same spot when the block has an image, and when it does not:

![image](https://user-images.githubusercontent.com/177561/67242980-7d914200-f40b-11e9-8688-5d8a77ac93a9.png)

I'm going to make a complementary theme PR for this as well, since I know some things in the style packs will need tweaking.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
