### PR TITLE
Improve the plugin extensibility.

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -67,8 +67,11 @@ class Newspack_Blocks_API {
 			return;
 		}
 
+		// Newspack=_Blocks handler.
+		$newspack_blocks = Newspack_Blocks::get_instance();
+
 		// Landscape image.
-		$landscape_size = Newspack_Blocks::image_size_for_orientation( 'landscape' );
+		$landscape_size = $newspack_blocks->image_size_for_orientation( 'landscape' );
 
 		$feat_img_array_landscape        = wp_get_attachment_image_src(
 			$object['featured_media'],
@@ -78,7 +81,7 @@ class Newspack_Blocks_API {
 		$featured_image_set['landscape'] = $feat_img_array_landscape[0];
 
 		// Portrait image.
-		$portrait_size = Newspack_Blocks::image_size_for_orientation( 'portrait' );
+		$portrait_size = $newspack_blocks->image_size_for_orientation( 'portrait' );
 
 		$feat_img_array_portrait        = wp_get_attachment_image_src(
 			$object['featured_media'],
@@ -88,7 +91,7 @@ class Newspack_Blocks_API {
 		$featured_image_set['portrait'] = $feat_img_array_portrait[0];
 
 		// Square image.
-		$square_size = Newspack_Blocks::image_size_for_orientation( 'square' );
+		$square_size = $newspack_blocks->image_size_for_orientation( 'square' );
 
 		$feat_img_array_square        = wp_get_attachment_image_src(
 			$object['featured_media'],

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -9,13 +9,32 @@
  * Newspack blocks functionality
  */
 class Newspack_Blocks {
+	/**
+	 * Class instance.
+	 *
+	 * @var Newspack_Blocks
+	 */
+	private static $instance = null;
+
+	/**
+	 * Creates instance.
+	 *
+	 * @return Newspack_Blocks
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
 
 	/**
 	 * Gather dependencies and paths needed for script enqueuing.
 	 *
 	 * @param string $script_path Path to the script relative to plugin root.
 	 *
-	 * @return array Associative array including dependency array, version, and web path to the script. Returns false if script doesn't exist.
+	 * @return array|boolean Associative array including dependency array, version, and web path to the script. Returns false if script doesn't exist.
 	 */
 	public static function script_enqueue_helper( $script_path ) {
 		$local_path = NEWSPACK_BLOCKS__PLUGIN_DIR . $script_path;
@@ -39,7 +58,7 @@ class Newspack_Blocks {
 	/**
 	 * Enqueue block scripts and styles for editor.
 	 */
-	public static function enqueue_block_editor_assets() {
+	public function enqueue_block_editor_assets() {
 		$script_data = self::script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'editor.js' );
 
 		if ( $script_data ) {
@@ -111,7 +130,7 @@ class Newspack_Blocks {
 	/**
 	 * Enqueue block styles stylesheet.
 	 */
-	public static function enqueue_block_styles_assets() {
+	public function enqueue_block_styles_assets() {
 		$style_path = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'block_styles' . ( is_rtl() ? '.rtl' : '' ) . '.css';
 		if ( file_exists( NEWSPACK_BLOCKS__PLUGIN_DIR . $style_path ) ) {
 			wp_enqueue_style(
@@ -162,7 +181,7 @@ class Newspack_Blocks {
 	 *
 	 * @return string Class list separated by spaces.
 	 */
-	public static function block_classes( $type, $attributes = array(), $extra = array() ) {
+	public function block_classes( $type, $attributes = array(), $extra = array() ) {
 		$align   = isset( $attributes['align'] ) ? $attributes['align'] : 'center';
 		$classes = array(
 			"wp-block-newspack-blocks-{$type}",
@@ -193,7 +212,7 @@ class Newspack_Blocks {
 	 *
 	 * @return string Returns the thumbnail key to use.
 	 */
-	public static function image_size_for_orientation( $orientation = 'landscape' ) {
+	public function image_size_for_orientation( $orientation = 'landscape' ) {
 		$sizes = array(
 			'landscape' => array(
 				'large'  => array(
@@ -265,7 +284,7 @@ class Newspack_Blocks {
 	/**
 	 * Registers image sizes required for Newspack Blocks.
 	 */
-	public static function add_image_sizes() {
+	public function add_image_sizes() {
 		add_image_size( 'newspack-article-block-landscape-large', 1200, 900, true );
 		add_image_size( 'newspack-article-block-portrait-large', 900, 1200, true );
 		add_image_size( 'newspack-article-block-square-large', 1200, 1200, true );

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -36,7 +36,7 @@ class Newspack_Blocks {
 	 *
 	 * @return array|boolean Associative array including dependency array, version, and web path to the script. Returns false if script doesn't exist.
 	 */
-	public static function script_enqueue_helper( $script_path ) {
+	public function script_enqueue_helper( $script_path ) {
 		$local_path = NEWSPACK_BLOCKS__PLUGIN_DIR . $script_path;
 		if ( ! file_exists( $local_path ) ) {
 			return false;
@@ -59,7 +59,7 @@ class Newspack_Blocks {
 	 * Enqueue block scripts and styles for editor.
 	 */
 	public function enqueue_block_editor_assets() {
-		$script_data = self::script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'editor.js' );
+		$script_data = $this->script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'editor.js' );
 
 		if ( $script_data ) {
 			wp_enqueue_script(
@@ -160,7 +160,7 @@ class Newspack_Blocks {
 		if ( self::is_amp() ) {
 			return;
 		}
-		$script_data = self::script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view.js' );
+		$script_data = self::get_instance()->script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view.js' );
 		if ( $script_data ) {
 			wp_enqueue_script(
 				"newspack-blocks-{$type}",

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -19,11 +19,14 @@ define( 'NEWSPACK_BLOCKS__VERSION', '1.0.0-alpha.17' );
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'class-newspack-blocks.php';
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'class-newspack-blocks-api.php';
 
-add_action( 'after_setup_theme', array( 'Newspack_Blocks', 'add_image_sizes' ) );
+// Newspack_Blocks handler.
+$newspack_blocks = Newspack_Blocks::get_instance();
+
+add_action( 'after_setup_theme', array( $newspack_blocks, 'add_image_sizes' ) );
 
 Newspack_Blocks::manage_view_scripts();
-add_action( 'enqueue_block_editor_assets', array( 'Newspack_Blocks', 'enqueue_block_editor_assets' ) );
-add_action( 'wp_enqueue_scripts', array( 'Newspack_Blocks', 'enqueue_block_styles_assets' ) );
+add_action( 'enqueue_block_editor_assets', array( $newspack_blocks, 'enqueue_block_editor_assets' ) );
+add_action( 'wp_enqueue_scripts', array( $newspack_blocks, 'enqueue_block_styles_assets' ) );
 
 /**
  * Load language files

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -59,7 +59,8 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 	if ( $autoplay ) {
 		$other[] = 'wp-block-newspack-blocks-carousel__autoplay-playing';
 	}
-	$classes = Newspack_Blocks::block_classes( 'carousel', $attributes, $other );
+	$newspack_blocks = Newspack_Blocks::get_instance();
+	$classes         = $newspack_blocks->block_classes( 'carousel', $attributes, $other );
 
 	$args          = array(
 		'posts_per_page'      => $posts_to_show,

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -46,7 +46,9 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	}
 	$article_query = new WP_Query( $args );
 
-	$classes = Newspack_Blocks::block_classes( 'homepage-articles', $attributes, array( 'wpnbha' ) );
+	// Newspack=_Blocks handler.
+	$newspack_blocks = Newspack_Blocks::get_instance();
+	$classes         = $newspack_blocks->block_classes( 'homepage-articles', $attributes, array( 'wpnbha' ) );
 
 	if ( isset( $attributes['postLayout'] ) && 'grid' === $attributes['postLayout'] ) {
 		$classes .= ' is-grid';
@@ -132,7 +134,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 								<?php
 								$image_size = 'newspack-article-block-uncropped';
 								if ( 'uncropped' !== $attributes['imageShape'] ) {
-									$image_size = Newspack_Blocks::image_size_for_orientation( $attributes['imageShape'] );
+									$image_size = $newspack_blocks->image_size_for_orientation( $attributes['imageShape'] );
 								}
 
 								// If the image position is behind, pass the object-fit setting to maintain styles with AMP.
@@ -248,7 +250,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 		<?php
 		endif;
 	$content = ob_get_clean();
-	Newspack_Blocks::enqueue_view_assets( 'homepage-articles' );
+	$newspack_blocks->enqueue_view_assets( 'homepage-articles' );
 	return $content;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR re-defines the methods of the main PHP class of the plugin as dynamic, in order to be able to overwrite some of their functionality when inheriting from it.

```php
class Newspack_Block {
    public function my_method() {
        // stuff from the main/parent class method
    }
}

class My_Custom_Newspack_Block extends Newspack_Block {
    public function my_method() {
        // Overwrite what this method does.
        // Call to the parent method if it's needed :-)
    }
}
```

It adds a static `get_instance()` to get an instance easier and avoiding to create a new one when it has been already created before.

```php
$newspack_instance = Newspack_Blocks::get_instance();
````

### How to test the changes in this Pull Request:

Apply these changes and confirm that everything works as expected. Create a block / update / save. No surprises here.


