### PR TITLE
Add dev centered npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To get set up for block development, run `composer install && npm install`
 
 ### Generating Builds
 
-To generate a build of the current blocks, run `npm run build:webpack`.
+To generate a build of the current blocks, run `npm run build`.
 
 To clean out the built blocks, run `npm run clean`.
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,17 @@ This plugin is meant to serve as a container for most Newspack Gutenberg blocks.
 
 To get set up for block development, run `composer install && npm install`
 
-To build blocks, run `npm run build:webpack`
+### Generating Builds
 
-To clean out the built blocks, run `npm run clean`
+To generate a build of the current blocks, run `npm run build:webpack`.
+
+To clean out the built blocks, run `npm run clean`.
+
+### Developing
+
+To work on Block development and have Webpack watch your files for changes run: `npm start`.
+
+### Building new Blocks
 
 To get started with a new block:
 

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
     "swiper": "4.5.1"
   },
   "scripts": {
-    "start": "npm run dev:webpack",
-    "dev:webpack": "calypso-build --watch",
-    "build:webpack": "calypso-build --watch --config='./webpack.config.js'",
+    "start": "npm run dev",
+    "dev": "calypso-build --watch --config='./webpack.config.js'",
+    "build": "calypso-build --config='./webpack.config.js'",
     "clean": "rm -rf dist/",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "release:archive": "run-p \"clean\" && NODE_ENV=production run-p \"build:webpack\" && mkdir -p assets/release && zip -r assets/release/newspack-blocks.zip . -x node_modules/\\* .git/\\* .github/\\* .gitignore .DS_Store vendor/\\*"
+    "release:archive": "run-p \"clean\" && NODE_ENV=production run-p \"build\" && mkdir -p assets/release && zip -r assets/release/newspack-blocks.zip . -x node_modules/\\* .git/\\* .github/\\* .gitignore .DS_Store vendor/\\*"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
     "swiper": "4.5.1"
   },
   "scripts": {
-    "start": "calypso-build --config='./webpack.config.js' --watch",
-    "build:webpack": "calypso-build --config='./webpack.config.js'",
+    "start": "npm run dev:webpack",
+    "dev:webpack": "calypso-build --watch",
+    "build:webpack": "calypso-build --watch --config='./webpack.config.js'",
     "clean": "rm -rf dist/",
     "test": "echo \"Error: no test specified\" && exit 1",
     "release:archive": "run-p \"clean\" && NODE_ENV=production run-p \"build:webpack\" && mkdir -p assets/release && zip -r assets/release/newspack-blocks.zip . -x node_modules/\\* .git/\\* .github/\\* .gitignore .DS_Store vendor/\\*"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?



### Changes proposed in this Pull Request:

Building on previous work update the build scripts as follows:

1. Remove unnecessary `:webpack` qualifier on build commands
2. Make a dedicated `dev` command.
3. Make `npm start` reference the `dev` command. It's better that `start` is an alias not a command in its own right.

### How to test the changes in this Pull Request:

1. `npm start`
2. Does it run the build in watch mode?


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
