### PR TITLE
WIP Article Block Height: Add range control for top padding (option C)

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -100,7 +100,7 @@ class Edit extends Component {
 				mediaPosition === 'behind' &&
 				showImage &&
 				post.newspack_featured_image_src &&
-				paddingTop + 'vw',
+				paddingTop + 'vh',
 		};
 
 		return (
@@ -402,7 +402,7 @@ class Edit extends Component {
 							value={ paddingTop }
 							onChange={ value => setAttributes( { paddingTop: value } ) }
 							min={ 0 }
-							max={ 50 }
+							max={ 100 }
 							required
 						/>
 					) }

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -84,7 +84,8 @@ class Edit extends Component {
 		const {
 			showImage,
 			imageShape,
-			imageFileSize,
+			mediaPosition,
+			paddingTop,
 			showCaption,
 			showExcerpt,
 			showAuthor,
@@ -93,8 +94,21 @@ class Edit extends Component {
 			showCategory,
 			sectionHeader,
 		} = attributes;
+
+		const styles = {
+			paddingTop:
+				mediaPosition === 'behind' &&
+				showImage &&
+				post.newspack_featured_image_src &&
+				paddingTop + 'vw',
+		};
+
 		return (
-			<article className={ post.newspack_featured_image_src && 'post-has-image' } key={ post.id }>
+			<article
+				className={ post.newspack_featured_image_src && 'post-has-image' }
+				key={ post.id }
+				style={ styles }
+			>
 				{ showImage && post.newspack_featured_image_src && (
 					<figure className="post-thumbnail" key="thumbnail">
 						<a href="#">
@@ -172,6 +186,7 @@ class Edit extends Component {
 			setTextColor,
 		} = this.props;
 		const hasPosts = Array.isArray( latestPosts ) && latestPosts.length;
+
 		const {
 			authors,
 			single,
@@ -182,6 +197,7 @@ class Edit extends Component {
 			showImage,
 			showCaption,
 			imageScale,
+			paddingTop,
 			showExcerpt,
 			typeScale,
 			showDate,
@@ -376,6 +392,17 @@ class Edit extends Component {
 							max={ 4 }
 							beforeIcon="images-alt2"
 							afterIcon="images-alt2"
+							required
+						/>
+					) }
+
+					{ showImage && mediaPosition === 'behind' && (
+						<RangeControl
+							label={ __( 'Top padding', 'newspack-blocks' ) }
+							value={ paddingTop }
+							onChange={ value => setAttributes( { paddingTop: value } ) }
+							min={ 0 }
+							max={ 50 }
 							required
 						/>
 					) }

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -65,6 +65,10 @@ export const settings = {
 			type: 'string',
 			default: 'landscape',
 		},
+		paddingTop: {
+			type: 'integer',
+			default: 0,
+		},
 		showAuthor: {
 			type: 'boolean',
 			default: true,
@@ -145,7 +149,14 @@ export const settings = {
 			{
 				type: 'block',
 				blocks: [ 'core/latest-posts' ],
-				transform: ( { displayPostContent, displayPostDate, postLayout, columns, postsToShow, categories } ) => {
+				transform: ( {
+					displayPostContent,
+					displayPostDate,
+					postLayout,
+					columns,
+					postsToShow,
+					categories,
+				} ) => {
 					return createBlock( 'newspack-blocks/homepage-articles', {
 						showExcerpt: displayPostContent,
 						showDate: displayPostDate,
@@ -169,7 +180,7 @@ export const settings = {
 						postLayout,
 						columns,
 						postsToShow,
-						categories: categories[0] || '',
+						categories: categories[ 0 ] || '',
 					} );
 				},
 			},

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -108,9 +108,14 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				}
 				$newspack_blocks_post_id[ get_the_ID() ] = true;
 				$post_counter++;
+
+				$styles = '';
+				if ( 'behind' === $attributes['mediaPosition'] && $attributes['showImage'] && has_post_thumbnail() ) {
+					$styles = 'padding-top: ' . $attributes['paddingTop'] . 'vw';
+				}
 				?>
 
-				<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?>>
+				<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?> <?php echo $styles ? 'style="' . esc_attr( $styles ) . '"' : ''; ?>>
 
 					<?php if ( has_post_thumbnail() && $attributes['showImage'] && $attributes['imageShape'] ) : ?>
 
@@ -337,6 +342,10 @@ function newspack_blocks_register_homepage_articles() {
 				'imageShape'    => array(
 					'type'    => 'string',
 					'default' => 'landscape',
+				),
+				'paddingTop'      => array(
+					'type'    => 'integer',
+					'default' => 0,
 				),
 				'sectionHeader'   => array(
 					'type'    => 'string',

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -111,7 +111,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 				$styles = '';
 				if ( 'behind' === $attributes['mediaPosition'] && $attributes['showImage'] && has_post_thumbnail() ) {
-					$styles = 'padding-top: ' . $attributes['paddingTop'] . 'vw';
+					$styles = 'padding-top: ' . $attributes['paddingTop'] . 'vh';
 				}
 				?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is another riff on #196 and #197, but rather than setting a minimum height, it sets a top padding.

It's similar to #197 in that it uses a measurement that changes with the viewport (in this case, `vw`, to better get a feel for how much that shifting affects things). 

One plus of this approach, over a minimum height, is that it doesn't fully disappear on smaller screens (even if the padding value is relatively smaller, it's always a value on top of the current height, vs. the minimum height becoming shorter than the actual height of the article, based on the content height.

See #153 

### How to test the changes in this Pull Request:

1. Apply the PR and run npm run build:webpack
2. Add an article block to a page.
3. Set the article block to use the Show media behind image position.
4. Confirm you now have a field in the Featured Image Settings labelled 'Top Padding', with a default of `0`:

![image](https://user-images.githubusercontent.com/177561/67992210-12105700-fbf9-11e9-90a2-43d9d074c963.png)

5. Try setting it to a variety of settings, and make sure they're respected on the front-end and in the editor.
6. Add a block with a taller top padding (40-50). On the front-end, try adjusting the width of the browser window and confirm that the padding on the block visually adjusts too.
7. Make sure the minimum height isn't applied to an article in the set that doesn't have a featured image.
8. Try hiding the featured image; make sure the 'Minimum height' option is hidden, and the height is no longer applied.
9. Try changing the image positioning to top, left, or right, and make sure the 'Minimum height' option is hidden, and the height is no longer applied.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
