### PR TITLE
Article Block: Add Co-Author Plus plugin support

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -130,11 +130,23 @@ class Newspack_Blocks_API {
 			$authors = get_coauthors();
 
 			foreach ( $authors as $author ) {
+				// Check if this is a guest author post type.
+				if ( 'guest-author' === get_post_type( $author->ID ) ) {
+					// If yes, make sure the author actually has an avatar set; otherwise, coauthors_get_avatar returns a featured image.
+					if ( get_post_thumbnail_id( $author->ID ) ) {
+						$author_avatar = coauthors_get_avatar( $author, 48 );
+					} else {
+						// If there is no avatar, force it to return the current fallback image.
+						$author_avatar = get_avatar( ' ' );
+					}
+				} else {
+					$author_avatar = coauthors_get_avatar( $author, 48 );
+				}
 				$author_data[] = array(
 					/* Get the author name */
 					'display_name' => esc_html( $author->display_name ),
 					/* Get the author avatar */
-					'avatar'       => wp_kses_post( coauthors_get_avatar( $author, 48 ) ),
+					'avatar'       => wp_kses_post( $author_avatar ),
 				);
 			}
 		else :

--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -125,14 +125,26 @@ class Newspack_Blocks_API {
 	 * @param Array $object  The object info.
 	 */
 	public static function newspack_blocks_get_author_info( $object ) {
-		$author_data = array(
-			/* Get the author name */
-			'display_name' => get_the_author_meta( 'display_name', $object['author'] ),
-			/* Get the author link */
-			'author_link'  => get_author_posts_url( $object['author'] ),
-			/* Get the author avatar */
-			'avatar'       => get_avatar( $object['author'], 48 ),
-		);
+
+		if ( function_exists( 'coauthors_posts_links' ) ) :
+			$authors = get_coauthors();
+
+			foreach ( $authors as $author ) {
+				$author_data[] = array(
+					/* Get the author name */
+					'display_name' => esc_html( $author->display_name ),
+					/* Get the author avatar */
+					'avatar'       => wp_kses_post( coauthors_get_avatar( $author, 48 ) ),
+				);
+			}
+		else :
+			$author_data[] = array(
+				/* Get the author name */
+				'display_name' => get_the_author_meta( 'display_name', $object['author'] ),
+				/* Get the author avatar */
+				'avatar'       => get_avatar( $object['author'], 48 ),
+			);
+		endif;
 
 		/* Return the author data */
 		return $author_data;

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -108,6 +108,8 @@ class Edit extends Component {
 				minHeight / 5 + 'vh',
 		};
 
+		const authorNumber = post.newspack_author_info.length;
+
 		return (
 			<article
 				className={ post.newspack_featured_image_src && 'post-has-image' }
@@ -134,6 +136,7 @@ class Edit extends Component {
 						) }
 					</figure>
 				) }
+
 				<div className="entry-wrapper">
 					{ showCategory && post.newspack_category_info.length && (
 						<div className="cat-links">
@@ -155,20 +158,28 @@ class Edit extends Component {
 						</RawHTML>
 					) }
 					<div className="entry-meta">
-						{ showAuthor && post.newspack_author_info.avatar && showAvatar && (
-							<span className="avatar author-avatar" key="author-avatar">
-								<RawHTML>{ post.newspack_author_info.avatar }</RawHTML>
-							</span>
-						) }
-
+						{ showAuthor &&
+							post.newspack_author_info.some( item => item.hasOwnProperty( 'avatar' ) ) &&
+							showAvatar &&
+							post.newspack_author_info.map( ( author, key ) => (
+								<span className="avatar author-avatar">
+									<RawHTML key={ author.id }>{ author.avatar }</RawHTML>
+								</span>
+							) ) }
 						{ showAuthor && (
 							<span className="byline">
-								{ __( 'by', 'newspack-blocks' ) }{' '}
-								<span className="author vcard">
-									<a className="url fn n" href="#">
-										{ post.newspack_author_info.display_name }
-									</a>
-								</span>
+								{ __( 'by', 'newspack-blocks' ) + ' ' }
+								{ post.newspack_author_info.map( ( author, key ) => (
+									<span className="author vcard">
+										<a className="url fn n" href="#">
+											{ author.display_name }
+										</a>
+										{ authorNumber > key + 1 &&
+											authorNumber !== key + 2 &&
+											__( ',', 'newspack-blocks' ) + ' ' }
+										{ authorNumber == key + 2 && ' ' + __( 'and', 'newspack-blocks' ) + ' ' }
+									</span>
+								) ) }
 							</span>
 						) }
 						{ showDate && (

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -158,30 +158,8 @@ class Edit extends Component {
 						</RawHTML>
 					) }
 					<div className="entry-meta">
-						{ showAuthor &&
-							post.newspack_author_info.some( item => item.hasOwnProperty( 'avatar' ) ) &&
-							showAvatar &&
-							post.newspack_author_info.map( ( author, key ) => (
-								<span className="avatar author-avatar">
-									<RawHTML key={ author.id }>{ author.avatar }</RawHTML>
-								</span>
-							) ) }
-						{ showAuthor && (
-							<span className="byline">
-								{ __( 'by', 'newspack-blocks' ) + ' ' }
-								{ post.newspack_author_info.map( ( author, key ) => (
-									<span className="author vcard">
-										<a className="url fn n" href="#">
-											{ author.display_name }
-										</a>
-										{ authorNumber > key + 1 &&
-											authorNumber !== key + 2 &&
-											__( ',', 'newspack-blocks' ) + ' ' }
-										{ authorNumber == key + 2 && ' ' + __( 'and', 'newspack-blocks' ) + ' ' }
-									</span>
-								) ) }
-							</span>
-						) }
+						{ showAuthor && showAvatar && this.formatAvatars( post.newspack_author_info ) }
+						{ showAuthor && this.formatByline( post.newspack_author_info ) }
 						{ showDate && (
 							<time className="entry-date published" key="pub-date">
 								{ moment( post.date_gmt )
@@ -194,6 +172,35 @@ class Edit extends Component {
 			</article>
 		);
 	};
+
+	formatAvatars = authorInfo =>
+		authorInfo.map( author => (
+			<span className="avatar author-avatar">
+				<a className="url fn n" href="#">
+					<RawHTML key={ author.id }>{ author.avatar }</RawHTML>
+				</a>
+			</span>
+		) );
+
+	formatByline = authorInfo => (
+		<span className="byline">
+			{ __( 'by', 'newspack-blocks' ) }{' '}
+			{ authorInfo.reduce( ( accumulator, author, index ) => {
+				return [
+					...accumulator,
+					<span className="author vcard" key={ author.id }>
+						<a className="url fn n" href="#">
+							{ author.display_name }
+						</a>
+					</span>,
+					index < authorInfo.length - 2 && ', ',
+					authorInfo.length > 1 &&
+						index === authorInfo.length - 2 &&
+						__( ' and ', 'newspack-blocks' ),
+				];
+			}, [] ) }
+		</span>
+	);
 
 	renderInspectorControls = () => {
 		const {

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -25,6 +25,14 @@
 		font-size: $font__size-xs;
 	}
 
+	span.avatar {
+		display: inline-block;
+		margin-right: 0.5em;
+		div {
+			display: inline;
+		}
+	}
+
 	/* Article excerpt */
 	.excerpt-contain p {
 		margin: 0.5em 0;

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -204,10 +204,24 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 											$authors = get_coauthors();
 
 											foreach ( $authors as $author ) {
-												echo wp_kses_post( coauthors_get_avatar( $author, 48 ) );
+												if ( function_exists( 'coauthors_posts_links' ) ) {
+													// Check if this is a guest author post type.
+													if ( 'guest-author' === get_post_type( $author->ID ) ) {
+														// If yes, make sure the author actually has an avatar set; otherwise, coauthors_get_avatar returns a featured image.
+														if ( get_post_thumbnail_id( $author->ID ) ) {
+															$author_avatar = coauthors_get_avatar( $author, 48 );
+														} else {
+															// If there is no avatar, force it to return the current fallback image.
+															$author_avatar = get_avatar( ' ' );
+														}
+													} else {
+														$author_avatar = coauthors_get_avatar( $author, 48 );
+													}
+													echo wp_kses_post( $author_avatar );
+												}
 											}
 										} else {
-											echo get_avatar( get_the_author_meta( 'ID' ) );
+											echo get_avatar( get_the_author_meta( 'ID' ), 48 );
 										}
 									}
 									?>

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -197,19 +197,55 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 							<div class="entry-meta">
 
-								<?php if ( $attributes['showAuthor'] ) : ?>
-									<?php
+								<?php
+								if ( $attributes['showAuthor'] ) :
 									if ( $attributes['showAvatar'] ) {
-										echo get_avatar( get_the_author_meta( 'ID' ) );
+										if ( function_exists( 'coauthors_posts_links' ) ) {
+											$authors = get_coauthors();
+
+											foreach ( $authors as $author ) {
+												echo wp_kses_post( coauthors_get_avatar( $author, 48 ) );
+											}
+										} else {
+											echo get_avatar( get_the_author_meta( 'ID' ) );
+										}
 									}
 									?>
 									<span class="byline">
 										<?php
-										printf(
-											/* translators: %s: post author. */
-											esc_html_x( 'by %s', 'post author', 'newspack-blocks' ),
-											'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
-										);
+										if ( function_exists( 'coauthors_posts_links' ) ) :
+											echo esc_html_x( 'by', 'post author', 'newspack-blocks' ) . ' ';
+
+											$authors      = get_coauthors();
+											$author_count = count( $authors );
+											$i            = 1;
+
+											foreach ( $authors as $author ) {
+												$i++;
+												if ( $author_count === $i ) :
+													/* translators: separates last two author names; needs a space on either side. */
+													$sep = esc_html__( ' and ', 'newspack-blocks' );
+												elseif ( $author_count > $i ) :
+													/* translators: separates all but the last two author names; needs a space at the end. */
+													$sep = esc_html__( ', ', 'newspack-blocks' );
+												else :
+													$sep = '';
+												endif;
+												printf(
+													/* translators: 1: author link. 2: author name. 3. variable seperator (comma, 'and', or empty) */
+													'<span class="author vcard"><a class="url fn n" href="%1$s">%2$s</a></span>%3$s ',
+													esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ),
+													esc_html( $author->display_name ),
+													esc_html( $sep )
+												);
+											}
+										else :
+											printf(
+												/* translators: %s: post author. */
+												esc_html_x( 'by %s', 'post author', 'newspack-blocks' ),
+												'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
+											);
+										endif;
 										?>
 									</span><!-- .author-name -->
 									<?php

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -107,6 +107,9 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 					continue;
 				}
 				$newspack_blocks_post_id[ get_the_ID() ] = true;
+
+				$authors = newspack_blocks_prepare_authors();
+
 				$post_counter++;
 
 				$styles = '';
@@ -198,69 +201,14 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 							<div class="entry-meta">
 
 								<?php
-								if ( $attributes['showAuthor'] ) :
-									if ( $attributes['showAvatar'] ) {
-										if ( function_exists( 'coauthors_posts_links' ) ) {
-											$authors = get_coauthors();
+								if ( $attributes['showAuthor'] && $attributes['showAvatar'] ) :
+									echo wp_kses_post( newspack_blocks_format_avatars( $authors ) );
+								endif;
 
-											foreach ( $authors as $author ) {
-												if ( function_exists( 'coauthors_posts_links' ) ) {
-													// Check if this is a guest author post type.
-													if ( 'guest-author' === get_post_type( $author->ID ) ) {
-														// If yes, make sure the author actually has an avatar set; otherwise, coauthors_get_avatar returns a featured image.
-														if ( get_post_thumbnail_id( $author->ID ) ) {
-															$author_avatar = coauthors_get_avatar( $author, 48 );
-														} else {
-															// If there is no avatar, force it to return the current fallback image.
-															$author_avatar = get_avatar( ' ' );
-														}
-													} else {
-														$author_avatar = coauthors_get_avatar( $author, 48 );
-													}
-													echo wp_kses_post( $author_avatar );
-												}
-											}
-										} else {
-											echo get_avatar( get_the_author_meta( 'ID' ), 48 );
-										}
-									}
+								if ( $attributes['showAuthor'] ) :
 									?>
 									<span class="byline">
-										<?php
-										if ( function_exists( 'coauthors_posts_links' ) ) :
-											echo esc_html_x( 'by', 'post author', 'newspack-blocks' ) . ' ';
-
-											$authors      = get_coauthors();
-											$author_count = count( $authors );
-											$i            = 1;
-
-											foreach ( $authors as $author ) {
-												$i++;
-												if ( $author_count === $i ) :
-													/* translators: separates last two author names; needs a space on either side. */
-													$sep = esc_html__( ' and ', 'newspack-blocks' );
-												elseif ( $author_count > $i ) :
-													/* translators: separates all but the last two author names; needs a space at the end. */
-													$sep = esc_html__( ', ', 'newspack-blocks' );
-												else :
-													$sep = '';
-												endif;
-												printf(
-													/* translators: 1: author link. 2: author name. 3. variable seperator (comma, 'and', or empty) */
-													'<span class="author vcard"><a class="url fn n" href="%1$s">%2$s</a></span>%3$s ',
-													esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ),
-													esc_html( $author->display_name ),
-													esc_html( $sep )
-												);
-											}
-										else :
-											printf(
-												/* translators: %s: post author. */
-												esc_html_x( 'by %s', 'post author', 'newspack-blocks' ),
-												'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
-											);
-										endif;
-										?>
+										<?php echo wp_kses_post( newspack_blocks_format_byline( $authors ) ); ?>
 									</span><!-- .author-name -->
 									<?php
 								endif;
@@ -419,3 +367,94 @@ function newspack_blocks_register_homepage_articles() {
 	);
 }
 add_action( 'init', 'newspack_blocks_register_homepage_articles' );
+
+/**
+ * Prepare an array of authors, taking presence of CoAuthors Plus into account.
+ *
+ * @return array Array of WP_User objects.
+ */
+function newspack_blocks_prepare_authors() {
+	if ( function_exists( 'coauthors_posts_links' ) ) {
+		$authors = get_coauthors();
+		foreach ( $authors as $author ) {
+			// Check if this is a guest author post type.
+			if ( 'guest-author' === get_post_type( $author->ID ) ) {
+				// If yes, make sure the author actually has an avatar set; otherwise, coauthors_get_avatar returns a featured image.
+				if ( get_post_thumbnail_id( $author->ID ) ) {
+					$author->avatar = coauthors_get_avatar( $author, 48 );
+				} else {
+					// If there is no avatar, force it to return the current fallback image.
+					$author->avatar = get_avatar( ' ' );
+				}
+			} else {
+				$author->avatar = coauthors_get_avatar( $author, 48 );
+			}
+			$author->url = get_author_posts_url( $author->ID, $author->user_nicename );
+		}
+		return $authors;
+	}
+	$id = get_the_author_meta( 'ID' );
+	return array(
+		(object) array(
+			'ID'            => $id,
+			'avatar'        => get_avatar( $id, 48 ),
+			'url'           => get_author_posts_url( $id ),
+			'user_nicename' => get_the_author(),
+			'display_name'  => get_the_author_meta( 'display_name' ),
+		),
+	);
+}
+
+/**
+ * Renders author avatar markup.
+ *
+ * @param array $author_info Author info array.
+ *
+ * @return string Returns formatted Avatar markup
+ */
+function newspack_blocks_format_avatars( $author_info ) {
+	$elements = array_map(
+		function( $author ) {
+			return sprintf( '<a href="%s">%s</a>', $author->url, $author->avatar );
+		},
+		$author_info
+	);
+	return implode( '', $elements );
+}
+/**
+ * Renders byline markup.
+ *
+ * @param array $author_info Author info array.
+ *
+ * @return string Returns byline markup.
+ */
+function newspack_blocks_format_byline( $author_info ) {
+	$index    = -1;
+	$elements = array_merge(
+		array(
+			esc_html_x( 'by', 'post author', 'newspack-blocks' ) . ' ',
+		),
+		array_reduce(
+			$author_info,
+			function( $accumulator, $author ) use ( $author_info, &$index ) {
+				$index ++;
+				$penultimate = count( $author_info ) - 2;
+				return array_merge(
+					$accumulator,
+					array(
+						sprintf(
+							/* translators: 1: author link. 2: author name. 3. variable seperator (comma, 'and', or empty) */
+							'<span class="author vcard"><a class="url fn n" href="%1$s">%2$s</a></span>',
+							esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ),
+							esc_html( $author->display_name )
+						),
+						( $index < $penultimate ) ? ', ' : '',
+						( count( $author_info ) > 1 && $penultimate === $index ) ? esc_html_x( ' and ', 'post author', 'newspack-blocks' ) : '',
+					)
+				);
+			},
+			array()
+		)
+	);
+	return implode( '', $elements );
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds support for the Co-Author Plus plugin to the Article block.

I also removed the link to the author archives from what we're making available to the API, since we don't actually use it in the editor anymore. 

Closes #200.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build:webpack`

2. If you haven't already, install and activate the [Co-Authors Plus](https://wordpress.org/plugins/co-authors-plus/) plugin.

3. Create one 'Guest Author'.

4. On one article, add a second author; on a second article, add two. Make sure one is the Guest author and the other is a standard WordPress user. This gives us a good mix of different author types and numbers.

5. On a page, add the article block, and adjust the settings to make sure the above two posts are displayed, plus one with one regular author.
6. View in the editor and confirm:
     a. Each author's display name and avatar are correct.
     b. Two authors are separated by 'and'; three plus authors are separated by commas, with the last two authors separated by 'and'
![image](https://user-images.githubusercontent.com/177561/68504323-8e1e2680-0219-11ea-868b-26969692a314.png)
![image](https://user-images.githubusercontent.com/177561/68504333-92e2da80-0219-11ea-975e-4fce328121f2.png)
     c. Scale down the block's Type Scale, and confirm the avatars successfully scale down.
![image](https://user-images.githubusercontent.com/177561/68504348-9c6c4280-0219-11ea-91ed-03179dbb031a.png)
     d. Hide the author avatar and confirm it works as expected.
     e. Hide the author completely and confirm it works as expected.
7. View the block on the front end, and run through the same a-e checks from step 6.
8. Deactivate the Co-Author Plus plugin and confirm things display the same as they did originally in the editor and on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
