### PR TITLE
Use `static` instead of `self` in order to make the method extensible

### DIFF
--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -40,7 +40,7 @@ class Newspack_Blocks {
 	 * Enqueue block scripts and styles for editor.
 	 */
 	public static function enqueue_block_editor_assets() {
-		$script_data = self::script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'editor.js' );
+		$script_data = static::script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'editor.js' );
 
 		if ( $script_data ) {
 			wp_enqueue_script(
@@ -138,10 +138,10 @@ class Newspack_Blocks {
 				NEWSPACK_BLOCKS__VERSION
 			);
 		}
-		if ( self::is_amp() ) {
+		if ( static::is_amp() ) {
 			return;
 		}
-		$script_data = self::script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view.js' );
+		$script_data = static::script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view.js' );
 		if ( $script_data ) {
 			wp_enqueue_script(
 				"newspack-blocks-{$type}",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

It replaces the how the static methods are internally called with `self::` by `static::`. It allows re-write them from the inherited class if it's needed.

```php
class MyCustomBlocks extends Newspack_Blocks {
    public static script_enqueue_helper() {
        // it will work because parent method is called with `static::` instead of `self::`
    }
}
```

### How to test the changes in this Pull Request:

Apply these changes. Everything should work as expected.