### PR TITLE
Add rendered posts' IDs as "Load More" query param

### DIFF
--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -64,13 +64,10 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 
 		$article_query_args = Newspack_Blocks::build_articles_query( $attributes );
 
-		// Append custom pagination arg for REST API endpoint.
-		$article_query_args['paged'] = $page;
-
 		$query = array_merge(
 			$article_query_args,
 			[
-				'posts_per_page' => $article_query_args['posts_per_page'] + count( $exclude_ids ),
+				'post__not_in' => $exclude_ids,
 			]
 		);
 
@@ -85,12 +82,6 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 		$post_counter = 0;
 		while ( $article_query->have_posts() ) {
 			$article_query->the_post();
-			if ( in_array( get_the_id(), $exclude_ids, true ) ) {
-				continue;
-			}
-			if ( ++$post_counter > $article_query_args['posts_per_page'] ) {
-				continue;
-			}
 			$items[]['html'] = Newspack_Blocks::template_inc(
 				__DIR__ . '/templates/article.php',
 				[

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -79,7 +79,6 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 		$next_url = '';
 
 		// The Loop.
-		$post_counter = 0;
 		while ( $article_query->have_posts() ) {
 			$article_query->the_post();
 			$items[]['html'] = Newspack_Blocks::template_inc(

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -42,7 +42,7 @@ call_user_func(
 			}
 		}
 		?>
-	<article
+	<article data-post-id="<?php the_id(); ?>"
 		<?php if ( has_post_thumbnail() ) : ?>
 		class="post-has-image"
 		<?php endif; ?>

--- a/src/blocks/homepage-articles/view.js
+++ b/src/blocks/homepage-articles/view.js
@@ -95,17 +95,22 @@ function buildLoadMoreHandler( btnEl ) {
 		};
 
 		const requestURL = new URL( btnEl.getAttribute( btnURLAttr ) );
+
+		// Set currenty rendered posts' IDs as a query param (e.g. exclude_ids=1,2,3)
 		requestURL.searchParams.set( 'exclude_ids', getRenderedPostsIds().join( ',' ) );
 
 		fetchWithRetry( { url: requestURL.toString(), onSuccess, onError }, fetchRetryCount );
 	};
 }
 
+/**
+ * Returns unique IDs for posts that are currently in the DOM.
+ */
 function getRenderedPostsIds() {
 	const postEls = document.querySelectorAll( 'article[data-post-id]' );
 	const postIds = Array.from( postEls ).map( el => el.getAttribute( 'data-post-id' ) );
 
-	return [ ...new Set( postIds ) ]; // returns unique IDs
+	return [ ...new Set( postIds ) ]; // Make values unique with Set
 }
 
 /**

--- a/src/blocks/homepage-articles/view.js
+++ b/src/blocks/homepage-articles/view.js
@@ -94,11 +94,21 @@ function buildLoadMoreHandler( btnEl ) {
 			showEl( btnEl );
 		};
 
+		const requestURL = new URL( btnEl.getAttribute( btnURLAttr ) );
+		requestURL.searchParams.set( 'exclude_ids', getRenderedPostsIds() );
+
 		fetchWithRetry(
-			{ url: btnEl.getAttribute( btnURLAttr ), onSuccess, onError },
+			{ url: requestURL.toString(), onSuccess, onError },
 			fetchRetryCount
 		);
 	};
+}
+
+function getRenderedPostsIds() {
+	const postEls = document.querySelectorAll( 'article[data-post-id]' );
+	const postIds = Array.from( postEls ).map( el => el.getAttribute( 'data-post-id' ) );
+
+	return [ ...new Set( postIds ) ]; // returns unique IDs
 }
 
 /**

--- a/src/blocks/homepage-articles/view.js
+++ b/src/blocks/homepage-articles/view.js
@@ -95,12 +95,9 @@ function buildLoadMoreHandler( btnEl ) {
 		};
 
 		const requestURL = new URL( btnEl.getAttribute( btnURLAttr ) );
-		requestURL.searchParams.set( 'exclude_ids', getRenderedPostsIds() );
+		requestURL.searchParams.set( 'exclude_ids', getRenderedPostsIds().join( ',' ) );
 
-		fetchWithRetry(
-			{ url: requestURL.toString(), onSuccess, onError },
-			fetchRetryCount
-		);
+		fetchWithRetry( { url: requestURL.toString(), onSuccess, onError }, fetchRetryCount );
 	};
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add `exclude_ids` query param with currently rendered posts IDs to the "More" request URL. This should be used to address the post duplication issue (paYJgx-jW-p2#comment-418, paYJgx-jW-p2#comment-433).

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Add `Homepage Posts` block & make sure there are any posts to render
2. Go to preview and open network tab in browser's devtools (filter by XHR)
3. Click the "Load more articles" button and check if `exclude_ids` param has been set to the request URL with correct posts' IDs.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
