### PR TITLE
Use a ButtonGroup and Button for the Featured Image Scale instead of RangeControl

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -17,6 +17,8 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment, RawHTML } from '@wordpress/element';
 import { InspectorControls, RichText, BlockControls } from '@wordpress/editor';
 import {
+	Button,
+	ButtonGroup,
 	PanelBody,
 	PanelRow,
 	RangeControl,
@@ -236,6 +238,29 @@ class Edit extends Component {
 			url,
 		} = attributes;
 
+		const imageSizeOptions = [
+		{
+			value: 1,
+			label: /* translators: label for small size option */ __( 'Small', 'newspack-blocks' ),
+			shortName: /* translators: abbreviation for small size */ __( 'S', 'newspack-blocks' ),
+		},
+		{
+			value: 2,
+			label: /* translators: label for medium size option */ __( 'Medium', 'newspack-blocks' ),
+			shortName: /* translators: abbreviation for medium size */ __( 'M', 'newspack-blocks' ),
+		},
+		{
+			value: 3,
+			label: /* translators: label for large size option */ __( 'Large', 'newspack-blocks' ),
+			shortName: /* translators: abbreviation for large size */ __( 'L', 'newspack-blocks' ),
+		},
+		{
+			value: 4,
+			label: /* translators: label for extra large size option */ __( 'Extra Large', 'newspack-blocks' ),
+			shortName: /* translators: abbreviation for extra large size */ __( 'XL', 'newspack-blocks' ),
+		},
+	];
+
 		return (
 			<Fragment>
 				<PanelBody title={ __( 'Display Settings', 'newspack-blocks' ) } initialOpen={ true }>
@@ -296,17 +321,26 @@ class Edit extends Component {
 									onChange={ () => setAttributes( { mobileStack: ! mobileStack } ) }
 								/>
 							</PanelRow>
-							<RangeControl
-								className="image-scale-slider"
-								label={ __( 'Featured Image Scale', 'newspack-blocks' ) }
-								value={ imageScale }
-								onChange={ value => setAttributes( { imageScale: value } ) }
-								min={ 1 }
-								max={ 4 }
-								beforeIcon="format-image"
-								afterIcon="format-image"
-								required
-							/>
+							<BaseControl label={ __( 'Featured Image Size', 'newspack-blocks' ) }>
+								<PanelRow>
+									<ButtonGroup aria-label={ __( 'Featured Image Size', 'newspack-blocks' ) }>
+										{ imageSizeOptions.map( ( option ) => {
+											const isCurrent = imageScale === option.value;
+											return (
+												<Button
+													isLarge
+													isPrimary={ isCurrent }
+													aria-pressed={ isCurrent }
+													aria-label={ option.label }
+													onClick={ () => setAttributes( { imageScale: option.value } ) }
+												>
+													{ option.shortName }
+												</Button>
+											);
+										} ) }
+									</ButtonGroup>
+								</PanelRow>
+							</BaseControl>
 						</Fragment>
 					) }
 

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -1,7 +1,6 @@
 @import "../../shared/sass/variables";
 
-.type-scale-slider,
-.image-scale-slider {
+.type-scale-slider {
 	.dashicon {
 		height: 16px;
 		width: 16px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* For the Featured Image Scale, replace the RangeControl with a combination of ButtonGroup and Button.
* Changed the label to "Featured Image Size"
* Instead of using numbers (1 - 4), I switched to sizes (S - XL) with aria-label

My reasoning is I feel like "1 - 4" is very abstract when it comes to image sizes whereas "S - XL" might be more appropriate here. What do you think?

_Note: Ditching the Dashicon here makes me happy._

__Before:__

![1 before](https://user-images.githubusercontent.com/177929/69719561-a7bfd900-1108-11ea-9bba-82cacf0907cc.png)

__After:__

![2 after](https://user-images.githubusercontent.com/177929/69719577-ae4e5080-1108-11ea-812b-994d6794e21d.png)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Add a Homepage Articles block to a page
3. Display the Featured Image on the right or left (make sure your posts have a Featured Image!)
4. In the sidebar you should see a "Featured Image Size" setting (vs "Featured Image Scale" previously). Play with it.
5. Does it make more sense than "1 - 4" to you?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->
