### PR TITLE
Add short version of block CSS class to reduce amount of styles.

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -564,7 +564,7 @@ class Edit extends Component {
 		return (
 			<Fragment>
 				<div
-					className={ classes }
+					className={ classes + ' wpnbha' }
 					style={ {
 						color: textColor.color,
 					} }

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -490,6 +490,7 @@ class Edit extends Component {
 			'has-text-color': textColor.color !== '',
 			'show-caption': showCaption,
 			'show-category': showCategory,
+			wpnbha: true,
 		} );
 
 		const blockControls = [
@@ -564,7 +565,7 @@ class Edit extends Component {
 		return (
 			<Fragment>
 				<div
-					className={ classes + ' wpnbha' }
+					className={ classes }
 					style={ {
 						color: textColor.color,
 					} }

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -15,7 +15,7 @@
 	}
 }
 
-.wp-block-newspack-blocks-homepage-articles {
+.wpnbha {
 	.editor-rich-text {
 		width: 100%;
 	}

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -46,6 +46,8 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 	$classes = Newspack_Blocks::block_classes( 'homepage-articles', $attributes );
 
+	$classes .= ' wpnbha';
+
 	if ( isset( $attributes['postLayout'] ) && 'grid' === $attributes['postLayout'] ) {
 		$classes .= ' is-grid';
 	}

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -44,9 +44,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	}
 	$article_query = new WP_Query( $args );
 
-	$classes = Newspack_Blocks::block_classes( 'homepage-articles', $attributes );
-
-	$classes .= ' wpnbha';
+	$classes = Newspack_Blocks::block_classes( 'homepage-articles', $attributes, array( 'wpnbha' ) );
 
 	if ( isset( $attributes['postLayout'] ) && 'grid' === $attributes['postLayout'] ) {
 		$classes .= ' is-grid';

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -1,7 +1,7 @@
 @import "../../shared/sass/variables";
 @import "../../shared/sass/mixins";
 
-.wp-block-newspack-blocks-homepage-articles {
+.wpnbha {
 	margin-bottom: 1em;
 
 	article {
@@ -286,7 +286,7 @@
 }
 
 /* Some really rough font sizing */
-.wp-block-newspack-blocks-homepage-articles {
+.wpnbha {
 	/* 'Normal' size */
 	article {
 		.entry-title {
@@ -500,7 +500,7 @@
 
 /* Block styles */
 
-.wp-block-newspack-blocks-homepage-articles.is-style-borders {
+.wpnbha.is-style-borders {
 	article {
 		border: solid rgba(0, 0, 0, 0.2);
 		border-width: 0 0 1px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a new class -- `wpnbha` -- as a short form to use for the block styles. It'll help reduce the CSS volume. In my testing, the generated view.css for this block went from 17kb to 12kb.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`
2. On a page with several article blocks, make sure that the styles are still applied as expected on the front-end, and in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
