### PR TITLE
Extract Query Builder

### DIFF
--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -290,4 +290,45 @@ class Newspack_Blocks {
 
 		add_image_size( 'newspack-article-block-uncropped', 1200, 9999, false );
 	}
+
+	/**
+	 * Builds and returns query args based on block attributes.
+	 *
+	 * @param array $attributes An array of block attributes.
+	 *
+	 * @return array
+	 */
+	public static function build_articles_query( $attributes ) {
+		global $newspack_blocks_post_id;
+		if ( ! $newspack_blocks_post_id ) {
+			$newspack_blocks_post_id = array();
+		}
+		$authors        = isset( $attributes['authors'] ) ? $attributes['authors'] : array();
+		$categories     = isset( $attributes['categories'] ) ? $attributes['categories'] : array();
+		$tags           = isset( $attributes['tags'] ) ? $attributes['tags'] : array();
+		$specific_posts = isset( $attributes['specificPosts'] ) ? $attributes['specificPosts'] : array();
+		$posts_to_show  = intval( $attributes['postsToShow'] );
+		$specific_mode  = intval( $attributes['specificMode'] );
+		$args           = array(
+			'post_status'         => 'publish',
+			'suppress_filters'    => false,
+			'ignore_sticky_posts' => true,
+		);
+		if ( $specific_mode && $specific_posts ) {
+			$args['post__in'] = $specific_posts;
+			$args['orderby']  = 'post__in';
+		} else {
+			$args['posts_per_page'] = $posts_to_show + count( $newspack_blocks_post_id );
+			if ( $authors ) {
+				$args['author__in'] = $authors;
+			}
+			if ( $categories ) {
+				$args['category__in'] = $categories;
+			}
+			if ( $tags ) {
+				$args['tag__in'] = $tags;
+			}
+		}
+		return $args;
+	}
 }

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -13,38 +13,9 @@
  * @return string Returns the post content with latest posts added.
  */
 function newspack_blocks_render_block_homepage_articles( $attributes ) {
-	global $newspack_blocks_post_id;
-	if ( ! $newspack_blocks_post_id ) {
-		$newspack_blocks_post_id = array();
-	}
-	$authors        = isset( $attributes['authors'] ) ? $attributes['authors'] : array();
-	$categories     = isset( $attributes['categories'] ) ? $attributes['categories'] : array();
-	$tags           = isset( $attributes['tags'] ) ? $attributes['tags'] : array();
-	$specific_posts = isset( $attributes['specificPosts'] ) ? $attributes['specificPosts'] : array();
-	$posts_to_show  = intval( $attributes['postsToShow'] );
-	$specific_mode  = intval( $attributes['specificMode'] );
-	$args           = array(
-		'post_status'         => 'publish',
-		'suppress_filters'    => false,
-		'ignore_sticky_posts' => true,
-	);
-	if ( $specific_mode && $specific_posts ) {
-		$args['post__in'] = $specific_posts;
-		$args['orderby']  = 'post__in';
-	} else {
-		$args['posts_per_page'] = $posts_to_show + count( $newspack_blocks_post_id );
+	$posts_to_show = intval( $attributes['postsToShow'] );
 
-		if ( $authors ) {
-			$args['author__in'] = $authors;
-		}
-		if ( $categories ) {
-			$args['category__in'] = $categories;
-		}
-		if ( $tags ) {
-			$args['tag__in'] = $tags;
-		}
-	}
-	$article_query = new WP_Query( $args );
+	$article_query = new WP_Query( Newspack_Blocks::build_articles_query( $attributes ) );
 
 	$classes = Newspack_Blocks::block_classes( 'homepage-articles', $attributes, array( 'wpnbha' ) );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Second PR taken from https://github.com/Automattic/newspack-blocks/pull/226 to extract pieces of functionality. This one extracts the preparation of the args to be used by `WP_Query`. Currently there is only one use of this function but in 226 it is needed in multiple places.

Differences between this PR and 226:
- `build_articles_query` is a static class method of `Newspack_Blocks` rather than a global function. 
- `$posts_to_show` needs to be available because it's used in the loop: https://github.com/Automattic/newspack-blocks/compare/try/extract-query-building?expand=1#diff-0bc1373b8d23b0320f8a67d468c37a1eR16

### How to test the changes in this Pull Request:

There should be no changes to the functionality of the block. Build and verify no regressions.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
