### PR TITLE
Donation Block: Simplify main donate block selector

### DIFF
--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -92,7 +92,7 @@ class Edit extends Component {
 		};
 
 		return (
-			<div className={ classNames( className, 'untiered' ) }>
+			<div className={ classNames( className, 'untiered wpbnbd' ) }>
 				<form>
 					<div className="wp-block-newspack-blocks-donate__options">
 						{ Object.keys( frequencies ).map( frequencySlug => (
@@ -158,7 +158,7 @@ class Edit extends Component {
 		};
 
 		return (
-			<div className={ classNames( className, 'tiered' ) }>
+			<div className={ classNames( className, 'tiered wpbnbd' ) }>
 				<form>
 					<div className="wp-block-newspack-blocks-donate__options">
 						<div className="wp-block-newspack-blocks-donate__frequencies">

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -44,7 +44,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 	if ( ! $settings['tiered'] ) :
 
 		?>
-		<div class='wp-block-newspack-blocks-donate untiered'>
+		<div class='wp-block-newspack-blocks-donate wpbnbd untiered'>
 			<form>
 				<input type='hidden' name='newspack_donate' value='1' />
 				<div class='wp-block-newspack-blocks-donate__options'>
@@ -100,7 +100,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 	else :
 
 		?>
-		<div class='wp-block-newspack-blocks-donate tiered'>
+		<div class='wp-block-newspack-blocks-donate wpbnbd tiered'>
 			<form>
 				<input type='hidden' name='newspack_donate' value='1' />
 				<div class='wp-block-newspack-blocks-donate__options'>

--- a/src/blocks/donate/view.scss
+++ b/src/blocks/donate/view.scss
@@ -1,6 +1,6 @@
 $primary_color: #36f;
 
-.wp-block-newspack-blocks-donate {
+.wpbnbd {
 	position: relative;
 	width: 100%;
 	background-color: $muriel-gray-0;
@@ -33,7 +33,7 @@ $primary_color: #36f;
 	}
 }
 
-.wp-block-newspack-blocks-donate.tiered {
+.wpbnbd.tiered {
 	.wp-block-newspack-blocks-donate__tiers {
 		margin-top: 2em;
 		display: none;
@@ -84,7 +84,7 @@ $primary_color: #36f;
 	}
 }
 
-.wp-block-newspack-blocks-donate.untiered {
+.wpbnbd.untiered {
 	padding-top: 3em;
 
 	.input-container {
@@ -175,7 +175,7 @@ $primary_color: #36f;
 }
 
 @media screen and (max-width: 600px) {
-	.wp-block-newspack-blocks-donate {
+	.wpbnbd {
 		.donation-frequency-label {
 			font-size: 12px;
 			height: 42px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a second, shorter main class used by the donate block, so it can then be used to make the CSS lighter.

### How to test the changes in this Pull Request:

1. Add a donation block to a post or page.
2. Apply the PR and run `npm run build:webpack`
3. Confirm that the donation block still looks the same on the front-end and in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
