### PR TITLE
Featured Image Settings: Use `format-image` for the Dashicon and move the toggle above the scale so all the toggle buttons are listed one after the other

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -289,17 +289,6 @@ class Edit extends Component {
 
 					{ showImage && mediaPosition !== 'top' && mediaPosition !== 'behind' && (
 						<Fragment>
-							<RangeControl
-								className="image-scale-slider"
-								label={ __( 'Featured Image Scale', 'newspack-blocks' ) }
-								value={ imageScale }
-								onChange={ value => setAttributes( { imageScale: value } ) }
-								min={ 1 }
-								max={ 4 }
-								beforeIcon="images-alt2"
-								afterIcon="images-alt2"
-								required
-							/>
 							<PanelRow>
 								<ToggleControl
 									label={ __( 'Stack on mobile', 'newspack-blocks' ) }
@@ -307,6 +296,17 @@ class Edit extends Component {
 									onChange={ () => setAttributes( { mobileStack: ! mobileStack } ) }
 								/>
 							</PanelRow>
+							<RangeControl
+								className="image-scale-slider"
+								label={ __( 'Featured Image Scale', 'newspack-blocks' ) }
+								value={ imageScale }
+								onChange={ value => setAttributes( { imageScale: value } ) }
+								min={ 1 }
+								max={ 4 }
+								beforeIcon="format-image"
+								afterIcon="format-image"
+								required
+							/>
 						</Fragment>
 					) }
 
@@ -554,9 +554,9 @@ export default compose( [
 		const { getAuthors, getEntityRecords } = select( 'core' );
 		const latestPostsQuery = pickBy(
 			specificMode && specificPosts && specificPosts.length
-				? { 
+				? {
 					include: specificPosts,
-					orderby: 'include' 
+					orderby: 'include'
 				}
 				: {
 						per_page: postsToShow,

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -2,16 +2,16 @@
 
 .type-scale-slider,
 .image-scale-slider {
-	.dashicons-editor-textcolor,
-	.dashicons-images-alt2 {
-		height: 24px;
-		width: 24px;
-	}
-
-	label + .dashicons-editor-textcolor,
-	label + .dashicons-images-alt2 {
+	.dashicon {
 		height: 16px;
 		width: 16px;
+	}
+
+	input + .dashicon {
+		height: 24px;
+		margin-left: 10px;
+		margin-right: 0;
+		width: 24px;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The current icon used for the featured image scale feels odd. It looks like multiple images. Since we must use Dashicon, I think the "format-image" works better.

Having "toggle - toggle - scale - toggle", feels inconsistent. By having all the toggle buttons first we "group" the similar elements together.

__Before:__

![1 before](https://user-images.githubusercontent.com/177929/69346232-604dce80-0c6a-11ea-8be0-23e61f70b69e.png)

__After:__

![2 after](https://user-images.githubusercontent.com/177929/69346248-65128280-0c6a-11ea-9751-a2ad6dae93b5.png)

_Note/Moan: I wish Core allowed us to use Material icons instead of Dashicons_

### How to test the changes in this Pull Request:

1. Add the Articles Block with a list of posts displaying the featured image on the right or left.
2. Check the "Featured Image Settings" in the sidebar.
3. Now switch to this branch and reload the editor. Do you see the changes?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->
