### PR TITLE
Replace apiFetch

### DIFF
--- a/src/blocks/homepage-articles/view.js
+++ b/src/blocks/homepage-articles/view.js
@@ -39,57 +39,41 @@ function attachLoadMoreHandler( btnEl ) {
  * @param {DOMElement} btnEl the button that was clicked
  */
 function buildLoadMoreHandler( btnEl ) {
-	/**
-	 * Set elements from scope determined by the clicked "Load more" button.
-	 */
+	// Set elements from scope determined by the clicked "Load more" button.
 	const blockWrapperEl = btnEl.parentElement; // scope root element
 	const postsContainerEl = blockWrapperEl.querySelector( '[data-posts-container]' );
 	const loadingEl = blockWrapperEl.querySelector( '[data-load-more-loading-text]' );
 	const errorEl = blockWrapperEl.querySelector( '[data-load-more-error-text]' );
 
-	/**
-	 * Set initial state flags.
-	 */
+	// Set initial state flags.
 	let isFetching = false;
 	let isEndOfData = false;
 
 	return () => {
-		/**
-		 * Early return if still fetching or no more posts to render.
-		 */
+		// Early return if still fetching or no more posts to render.
 		if ( isFetching || isEndOfData ) {
 			return false;
 		}
 
 		isFetching = true;
 
-		/**
-		 * Set elements visibility for fetching state.
-		 */
+		// Set elements visibility for fetching state.
 		hideEl( btnEl );
 		hideEl( errorEl );
 		showEl( loadingEl );
 
 		const onSuccess = data => {
-			/**
-			 * Validate received data.
-			 */
+			// Validate received data.
 			if ( isPostsDataValid( data ) ) {
-				/**
-				 * Render posts' HTML from string.
-				 */
+				// Render posts' HTML from string.
 				const postsHTML = data.items.map( item => item.html ).join( '' );
 				postsContainerEl.insertAdjacentHTML( 'beforeend', postsHTML );
 
 				if ( data.next ) {
-					/**
-					 * Save next URL as button's attribute.
-					 */
+					// Save next URL as button's attribute.
 					btnEl.setAttribute( btnURLAttr, data.next );
 
-					/**
-					 * Unhide button since there are more posts available.
-					 */
+					// Unhide button since there are more posts available.
 					showEl( btnEl );
 				} else {
 					isEndOfData = true;
@@ -104,9 +88,7 @@ function buildLoadMoreHandler( btnEl ) {
 		const onError = () => {
 			isFetching = false;
 
-			/**
-			 * Display error message and keep the button visible to enable retrying.
-			 */
+			// Display error message and keep the button visible to enable retrying.
 			hideEl( loadingEl );
 			showEl( errorEl );
 			showEl( btnEl );
@@ -130,32 +112,24 @@ function fetchWithRetry( options, n ) {
 	const xhr = new XMLHttpRequest();
 
 	xhr.onreadystatechange = () => {
-		/**
-		 * Return if the request is completed.
-		 */
+		// Return if the request is completed.
 		if ( xhr.readyState !== 4 ) {
 			return;
 		}
 
-		/**
-		 * Call onSuccess with parsed JSON if the request is successful.
-		 */
+		// Call onSuccess with parsed JSON if the request is successful.
 		if ( xhr.status >= 200 && xhr.status < 300 ) {
 			const data = JSON.parse( xhr.responseText );
 
 			return options.onSuccess( data );
 		}
 
-		/**
-		 * Call onError if the request has failed n + 1 times (or if n is undefined).
-		 */
+		// Call onError if the request has failed n + 1 times (or if n is undefined).
 		if ( ! n ) {
 			return options.onError();
 		}
 
-		/**
-		 * Retry fetching if request has failed and n > 0.
-		 */
+		// Retry fetching if request has failed and n > 0.
 		return fetchWithRetry( options, n - 1 );
 	};
 

--- a/src/blocks/homepage-articles/view.js
+++ b/src/blocks/homepage-articles/view.js
@@ -70,7 +70,7 @@ function buildLoadMoreHandler( btnEl ) {
 		hideEl( errorEl );
 		showEl( loadingEl );
 
-		const onSuccess = ( data ) => {
+		const onSuccess = data => {
 			/**
 			 * Validate received data.
 			 */
@@ -112,7 +112,10 @@ function buildLoadMoreHandler( btnEl ) {
 			showEl( btnEl );
 		};
 
-		apiFetchWithRetry( { url: btnEl.getAttribute( btnURLAttr ), onSuccess, onError }, fetchRetryCount );
+		apiFetchWithRetry(
+			{ url: btnEl.getAttribute( btnURLAttr ), onSuccess, onError },
+			fetchRetryCount
+		);
 	};
 }
 
@@ -141,7 +144,7 @@ function apiFetchWithRetry( options, n ) {
 
 		options.onError();
 
-		apiFetchWithRetry( options, n -1 );
+		apiFetchWithRetry( options, n - 1 );
 	};
 	xhr.open( 'GET', options.url );
 	xhr.send();

--- a/src/blocks/homepage-articles/view.js
+++ b/src/blocks/homepage-articles/view.js
@@ -126,9 +126,7 @@ function buildLoadMoreHandler( btnEl ) {
 function apiFetchWithRetry( options, n ) {
 	const xhr = new XMLHttpRequest();
 	xhr.onreadystatechange = () => {
-
-		// Only run if the request is complete.
-		if ( xhr.readyState !== 4 ) {
+		if ( xhr.readyState !== 4 || n === 0 ) {
 			return;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Replaces apiFetch with XMLHttpRequest. (I wasn't sure how serious we take IE11 support).
This fixes a bug with apiFetch on wp.com, where it always sends an `X-wp-nonce` header that wp.com rejects. See https://github.com/Automattic/jetpack/pull/12823/commits/c8029269a4ee6bc126fd072d1e00043f7871d6cd

I open to other fixes. Jetpack seems to have just gone with `fetch`, fine with that, too. I'd just like it to work on wp.com :) 

### How to test the changes in this Pull Request:

1. Set up a block with more button and make sure it still loads new posts.

