### PR TITLE
Article Block Height: Add range control for minimum height + top padding (option D)

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -84,7 +84,8 @@ class Edit extends Component {
 		const {
 			showImage,
 			imageShape,
-			imageFileSize,
+			mediaPosition,
+			minHeight,
 			showCaption,
 			showExcerpt,
 			showAuthor,
@@ -93,8 +94,26 @@ class Edit extends Component {
 			showCategory,
 			sectionHeader,
 		} = attributes;
+
+		const styles = {
+			minHeight:
+				mediaPosition === 'behind' &&
+				showImage &&
+				post.newspack_featured_image_src &&
+				minHeight + 'vh',
+			paddingTop:
+				mediaPosition === 'behind' &&
+				showImage &&
+				post.newspack_featured_image_src &&
+				minHeight / 5 + 'vh',
+		};
+
 		return (
-			<article className={ post.newspack_featured_image_src && 'post-has-image' } key={ post.id }>
+			<article
+				className={ post.newspack_featured_image_src && 'post-has-image' }
+				key={ post.id }
+				style={ styles }
+			>
 				{ showImage && post.newspack_featured_image_src && (
 					<figure className="post-thumbnail" key="thumbnail">
 						<a href="#">
@@ -172,6 +191,7 @@ class Edit extends Component {
 			setTextColor,
 		} = this.props;
 		const hasPosts = Array.isArray( latestPosts ) && latestPosts.length;
+
 		const {
 			authors,
 			single,
@@ -182,6 +202,7 @@ class Edit extends Component {
 			showImage,
 			showCaption,
 			imageScale,
+			minHeight,
 			showExcerpt,
 			typeScale,
 			showDate,
@@ -376,6 +397,17 @@ class Edit extends Component {
 							max={ 4 }
 							beforeIcon="images-alt2"
 							afterIcon="images-alt2"
+							required
+						/>
+					) }
+
+					{ showImage && mediaPosition === 'behind' && (
+						<RangeControl
+							label={ __( 'Minimum height', 'newspack-blocks' ) }
+							value={ minHeight }
+							onChange={ value => setAttributes( { minHeight: value } ) }
+							min={ 0 }
+							max={ 100 }
 							required
 						/>
 					) }

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -65,6 +65,10 @@ export const settings = {
 			type: 'string',
 			default: 'landscape',
 		},
+		minHeight: {
+			type: 'integer',
+			default: 0,
+		},
 		showAuthor: {
 			type: 'boolean',
 			default: true,
@@ -145,7 +149,14 @@ export const settings = {
 			{
 				type: 'block',
 				blocks: [ 'core/latest-posts' ],
-				transform: ( { displayPostContent, displayPostDate, postLayout, columns, postsToShow, categories } ) => {
+				transform: ( {
+					displayPostContent,
+					displayPostDate,
+					postLayout,
+					columns,
+					postsToShow,
+					categories,
+				} ) => {
 					return createBlock( 'newspack-blocks/homepage-articles', {
 						showExcerpt: displayPostContent,
 						showDate: displayPostDate,
@@ -169,7 +180,7 @@ export const settings = {
 						postLayout,
 						columns,
 						postsToShow,
-						categories: categories[0] || '',
+						categories: categories[ 0 ] || '',
 					} );
 				},
 			},

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -108,9 +108,14 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				}
 				$newspack_blocks_post_id[ get_the_ID() ] = true;
 				$post_counter++;
+
+				$styles = '';
+				if ( 'behind' === $attributes['mediaPosition'] && $attributes['showImage'] && has_post_thumbnail() ) {
+					$styles = 'min-height: ' . $attributes['minHeight'] . 'vh; padding-top: ' . ( $attributes['minHeight'] / 5 ) . 'vh;';
+				}
 				?>
 
-				<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?>>
+				<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?> <?php echo $styles ? 'style="' . esc_attr( $styles ) . '"' : ''; ?>>
 
 					<?php if ( has_post_thumbnail() && $attributes['showImage'] && $attributes['imageShape'] ) : ?>
 
@@ -337,6 +342,10 @@ function newspack_blocks_register_homepage_articles() {
 				'imageShape'    => array(
 					'type'    => 'string',
 					'default' => 'landscape',
+				),
+				'minHeight'       => array(
+					'type'    => 'integer',
+					'default' => 0,
 				),
 				'sectionHeader'   => array(
 					'type'    => 'string',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is kind of a combination of #197 and #198 -- it adds a 'min-height' control to the article block when you have the image set to display behind the article. But rather than just adding a minimum height, it also adds 20% of that value as a top padding. 

This is to help make sure the blocks don't lose all top spacing on smaller screens -- I was finding when you added a moderate min-height to an article with an excerpt, as it scaled down for smaller screens, it would often be 'shorter' than the article's new height, making it seem like it wasn't applied at all. 

The padding won't add anything when the min-height is taller than the article would normally be, but adds a bit of top padding when the min-height is shorter than the content. 

See #153 .

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`
2. Add an article block to a page.
3. Set the article block to use the Show media behind image position.
4. Confirm you now have a field in the Featured Image Settings labelled 'Minimum height':

![image](https://user-images.githubusercontent.com/177561/68055522-0d59aa80-fcae-11e9-862e-bfa06f74cfa3.png)

5. Try setting it to a variety of settings, and make sure they're respected on the front-end and in the editor.
6. Add a block with a taller minimum height (60-70). On the front-end, try adjusting the height of the browser window and confirm that the minimum height on the block visually adjusts too.
7. Make sure the minimum height isn't applied to an article in the set that doesn't have a featured image.
8. Try hiding the featured image; make sure the 'Minimum height' option is hidden, and the height is no longer applied.
9. Try changing the image positioning to top, left, or right, and make sure the 'Minimum height' option is hidden, and the height is no longer applied.
10. In an article block showing the excerpt, set the minimum height just tall enough that it adds a bit of space on the top. Scale it down on the front-end, and make sure that there's always a bit more padding on the top than bottom:

![image](https://user-images.githubusercontent.com/177561/68055648-63c6e900-fcae-11e9-9d2e-8c1186170896.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
