### PR TITLE
Article Block: Add option to not crop the images

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -97,6 +97,16 @@ class Newspack_Blocks_API {
 		);
 		$featured_image_set['square'] = $feat_img_array_square[0];
 
+		// Uncropped image.
+		$uncropped_size = 'newspack-article-block-uncropped';
+
+		$feat_img_array_uncropped        = wp_get_attachment_image_src(
+			$object['featured_media'],
+			$uncropped_size,
+			false
+		);
+		$featured_image_set['uncropped'] = $feat_img_array_uncropped[0];
+
 		return $featured_image_set;
 	}
 

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -203,6 +203,8 @@ function newspack_blocks_image_sizes() {
 	add_image_size( 'newspack-article-block-landscape-tiny', 200, 150, true );
 	add_image_size( 'newspack-article-block-portrait-tiny', 150, 200, true );
 	add_image_size( 'newspack-article-block-square-tiny', 200, 200, true );
+
+	add_image_size( 'newspack-article-block-uncropped', 1200, 9999, false );
 }
 add_action( 'after_setup_theme', 'newspack_blocks_image_sizes' );
 

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -64,6 +64,13 @@ const squareIcon = (
 	</SVG>
 );
 
+const uncroppedIcon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<Path d="M0 0h24v24H0z" fill="none" />
+		<Path d="M3 5v4h2V5h4V3H5c-1.1 0-2 .9-2 2zm2 10H3v4c0 1.1.9 2 2 2h4v-2H5v-4zm14 4h-4v2h4c1.1 0 2-.9 2-2v-4h-2v4zm0-16h-4v2h4v4h2V5c0-1.1-.9-2-2-2z" />
+	</SVG>
+);
+
 const coverIcon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 		<Path d="M0 0h24v24H0z" fill="none" />
@@ -98,6 +105,10 @@ class Edit extends Component {
 								<img src={ post.newspack_featured_image_src.portrait } />
 							) }
 							{ imageShape === 'square' && <img src={ post.newspack_featured_image_src.square } /> }
+
+							{ imageShape === 'uncropped' && (
+								<img src={ post.newspack_featured_image_src.uncropped } />
+							) }
 						</a>
 						{ showCaption && '' !== post.newspack_featured_image_caption && (
 							<figcaption>{ post.newspack_featured_image_caption }</figcaption>
@@ -539,6 +550,12 @@ class Edit extends Component {
 				title: __( 'Square Image Shape', 'newspack-blocks' ),
 				isActive: imageShape === 'square',
 				onClick: () => setAttributes( { imageShape: 'square' } ),
+			},
+			{
+				icon: uncroppedIcon,
+				title: __( 'Uncropped', 'newspack-blocks' ),
+				isActive: imageShape === 'uncropped',
+				onClick: () => setAttributes( { imageShape: 'uncropped' } ),
 			},
 		];
 

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -114,7 +114,10 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 						<figure class="post-thumbnail">
 							<a href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
 								<?php
-								$image_size = newspack_blocks_image_size_for_orientation( $attributes['imageShape'] );
+								$image_size = 'newspack-article-block-uncropped';
+								if ( 'uncropped' !== $attributes['imageShape'] ) {
+									$image_size = newspack_blocks_image_size_for_orientation( $attributes['imageShape'] );
+								}
 
 								// If the image position is behind, pass the object-fit setting to maintain styles with AMP.
 								if ( 'behind' === $attributes['mediaPosition'] ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an image sizing option to not crop the featured images in the Article Block.

It sets the 'crop' image size to 1200px wide by any height; if the original image is smaller than this it won't be changed at all, but unlike the images for the other settings, it's totally fine if images with these settings aren't cropped.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`
2. To affect existing images, Install and run the Regenerate Thumbnails plugin. 
3. Create a new post; use this test image as the featured image: https://cloudup.com/crTPisEKtkg
4. Set up an article block to pull this post; view how it looks with the default (Landscape) image shape:

![image](https://user-images.githubusercontent.com/177561/67258892-af27fe80-f447-11e9-98d7-525b131f0110.png)

5. Edit the block; switch the image cropping to "no crop" (last option):

![image](https://user-images.githubusercontent.com/177561/67258985-31b0be00-f448-11e9-985d-e343180ffa7f.png)

6. Confirm that the full image is now displayed:

![image](https://user-images.githubusercontent.com/177561/67259008-573dc780-f448-11e9-8130-92b872f09095.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
