### PR TITLE
Make sure images have a max-width on small screens

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -224,6 +224,7 @@ class Edit extends Component {
 			showImage,
 			showCaption,
 			imageScale,
+			mobileStack,
 			minHeight,
 			showExcerpt,
 			typeScale,
@@ -410,17 +411,26 @@ class Edit extends Component {
 					) }
 
 					{ showImage && mediaPosition !== 'top' && mediaPosition !== 'behind' && (
-						<RangeControl
-							className="image-scale-slider"
-							label={ __( 'Featured Image Scale', 'newspack-blocks' ) }
-							value={ imageScale }
-							onChange={ value => setAttributes( { imageScale: value } ) }
-							min={ 1 }
-							max={ 4 }
-							beforeIcon="images-alt2"
-							afterIcon="images-alt2"
-							required
-						/>
+						<Fragment>
+							<RangeControl
+								className="image-scale-slider"
+								label={ __( 'Featured Image Scale', 'newspack-blocks' ) }
+								value={ imageScale }
+								onChange={ value => setAttributes( { imageScale: value } ) }
+								min={ 1 }
+								max={ 4 }
+								beforeIcon="images-alt2"
+								afterIcon="images-alt2"
+								required
+							/>
+							<PanelRow>
+								<ToggleControl
+									label={ __( 'Stack on mobile', 'newspack-blocks' ) }
+									checked={ mobileStack }
+									onChange={ () => setAttributes( { mobileStack: ! mobileStack } ) }
+								/>
+							</PanelRow>
+						</Fragment>
 					) }
 
 					{ showImage && mediaPosition === 'behind' && (
@@ -532,6 +542,7 @@ class Edit extends Component {
 			categories,
 			typeScale,
 			imageScale,
+			mobileStack,
 			sectionHeader,
 			showCaption,
 			showCategory,
@@ -544,6 +555,7 @@ class Edit extends Component {
 			[ `ts-${ typeScale }` ]: typeScale !== '5',
 			[ `image-align${ mediaPosition }` ]: showImage,
 			[ `is-${ imageScale }` ]: imageScale !== '1' && showImage,
+			'mobile-stack': mobileStack,
 			[ `image-shape${ imageShape }` ]: imageShape !== 'landscape',
 			'has-text-color': textColor.color !== '',
 			'show-caption': showCaption,

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -117,6 +117,10 @@ export const settings = {
 			type: 'integer',
 			default: 3,
 		},
+		mobileStack: {
+			type: 'boolean',
+			default: false,
+		},
 		sectionHeader: {
 			type: 'string',
 			default: '',

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -64,6 +64,9 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	if ( $attributes['showImage'] && isset( $attributes['imageScale'] ) ) {
 		$classes .= ' is-' . $attributes['imageScale'];
 	}
+	if ( $attributes['showImage'] && $attributes['mobileStack'] ) {
+		$classes .= ' mobile-stack';
+	}
 	if ( $attributes['showCaption'] ) {
 		$classes .= ' show-caption';
 	}
@@ -336,6 +339,10 @@ function newspack_blocks_register_homepage_articles() {
 				'imageScale'      => array(
 					'type'    => 'integer',
 					'default' => 3,
+				),
+				'mobileStack'     => array(
+					'type'    => 'boolean',
+					'default' => false,
 				),
 				'imageShape'    => array(
 					'type'    => 'string',

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -95,31 +95,33 @@
 		.post-has-image {
 			display: flex;
 
-			.post-thumbnail,
-			.entry-wrapper {
-				flex-basis: 50%;
-			}
-		}
-
-		// Image scale
-		&.is-4 {
-			.post-thumbnail {
-				flex-basis: 75%;
-			}
-			.entry-wrapper {
-				flex-basis: 25%;
-			}
-		}
-
-		// .is-3 is the default - 50%
-
-		&.is-2 {
 			.post-thumbnail {
 				flex-basis: 33%;
 			}
 			.entry-wrapper {
 				flex-basis: 67%;
 			}
+		}
+
+		// Image scale
+		@include media(mobile) {
+			&.is-4 {
+				.post-thumbnail {
+					flex-basis: 75%;
+				}
+				.entry-wrapper {
+					flex-basis: 25%;
+				}
+			}
+
+			&.is-3 {
+				.post-thumbnail,
+				.entry-wrapper {
+					flex-basis: 50%;
+				}
+			}
+
+			// is-2 matches the mobile default above
 		}
 
 		&.is-1 {

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -103,8 +103,16 @@
 			}
 		}
 
+		&.mobile-stack .post-has-image {
+			display: block;
+		}
+
 		// Image scale
 		@include media(mobile) {
+			&.mobile-stack .post-has-image {
+				display: flex;
+			}
+
 			&.is-4 {
 				.post-thumbnail {
 					flex-basis: 75%;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR is kind of a proof of concept for a suggested alternative to #215.

It makes sure that, when images are floated left or right, they will display at 33% of the screen width on mobile (rather than the 50% or 75% you can pick in the settings). 

This is an attempt in making sure the images and associated article content don't get too wildly different in size.

### How to test the changes in this Pull Request:

1.[ Copy paste this test content into a page](https://cloudup.com/cbRSWTxIOmB) -- it includes four article blocks, each with a different 'image scale' setting, a text size of 2, and no author/date displayed. They're also nested in a column block, so it's a little closer to a normal case where you'd have image/text side by side.
2. View on front-end; make sure each article has an image (if not, add one to that post).
3. Shrink down the browser window and note the appearance of the images-to-text:

![image](https://user-images.githubusercontent.com/177561/69100781-c809dc80-0a12-11ea-9c15-deef68a94297.png)

Note the odd balance, especially in articles 3 and 4.

4. Apply the PR and run `npm run build:webpack`
5. View on front end again; note the balance again, and whether it seems like an improvement -- it makes the 'default' for mobile be displaying the image at 33% width and text at 66%; if you've picked the smallest image scale (25%-75%), it respects that:

![image](https://user-images.githubusercontent.com/177561/69100865-ff788900-0a12-11ea-9f87-2c9c7347b8fd.png)

6. Edit the page and try switching the blocks to 'Stack on mobile' under Featured Image settings:

![image](https://user-images.githubusercontent.com/177561/69178153-e1b42e00-0abd-11ea-92b6-80fb8e3f75a4.png)

7. View on the front-end and confirm the blocks look the same.
8. Try scaling down the browser window to mobile size; confirm that the images stack above the article titles, instead of sitting next to them:

![image](https://user-images.githubusercontent.com/177561/69178816-35734700-0abf-11ea-8817-de8612e16834.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
