### PR TITLE
Increase vertical spacing for columns block when stacked

### DIFF
--- a/src/block-styles/core/columns/view.scss
+++ b/src/block-styles/core/columns/view.scss
@@ -3,6 +3,14 @@
 
 .wp-block-columns {
 
+	.wp-block-column {
+		margin-bottom: 32px;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
 	@include media( mobile ) {
 		flex-wrap: nowrap;
 		margin-left: -16px;

--- a/src/block-styles/core/columns/view.scss
+++ b/src/block-styles/core/columns/view.scss
@@ -4,7 +4,7 @@
 .wp-block-columns {
 
 	.wp-block-column {
-		margin-bottom: 32px;
+		margin-bottom: 64px;
 
 		&:last-child {
 			margin-bottom: 0;
@@ -66,7 +66,7 @@
 			&:after {
 				border: 0 solid $color__border;
 				border-top-width: 1px;
-				bottom: -1em;
+				bottom: -32px;
 				content: '';
 				left: 0;
 				position: absolute;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR increases the vertical space between columns when they're stacked on small screens. 

Before: 

![image](https://user-images.githubusercontent.com/177561/67250210-5e041480-f41f-11e9-9ca6-a9825bd3b845.png)

After:

![image](https://user-images.githubusercontent.com/177561/67250169-3a40ce80-f41f-11e9-88b0-be212a7920d9.png)

### How to test the changes in this Pull Request:

1. Add a column block to a page, and add some content; apply the border style to make testing easier.
2. View on the front end and shrink the browser window down to mobile size; note the spacing between the columns.
3. Apply the PR and run `npm run build:webpack`
4. Confirm that the spacing is now increased.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
