### PR TITLE
Update block icon to avoid clash with Jetpack Tiled Gallery

### DIFF
--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -23,7 +23,7 @@ export const title = __( 'Newspack Homepage Articles', 'newspack-blocks' );
 export const icon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 		<Path d="M0 0h24v24H0z" fill="none" />
-		<Path d="M3 13h8V3H3v10zm0 8h8v-6H3v6zm10 0h8V11h-8v10zm0-18v6h8V3h-8z" />
+		<Path d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H8V4h12v12zM10 9h8v2h-8zm0 3h4v2h-4zm0-6h8v2h-8z" />
 	</SVG>
 );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Instead of using the "Dashboard" Material icon, like Jetpack Tiled Gallery, I suggest we use a different one: "Library Books" as it feels more generic.

__Before:__

![1 before](https://user-images.githubusercontent.com/177929/69566489-1d179680-0faf-11ea-9492-f5eac0498586.png)

__After:__

![2 after](https://user-images.githubusercontent.com/177929/69566330-bdb98680-0fae-11ea-9545-67ba7a232ae7.png)

### How to test the changes in this Pull Request:

1. Try to add an Homepage Articles block. And a Jetpack Tiled Gallery. Icons should look fairly similar (one is outline the other isn't...)
2. Switch to this branch
3. Do the same. Does it look better?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->
