### PR TITLE
Article Block: Add 'help' text to the minimum height control

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -404,6 +404,10 @@ class Edit extends Component {
 					{ showImage && mediaPosition === 'behind' && (
 						<RangeControl
 							label={ __( 'Minimum height', 'newspack-blocks' ) }
+							help={ __(
+								"Sets a minimum height for the block, using a percentage of the screen's current height.",
+								'newspack-blocks'
+							) }
 							value={ minHeight }
 							onChange={ value => setAttributes( { minHeight: value } ) }
 							min={ 0 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds 'help' text to the Article Block's minimum height control:

![image](https://user-images.githubusercontent.com/177561/68551258-da0ad000-03bf-11ea-8221-44f99ea3580f.png)

See #199 

### How to test the changes in this Pull Request:

1. Apply PR and run `npm run build:webpack`
2. Add an article block to the editor; set it up to show the featured image behind the text.
3. Confirm you see the 'help' text, like in the screenshot above.
4. Confirm it makes sense (or suggest improvements! It's kind of a weird thing to try to describe, especially when many people seeing it will have no idea what `vh` is). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
