### PR TITLE
Simplify type scale class to reduce CSS.

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -483,7 +483,7 @@ class Edit extends Component {
 			'is-grid': postLayout === 'grid',
 			'show-image': showImage,
 			[ `columns-${ columns }` ]: postLayout === 'grid',
-			[ `type-scale${ typeScale }` ]: typeScale !== '5',
+			[ `ts-${ typeScale }` ]: typeScale !== '5',
 			[ `image-align${ mediaPosition }` ]: showImage,
 			[ `image-scale${ imageScale }` ]: imageScale !== '1' && showImage,
 			[ `image-shape${ imageShape }` ]: imageShape !== 'landscape',

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -59,7 +59,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 		$classes .= ' image-align' . $attributes['mediaPosition'];
 	}
 	if ( isset( $attributes['typeScale'] ) ) {
-		$classes .= ' type-scale' . $attributes['typeScale'];
+		$classes .= ' ts-' . $attributes['typeScale'];
 	}
 	if ( $attributes['showImage'] && isset( $attributes['imageScale'] ) ) {
 		$classes .= ' image-scale' . $attributes['imageScale'];

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -313,9 +313,9 @@
 		}
 	}
 
-	&.type-scale10,
-	&.type-scale9,
-	&.type-scale8 {
+	&.ts-10,
+	&.ts-9,
+	&.ts-8 {
 		.entry-title {
 			line-height: 1.1em;
 		}
@@ -328,7 +328,7 @@
 
 	}
 
-	&.type-scale10 article {
+	&.ts-10 article {
 		.entry-title {
 			font-size: 2.6em;
 		}
@@ -344,7 +344,7 @@
 		}
 	}
 
-	&.type-scale9 article {
+	&.ts-9 article {
 		.entry-title {
 			font-size: 2.4em;
 		}
@@ -360,7 +360,7 @@
 		}
 	}
 
-	&.type-scale8 article {
+	&.ts-8 article {
 		.entry-title {
 			font-size: 2.2em;
 		}
@@ -376,7 +376,7 @@
 		}
 	}
 
-	&.type-scale7 article {
+	&.ts-7 article {
 		.entry-title {
 			font-size: 2em;
 		}
@@ -396,7 +396,7 @@
 		}
 	}
 
-	&.type-scale6 article {
+	&.ts-6 article {
 		.entry-title {
 			font-size: 1.7em;
 		}
@@ -416,7 +416,7 @@
 		}
 	}
 
-	&.type-scale5 article {
+	&.ts-5 article {
 		.entry-title {
 			font-size: 1.4em;
 		}
@@ -438,7 +438,7 @@
 
 	/* Type Scale 4: default */
 
-	&.type-scale3 article {
+	&.ts-3 article {
 		.entry-title {
 			font-size: 1.0em;
 		}
@@ -460,7 +460,7 @@
 		}
 	}
 
-	&.type-scale2 article {
+	&.ts-2 article {
 		.entry-title {
 			font-size: 0.8em;
 		}
@@ -481,7 +481,7 @@
 		}
 	}
 
-	&.type-scale1 article {
+	&.ts-1 article {
 		.entry-title,
 		.entry-wrapper p {
 			font-size: 0.7em;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR replaces the `type-scale#` classes with `ts-#`, to help reduce the generated CSS size.

### How to test the changes in this Pull Request:

1. Start with a handful of article blocks set to different type sizes.
2. Apply the PR and run `npm run build:webpack`
3. Confirm that the different type scales are still in place.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
