### PR TITLE
Make block name and args filterable before registration

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -256,126 +256,131 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
  * Registers the `newspack-blocks/homepage-articles` block on server.
  */
 function newspack_blocks_register_homepage_articles() {
+	$name = 'newspack-blocks/homepage-articles';
 	register_block_type(
-		'newspack-blocks/homepage-articles',
-		array(
-			'attributes'      => array(
-				'className'       => array(
-					'type' => 'string',
-				),
-				'showExcerpt'     => array(
-					'type'    => 'boolean',
-					'default' => true,
-				),
-				'showDate'        => array(
-					'type'    => 'boolean',
-					'default' => true,
-				),
-				'showImage'       => array(
-					'type'    => 'boolean',
-					'default' => true,
-				),
-				'showCaption'     => array(
-					'type'    => 'boolean',
-					'default' => false,
-				),
-				'showAuthor'      => array(
-					'type'    => 'boolean',
-					'default' => true,
-				),
-				'showAvatar'      => array(
-					'type'    => 'boolean',
-					'default' => true,
-				),
-				'showCategory'  => array(
-					'type'    => 'boolean',
-					'default' => false,
-				),
-				'content'         => array(
-					'type' => 'string',
-				),
-				'postLayout'      => array(
-					'type'    => 'string',
-					'default' => 'list',
-				),
-				'columns'         => array(
-					'type'    => 'integer',
-					'default' => 3,
-				),
-				'postsToShow'     => array(
-					'type'    => 'integer',
-					'default' => 3,
-				),
-				'mediaPosition'   => array(
-					'type'    => 'string',
-					'default' => 'top',
-				),
-				'authors'         => array(
-					'type'    => 'array',
-					'default' => array(),
-					'items'   => array(
-						'type' => 'integer',
+		apply_filters( 'newspack_blocks_block_name', $name ),
+		apply_filters(
+			'newspack_blocks_block_args',
+			array(
+				'attributes'      => array(
+					'className'       => array(
+						'type' => 'string',
+					),
+					'showExcerpt'     => array(
+						'type'    => 'boolean',
+						'default' => true,
+					),
+					'showDate'        => array(
+						'type'    => 'boolean',
+						'default' => true,
+					),
+					'showImage'       => array(
+						'type'    => 'boolean',
+						'default' => true,
+					),
+					'showCaption'     => array(
+						'type'    => 'boolean',
+						'default' => false,
+					),
+					'showAuthor'      => array(
+						'type'    => 'boolean',
+						'default' => true,
+					),
+					'showAvatar'      => array(
+						'type'    => 'boolean',
+						'default' => true,
+					),
+					'showCategory'    => array(
+						'type'    => 'boolean',
+						'default' => false,
+					),
+					'content'         => array(
+						'type' => 'string',
+					),
+					'postLayout'      => array(
+						'type'    => 'string',
+						'default' => 'list',
+					),
+					'columns'         => array(
+						'type'    => 'integer',
+						'default' => 3,
+					),
+					'postsToShow'     => array(
+						'type'    => 'integer',
+						'default' => 3,
+					),
+					'mediaPosition'   => array(
+						'type'    => 'string',
+						'default' => 'top',
+					),
+					'authors'         => array(
+						'type'    => 'array',
+						'default' => array(),
+						'items'   => array(
+							'type' => 'integer',
+						),
+					),
+					'categories'      => array(
+						'type'    => 'array',
+						'default' => array(),
+						'items'   => array(
+							'type' => 'integer',
+						),
+					),
+					'tags'            => array(
+						'type'    => 'array',
+						'default' => array(),
+						'items'   => array(
+							'type' => 'integer',
+						),
+					),
+					'specificPosts'   => array(
+						'type'    => 'array',
+						'default' => array(),
+						'items'   => array(
+							'type' => 'integer',
+						),
+					),
+					'typeScale'       => array(
+						'type'    => 'integer',
+						'default' => 4,
+					),
+					'imageScale'      => array(
+						'type'    => 'integer',
+						'default' => 3,
+					),
+					'mobileStack'     => array(
+						'type'    => 'boolean',
+						'default' => false,
+					),
+					'imageShape'      => array(
+						'type'    => 'string',
+						'default' => 'landscape',
+					),
+					'minHeight'       => array(
+						'type'    => 'integer',
+						'default' => 0,
+					),
+					'sectionHeader'   => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'specificMode'    => array(
+						'type'    => 'boolean',
+						'default' => false,
+					),
+					'textColor'       => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'customTextColor' => array(
+						'type'    => 'string',
+						'default' => '',
 					),
 				),
-				'categories'      => array(
-					'type'    => 'array',
-					'default' => array(),
-					'items'   => array(
-						'type' => 'integer',
-					),
-				),
-				'tags'            => array(
-					'type'    => 'array',
-					'default' => array(),
-					'items'   => array(
-						'type' => 'integer',
-					),
-				),
-				'specificPosts'   => array(
-					'type'    => 'array',
-					'default' => array(),
-					'items'   => array(
-						'type' => 'integer',
-					),
-				),
-				'typeScale'       => array(
-					'type'    => 'integer',
-					'default' => 4,
-				),
-				'imageScale'      => array(
-					'type'    => 'integer',
-					'default' => 3,
-				),
-				'mobileStack'     => array(
-					'type'    => 'boolean',
-					'default' => false,
-				),
-				'imageShape'    => array(
-					'type'    => 'string',
-					'default' => 'landscape',
-				),
-				'minHeight'       => array(
-					'type'    => 'integer',
-					'default' => 0,
-				),
-				'sectionHeader'   => array(
-					'type'    => 'string',
-					'default' => '',
-				),
-				'specificMode'    => array(
-					'type'    => 'boolean',
-					'default' => false,
-				),
-				'textColor'       => array(
-					'type'    => 'string',
-					'default' => '',
-				),
-				'customTextColor' => array(
-					'type'    => 'string',
-					'default' => '',
-				),
+				'render_callback' => 'newspack_blocks_render_block_homepage_articles',
 			),
-			'render_callback' => 'newspack_blocks_render_block_homepage_articles',
+			$name
 		)
 	);
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add filter for Homepage Posts block registration in order to allow other plugins to override it or change as needed.

### How to test the changes in this Pull Request:

1. Install the plugin
2. Build its assets
3. Use plugin and confirm Homepage Posts block work as expected (both in editor and on frontend)

Filter call is added but not implemented directly in this plugin so there should not be any change in functionality. 

The diff on GitHub doesn't look very clean but all that was done it that arguments were wrapped in a filter call.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
