### PR TITLE
Swap out 'image-scale' class with 'is-'.

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -485,7 +485,7 @@ class Edit extends Component {
 			[ `columns-${ columns }` ]: postLayout === 'grid',
 			[ `type-scale${ typeScale }` ]: typeScale !== '5',
 			[ `image-align${ mediaPosition }` ]: showImage,
-			[ `image-scale${ imageScale }` ]: imageScale !== '1' && showImage,
+			[ `is-${ imageScale }` ]: imageScale !== '1' && showImage,
 			[ `image-shape${ imageShape }` ]: imageShape !== 'landscape',
 			'has-text-color': textColor.color !== '',
 			'show-caption': showCaption,

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -62,7 +62,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 		$classes .= ' type-scale' . $attributes['typeScale'];
 	}
 	if ( $attributes['showImage'] && isset( $attributes['imageScale'] ) ) {
-		$classes .= ' image-scale' . $attributes['imageScale'];
+		$classes .= ' is-' . $attributes['imageScale'];
 	}
 	if ( $attributes['showCaption'] ) {
 		$classes .= ' show-caption';

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -101,7 +101,8 @@
 			}
 		}
 
-		&.image-scale4 {
+		// Image scale
+		&.is-4 {
 			.post-thumbnail {
 				flex-basis: 75%;
 			}
@@ -110,9 +111,9 @@
 			}
 		}
 
-		// .image-scale3 is the default - 50%
+		// .is-3 is the default - 50%
 
-		&.image-scale2 {
+		&.is-2 {
 			.post-thumbnail {
 				flex-basis: 33%;
 			}
@@ -121,7 +122,7 @@
 			}
 		}
 
-		&.image-scale1 {
+		&.is-1 {
 			.post-thumbnail {
 				flex-basis: 25%;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR replaces the `image-scale#` class with `is-#`, to reduce CSS characters.

### How to test the changes in this Pull Request:

1. Add a couple article blocks to a page; make sure the articles have images.
2. Float all of the images right or left, and give them different image scales.
3. Apply the PR and run `npm run build:webpack`
4. Make sure the image scale sizes are still respected in the editor and on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
