### PR TITLE
change newspack_blocks_enqueue_view_assets

### DIFF
--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -129,17 +129,18 @@ class Newspack_Blocks {
 	 * @param string $type The block's type.
 	 */
 	public static function enqueue_view_assets( $type ) {
-		$style_path = apply_filters(
+		$style_path = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css';
+		$plugin_url = apply_filters(
 			'newspack_blocks_enqueue_view_assets',
-			NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css',
+			plugins_url( $style_path, __FILE__ ),
 			$type,
 			is_rtl()
 		);
 
-		if ( file_exists( NEWSPACK_BLOCKS__PLUGIN_DIR . $style_path ) ) {
+		if ( $plugin_url ) {
 			wp_enqueue_style(
 				"newspack-blocks-{$type}",
-				plugins_url( $style_path, __FILE__ ),
+				$plugin_url,
 				array(),
 				NEWSPACK_BLOCKS__VERSION
 			);


### PR DESCRIPTION
It expects the URL instead of the path

### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

```php
function homepage_posts_view_assets( $style_path, $type, $is_rtl ) {
	if ( 'homepage-articles' !== $type ) {
		return $style_path;
	}

	if ( $is_rtl ) {
		return plugins_url( 'dist/view.rtl.css', __FILE__ );
	}

	return plugins_url( 'dist/view.css', __FILE__ );
}

add_filter( 'newspack_blocks_enqueue_view_assets', 'homepage_posts_view_assets', 10, 3 );
```

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
