### PR TITLE
WIP Article Block Height: Add input for setting `min-height` (option A)

### DIFF
--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -65,6 +65,10 @@ export const settings = {
 			type: 'string',
 			default: 'landscape',
 		},
+		minHeight: {
+			type: 'integer',
+			default: 100,
+		},
 		showAuthor: {
 			type: 'boolean',
 			default: true,
@@ -145,7 +149,14 @@ export const settings = {
 			{
 				type: 'block',
 				blocks: [ 'core/latest-posts' ],
-				transform: ( { displayPostContent, displayPostDate, postLayout, columns, postsToShow, categories } ) => {
+				transform: ( {
+					displayPostContent,
+					displayPostDate,
+					postLayout,
+					columns,
+					postsToShow,
+					categories,
+				} ) => {
 					return createBlock( 'newspack-blocks/homepage-articles', {
 						showExcerpt: displayPostContent,
 						showDate: displayPostDate,
@@ -169,7 +180,7 @@ export const settings = {
 						postLayout,
 						columns,
 						postsToShow,
-						categories: categories[0] || '',
+						categories: categories[ 0 ] || '',
 					} );
 				},
 			},

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -110,14 +110,12 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				$post_counter++;
 
 				$styles = '';
-
 				if ( 'behind' === $attributes['mediaPosition'] && $attributes['showImage'] && has_post_thumbnail() ) {
 					$styles = 'min-height: ' . $attributes['minHeight'] . 'px';
 				}
-
 				?>
 
-				<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?> style="<?php echo esc_attr( $styles ); ?>">
+				<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?> <?php echo $styles ? 'style="' . esc_attr( $styles ) . '"' : ''; ?>>
 
 					<?php if ( has_post_thumbnail() && $attributes['showImage'] && $attributes['imageShape'] ) : ?>
 

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -108,9 +108,16 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				}
 				$newspack_blocks_post_id[ get_the_ID() ] = true;
 				$post_counter++;
+
+				$styles = '';
+
+				if ( 'behind' === $attributes['mediaPosition'] && $attributes['showImage'] && has_post_thumbnail() ) {
+					$styles = 'min-height: ' . $attributes['minHeight'] . 'px';
+				}
+
 				?>
 
-				<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?>>
+				<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?> style="<?php echo esc_attr( $styles ); ?>">
 
 					<?php if ( has_post_thumbnail() && $attributes['showImage'] && $attributes['imageShape'] ) : ?>
 
@@ -337,6 +344,10 @@ function newspack_blocks_register_homepage_articles() {
 				'imageShape'    => array(
 					'type'    => 'string',
 					'default' => 'landscape',
+				),
+				'minHeight'       => array(
+					'type'    => 'integer',
+					'default' => 100,
 				),
 				'sectionHeader'   => array(
 					'type'    => 'string',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a 'Minimum height in pixels' field to the article block, when you have the image positioned in the background. 

It's a starting point for some of the ideas suggested in #153; two other PRs (#196 and #197) illustrate a couple other approaches we could look at. 

The main issue I see with this approach could be mobile: in looking at CoBlock's Hero block, it lets you set a mobile and tablet min-height in pixels separately. However, the way they override the inline desktop height is by adding `!important`, which we can't use with AMP. 

I think this is something we need to resolve to some extent before merging -- a 1000px tall article on desktop may make sense, and then look terrible on mobile. But I wanted to put this out there first to see how it feels :) 

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`
2. Add an article block to a page.
3. Set the article block to use the `Show media behind` image position.
4. Confirm you now have a field in the Featured Image Settings labelled 'Minimum height in pixels':

![image](https://user-images.githubusercontent.com/177561/67980949-bdf77980-fbdc-11e9-8b0c-21aac7d9925b.png)

5. Try setting it to a variety of settings, and make sure they're respected on the front-end and in the editor.
6. Make sure the minimum height isn't applied to an article in the set that doesn't have a featured image.
7. Try hiding the featured image; make sure the 'Minimum height' option is hidden, and the height is no longer applied.
8. Try changing the image positioning to top, left, or right, and make sure the 'Minimum height' option is hidden, and the height is no longer applied. 
9. Give some feedback on how to approach this for mobile (please and thank you!). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
