### PR TITLE
Add newspack_blocks_enqueue_view_assets filter

### DIFF
--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -129,7 +129,13 @@ class Newspack_Blocks {
 	 * @param string $type The block's type.
 	 */
 	public static function enqueue_view_assets( $type ) {
-		$style_path = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css';
+		$style_path = apply_filters(
+			'newspack_blocks_enqueue_view_assets',
+			NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css',
+			$type,
+			is_rtl()
+		);
+
 		if ( file_exists( NEWSPACK_BLOCKS__PLUGIN_DIR . $style_path ) ) {
 			wp_enqueue_style(
 				"newspack-blocks-{$type}",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the `newspack_blocks_enqueue_view_assets` filter in order to be able to re-define the style file path which will be loaded on the site.

#### How to use it

```php
function custom_styles( $style_path, $type, $is_rtl ) {
	if ( 'homepage-articles' !== $type ) {
		return $style_path;
	}
	
	if ( $is_rtl ) {
		return 'dist/editor.rtl.css';
	}

	return 'dist/editor.css';
}

add_filter( 'newspack_blocks_enqueue_view_assets',  'custom_styles', 10, 3 );
```

Everything should work as expected.
