### PR TITLE
Build: add start task to watch and rebuild source

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "swiper": "4.5.1"
   },
   "scripts": {
+    "start": "calypso-build --config='./webpack.config.js' --watch",
     "build:webpack": "calypso-build --config='./webpack.config.js'",
     "clean": "rm -rf dist/",
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I've noticed this repo is missing a start script — a way to rebuild sources on file update. Calypso build has the watch param so I've used it here. 

Previously, I was using `npm run build:webpack -- --watch` which is kinda inconvenient.  This way it would be just `npm start`, like it's common in many other projects.

### How to test the changes in this Pull Request:

1. `npm start`
1. Build succeeds
1. Edit JS/CSS file
1. It should rebuild automatically
