### PR TITLE
Add REST endpoint from #226

### DIFF
--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -19,6 +19,18 @@ define( 'NEWSPACK_BLOCKS__VERSION', '1.0.0-alpha.17' );
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'class-newspack-blocks.php';
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'class-newspack-blocks-api.php';
 
+// REST Controller for Articles Block.
+require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php';
+
+/**
+ * Registers Articles block routes.
+ */
+function newspack_articles_block_register_rest_routes() {
+	$articles_controller = new WP_REST_Newspack_Articles_Controller();
+	$articles_controller->register_routes();
+}
+add_action( 'rest_api_init', 'newspack_articles_block_register_rest_routes' );
+
 add_action( 'after_setup_theme', array( 'Newspack_Blocks', 'add_image_sizes' ) );
 
 Newspack_Blocks::manage_view_scripts();

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * WP_REST_Newspack_Articles_Controller file.
+ */
+
+/**
+ * Class WP_REST_Newspack_Articles_Controller.
+ */
+class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
+
+	/**
+	 * Attribute schema.
+	 *
+	 * @var array
+	 */
+	public $attribute_schema;
+
+	/**
+	 * Constructs the controller.
+	 *
+	 * @access public
+	 */
+	public function __construct() {
+		$this->namespace = 'newspack-blocks/v1';
+		$this->rest_base = 'articles';
+	}
+
+	/**
+	 * Registers the necessary REST API routes.
+	 *
+	 * @access public
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_items' ],
+					'args'                => $this->get_attribute_schema(),
+					'permission_callback' => '__return_true',
+				],
+			]
+		);
+	}
+
+	/**
+	 * Returns a list of rendered posts.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$page       = $request->get_param( 'page' ) ?? 1;
+		$next_page  = $page + 1;
+		$attributes = wp_parse_args(
+			$request->get_params() ?? [],
+			wp_list_pluck( $this->get_attribute_schema(), 'default' )
+		);
+
+		$article_query_args = newspack_build_articles_query( $attributes );
+
+		// Append custom pagination arg for REST API endpoint.
+		$article_query_args['paged'] = $page;
+
+		// Run Query.
+		$article_query = new WP_Query( $article_query_args );
+
+		// Defaults.
+		$items    = [];
+		$next_url = '';
+
+		// The Loop.
+		while ( $article_query->have_posts() ) {
+			$article_query->the_post();
+
+			$items[]['html'] = newspack_blocks_template_inc(
+				__DIR__ . '/article.php',
+				[
+					'attributes' => $attributes,
+				]
+			);
+		}
+
+		// Provide next URL if there are more pages.
+		if ( $next_page <= $article_query->max_num_pages ) {
+			$next_url = add_query_arg(
+				array_merge( $attributes, [ 'page' => $next_page ] ),
+				rest_url( $this->namespace . '/' . $this->rest_base )
+			);
+		}
+
+		return rest_ensure_response( [
+			'items' => $items,
+			'next'  => $next_url,
+		] );
+	}
+
+	/**
+	 * Sets up and returns attribute schema.
+	 *
+	 * @return array
+	 */
+	public function get_attribute_schema() {
+		if ( empty( $this->attribute_schema ) ) {
+			$block_json = json_decode(
+				file_get_contents( __DIR__ . '/block.json' ),
+				true
+			);
+			$this->attribute_schema = $block_json['attributes'];
+		}
+
+		return $this->attribute_schema;
+	}
+}

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -59,7 +59,7 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 			wp_list_pluck( $this->get_attribute_schema(), 'default' )
 		);
 
-		$article_query_args = newspack_build_articles_query( $attributes );
+		$article_query_args = Newspack_Blocks::build_articles_query( $attributes );
 
 		// Append custom pagination arg for REST API endpoint.
 		$article_query_args['paged'] = $page;
@@ -74,9 +74,8 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 		// The Loop.
 		while ( $article_query->have_posts() ) {
 			$article_query->the_post();
-
-			$items[]['html'] = newspack_blocks_template_inc(
-				__DIR__ . '/article.php',
+			$items[]['html'] = Newspack_Blocks::template_inc(
+				__DIR__ . '/templates/article.php',
 				[
 					'attributes' => $attributes,
 				]


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds API endpoint from #226 (incl. `block.json`).

### How to test the changes in this Pull Request:

Navigate to `/wp-json/newspack-blocks/v1` on your test site and make sure you get a valid response.

