### PR TITLE
Extract To Templates

### DIFF
--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -357,4 +357,41 @@ class Newspack_Blocks {
 		ob_end_clean();
 		return $contents;
 	}
+
+	/**
+	 * Prepare an array of authors, taking presence of CoAuthors Plus into account.
+	 *
+	 * @return array Array of WP_User objects.
+	 */
+	public static function prepare_authors() {
+		if ( function_exists( 'coauthors_posts_links' ) ) {
+			$authors = get_coauthors();
+			foreach ( $authors as $author ) {
+				// Check if this is a guest author post type.
+				if ( 'guest-author' === get_post_type( $author->ID ) ) {
+					// If yes, make sure the author actually has an avatar set; otherwise, coauthors_get_avatar returns a featured image.
+					if ( get_post_thumbnail_id( $author->ID ) ) {
+						$author->avatar = coauthors_get_avatar( $author, 48 );
+					} else {
+						// If there is no avatar, force it to return the current fallback image.
+						$author->avatar = get_avatar( ' ' );
+					}
+				} else {
+					$author->avatar = coauthors_get_avatar( $author, 48 );
+				}
+				$author->url = get_author_posts_url( $author->ID, $author->user_nicename );
+			}
+			return $authors;
+		}
+		$id = get_the_author_meta( 'ID' );
+		return array(
+			(object) array(
+				'ID'            => $id,
+				'avatar'        => get_avatar( $id, 48 ),
+				'url'           => get_author_posts_url( $id ),
+				'user_nicename' => get_the_author(),
+				'display_name'  => get_the_author_meta( 'display_name' ),
+			),
+		);
+	}
 }

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -331,4 +331,30 @@ class Newspack_Blocks {
 		}
 		return $args;
 	}
+
+	/**
+	 * Loads a template with given data in scope.
+	 *
+	 * @param string $template full Path to the template to be included.
+	 * @param array  $data          Data to be passed into the template to be included.
+	 * @return string
+	 */
+	public static function template_inc( $template, $data = array() ) {
+		if ( ! strpos( $template, '.php' ) ) {
+			$template = $template . '.php';
+		}
+		if ( ! is_file( $template ) ) {
+			return '';
+		}
+		// Optionally provided an assoc array of data to pass to template
+		// and it will be extracted into variables
+		if ( is_array( $data ) ) {
+			extract( $data );
+		}
+		ob_start();
+		include $template;
+		$contents = ob_get_contents();
+		ob_end_clean();
+		return $contents;
+	}
 }

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -346,11 +346,6 @@ class Newspack_Blocks {
 		if ( ! is_file( $template ) ) {
 			return '';
 		}
-		// Optionally provided an assoc array of data to pass to template
-		// and it will be extracted into variables
-		if ( is_array( $data ) ) {
-			extract( $data );
-		}
 		ob_start();
 		include $template;
 		$contents = ob_get_contents();

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -99,7 +99,7 @@ call_user_func(
 							$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
 						endif;
 						printf(
-							esc_attr( $time_string ),
+							wp_kses_post( $time_string ),
 							esc_attr( get_the_date( DATE_W3C ) ),
 							esc_html( get_the_date() ),
 							esc_attr( get_the_modified_date( DATE_W3C ) ),

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -99,7 +99,15 @@ call_user_func(
 							$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
 						endif;
 						printf(
-							wp_kses_post( $time_string ),
+							wp_kses(
+								$time_string,
+								array(
+									'time' => array(
+										'class'    => true,
+										'datetime' => true,
+									),
+								)
+							),
 							esc_attr( get_the_date( DATE_W3C ) ),
 							esc_html( get_the_date() ),
 							esc_attr( get_the_modified_date( DATE_W3C ) ),

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -3,97 +3,116 @@
  * Article template.
  *
  * @global array $attributes Block attributes.
+ * @package WordPress
  */
 
-$newspack_blocks_authors = Newspack_Blocks::prepare_authors();
-$styles = '';
-if ( 'behind' === $attributes['mediaPosition'] && $attributes['showImage'] && has_post_thumbnail() ) {
-	$styles = 'min-height: ' . $attributes['minHeight'] . 'vh; padding-top: ' . ( $attributes['minHeight'] / 5 ) . 'vh;';
-}
-$image_size = 'newspack-article-block-uncropped';
-if ( 'uncropped' !== $attributes['imageShape'] ) {
-	$image_size = Newspack_Blocks::image_size_for_orientation( $attributes['imageShape'] );
-}
-$thumbnail_args = '';
-// If the image position is behind, pass the object-fit setting to maintain styles with AMP.
-if ( 'behind' === $attributes['mediaPosition'] ) {
-	$thumbnail_args = array( 'object-fit' => 'cover' );
-}
-$category = false;
-// Use Yoast primary category if set.
-if ( class_exists( 'WPSEO_Primary_Term' ) ) {
-	$primary_term = new WPSEO_Primary_Term( 'category', get_the_ID() );
-	$category_id  = $primary_term->get_primary_term();
-	if ( $category_id ) {
-		$category = get_term( $category_id );
-	}
-}
-if ( ! $category ) {
-	$categories_list = get_the_category();
-	if ( ! empty( $categories_list ) ) {
-		$category = $categories_list[0];
-	}
-}
-?>
-<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?> <?php echo $styles ? 'style="' . esc_attr( $styles ) . '"' : ''; ?>>
-	<?php if ( has_post_thumbnail() && $attributes['showImage'] && $attributes['imageShape'] ) : ?>
-		<figure class="post-thumbnail">
-			<a href="<?php the_permalink(); ?>" rel="bookmark">
-				<?php the_post_thumbnail( $image_size, $thumbnail_args ); ?>
-			</a>
+call_user_func(
+	function( $data ) {
+		$attributes = $data['attributes'];
 
-			<?php if ( $attributes['showCaption'] && '' !== get_the_post_thumbnail_caption() ) : ?>
-				<figcaption><?php the_post_thumbnail_caption(); ?></figcaption>
-			<?php endif; ?>
-		</figure><!-- .featured-image -->
-	<?php endif; ?>
+		$authors = Newspack_Blocks::prepare_authors();
 
-	<div class="entry-wrapper">
-		<?php if ( $attributes['showCategory'] && $category ) : ?>
-			<div class="cat-links">
-				<a href="<?php echo esc_url( get_category_link( $category->term_id ) ); ?>">
-					<?php echo esc_html( $category->name ); ?>
+		$styles = '';
+
+		if ( 'behind' === $attributes['mediaPosition'] && $attributes['showImage'] && has_post_thumbnail() ) {
+			$styles = 'min-height: ' . $attributes['minHeight'] . 'vh; padding-top: ' . ( $attributes['minHeight'] / 5 ) . 'vh;';
+		}
+		$image_size = 'newspack-article-block-uncropped';
+		if ( 'uncropped' !== $attributes['imageShape'] ) {
+			$image_size = Newspack_Blocks::image_size_for_orientation( $attributes['imageShape'] );
+		}
+		$thumbnail_args = '';
+		// If the image position is behind, pass the object-fit setting to maintain styles with AMP.
+		if ( 'behind' === $attributes['mediaPosition'] ) {
+			$thumbnail_args = array( 'object-fit' => 'cover' );
+		}
+		$category = false;
+		// Use Yoast primary category if set.
+		if ( class_exists( 'WPSEO_Primary_Term' ) ) {
+			$primary_term = new WPSEO_Primary_Term( 'category', get_the_ID() );
+			$category_id  = $primary_term->get_primary_term();
+			if ( $category_id ) {
+				$category = get_term( $category_id );
+			}
+		}
+		if ( ! $category ) {
+			$categories_list = get_the_category();
+			if ( ! empty( $categories_list ) ) {
+				$category = $categories_list[0];
+			}
+		}
+		?>
+	<article
+		<?php if ( has_post_thumbnail() ) : ?>
+		class="post-has-image"
+		<?php endif; ?>
+		<?php if ( $styles ) : ?>
+		style="<?php echo esc_attr( $styles ); ?>"
+		<?php endif; ?>
+		>
+		<?php if ( has_post_thumbnail() && $attributes['showImage'] && $attributes['imageShape'] ) : ?>
+			<figure class="post-thumbnail">
+				<a href="<?php the_permalink(); ?>" rel="bookmark">
+					<?php the_post_thumbnail( $image_size, $thumbnail_args ); ?>
 				</a>
-			</div>
-			<?php
-		endif;
-		if ( '' === $attributes['sectionHeader'] ) :
-			the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
-		else :
-			the_title( '<h3 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h3>' );
-		endif;
-		if ( $attributes['showExcerpt'] ) :
-			the_excerpt();
-		endif;
-		if ( $attributes['showAuthor'] || $attributes['showDate'] ) :
-			?>
-			<div class="entry-meta">
+
+				<?php if ( $attributes['showCaption'] && '' !== get_the_post_thumbnail_caption() ) : ?>
+					<figcaption><?php the_post_thumbnail_caption(); ?></figcaption>
+				<?php endif; ?>
+			</figure><!-- .featured-image -->
+		<?php endif; ?>
+
+		<div class="entry-wrapper">
+			<?php if ( $attributes['showCategory'] && $category ) : ?>
+				<div class="cat-links">
+					<a href="<?php echo esc_url( get_category_link( $category->term_id ) ); ?>">
+						<?php echo esc_html( $category->name ); ?>
+					</a>
+				</div>
 				<?php
-				if ( $attributes['showAuthor'] ) :
-					if ( $attributes['showAvatar'] ) :
-						echo wp_kses_post( newspack_blocks_format_avatars( $newspack_blocks_authors ) );
+			endif;
+			if ( '' === $attributes['sectionHeader'] ) :
+				the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
+			else :
+				the_title( '<h3 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h3>' );
+			endif;
+			if ( $attributes['showExcerpt'] ) :
+				the_excerpt();
+			endif;
+			if ( $attributes['showAuthor'] || $attributes['showDate'] ) :
+				?>
+				<div class="entry-meta">
+					<?php
+					if ( $attributes['showAuthor'] ) :
+						if ( $attributes['showAvatar'] ) :
+							echo wp_kses_post( newspack_blocks_format_avatars( $authors ) );
+						endif;
+						?>
+						<span class="byline">
+							<?php echo wp_kses_post( newspack_blocks_format_byline( $newspack_blocks_authors ) ); ?>
+						</span><!-- .author-name -->
+						<?php
+					endif;
+					if ( $attributes['showDate'] ) :
+						$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
+						if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) :
+							$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
+						endif;
+						printf(
+							esc_attr( $time_string ),
+							esc_attr( get_the_date( DATE_W3C ) ),
+							esc_html( get_the_date() ),
+							esc_attr( get_the_modified_date( DATE_W3C ) ),
+							esc_html( get_the_modified_date() )
+						);
 					endif;
 					?>
-					<span class="byline">
-						<?php echo wp_kses_post( newspack_blocks_format_byline( $newspack_blocks_authors ) ); ?>
-					</span><!-- .author-name -->
-					<?php
-				endif;
-				if ( $attributes['showDate'] ) :
-					$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
-					if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) :
-						$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
-					endif;
-					printf(
-						$time_string,
-						esc_attr( get_the_date( DATE_W3C ) ),
-						esc_html( get_the_date() ),
-						esc_attr( get_the_modified_date( DATE_W3C ) ),
-						esc_html( get_the_modified_date() )
-					);
-				endif;
-				?>
-			</div><!-- .entry-meta -->
-		<?php endif; ?>
-	</div><!-- .entry-wrapper -->
-</article>
+				</div><!-- .entry-meta -->
+			<?php endif; ?>
+		</div><!-- .entry-wrapper -->
+	</article>
+
+		<?php
+	},
+	$data
+);

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Article template.
+ *
+ * @global array $attributes Block attributes.
+ */
+
+$authors = newspack_blocks_prepare_authors();
+$styles = '';
+if ( 'behind' === $attributes['mediaPosition'] && $attributes['showImage'] && has_post_thumbnail() ) {
+	$styles = 'min-height: ' . $attributes['minHeight'] . 'vh; padding-top: ' . ( $attributes['minHeight'] / 5 ) . 'vh;';
+}
+$image_size = 'newspack-article-block-uncropped';
+if ( 'uncropped' !== $attributes['imageShape'] ) {
+	$image_size = Newspack_Blocks::image_size_for_orientation( $attributes['imageShape'] );
+}
+$thumbnail_args = '';
+// If the image position is behind, pass the object-fit setting to maintain styles with AMP.
+if ( 'behind' === $attributes['mediaPosition'] ) {
+	$thumbnail_args = array( 'object-fit' => 'cover' );
+}
+$category = false;
+// Use Yoast primary category if set.
+if ( class_exists( 'WPSEO_Primary_Term' ) ) {
+	$primary_term = new WPSEO_Primary_Term( 'category', get_the_ID() );
+	$category_id  = $primary_term->get_primary_term();
+	if ( $category_id ) {
+		$category = get_term( $category_id );
+	}
+}
+if ( ! $category ) {
+	$categories_list = get_the_category();
+	if ( ! empty( $categories_list ) ) {
+		$category = $categories_list[0];
+	}
+}
+?>
+<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?> <?php echo $styles ? 'style="' . esc_attr( $styles ) . '"' : ''; ?>>
+	<?php if ( has_post_thumbnail() && $attributes['showImage'] && $attributes['imageShape'] ) : ?>
+		<figure class="post-thumbnail">
+			<a href="<?php the_permalink(); ?>" rel="bookmark">
+				<?php the_post_thumbnail( $image_size, $thumbnail_args ); ?>
+			</a>
+
+			<?php if ( $attributes['showCaption'] && '' !== get_the_post_thumbnail_caption() ) : ?>
+				<figcaption><?php the_post_thumbnail_caption(); ?></figcaption>
+			<?php endif; ?>
+		</figure><!-- .featured-image -->
+	<?php endif; ?>
+
+	<div class="entry-wrapper">
+		<?php if ( $attributes['showCategory'] && $category ) : ?>
+			<div class="cat-links">
+				<a href="<?php echo esc_url( get_category_link( $category->term_id ) ); ?>">
+					<?php echo esc_html( $category->name ); ?>
+				</a>
+			</div>
+			<?php
+		endif;
+		if ( '' === $attributes['sectionHeader'] ) :
+			the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
+		else :
+			the_title( '<h3 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h3>' );
+		endif;
+		if ( $attributes['showExcerpt'] ) :
+			the_excerpt();
+		endif;
+		if ( $attributes['showAuthor'] || $attributes['showDate'] ) :
+			?>
+			<div class="entry-meta">
+				<?php
+				if ( $attributes['showAuthor'] ) :
+					if ( $attributes['showAvatar'] ) :
+						echo wp_kses_post( newspack_blocks_format_avatars( $authors ) );
+					endif;
+					?>
+					<span class="byline">
+						<?php echo wp_kses_post( newspack_blocks_format_byline( $authors ) ); ?>
+					</span><!-- .author-name -->
+					<?php
+				endif;
+				if ( $attributes['showDate'] ) :
+					$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
+					if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) :
+						$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
+					endif;
+					printf(
+						$time_string,
+						esc_attr( get_the_date( DATE_W3C ) ),
+						esc_html( get_the_date() ),
+						esc_attr( get_the_modified_date( DATE_W3C ) ),
+						esc_html( get_the_modified_date() )
+					);
+				endif;
+				?>
+			</div><!-- .entry-meta -->
+		<?php endif; ?>
+	</div><!-- .entry-wrapper -->
+</article>

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -5,7 +5,7 @@
  * @global array $attributes Block attributes.
  */
 
-$authors = newspack_blocks_prepare_authors();
+$newspack_blocks_authors = Newspack_Blocks::prepare_authors();
 $styles = '';
 if ( 'behind' === $attributes['mediaPosition'] && $attributes['showImage'] && has_post_thumbnail() ) {
 	$styles = 'min-height: ' . $attributes['minHeight'] . 'vh; padding-top: ' . ( $attributes['minHeight'] / 5 ) . 'vh;';
@@ -71,11 +71,11 @@ if ( ! $category ) {
 				<?php
 				if ( $attributes['showAuthor'] ) :
 					if ( $attributes['showAvatar'] ) :
-						echo wp_kses_post( newspack_blocks_format_avatars( $authors ) );
+						echo wp_kses_post( newspack_blocks_format_avatars( $newspack_blocks_authors ) );
 					endif;
 					?>
 					<span class="byline">
-						<?php echo wp_kses_post( newspack_blocks_format_byline( $authors ) ); ?>
+						<?php echo wp_kses_post( newspack_blocks_format_byline( $newspack_blocks_authors ) ); ?>
 					</span><!-- .author-name -->
 					<?php
 				endif;

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -89,7 +89,7 @@ call_user_func(
 						endif;
 						?>
 						<span class="byline">
-							<?php echo wp_kses_post( newspack_blocks_format_byline( $newspack_blocks_authors ) ); ?>
+							<?php echo wp_kses_post( newspack_blocks_format_byline( $authors ) ); ?>
 						</span><!-- .author-name -->
 						<?php
 					endif;

--- a/src/blocks/homepage-articles/templates/articles-list.php
+++ b/src/blocks/homepage-articles/templates/articles-list.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * @global WP_Query $article_query Article query.
+ * @global array    $attributes
+ */
+
+echo Newspack_Blocks::template_inc( __DIR__ . '/articles-loop.php', [
+	'attributes'    => $attributes,
+	'article_query' => $article_query,
+] );

--- a/src/blocks/homepage-articles/templates/articles-list.php
+++ b/src/blocks/homepage-articles/templates/articles-list.php
@@ -9,13 +9,11 @@
 
 call_user_func(
 	function( $data ) {
-		echo wp_kses_post(
-			Newspack_Blocks::template_inc(
-				__DIR__ . '/articles-loop.php',
-				array(
-					'attributes'    => $data['attributes'],
-					'article_query' => $data['article_query'],
-				)
+		echo Newspack_Blocks::template_inc( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			__DIR__ . '/articles-loop.php',
+			array(
+				'attributes'    => $data['attributes'],
+				'article_query' => $data['article_query'],
 			)
 		);
 	},

--- a/src/blocks/homepage-articles/templates/articles-list.php
+++ b/src/blocks/homepage-articles/templates/articles-list.php
@@ -1,10 +1,23 @@
 <?php
 /**
+ * Article list template.
+ *
  * @global WP_Query $article_query Article query.
  * @global array    $attributes
+ * @package WordPress
  */
 
-echo Newspack_Blocks::template_inc( __DIR__ . '/articles-loop.php', [
-	'attributes'    => $attributes,
-	'article_query' => $article_query,
-] );
+call_user_func(
+	function( $data ) {
+		echo wp_kses_post(
+			Newspack_Blocks::template_inc(
+				__DIR__ . '/articles-loop.php',
+				array(
+					'attributes'    => $data['attributes'],
+					'article_query' => $data['article_query'],
+				)
+			)
+		);
+	},
+	$data
+);

--- a/src/blocks/homepage-articles/templates/articles-loop.php
+++ b/src/blocks/homepage-articles/templates/articles-loop.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Articles loop template.
+ *
+ */
+/**
+ * @global \WP_Query $article_query Article query.
+ * @global array     $attributes
+ * @global array     $newspack_blocks_post_id
+ */
+global $newspack_blocks_post_id;
+$post_counter = 0;
+while ( $article_query->have_posts() ) {
+	$article_query->the_post();
+	if ( ! $attributes['specificMode'] && ( isset( $newspack_blocks_post_id[ get_the_ID() ] ) || $post_counter >= $attributes['postsToShow'] ) ) {
+		continue;
+	}
+	$newspack_blocks_post_id[ get_the_ID() ] = true;
+	$post_counter++;
+	echo Newspack_Blocks::template_inc( __DIR__ . '/article.php', [ 'attributes' => $attributes ] );
+}
+wp_reset_postdata();

--- a/src/blocks/homepage-articles/templates/articles-loop.php
+++ b/src/blocks/homepage-articles/templates/articles-loop.php
@@ -21,7 +21,7 @@ call_user_func(
 			}
 			$newspack_blocks_post_id[ get_the_ID() ] = true;
 			$post_counter++;
-			echo wp_kses_post( Newspack_Blocks::template_inc( __DIR__ . '/article.php', array( 'attributes' => $attributes ) ) );
+			echo Newspack_Blocks::template_inc( __DIR__ . '/article.php', array( 'attributes' => $attributes ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 		wp_reset_postdata();
 	},

--- a/src/blocks/homepage-articles/templates/articles-loop.php
+++ b/src/blocks/homepage-articles/templates/articles-loop.php
@@ -2,21 +2,28 @@
 /**
  * Articles loop template.
  *
- */
-/**
+ * @package WordPress
  * @global \WP_Query $article_query Article query.
  * @global array     $attributes
  * @global array     $newspack_blocks_post_id
  */
-global $newspack_blocks_post_id;
-$post_counter = 0;
-while ( $article_query->have_posts() ) {
-	$article_query->the_post();
-	if ( ! $attributes['specificMode'] && ( isset( $newspack_blocks_post_id[ get_the_ID() ] ) || $post_counter >= $attributes['postsToShow'] ) ) {
-		continue;
-	}
-	$newspack_blocks_post_id[ get_the_ID() ] = true;
-	$post_counter++;
-	echo Newspack_Blocks::template_inc( __DIR__ . '/article.php', [ 'attributes' => $attributes ] );
-}
-wp_reset_postdata();
+
+call_user_func(
+	function( $data ) {
+		$attributes    = $data['attributes'];
+		$article_query = $data['article_query'];
+		global $newspack_blocks_post_id;
+		$post_counter = 0;
+		while ( $article_query->have_posts() ) {
+			$article_query->the_post();
+			if ( ! $attributes['specificMode'] && ( isset( $newspack_blocks_post_id[ get_the_ID() ] ) || $post_counter >= $attributes['postsToShow'] ) ) {
+				continue;
+			}
+			$newspack_blocks_post_id[ get_the_ID() ] = true;
+			$post_counter++;
+			echo wp_kses_post( Newspack_Blocks::template_inc( __DIR__ . '/article.php', array( 'attributes' => $attributes ) ) );
+		}
+		wp_reset_postdata();
+	},
+	$data
+);

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -86,33 +86,11 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				* As a result we render the same standards-based markup for all requests.
 				*/
 				echo Newspack_Blocks::template_inc( __DIR__ . '/templates/articles-list.php', [
-					'article_query'     => $article_query,
-					'attributes'        => $attributes,
+					'article_query' => $article_query,
+					'attributes'    => $attributes,
 				] );
 				?>
 			</div>
-			<?php
-			/*
-			 * AMP-requests cannot contain client-side scripting (eg: JavaScript). As a result
-			 * we do not display the "More" button on AMP-requests. This feature is deliberately
-			 * disabled.
-			 *
-			 * @see https://github.com/Automattic/newspack-blocks/pull/226#issuecomment-558695909
-			 * @see https://wp.me/paYJgx-jW
-			 */
-			$page = $article_query->paged ?? 1;
-			$has_more_pages = (++$page) <= $article_query->max_num_pages;
-			if ( ! Newspack_Blocks::is_amp() && $has_more_pages ) : ?>
-				<button type="button" data-load-more-btn data-load-more-url="<?php echo esc_url( $articles_rest_url ) ?>">
-					<?php _e( 'Load more articles' ); ?>
-				</button>
-				<p data-load-more-loading-text hidden>
-					<?php _e( 'Loading...' ); ?>
-				</p>
-				<p data-load-more-error-text hidden>
-					<?php _e( 'Something went wrong. Please refresh the page and/or try again.'); ?>
-				</p>
-			<?php endif; ?>
 		</div>
 	<?php
 	endif;

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -145,43 +145,6 @@ function newspack_blocks_register_homepage_articles() {
 add_action( 'init', 'newspack_blocks_register_homepage_articles' );
 
 /**
- * Prepare an array of authors, taking presence of CoAuthors Plus into account.
- *
- * @return array Array of WP_User objects.
- */
-function newspack_blocks_prepare_authors() {
-	if ( function_exists( 'coauthors_posts_links' ) ) {
-		$authors = get_coauthors();
-		foreach ( $authors as $author ) {
-			// Check if this is a guest author post type.
-			if ( 'guest-author' === get_post_type( $author->ID ) ) {
-				// If yes, make sure the author actually has an avatar set; otherwise, coauthors_get_avatar returns a featured image.
-				if ( get_post_thumbnail_id( $author->ID ) ) {
-					$author->avatar = coauthors_get_avatar( $author, 48 );
-				} else {
-					// If there is no avatar, force it to return the current fallback image.
-					$author->avatar = get_avatar( ' ' );
-				}
-			} else {
-				$author->avatar = coauthors_get_avatar( $author, 48 );
-			}
-			$author->url = get_author_posts_url( $author->ID, $author->user_nicename );
-		}
-		return $authors;
-	}
-	$id = get_the_author_meta( 'ID' );
-	return array(
-		(object) array(
-			'ID'            => $id,
-			'avatar'        => get_avatar( $id, 48 ),
-			'url'           => get_author_posts_url( $id ),
-			'user_nicename' => get_the_author(),
-			'display_name'  => get_the_author_meta( 'display_name' ),
-		),
-	);
-}
-
-/**
  * Renders author avatar markup.
  *
  * @param array $author_info Author info array.

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -69,7 +69,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 	if ( $article_query->have_posts() ) :
 		?>
-		<div class="<?php echo esc_attr( $classes ); ?>" style="<?php echo esc_attr( $styles ); ?>">
+		<div>
 
 			<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
 				<h2 class="article-section-title">
@@ -77,147 +77,46 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				</h2>
 			<?php
 			endif;
-			while ( $article_query->have_posts() ) :
-				$article_query->the_post();
-				if ( ! $attributes['specificMode'] && ( isset( $newspack_blocks_post_id[ get_the_ID() ] ) || $post_counter >= $posts_to_show ) ) {
-					continue;
-				}
-				$newspack_blocks_post_id[ get_the_ID() ] = true;
-
-				$authors = newspack_blocks_prepare_authors();
-
-				$post_counter++;
-
-				$styles = '';
-				if ( 'behind' === $attributes['mediaPosition'] && $attributes['showImage'] && has_post_thumbnail() ) {
-					$styles = 'min-height: ' . $attributes['minHeight'] . 'vh; padding-top: ' . ( $attributes['minHeight'] / 5 ) . 'vh;';
-				}
-				?>
-
-				<article <?php echo has_post_thumbnail() ? 'class="post-has-image"' : ''; ?> <?php echo $styles ? 'style="' . esc_attr( $styles ) . '"' : ''; ?>>
-
-					<?php if ( has_post_thumbnail() && $attributes['showImage'] && $attributes['imageShape'] ) : ?>
-
-						<figure class="post-thumbnail">
-							<a href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
-								<?php
-								$image_size = 'newspack-article-block-uncropped';
-								if ( 'uncropped' !== $attributes['imageShape'] ) {
-									$image_size = Newspack_Blocks::image_size_for_orientation( $attributes['imageShape'] );
-								}
-
-								// If the image position is behind, pass the object-fit setting to maintain styles with AMP.
-								if ( 'behind' === $attributes['mediaPosition'] ) {
-									the_post_thumbnail(
-										$image_size,
-										array(
-											'object-fit' => 'cover',
-										)
-									);
-								} else {
-									the_post_thumbnail( $image_size );
-								}
-								?>
-							</a>
-
-							<?php if ( $attributes['showCaption'] && '' !== get_the_post_thumbnail_caption() ) : ?>
-								<figcaption><?php the_post_thumbnail_caption(); ?>
-							<?php endif; ?>
-						</figure><!-- .featured-image -->
-					<?php endif; ?>
-
-					<div class="entry-wrapper">
-
-						<?php
-						if ( $attributes['showCategory'] ) :
-							$category = false;
-
-							// Use Yoast primary category if set.
-							if ( class_exists( 'WPSEO_Primary_Term' ) ) {
-								$primary_term = new WPSEO_Primary_Term( 'category', get_the_ID() );
-								$category_id = $primary_term->get_primary_term();
-								if ( $category_id ) {
-									$category = get_term( $category_id );
-								}
-							}
-
-							if ( ! $category ) {
-								$categories_list = get_the_category();
-								if ( ! empty( $categories_list ) ) {
-									$category = $categories_list[0];
-								}
-							}
-
-							if ( $category ) :
-								?>
-								<div class='cat-links'>
-									<a href="<?php echo esc_url( get_category_link( $category->term_id ) ); ?>">
-										<?php echo esc_html( $category->name ); ?>
-									</a>
-								</div>
-								<?php
-							endif;
-						endif;
-						?>
-
-						<?php
-						if ( '' === $attributes['sectionHeader'] ) {
-							the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
-						} else {
-							the_title( '<h3 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h3>' );
-						}
-						?>
-
-						<?php if ( $attributes['showExcerpt'] ) : ?>
-							<?php the_excerpt(); ?>
-						<?php endif; ?>
-
-						<?php if ( $attributes['showAuthor'] || $attributes['showDate'] ) : ?>
-
-							<div class="entry-meta">
-
-								<?php
-								if ( $attributes['showAuthor'] && $attributes['showAvatar'] ) :
-									echo wp_kses_post( newspack_blocks_format_avatars( $authors ) );
-								endif;
-
-								if ( $attributes['showAuthor'] ) :
-									?>
-									<span class="byline">
-										<?php echo wp_kses_post( newspack_blocks_format_byline( $authors ) ); ?>
-									</span><!-- .author-name -->
-									<?php
-								endif;
-
-								if ( $attributes['showDate'] ) {
-									$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
-
-									if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
-										$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
-									}
-
-									$time_string = sprintf(
-										$time_string,
-										esc_attr( get_the_date( DATE_W3C ) ),
-										esc_html( get_the_date() ),
-										esc_attr( get_the_modified_date( DATE_W3C ) ),
-										esc_html( get_the_modified_date() )
-									);
-
-									echo $time_string; // WPCS: XSS OK.
-								}
-								?>
-							</div><!-- .entry-meta -->
-						<?php endif; ?>
-					</div><!-- .entry-wrapper -->
-				</article>
-				<?php
-			endwhile;
 			?>
-			<?php wp_reset_postdata(); ?>
+			<div data-posts-container class="<?php echo esc_attr( $classes ); ?>" style="<?php echo esc_attr( $styles ); ?>">
+				<?php
+				/*
+				* We are not using an AMP-based renderer on AMP requests because it has limitations
+				* around dynamically calculating the height of the the article list on load.
+				* As a result we render the same standards-based markup for all requests.
+				*/
+				echo Newspack_Blocks::template_inc( __DIR__ . '/templates/articles-list.php', [
+					'article_query'     => $article_query,
+					'attributes'        => $attributes,
+				] );
+				?>
+			</div>
+			<?php
+			/*
+			 * AMP-requests cannot contain client-side scripting (eg: JavaScript). As a result
+			 * we do not display the "More" button on AMP-requests. This feature is deliberately
+			 * disabled.
+			 *
+			 * @see https://github.com/Automattic/newspack-blocks/pull/226#issuecomment-558695909
+			 * @see https://wp.me/paYJgx-jW
+			 */
+			$page = $article_query->paged ?? 1;
+			$has_more_pages = (++$page) <= $article_query->max_num_pages;
+			if ( ! Newspack_Blocks::is_amp() && $has_more_pages ) : ?>
+				<button type="button" data-load-more-btn data-load-more-url="<?php echo esc_url( $articles_rest_url ) ?>">
+					<?php _e( 'Load more articles' ); ?>
+				</button>
+				<p data-load-more-loading-text hidden>
+					<?php _e( 'Loading...' ); ?>
+				</p>
+				<p data-load-more-error-text hidden>
+					<?php _e( 'Something went wrong. Please refresh the page and/or try again.'); ?>
+				</p>
+			<?php endif; ?>
 		</div>
-		<?php
-		endif;
+	<?php
+	endif;
+
 	$content = ob_get_clean();
 	Newspack_Blocks::enqueue_view_assets( 'homepage-articles' );
 	return $content;

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -70,15 +70,14 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	if ( $article_query->have_posts() ) :
 		?>
 		<div>
-
-			<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
-				<h2 class="article-section-title">
-					<span><?php echo wp_kses_post( $attributes['sectionHeader'] ); ?></span>
-				</h2>
-			<?php
-			endif;
-			?>
 			<div data-posts-container class="<?php echo esc_attr( $classes ); ?>" style="<?php echo esc_attr( $styles ); ?>">
+				<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
+					<h2 class="article-section-title">
+						<span><?php echo wp_kses_post( $attributes['sectionHeader'] ); ?></span>
+					</h2>
+					<?php
+				endif;
+				?>
 				<?php
 				/*
 				* We are not using an AMP-based renderer on AMP requests because it has limitations


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR extracts the templates from https://github.com/Automattic/newspack-blocks/pull/226, and copies over a the template include function (`newspack_blocks_template_inc` in 226, `Newspack_Blocks::template_inc` here). On a great tip from @claudiulodro the templates are wrapped in  `call_user_func(function( $data ) { template_contents }, $data)` so variables used within are scoped and don't need to be prefixed. I did not carry over the `READ MORE` button markup from 226, but I did leave the wrapper `<div>` and new placement of the heading to help us see if either of these changes will cause visual regressions.

This is the last of three PRs that deal with significant code refactoring related to the Read More button.

### How to test the changes in this Pull Request:

Output should be visually and functionally identical to `master` branch. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
