### PR TITLE
Article Block: Add 'show-category' class when category is displayed

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -476,6 +476,7 @@ class Edit extends Component {
 			imageScale,
 			sectionHeader,
 			showCaption,
+			showCategory,
 		} = attributes;
 
 		const classes = classNames( className, {
@@ -488,6 +489,7 @@ class Edit extends Component {
 			[ `image-shape${ imageShape }` ]: imageShape !== 'landscape',
 			'has-text-color': textColor.color !== '',
 			'show-caption': showCaption,
+			'show-category': showCategory,
 		} );
 
 		const blockControls = [

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -67,6 +67,9 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	if ( $attributes['showCaption'] ) {
 		$classes .= ' show-caption';
 	}
+	if ( $attributes['showCategory'] ) {
+		$classes .= ' show-category';
+	}
 	if ( isset( $attributes['className'] ) ) {
 		$classes .= ' ' . $attributes['className'];
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the class `.show-category` to the `wp-block-newspack-blocks-homepage-articles` container when you've selected the 'Show Category' option for the block.

This can then be used to adjust styles in themes (for our purposes, it'll be super helpful for styling 'Style 3').

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`
2. Add an article block; turn on 'Show category' in the settings.
3. On the front-end and in the editor, confirm that there's a `.show-category' class added to the block.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
