### PR TITLE
Extract Block Settings

### DIFF
--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -1,0 +1,117 @@
+{
+  "name": "homepage-articles",
+  "category": "newspack",
+  "attributes": {
+    "className": {
+      "type": "string",
+      "default": ""
+    },
+    "showExcerpt": {
+      "type": "boolean",
+      "default": true
+    },
+    "showDate": {
+      "type": "boolean",
+      "default": true
+    },
+    "showImage": {
+      "type": "boolean",
+      "default": true
+    },
+    "showCaption": {
+      "type": "boolean",
+      "default": false
+    },
+    "imageShape": {
+      "type": "string",
+      "default": "landscape"
+    },
+    "minHeight": {
+      "type": "integer",
+      "default": 0
+    },
+    "moreButton": {
+      "type": "boolean",
+      "default": false
+    },
+    "showAuthor": {
+      "type": "boolean",
+      "default": true
+    },
+    "showAvatar": {
+      "type": "boolean",
+      "default": true
+    },
+    "showCategory": {
+      "type": "boolean",
+      "default": false
+    },
+    "postLayout": {
+      "type": "string",
+      "default": "list"
+    },
+    "columns": {
+      "type": "integer",
+      "default": 3
+    },
+    "postsToShow": {
+      "type": "integer",
+      "default": 3
+    },
+    "mediaPosition": {
+      "type": "string",
+      "default": "top"
+    },
+    "authors": {
+      "type": "array",
+      "default": [],
+       "items": { "type": "integer" }
+    },
+    "categories": {
+      "type": "array",
+      "default": [],
+      "items": { "type": "integer" }
+    },
+    "tags": {
+      "type": "array",
+      "default": [],
+       "items": { "type": "integer" }
+    },
+    "specificPosts": {
+      "type": "array",
+      "default": []
+    },
+    "typeScale": {
+      "type": "integer",
+      "default": 4
+    },
+    "imageScale": {
+      "type": "integer",
+      "default": 3
+    },
+    "mobileStack": {
+      "type": "boolean",
+      "default": false
+    },
+    "sectionHeader": {
+      "type": "string",
+      "default": ""
+    },
+    "specificMode": {
+      "type": "boolean",
+      "default": false
+    },
+    "textColor": {
+      "type": "string",
+      "default": ""
+    },
+    "customTextColor": {
+      "type": "string",
+      "default": ""
+    },
+    "singleMode": {
+      "type": "boolean",
+      "default": false
+    }
+  }
+}

--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -65,7 +65,7 @@
     "authors": {
       "type": "array",
       "default": [],
-       "items": { "type": "integer" }
+      "items": { "type": "integer" }
     },
     "categories": {
       "type": "array",
@@ -75,11 +75,12 @@
     "tags": {
       "type": "array",
       "default": [],
-       "items": { "type": "integer" }
+      "items": { "type": "integer" }
     },
     "specificPosts": {
       "type": "array",
-      "default": []
+      "default": [],
+      "items": { "type": "integer" }
     },
     "typeScale": {
       "type": "integer",

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -15,8 +15,12 @@ import edit from './edit';
  */
 import './editor.scss';
 import './view.scss';
+import metadata from './block.json';
+const { name, attributes, category } = metadata;
 
-export const name = 'homepage-articles';
+// Name must be exported separately.
+export { name };
+
 export const title = __( 'Homepage Posts', 'newspack-blocks' );
 
 /* From https://material.io/tools/icons */
@@ -30,7 +34,8 @@ export const icon = (
 export const settings = {
 	title,
 	icon,
-	category: 'newspack',
+	attributes,
+	category,
 	keywords: [
 		__( 'posts', 'newspack-blocks' ),
 		__( 'articles', 'newspack-blocks' ),
@@ -41,103 +46,6 @@ export const settings = {
 		{ name: 'default', label: _x( 'Default', 'block style', 'newspack-blocks' ), isDefault: true },
 		{ name: 'borders', label: _x( 'Borders', 'block style', 'newspack-blocks' ) },
 	],
-	attributes: {
-		className: {
-			type: 'string',
-		},
-		showExcerpt: {
-			type: 'boolean',
-			default: true,
-		},
-		showDate: {
-			type: 'boolean',
-			default: true,
-		},
-		showImage: {
-			type: 'boolean',
-			default: true,
-		},
-		showCaption: {
-			type: 'boolean',
-			default: false,
-		},
-		imageShape: {
-			type: 'string',
-			default: 'landscape',
-		},
-		minHeight: {
-			type: 'integer',
-			default: 0,
-		},
-		showAuthor: {
-			type: 'boolean',
-			default: true,
-		},
-		showAvatar: {
-			type: 'boolean',
-			default: true,
-		},
-		showCategory: {
-			type: 'boolean',
-			default: false,
-		},
-		postLayout: {
-			type: 'string',
-			default: 'list',
-		},
-		columns: {
-			type: 'integer',
-			default: 3,
-		},
-		postsToShow: {
-			type: 'integer',
-			default: 3,
-		},
-		mediaPosition: {
-			type: 'string',
-			default: 'top',
-		},
-		authors: {
-			type: 'array',
-		},
-		categories: {
-			type: 'array',
-		},
-		tags: {
-			type: 'array',
-		},
-		specificPosts: {
-			type: 'array',
-		},
-		typeScale: {
-			type: 'integer',
-			default: 4,
-		},
-		imageScale: {
-			type: 'integer',
-			default: 3,
-		},
-		mobileStack: {
-			type: 'boolean',
-			default: false,
-		},
-		sectionHeader: {
-			type: 'string',
-			default: '',
-		},
-		specificMode: {
-			type: 'boolean',
-			default: false,
-		},
-		textColor: {
-			type: 'string',
-			default: '',
-		},
-		customTextColor: {
-			type: 'string',
-			default: '',
-		},
-	},
 	supports: {
 		html: false,
 		align: [ 'wide', 'full' ],

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -256,131 +256,19 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
  * Registers the `newspack-blocks/homepage-articles` block on server.
  */
 function newspack_blocks_register_homepage_articles() {
-	$name = 'newspack-blocks/homepage-articles';
+	$block = json_decode(
+		file_get_contents( __DIR__ . '/block.json' ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		true
+	);
 	register_block_type(
-		apply_filters( 'newspack_blocks_block_name', $name ),
+		apply_filters( 'newspack_blocks_block_name', 'newspack-blocks/' . $block['name'] ),
 		apply_filters(
 			'newspack_blocks_block_args',
 			array(
-				'attributes'      => array(
-					'className'       => array(
-						'type' => 'string',
-					),
-					'showExcerpt'     => array(
-						'type'    => 'boolean',
-						'default' => true,
-					),
-					'showDate'        => array(
-						'type'    => 'boolean',
-						'default' => true,
-					),
-					'showImage'       => array(
-						'type'    => 'boolean',
-						'default' => true,
-					),
-					'showCaption'     => array(
-						'type'    => 'boolean',
-						'default' => false,
-					),
-					'showAuthor'      => array(
-						'type'    => 'boolean',
-						'default' => true,
-					),
-					'showAvatar'      => array(
-						'type'    => 'boolean',
-						'default' => true,
-					),
-					'showCategory'    => array(
-						'type'    => 'boolean',
-						'default' => false,
-					),
-					'content'         => array(
-						'type' => 'string',
-					),
-					'postLayout'      => array(
-						'type'    => 'string',
-						'default' => 'list',
-					),
-					'columns'         => array(
-						'type'    => 'integer',
-						'default' => 3,
-					),
-					'postsToShow'     => array(
-						'type'    => 'integer',
-						'default' => 3,
-					),
-					'mediaPosition'   => array(
-						'type'    => 'string',
-						'default' => 'top',
-					),
-					'authors'         => array(
-						'type'    => 'array',
-						'default' => array(),
-						'items'   => array(
-							'type' => 'integer',
-						),
-					),
-					'categories'      => array(
-						'type'    => 'array',
-						'default' => array(),
-						'items'   => array(
-							'type' => 'integer',
-						),
-					),
-					'tags'            => array(
-						'type'    => 'array',
-						'default' => array(),
-						'items'   => array(
-							'type' => 'integer',
-						),
-					),
-					'specificPosts'   => array(
-						'type'    => 'array',
-						'default' => array(),
-						'items'   => array(
-							'type' => 'integer',
-						),
-					),
-					'typeScale'       => array(
-						'type'    => 'integer',
-						'default' => 4,
-					),
-					'imageScale'      => array(
-						'type'    => 'integer',
-						'default' => 3,
-					),
-					'mobileStack'     => array(
-						'type'    => 'boolean',
-						'default' => false,
-					),
-					'imageShape'      => array(
-						'type'    => 'string',
-						'default' => 'landscape',
-					),
-					'minHeight'       => array(
-						'type'    => 'integer',
-						'default' => 0,
-					),
-					'sectionHeader'   => array(
-						'type'    => 'string',
-						'default' => '',
-					),
-					'specificMode'    => array(
-						'type'    => 'boolean',
-						'default' => false,
-					),
-					'textColor'       => array(
-						'type'    => 'string',
-						'default' => '',
-					),
-					'customTextColor' => array(
-						'type'    => 'string',
-						'default' => '',
-					),
-				),
+				'attributes'      => $block['attributes'],
 				'render_callback' => 'newspack_blocks_render_block_homepage_articles',
 			),
-			$name
+			$block['name']
 		)
 	);
 }


### PR DESCRIPTION
#239 # All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR is the first in a series of smaller PRs taken from https://github.com/Automattic/newspack-blocks/pull/226. This one extracts block `name`, `category` and `attributes` to a JSON file, which is imported into the block's `index.js` and `view.php` files. Here are the changes between this PR and the equivalent code in 226:

- `"items": { "type": "integer" }` added to the authors, categories, and tags attribute definitions. Added to mirror https://github.com/Automattic/newspack-blocks/blob/master/src/blocks/homepage-articles/view.php#L316-L343
- Added namespace in the default filter value for  `newspack_blocks_block_name` in https://github.com/Automattic/newspack-blocks/compare/try/extract-block-attributes?expand=1#diff-0bc1373b8d23b0320f8a67d468c37a1eR257-R261. 

### How to test the changes in this Pull Request:

Build the block, verify everything works exactly as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
