### PR TITLE
Only display the Featured Image on the Right or Left on devices with larger screens

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -90,60 +90,62 @@
 		}
 	}
 
-	&.image-alignleft,
-	&.image-alignright {
-		.post-has-image {
-			display: flex;
+	@include media( mobile ) {
+		&.image-alignleft,
+		&.image-alignright {
+			.post-has-image {
+				display: flex;
 
-			.post-thumbnail,
-			.entry-wrapper {
-				flex-basis: 50%;
+				.post-thumbnail,
+				.entry-wrapper {
+					flex-basis: 50%;
+				}
+			}
+
+			// Image scale
+			&.is-4 {
+				.post-thumbnail {
+					flex-basis: 75%;
+				}
+				.entry-wrapper {
+					flex-basis: 25%;
+				}
+			}
+
+			// .is-3 is the default - 50%
+
+			&.is-2 {
+				.post-thumbnail {
+					flex-basis: 33%;
+				}
+				.entry-wrapper {
+					flex-basis: 67%;
+				}
+			}
+
+			&.is-1 {
+				.post-thumbnail {
+					flex-basis: 25%;
+				}
+				.entry-wrapper {
+					flex-basis: 75%;
+				}
 			}
 		}
 
-		// Image scale
-		&.is-4 {
+		&.image-alignleft {
 			.post-thumbnail {
-				flex-basis: 75%;
-			}
-			.entry-wrapper {
-				flex-basis: 25%;
+				margin-right: 1em;
 			}
 		}
 
-		// .is-3 is the default - 50%
-
-		&.is-2 {
+		&.image-alignright {
 			.post-thumbnail {
-				flex-basis: 33%;
+				margin-left: 1em;
 			}
 			.entry-wrapper {
-				flex-basis: 67%;
+				order: -1;
 			}
-		}
-
-		&.is-1 {
-			.post-thumbnail {
-				flex-basis: 25%;
-			}
-			.entry-wrapper {
-				flex-basis: 75%;
-			}
-		}
-	}
-
-	&.image-alignleft {
-		.post-thumbnail {
-			margin-right: 1em;
-		}
-	}
-
-	&.image-alignright {
-		.post-thumbnail {
-			margin-left: 1em;
-		}
-		.entry-wrapper {
-			order: -1;
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Instead of splitting the screen in 2 on small screens, we only do this when breakpoint is >= 600px that way we avoid having an image with just a little bit of next next to it.

_Attempt to close https://github.com/Automattic/newspack-issues/issues/103_

__Before:__

![1 before-iphone](https://user-images.githubusercontent.com/177929/69076170-cfd57b00-0a2a-11ea-82f5-f0fd50d6457b.png)

__After:__

![2 after-iphone](https://user-images.githubusercontent.com/177929/69076181-d82db600-0a2a-11ea-98c0-221974a2a6ed.png)

### How to test the changes in this Pull Request:

1. On a page, add the Articles Block and add a bunch of posts with the featured image either right or left. Check on mobile/small screen.
2. Switch to this branch and run `npm run build:webpack`
3. Now check the same page on mobile/small screen -- Does it look better?

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
