### PR TITLE
Reduce vertical spacing between columns when stacked on mobile.

### DIFF
--- a/src/block-styles/core/columns/view.scss
+++ b/src/block-styles/core/columns/view.scss
@@ -4,7 +4,7 @@
 .wp-block-columns {
 
 	.wp-block-column {
-		margin-bottom: 64px;
+		margin-bottom: 32px;
 
 		&:last-child {
 			margin-bottom: 0;
@@ -62,6 +62,11 @@
 	&.is-style-borders {
 		.wp-block-column {
 			position: relative;
+			margin-bottom: 64px;
+
+			&:last-child {
+				margin-bottom: 0;
+			}
 
 			&:after {
 				border: 0 solid $color__border;
@@ -78,6 +83,8 @@
 			}
 
 			@include media( mobile ) {
+				margin-bottom: 0;
+
 				&:after {
 					border-right-width: 1px;
 					border-top-width: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR tightens up the vertical spacing on columns when stacked on mobile; their originally spacing worked well for the article blocks, but looked a bit odd with anything else. 

Closes #201 .

### How to test the changes in this Pull Request:

1. Set up a page with a couple columns blocks; add paragraphs to each, and set one to use the border style, and one to use the default style (you can also copy-paste [this](https://cloudup.com/c17cyvkzAOC) into the code editor).
2. View on the front-end; make the browser window very narrow and note the spacing -- it seems to work with the border style, but a bit spacy without the borders:

![image](https://user-images.githubusercontent.com/177561/68548916-d9b20b00-03a6-11ea-9c84-2bb5b3af19e8.png)

3. Apply the PR and run `npm run build:webpack`
4. Confirm that the spacing is now tightened up:

![image](https://user-images.githubusercontent.com/177561/68548906-b4250180-03a6-11ea-9f88-767b78bccd3b.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
