### PR TITLE
WIP Article Block Height: Add input for setting `min-height` (option B)

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -84,7 +84,8 @@ class Edit extends Component {
 		const {
 			showImage,
 			imageShape,
-			imageFileSize,
+			mediaPosition,
+			minHeight,
 			showCaption,
 			showExcerpt,
 			showAuthor,
@@ -93,8 +94,21 @@ class Edit extends Component {
 			showCategory,
 			sectionHeader,
 		} = attributes;
+
+		const styles = {
+			minHeight:
+				mediaPosition === 'behind' &&
+				showImage &&
+				post.newspack_featured_image_src &&
+				minHeight + 'vh',
+		};
+
 		return (
-			<article className={ post.newspack_featured_image_src && 'post-has-image' } key={ post.id }>
+			<article
+				className={ post.newspack_featured_image_src && 'post-has-image' }
+				key={ post.id }
+				style={ styles }
+			>
 				{ showImage && post.newspack_featured_image_src && (
 					<figure className="post-thumbnail" key="thumbnail">
 						<a href="#">
@@ -172,6 +186,7 @@ class Edit extends Component {
 			setTextColor,
 		} = this.props;
 		const hasPosts = Array.isArray( latestPosts ) && latestPosts.length;
+
 		const {
 			authors,
 			single,
@@ -182,6 +197,7 @@ class Edit extends Component {
 			showImage,
 			showCaption,
 			imageScale,
+			minHeight,
 			showExcerpt,
 			typeScale,
 			showDate,
@@ -376,6 +392,17 @@ class Edit extends Component {
 							max={ 4 }
 							beforeIcon="images-alt2"
 							afterIcon="images-alt2"
+							required
+						/>
+					) }
+
+					{ showImage && mediaPosition === 'behind' && (
+						<RangeControl
+							label={ __( 'Minimum height', 'newspack-blocks' ) }
+							value={ minHeight }
+							onChange={ value => setAttributes( { minHeight: value } ) }
+							min={ 1 }
+							max={ 100 }
 							required
 						/>
 					) }

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -65,6 +65,10 @@ export const settings = {
 			type: 'string',
 			default: 'landscape',
 		},
+		minHeight: {
+			type: 'integer',
+			default: 10,
+		},
 		showAuthor: {
 			type: 'boolean',
 			default: true,
@@ -145,7 +149,14 @@ export const settings = {
 			{
 				type: 'block',
 				blocks: [ 'core/latest-posts' ],
-				transform: ( { displayPostContent, displayPostDate, postLayout, columns, postsToShow, categories } ) => {
+				transform: ( {
+					displayPostContent,
+					displayPostDate,
+					postLayout,
+					columns,
+					postsToShow,
+					categories,
+				} ) => {
 					return createBlock( 'newspack-blocks/homepage-articles', {
 						showExcerpt: displayPostContent,
 						showDate: displayPostDate,
@@ -169,7 +180,7 @@ export const settings = {
 						postLayout,
 						columns,
 						postsToShow,
-						categories: categories[0] || '',
+						categories: categories[ 0 ] || '',
 					} );
 				},
 			},

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -108,9 +108,14 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				}
 				$newspack_blocks_post_id[ get_the_ID() ] = true;
 				$post_counter++;
+
+				$styles = '';
+				if ( 'behind' === $attributes['mediaPosition'] && $attributes['showImage'] && has_post_thumbnail() ) {
+					$styles = 'min-height: ' . $attributes['minHeight'] . 'vh';
+				}
 				?>
 
-				<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?>>
+				<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?> <?php echo $styles ? 'style="' . esc_attr( $styles ) . '"' : ''; ?>>
 
 					<?php if ( has_post_thumbnail() && $attributes['showImage'] && $attributes['imageShape'] ) : ?>
 
@@ -337,6 +342,10 @@ function newspack_blocks_register_homepage_articles() {
 				'imageShape'    => array(
 					'type'    => 'string',
 					'default' => 'landscape',
+				),
+				'minHeight'       => array(
+					'type'    => 'integer',
+					'default' => 10,
 				),
 				'sectionHeader'   => array(
 					'type'    => 'string',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is a riff on #196, switching the text input for pixels with a range control for `vh` to set the minimum height for articles with the image as background.

The hope with using a measurement relative to the screensize is that it will behave a bit more predictably on small screens (compared to pixels, which are fixed regardless of screensize). I'm not 100% `vh` is the best option, but figured it would give a rough feel for how this kind of thing would behave. 

See #153.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`
2. Add an article block to a page.
3. Set the article block to use the Show media behind image position.
4. Confirm you now have a field in the Featured Image Settings labelled 'Minimum height':

![image](https://user-images.githubusercontent.com/177561/67988430-29494780-fbed-11e9-8fc1-7bf9f7fcf517.png)

5. Try setting it to a variety of settings, and make sure they're respected on the front-end and in the editor.
6. Add a block with a taller minimum height (60-70). On the front-end, try adjusting the height of the browser window and confirm that the minimum height on the block visually adjusts too.
7. Make sure the minimum height isn't applied to an article in the set that doesn't have a featured image.
8. Try hiding the featured image; make sure the 'Minimum height' option is hidden, and the height is no longer applied.
9. Try changing the image positioning to top, left, or right, and make sure the 'Minimum height' option is hidden, and the height is no longer applied.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
