### PR TITLE
Block List

### DIFF
--- a/block-list.json
+++ b/block-list.json
@@ -1,0 +1,3 @@
+{
+  "production": [ "carousel", "donate", "homepage-articles" ]
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build:webpack": "calypso-build --config='./webpack.config.js'",
     "clean": "rm -rf dist/",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "release:archive": "run-p \"clean\" && run-p \"build:webpack\" && mkdir -p assets/release && zip -r assets/release/newspack-blocks.zip . -x node_modules/\\* .git/\\* .github/\\* .gitignore .DS_Store vendor/\\*"
+    "release:archive": "run-p \"clean\" && NODE_ENV=production run-p \"build:webpack\" && mkdir -p assets/release && zip -r assets/release/newspack-blocks.zip . -x node_modules/\\* .git/\\* .github/\\* .gitignore .DS_Store vendor/\\*"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,11 +9,9 @@
 const fs = require( 'fs' );
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
 const path = require( 'path' );
-
-/**
- * Internal dependencies
- */
-// const { workerCount } = require( './webpack.common' ); // todo: shard...
+const isDevelopment = process.env.NODE_ENV !== 'production';
+const blockListFile = process.env.npm_config_block_list || 'block-list.json';
+const blockList = JSON.parse( fs.readFileSync( blockListFile ) );
 
 /**
  * Internal variables
@@ -29,8 +27,9 @@ function blockScripts( type, inputDir, blocks ) {
 
 const blocksDir = path.join( __dirname, 'src', 'blocks' );
 const blocks = fs
-  .readdirSync( blocksDir )
-  .filter( block => fs.existsSync( path.join( __dirname, 'src', 'blocks', block, 'editor.js' ) ) );
+	.readdirSync( blocksDir )
+	.filter( block => isDevelopment || blockList.production.includes( block ) )
+	.filter( block => fs.existsSync( path.join( __dirname, 'src', 'blocks', block, 'editor.js' ) ) );
 
 // Helps split up each block into its own folder view script
 const viewBlocksScripts = blocks.reduce( ( viewBlocks, block ) => {
@@ -47,9 +46,7 @@ const editorScript = [
 	...blockScripts( 'editor', path.join( __dirname, 'src' ), blocks ),
 ];
 
-const blockStylesScript = [
-	path.join( __dirname, 'src', 'block-styles', 'view' ),
-];
+const blockStylesScript = [ path.join( __dirname, 'src', 'block-styles', 'view' ) ];
 
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

An alternate approach to block exclusion. `block-list.json` provides a list of blocks to be built in production builds. In non-production builds all available blocks are built, but in production only the ones explicitly named in the `production` array will be. Optional `--block-list=filename.json` parameter allows overwriting the default list. Releases packaged using the `release:archive` script are now production builds. 

Replaces https://github.com/Automattic/newspack-blocks/pull/177.

### How to test the changes in this Pull Request:

1. Run `npm run build:webpack`, verify all current blocks are built and available (Donate, Articles Carousel, Newspack Homepage Articles).
2. Run `NODE_ENV=production npm run build:webpack`, verify the same. 
3. Edit `block-list.json`, and remove `carousel` from the `production` array. 
4. Run `npm run build:webpack`, verify all blocks are built and available (including Carousel).
5. Run `NODE_ENV=production npm run build:webpack`, verify Carousel is now removed.
6. Duplicate `block-list.json`, name it `test-block-list.json`, and leave only donate:
```
{
  "production": [ "donate" ]
}
```
7. Run `NODE_ENV=production npm run build:webpack --block-list=test-block-list.json`, verify that only Donate is available. (If you run the same without `NODE_ENV=production` all blocks should be present)
8. Run `npm run release:archive`. 
9. Navigate to `assets/release` and unzip `newspack-blocks.zip`. Verify that the Javascript and CSS files in  `dist/` are minified. For bonus points, remove a block from the block list, run `release:archive` and verify the removed block is not in the distribution.

cc @marekhrabe — this approach may be useful to you as a an approach to generating single block distributions of the plugin?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
