### PR TITLE
Article Block: Tighten up vertical spacing around article excerpt

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -130,7 +130,11 @@ class Edit extends Component {
 							<a href="#">{ decodeEntities( post.title.rendered.trim() ) }</a>
 						</h3>
 					) }
-					{ showExcerpt && <RawHTML key="excerpt">{ post.excerpt.rendered }</RawHTML> }
+					{ showExcerpt && (
+						<RawHTML key="excerpt" className="excerpt-contain">
+							{ post.excerpt.rendered }
+						</RawHTML>
+					) }
 					<div className="entry-meta">
 						{ showAuthor && post.newspack_author_info.avatar && showAvatar && (
 							<span className="avatar author-avatar" key="author-avatar">

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -24,4 +24,13 @@
 	.cat-links {
 		font-size: $font__size-xs;
 	}
+
+	/* Article excerpt */
+	.excerpt-contain {
+		display: inline;
+
+		p {
+			margin: 0.5em 0;
+		}
+	}
 }

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -26,11 +26,7 @@
 	}
 
 	/* Article excerpt */
-	.excerpt-contain {
-		display: inline;
-
-		p {
-			margin: 0.5em 0;
-		}
+	.excerpt-contain p {
+		margin: 0.5em 0;
 	}
 }

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -189,7 +189,7 @@
 	}
 
 	p {
-		margin-top: 0.5em;
+		margin: 0.5em 0;
 	}
 
 	&.has-text-color {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR tightens up the top and bottom spacing for the excerpt in the article block.

This will help create more distinction between separate articles. 

### How to test the changes in this Pull Request:

1. Add an article block to a page. Note the spacing around the excerpt in the editor:

![image](https://user-images.githubusercontent.com/177561/68549225-d3259280-03aa-11ea-8371-296ca6a8c7d6.png)

2. Note the spacing on the front-end (tighter on the top, but spacier between the bottom and author):

![image](https://user-images.githubusercontent.com/177561/68549215-bee19580-03aa-11ea-9f42-02a085cde92e.png)

3. Apply the PR and run `npm run build:webpack`
4. View the block in the editor; confirm it's tightened up:

![image](https://user-images.githubusercontent.com/177561/68549237-fe0fe680-03aa-11ea-928a-a642591c6496.png)

5. View on the front end:

![image](https://user-images.githubusercontent.com/177561/68549241-0831e500-03ab-11ea-9fa6-178e5653d335.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
