### PR TITLE
Don't set default alignment.

### DIFF
--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -169,17 +169,18 @@ class Newspack_Blocks {
 	 * @return string Class list separated by spaces.
 	 */
 	public static function block_classes( $type, $attributes = array(), $extra = array() ) {
-		$align   = isset( $attributes['align'] ) ? $attributes['align'] : 'center';
-		$classes = array(
-			"wp-block-newspack-blocks-{$type}",
-			"align{$align}",
-		);
+		$classes = [ "wp-block-newspack-blocks-{$type}" ];
+
+		if ( ! empty( $attributes['align'] ) ) {
+			$classes[] = 'align' . $attributes['align'];
+		}
 		if ( isset( $attributes['className'] ) ) {
 			array_push( $classes, $attributes['className'] );
 		}
 		if ( is_array( $extra ) && ! empty( $extra ) ) {
 			$classes = array_merge( $classes, $extra );
 		}
+
 		return implode( $classes, ' ' );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Doesn't add a default alignment.
We could also remove the `align` attribute business altogether, given the block doesn't support that attribute currently.

Closes #26.

### How to test the changes in this Pull Request:

1. Load the block in the frontend and make sure the wrapping div does not have the class `aligncenter`.

#### Before:
![Screen Shot 2019-12-03 at 1 28 30 PM](https://user-images.githubusercontent.com/1398304/70091405-e2c28080-15d0-11ea-8967-392226a56d38.png)

#### After:
![Screen Shot 2019-12-03 at 1 28 13 PM](https://user-images.githubusercontent.com/1398304/70091417-e7873480-15d0-11ea-8214-1e8003291fe5.png)
