### PR TITLE
Article Blocks: Update sanitization for author avatar

### DIFF
--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -85,7 +85,21 @@ call_user_func(
 					<?php
 					if ( $attributes['showAuthor'] ) :
 						if ( $attributes['showAvatar'] ) :
-							echo wp_kses_post( newspack_blocks_format_avatars( $authors ) );
+							echo wp_kses(
+								newspack_blocks_format_avatars( $authors ),
+								array(
+									'img' => array(
+										'class'  => true,
+										'src'    => true,
+										'alt'    => true,
+										'width'  => true,
+										'height' => true,
+										'data-*' => true,
+										'srcset' => true,
+									),
+									'noscript' => array(),
+								)
+							);
 						endif;
 						?>
 						<span class="byline">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR replaces the `wp_kses_post()` sanitation on avatars with a custom `wp_kses()` one, to make sure we're not accidentally stripping out things needed for Jetpack lazy loading images to work correctly (like `data-*` attributes, or the `noscript` tag). 

Closes #249.

### How to test the changes in this Pull Request:

1. Add the article block to a page, and make sure avatars are enabled on it.
2. Turn on Jetpack's lazy loading images, and turn off AMP.
3. View on front-end and note the double-images:

![image](https://user-images.githubusercontent.com/177561/70182763-562fc500-1699-11ea-87ef-35df6ffd3d97.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the avatars are no longer duplicated:

![image](https://user-images.githubusercontent.com/177561/70182915-a6a72280-1699-11ea-8675-8b30b1dfdeac.png)

6. Try turning on AMP, and confirm there are no issues.
7. Toggle Co-Authors Plus (either activate the plugin if it's deactivated, or deactivate it if it's activated), and make sure there are no issues. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
