### PR TITLE
Load More Button: AMP Compatibility

### DIFF
--- a/amp/homepage-articles/view.js
+++ b/amp/homepage-articles/view.js
@@ -1,0 +1,217 @@
+const btnURLAttr = 'data-load-more-url';
+const fetchRetryCount = 3;
+
+/**
+ * Load More Button Handling
+ */
+
+attachLoadMoreHandler( document.querySelector( '[data-load-more-btn]' ) );
+
+/**
+ * Attaches an event handler to the Load more button.
+ * @param {DOMElement} btnEl the button that was clicked
+ */
+function attachLoadMoreHandler( btnEl ) {
+	if ( ! btnEl ) {
+		return null;
+	}
+
+	const handler = buildLoadMoreHandler( btnEl );
+
+	btnEl.addEventListener( 'click', handler );
+}
+
+/**
+ * Builds a function to handle clicks on the load more button.
+ * Creates internal state via closure to ensure all state is
+ * isolated to a single Block + button instance.
+ *
+ * @param {DOMElement} btnEl the button that was clicked
+ */
+function buildLoadMoreHandler( btnEl ) {
+	/**
+	 * Set elements from scope determined by the clicked "Load more" button.
+	 */
+	const blockWrapperEl = btnEl.parentNode; // scope root element
+	const postsContainerEl = blockWrapperEl.querySelector( '[data-posts-container]' );
+	const loadingEl = blockWrapperEl.querySelector( '[data-load-more-loading-text]' );
+	const errorEl = blockWrapperEl.querySelector( '[data-load-more-error-text]' );
+
+	/**
+	 * Set initial state flags.
+	 */
+	let isFetching = false;
+	let isEndOfData = false;
+
+	return () => {
+		/**
+		 * Early return if still fetching or no more posts to render.
+		 */
+		if ( isFetching || isEndOfData ) {
+			return false;
+		}
+
+		isFetching = true;
+
+		/**
+		 * Set elements visibility for fetching state.
+		 */
+		hideEl( btnEl );
+		hideEl( errorEl );
+		showEl( loadingEl );
+
+		const onSuccess = data => {
+			console.log( data );
+			/**
+			 * Validate received data.
+			 */
+			if ( isPostsDataValid( data ) ) {
+				/**
+				 * Render posts' HTML from string.
+				 */
+				const postsHTML = data.items.map( item => item.html ).join( '' );
+				const ampLayout = document.createElement( 'amp-layout' );
+				ampLayout.innerHTML = postsHTML;
+				blockWrapperEl.insertBefore( ampLayout, btnEl );
+
+				if ( data.next ) {
+					/**
+					 * Save next URL as button's attribute.
+					 */
+					btnEl.setAttribute( btnURLAttr, data.next );
+
+					/**
+					 * Unhide button since there are more posts available.
+					 */
+					showEl( btnEl );
+				} else {
+					isEndOfData = true;
+				}
+
+				isFetching = false;
+
+				hideEl( loadingEl );
+			}
+		};
+
+		const onError = () => {
+			isFetching = false;
+
+			/**
+			 * Display error message and keep the button visible to enable retrying.
+			 */
+			hideEl( loadingEl );
+			showEl( errorEl );
+			showEl( btnEl );
+		};
+
+		apiFetchWithRetry(
+			{ url: btnEl.getAttribute( btnURLAttr ), onSuccess, onError },
+			fetchRetryCount
+		);
+	};
+}
+
+/**
+ * Wrapper for XMLHttpRequest that performs given number of retries when error
+ * occurs.
+ *
+ * @param {Object} options XMLHttpRequest options
+ * @param {Number} n retry count before throwing
+ */
+function apiFetchWithRetry( options, n ) {
+	const xhr = new XMLHttpRequest();
+	xhr.onreadystatechange = () => {
+		if ( xhr.readyState !== 4 || n === 0 ) {
+			return;
+		}
+
+		// Process our return data.
+		if ( xhr.status >= 200 && xhr.status < 300 ) {
+			// What do when the request is successful
+			const data = JSON.parse( xhr.responseText );
+
+			options.onSuccess( data );
+			return;
+		}
+
+		options.onError();
+
+		apiFetchWithRetry( options, n - 1 );
+	};
+	xhr.open( 'GET', options.url );
+	xhr.send();
+}
+
+/**
+ * Validates the "Load more" posts endpoint schema:
+ * {
+ * 	"type": "object",
+ * 	"properties": {
+ * 		"items": {
+ * 			"type": "array",
+ * 			"items": {
+ * 				"type": "object",
+ * 				"properties": {
+ * 					"html": {
+ * 						"type": "string"
+ * 					}
+ * 				},
+ * 				"required": ["html"]
+ * 			},
+ * 			"required": ["items"]
+ * 		},
+ * 		"next": {
+ * 			"type": ["string", "null"]
+ * 		}
+ * 	},
+ * 	"required": ["items", "next"]
+ * }
+ *
+ * @param {Object} data posts endpoint payload
+ */
+function isPostsDataValid( data ) {
+	if (
+		data &&
+		hasOwnProp( data, 'items' ) &&
+		hasOwnProp( data, 'next' ) &&
+		Array.isArray( data.items ) &&
+		data.items.length &&
+		hasOwnProp( data.items[ 0 ], 'html' ) &&
+		typeof data.items[ 0 ].html === 'string'
+	) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Hides given DOM element.
+ *
+ * @param {DOMElement} el
+ */
+function hideEl( el ) {
+	el.style.display = 'none';
+	el.setAttribute( 'hidden', '' );
+}
+
+/**
+ * Unhides given DOM element.
+ *
+ * @param {DOMElement} el
+ */
+function showEl( el ) {
+	el.style.display = '';
+	el.removeAttribute( 'hidden' );
+}
+
+/**
+ * Checks if object has own property.
+ *
+ * @param {Object} obj
+ * @param {String} prop
+ */
+function hasOwnProp( obj, prop ) {
+	return Object.prototype.hasOwnProperty.call( obj, prop );
+}

--- a/amp/homepage-articles/view.js
+++ b/amp/homepage-articles/view.js
@@ -1,175 +1,70 @@
-const btnURLAttr = 'data-load-more-url';
-const fetchRetryCount = 3;
-
-/**
- * Load More Button Handling
- */
-
-attachLoadMoreHandler( document.querySelector( '[data-load-more-btn]' ) );
-
-/**
- * Attaches an event handler to the Load more button.
- * @param {DOMElement} btnEl the button that was clicked
- */
-function attachLoadMoreHandler( btnEl ) {
+let isFetching = false;
+let isEndOfData = false;
+buildLoadMoreHandler( document.querySelector( '.wp-block-newspack-blocks-homepage-articles') );
+function buildLoadMoreHandler( blockWrapperEl ) {
+	const btnEl = blockWrapperEl.querySelector( '[data-next]' );
 	if ( ! btnEl ) {
-		return null;
+		return;
 	}
-	const handler = buildLoadMoreHandler( btnEl );
-	btnEl.addEventListener( 'click', handler );
-}
-
-/**
- * Builds a function to handle clicks on the load more button.
- * Creates internal state via closure to ensure all state is
- * isolated to a single Block + button instance.
- *
- * @param {DOMElement} btnEl the button that was clicked
- */
-function buildLoadMoreHandler( btnEl ) {
-	/**
-	 * Set elements from scope determined by the clicked "Load more" button.
-	 */
-	const blockWrapperEl = btnEl.parentNode; // scope root element
-	const postsContainerEl = document.querySelector( '[data-posts-container]' );
-	const loadingEl = blockWrapperEl.querySelector( '[data-load-more-loading-text]' );
-	const errorEl = blockWrapperEl.querySelector( '[data-load-more-error-text]' );
-
-	/**
-	 * Set initial state flags.
-	 */
-	let isFetching = false;
-	let isEndOfData = false;
-	return () => {
-		/**
-		 * Early return if still fetching or no more posts to render.
-		 */
+	const postsContainerEl = blockWrapperEl.querySelector( '[data-posts]' );
+	btnEl.addEventListener( 'click', function( e ) {
 		if ( isFetching || isEndOfData ) {
 			return false;
 		}
-
 		isFetching = true;
-
-		/**
-		 * Set elements visibility for fetching state.
-		 */
-		hideEl( btnEl );
-		hideEl( errorEl );
-		showEl( loadingEl );
-		AMP.getState( 'newspackHomepagePosts.exclude_ids' ).then( exclude_ids => {
-			const requestURL = new URL( btnEl.getAttribute( btnURLAttr ) );
+		blockWrapperEl.classList.remove( 'is-error' );
+		blockWrapperEl.classList.add( 'is-loading' );
+		AMP.getState( 'newspackHomepagePosts.exclude_ids' ).then( function( exclude_ids ) {
+			const requestURL = new URL( btnEl.getAttribute( 'data-next' ) );
 			requestURL.searchParams.set( 'exclude_ids', JSON.parse( exclude_ids ).join( ',' ) );
-			apiFetchWithRetry( { url: requestURL.toString(), onSuccess, onError }, fetchRetryCount );
+			apiFetchWithRetry( { url: requestURL.toString(), onSuccess, onError }, 3 );
 		} );
-		const onSuccess = data => {
-			AMP.getState( 'newspackHomepagePosts.exclude_ids' ).then( exclude_ids => {
+		function onSuccess( data ) {
+			AMP.getState( 'newspackHomepagePosts.exclude_ids' ).then( function( exclude_ids ) {
 				AMP.setState( {
 					newspackHomepagePosts: { exclude_ids: JSON.parse( exclude_ids ).concat( data.ids ) },
 				} );
 			} );
-			/**
-			 * Validate received data.
-			 */
 			if ( isPostsDataValid( data ) ) {
-				/**
-				 * Render posts' HTML from string.
-				 */
 				const postsHTML = data.items.map( item => item.html ).join( '' );
 				const ampLayout = document.createElement( 'amp-layout' );
 				ampLayout.innerHTML = postsHTML;
 				postsContainerEl.appendChild( ampLayout );
-
 				if ( data.next ) {
-					/**
-					 * Save next URL as button's attribute.
-					 */
-					btnEl.setAttribute( btnURLAttr, data.next );
-
-					/**
-					 * Unhide button since there are more posts available.
-					 */
-					showEl( btnEl );
-				} else {
-					isEndOfData = true;
+					btnEl.setAttribute( 'data-next', data.next );
 				}
-
+				if ( ! data.items.length || ! data.next ) {
+					isEndOfData = true;
+					blockWrapperEl.classList.remove( 'has-more-button' );
+				}
 				isFetching = false;
-
-				hideEl( loadingEl );
+				blockWrapperEl.classList.remove( 'is-loading' );
 			}
 		};
-
-		const onError = () => {
+		function onError() {
 			isFetching = false;
-
-			/**
-			 * Display error message and keep the button visible to enable retrying.
-			 */
-			hideEl( loadingEl );
-			showEl( errorEl );
-			showEl( btnEl );
-		};
-	};
+			blockWrapperEl.classList.remove( 'is-loading' );
+			blockWrapperEl.classList.add( 'is-error' );
+		}
+	} );
 }
-
-/**
- * Wrapper for XMLHttpRequest that performs given number of retries when error
- * occurs.
- *
- * @param {Object} options XMLHttpRequest options
- * @param {Number} n retry count before throwing
- */
 function apiFetchWithRetry( options, n ) {
 	const xhr = new XMLHttpRequest();
 	xhr.onreadystatechange = () => {
 		if ( xhr.readyState !== 4 || n === 0 ) {
 			return;
 		}
-
-		// Process our return data.
 		if ( xhr.status >= 200 && xhr.status < 300 ) {
-			// What do when the request is successful
 			const data = JSON.parse( xhr.responseText );
-
 			options.onSuccess( data );
 			return;
 		}
-
 		options.onError();
-
 		apiFetchWithRetry( options, n - 1 );
 	};
 	xhr.open( 'GET', options.url );
 	xhr.send();
 }
-
-/**
- * Validates the "Load more" posts endpoint schema:
- * {
- * 	"type": "object",
- * 	"properties": {
- * 		"items": {
- * 			"type": "array",
- * 			"items": {
- * 				"type": "object",
- * 				"properties": {
- * 					"html": {
- * 						"type": "string"
- * 					}
- * 				},
- * 				"required": ["html"]
- * 			},
- * 			"required": ["items"]
- * 		},
- * 		"next": {
- * 			"type": ["string", "null"]
- * 		}
- * 	},
- * 	"required": ["items", "next"]
- * }
- *
- * @param {Object} data posts endpoint payload
- */
 function isPostsDataValid( data ) {
 	if (
 		data &&
@@ -185,33 +80,6 @@ function isPostsDataValid( data ) {
 
 	return false;
 }
-
-/**
- * Hides given DOM element.
- *
- * @param {DOMElement} el
- */
-function hideEl( el ) {
-	el.style.display = 'none';
-	el.setAttribute( 'hidden', '' );
-}
-
-/**
- * Unhides given DOM element.
- *
- * @param {DOMElement} el
- */
-function showEl( el ) {
-	el.style.display = '';
-	el.removeAttribute( 'hidden' );
-}
-
-/**
- * Checks if object has own property.
- *
- * @param {Object} obj
- * @param {String} prop
- */
 function hasOwnProp( obj, prop ) {
 	return Object.prototype.hasOwnProperty.call( obj, prop );
 }

--- a/amp/homepage-articles/view.js
+++ b/amp/homepage-articles/view.js
@@ -15,9 +15,7 @@ function attachLoadMoreHandler( btnEl ) {
 	if ( ! btnEl ) {
 		return null;
 	}
-
 	const handler = buildLoadMoreHandler( btnEl );
-
 	btnEl.addEventListener( 'click', handler );
 }
 
@@ -42,7 +40,6 @@ function buildLoadMoreHandler( btnEl ) {
 	 */
 	let isFetching = false;
 	let isEndOfData = false;
-
 	return () => {
 		/**
 		 * Early return if still fetching or no more posts to render.
@@ -59,13 +56,13 @@ function buildLoadMoreHandler( btnEl ) {
 		hideEl( btnEl );
 		hideEl( errorEl );
 		showEl( loadingEl );
-		AMP.getState( 'newspackHomepagePosts.exclude_ids' ).then( function( exclude_ids ) {
+		AMP.getState( 'newspackHomepagePosts.exclude_ids' ).then( exclude_ids => {
 			const requestURL = new URL( btnEl.getAttribute( btnURLAttr ) );
 			requestURL.searchParams.set( 'exclude_ids', JSON.parse( exclude_ids ).join( ',' ) );
 			apiFetchWithRetry( { url: requestURL.toString(), onSuccess, onError }, fetchRetryCount );
 		} );
 		const onSuccess = data => {
-			AMP.getState( 'newspackHomepagePosts.exclude_ids' ).then( function( exclude_ids ) {
+			AMP.getState( 'newspackHomepagePosts.exclude_ids' ).then( exclude_ids => {
 				AMP.setState( {
 					newspackHomepagePosts: { exclude_ids: JSON.parse( exclude_ids ).concat( data.ids ) },
 				} );

--- a/amp/homepage-articles/view.js
+++ b/amp/homepage-articles/view.js
@@ -61,7 +61,6 @@ function buildLoadMoreHandler( btnEl ) {
 		showEl( loadingEl );
 
 		const onSuccess = data => {
-			console.log( data );
 			/**
 			 * Validate received data.
 			 */

--- a/amp/homepage-articles/view.js
+++ b/amp/homepage-articles/view.js
@@ -33,7 +33,7 @@ function buildLoadMoreHandler( btnEl ) {
 	 * Set elements from scope determined by the clicked "Load more" button.
 	 */
 	const blockWrapperEl = btnEl.parentNode; // scope root element
-	const postsContainerEl = blockWrapperEl.querySelector( '[data-posts-container]' );
+	const postsContainerEl = document.querySelector( '[data-posts-container]' );
 	const loadingEl = blockWrapperEl.querySelector( '[data-load-more-loading-text]' );
 	const errorEl = blockWrapperEl.querySelector( '[data-load-more-error-text]' );
 
@@ -72,7 +72,7 @@ function buildLoadMoreHandler( btnEl ) {
 				const postsHTML = data.items.map( item => item.html ).join( '' );
 				const ampLayout = document.createElement( 'amp-layout' );
 				ampLayout.innerHTML = postsHTML;
-				blockWrapperEl.insertBefore( ampLayout, btnEl );
+				postsContainerEl.appendChild( ampLayout );
 
 				if ( data.next ) {
 					/**

--- a/amp/homepage-articles/view.js
+++ b/amp/homepage-articles/view.js
@@ -59,8 +59,17 @@ function buildLoadMoreHandler( btnEl ) {
 		hideEl( btnEl );
 		hideEl( errorEl );
 		showEl( loadingEl );
-
+		AMP.getState( 'newspackHomepagePosts.exclude_ids' ).then( function( exclude_ids ) {
+			const requestURL = new URL( btnEl.getAttribute( btnURLAttr ) );
+			requestURL.searchParams.set( 'exclude_ids', JSON.parse( exclude_ids ).join( ',' ) );
+			apiFetchWithRetry( { url: requestURL.toString(), onSuccess, onError }, fetchRetryCount );
+		} );
 		const onSuccess = data => {
+			AMP.getState( 'newspackHomepagePosts.exclude_ids' ).then( function( exclude_ids ) {
+				AMP.setState( {
+					newspackHomepagePosts: { exclude_ids: JSON.parse( exclude_ids ).concat( data.ids ) },
+				} );
+			} );
 			/**
 			 * Validate received data.
 			 */
@@ -103,11 +112,6 @@ function buildLoadMoreHandler( btnEl ) {
 			showEl( errorEl );
 			showEl( btnEl );
 		};
-
-		apiFetchWithRetry(
-			{ url: btnEl.getAttribute( btnURLAttr ), onSuccess, onError },
-			fetchRetryCount
-		);
 	};
 }
 

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -165,11 +165,10 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 				'use_document_element' => false,
 			]
 		);
-		foreach ( iterator_to_array( $dom->getElementsByTagName( 'noscript' ) ) as $noscript ) {
-			$noscript->parentNode->removeChild( $noscript ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
+		$xpath = new DOMXPath( $dom );
+		foreach ( iterator_to_array( $xpath->query( '//noscript | //comment()' ) ) as $node ) {
+			$node->parentNode->removeChild( $node ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
 		}
-		$markup = AMP_DOM_Utils::get_content_from_dom( $dom );
-		$markup = preg_replace( '/<!--(.|\s)*?-->/', '', $markup );
-		return $markup;
+		return AMP_DOM_Utils::get_content_from_dom( $dom );
 	}
 }

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -100,7 +100,7 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 				array_merge(
 					array_map(
 						function( $attribute ) {
-							return false === $attribute ? '0' : $attribute;
+							return false === $attribute ? '0' : str_replace( '#', '%23', $attribute );
 						},
 						$attributes
 					),

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -76,6 +76,7 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 
 		// Defaults.
 		$items    = [];
+		$ids      = [];
 		$next_url = '';
 
 		// The Loop.
@@ -92,6 +93,7 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 				$html = $this->generate_amp_partial( $html );
 			}
 			$items[]['html'] = $html;
+			$ids[]           = get_the_ID();
 		}
 
 		// Provide next URL if there are more pages.
@@ -116,6 +118,7 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 		return rest_ensure_response(
 			[
 				'items' => $items,
+				'ids'   => $ids,
 				'next'  => $next_url,
 			]
 		);

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -327,7 +327,6 @@ class Edit extends Component {
 							label={ __( 'Show "More" Button', 'newspack-blocks' ) }
 							checked={ moreButton }
 							onChange={ () => setAttributes( { moreButton: ! moreButton } ) }
-							help={ __( 'Only available for non-AMP requests.', 'newspack-blocks' ) }
 						/>
 					) }
 				</PanelBody>

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -228,3 +228,31 @@ function newspack_blocks_format_byline( $author_info ) {
 
 	return implode( '', $elements );
 }
+
+
+/**
+ * Inject amp-state containing all post IDs visible on page load.
+ */
+function newspack_blocks_inject_amp_state() {
+	if ( ! Newspack_Blocks::is_amp() ) {
+		return;
+	}
+	global $newspack_blocks_post_id;
+	if ( ! $newspack_blocks_post_id || ! count( $newspack_blocks_post_id ) ) {
+		return;
+	}
+	$post_ids = implode( ', ', array_keys( $newspack_blocks_post_id ) );
+	ob_start();
+	?>
+	<amp-state id='newspackHomepagePosts'>
+		<script type="application/json">
+			{
+				"exclude_ids": [ <?php echo esc_attr( $post_ids ); ?> ]
+			}
+		</script>
+	</amp-state>
+	<?php
+	echo ob_get_clean(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+}
+
+add_action( 'wp_footer', 'newspack_blocks_inject_amp_state' );

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -89,7 +89,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	ob_start();
 
 	if ( $article_query->have_posts() ) : ?>
-		<?php if ( Newspack_Blocks::is_amp() ) : ?>
+		<?php if ( $has_more_button && Newspack_Blocks::is_amp() ) : ?>
 			<amp-script layout="container" src="<?php echo esc_url( plugins_url( '/newspack-blocks/amp/homepage-articles/view.js' ) ); ?>">
 		<?php endif; ?>
 		<div
@@ -136,7 +136,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 			<?php endif; ?>
 
 		</div>
-		<?php if ( Newspack_Blocks::is_amp() ) : ?>
+		<?php if ( $has_more_button && Newspack_Blocks::is_amp() ) : ?>
 			</amp-script>
 		<?php endif; ?>
 		<?php

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -60,12 +60,11 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	if ( '' !== $attributes['customTextColor'] ) {
 		$styles = 'color: ' . $attributes['customTextColor'] . ';';
 	}
-
 	$articles_rest_url = add_query_arg(
 		array_merge(
 			array_map(
 				function( $attribute ) {
-					return false === $attribute ? '0' : $attribute;
+					return false === $attribute ? '0' : str_replace( '#', '%23', $attribute );
 				},
 				$attributes
 			),

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -69,7 +69,10 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				},
 				$attributes
 			),
-			[ 'page' => 2 ]
+			[
+				'page' => 2,
+				'amp'  => Newspack_Blocks::is_amp(),
+			]
 		),
 		rest_url( '/newspack-blocks/v1/articles' )
 	);
@@ -78,7 +81,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 	$has_more_pages = ( ++$page ) <= $article_query->max_num_pages;
 
-	$has_more_button = ! Newspack_Blocks::is_amp() && $has_more_pages && boolval( $attributes['moreButton'] );
+	$has_more_button = $has_more_pages && boolval( $attributes['moreButton'] );
 
 	if ( $has_more_button ) {
 		$classes .= ' has-more-button';
@@ -87,6 +90,9 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	ob_start();
 
 	if ( $article_query->have_posts() ) : ?>
+		<?php if ( Newspack_Blocks::is_amp() ) : ?>
+			<amp-script layout="container" src="https://newspack1.ngrok.io/wp-content/plugins/newspack-blocks/amp/homepage-articles/view.js">
+		<?php endif; ?>
 		<div
 			class="<?php echo esc_attr( $classes ); ?>"
 			style="<?php echo esc_attr( $styles ); ?>"
@@ -98,13 +104,6 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 					</h2>
 				<?php endif; ?>
 				<?php
-
-				/*
-				* We are not using an AMP-based renderer on AMP requests because it has limitations
-				* around dynamically calculating the height of the the article list on load.
-				* As a result we render the same standards-based markup for all requests.
-				*/
-
 				echo Newspack_Blocks::template_inc(
 					__DIR__ . '/templates/articles-list.php',
 					[
@@ -116,15 +115,6 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				?>
 			</div>
 			<?php
-
-			/*
-			 * AMP-requests cannot contain client-side scripting (eg: JavaScript). As a result
-			 * we do not display the "More" button on AMP-requests. This feature is deliberately
-			 * disabled.
-			 *
-			 * @see https://github.com/Automattic/newspack-blocks/pull/226#issuecomment-558695909
-			 * @see https://wp.me/paYJgx-jW
-			 */
 
 			if ( $has_more_button ) :
 				?>
@@ -143,9 +133,13 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				<p class="error">
 					<?php _e( 'Something went wrong. Please refresh the page and/or try again.', 'newspack-blocks' ); ?>
 				</p>
+
 			<?php endif; ?>
 
 		</div>
+		<?php if ( Newspack_Blocks::is_amp() ) : ?>
+			</amp-script>
+		<?php endif; ?>
 		<?php
 	endif;
 

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -91,7 +91,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 	if ( $article_query->have_posts() ) : ?>
 		<?php if ( Newspack_Blocks::is_amp() ) : ?>
-			<amp-script layout="container" src="https://newspack1.ngrok.io/wp-content/plugins/newspack-blocks/amp/homepage-articles/view.js">
+			<amp-script layout="container" src="<?php echo esc_url( plugins_url( '/newspack-blocks/amp/homepage-articles/view.js' ) ); ?>">
 		<?php endif; ?>
 		<div
 			class="<?php echo esc_attr( $classes ); ?>"

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -1,5 +1,5 @@
-@import "../../shared/sass/variables";
-@import "../../shared/sass/mixins";
+@import '../../shared/sass/variables';
+@import '../../shared/sass/mixins';
 
 .wpnbha {
 	margin-bottom: 1em;
@@ -35,7 +35,7 @@
 		article {
 			flex-basis: 100%;
 
-			@include media(tablet) {
+			@include media( tablet ) {
 				&:last-child,
 				& {
 					margin-bottom: 1em;
@@ -44,7 +44,7 @@
 		}
 	}
 
-	@include media(mobile) {
+	@include media( mobile ) {
 		&.columns-3 article,
 		&.columns-6 article {
 			flex-basis: calc( 33.333% - 16px );
@@ -53,15 +53,15 @@
 		&.columns-2 article,
 		&.columns-4 article,
 		&.columns-5 article {
-			flex-basis: calc( 50% - 16px);
+			flex-basis: calc( 50% - 16px );
 		}
 
-		&.columns-5 article:last-of-type:nth-child(odd) {
+		&.columns-5 article:last-of-type:nth-child( odd ) {
 			flex-grow: 1;
 		}
 	}
 
-	@include media(tablet) {
+	@include media( tablet ) {
 		@for $i from 2 through 6 {
 			&.columns-#{ $i } article {
 				flex-basis: calc( ( 100% / #{$i} ) - 16px );
@@ -109,14 +109,14 @@
 			display: block;
 		}
 
-		@include media(mobile) {
+		@include media( mobile ) {
 			&.mobile-stack .post-has-image {
 				display: flex;
 			}
 		}
 
 		// Image scale
-		@include media(mobile) {
+		@include media( mobile ) {
 			&.is-4 {
 				.post-thumbnail {
 					flex-basis: 75%;
@@ -210,11 +210,11 @@
 		align-items: center;
 		margin-top: 0.5em;
 
-		.byline:not(:last-child) {
+		.byline:not( :last-child ) {
 			margin-right: 1.5em;
 		}
 
-		.updated:not(.published) {
+		.updated:not( .published ) {
 			display: none;
 		}
 	}
@@ -247,7 +247,7 @@
 	}
 
 	&.has-text-color {
-		.entry-meta span:not(.avatar) {
+		.entry-meta span:not( .avatar ) {
 			opacity: 0.8;
 		}
 	}
@@ -278,7 +278,7 @@
 					bottom: 1em;
 					/* autoprefixer: ignore next */
 					-webkit-box-orient: vertical;
-					color: rgba(white, 0.9);
+					color: rgba( white, 0.9 );
 					display: -webkit-box;
 					font-style: italic;
 					left: 0;
@@ -319,7 +319,6 @@
 			.cat-links a {
 				color: #fff;
 			}
-
 		}
 	}
 }
@@ -340,7 +339,7 @@
 			width: 25px;
 		}
 
-		@include media(tablet) {
+		@include media( tablet ) {
 			.entry-title {
 				font-size: 1.6em;
 			}
@@ -358,7 +357,7 @@
 		.entry-title {
 			line-height: 1.1em;
 		}
-		@include media(tablet) {
+		@include media( tablet ) {
 			article .avatar {
 				height: 2.4em;
 				width: 2.4em;
@@ -379,12 +378,12 @@
 		.entry-title {
 			font-size: 2.6em;
 		}
-		@include media(tablet) {
+		@include media( tablet ) {
 			.entry-title {
 				font-size: 3.6em;
 			}
 		}
-		@include media(desktop) {
+		@include media( desktop ) {
 			.entry-title {
 				font-size: 4.8em;
 			}
@@ -395,12 +394,12 @@
 		.entry-title {
 			font-size: 2.4em;
 		}
-		@include media(tablet) {
+		@include media( tablet ) {
 			.entry-title {
 				font-size: 3.4em;
 			}
 		}
-		@include media(desktop) {
+		@include media( desktop ) {
 			.entry-title {
 				font-size: 4.2em;
 			}
@@ -411,12 +410,12 @@
 		.entry-title {
 			font-size: 2.2em;
 		}
-		@include media(tablet) {
+		@include media( tablet ) {
 			.entry-title {
-				font-size: 3.0em;
+				font-size: 3em;
 			}
 		}
-		@include media(desktop) {
+		@include media( desktop ) {
 			.entry-title {
 				font-size: 3.6em;
 			}
@@ -427,7 +426,7 @@
 		.entry-title {
 			font-size: 2em;
 		}
-		@include media( tablet) {
+		@include media( tablet ) {
 			.entry-title {
 				font-size: 2.4em;
 			}
@@ -436,7 +435,7 @@
 				width: 48px;
 			}
 		}
-		@include media(desktop) {
+		@include media( desktop ) {
 			.entry-title {
 				font-size: 3em;
 			}
@@ -450,16 +449,16 @@
 		.newspack-post-subtitle {
 			font-size: 1.4em;
 		}
-		@include media(tablet) {
+		@include media( tablet ) {
 			.entry-title {
-				font-size: 2.0em;
+				font-size: 2em;
 			}
 			.avatar {
 				height: 44px;
 				width: 44px;
 			}
 		}
-		@include media(desktop) {
+		@include media( desktop ) {
 			.entry-title {
 				font-size: 2.4em;
 			}
@@ -473,7 +472,7 @@
 		.newspack-post-subtitle {
 			font-size: 1.2em;
 		}
-		@include media(tablet) {
+		@include media( tablet ) {
 			.entry-title {
 				font-size: 1.8em;
 			}
@@ -482,9 +481,9 @@
 				width: 40px;
 			}
 		}
-		@include media(desktop) {
+		@include media( desktop ) {
 			.entry-title {
-				font-size: 2.0em;
+				font-size: 2em;
 			}
 		}
 	}
@@ -493,7 +492,7 @@
 
 	&.ts-3 article {
 		.entry-title {
-			font-size: 1.0em;
+			font-size: 1em;
 		}
 		.newspack-post-subtitle,
 		.entry-wrapper p {
@@ -504,7 +503,7 @@
 		}
 		@include media( tablet ) {
 			.entry-title {
-				font-size: 1.2em
+				font-size: 1.2em;
 			}
 
 			.avatar {
@@ -562,7 +561,7 @@
 
 .wpnbha.is-style-borders {
 	article {
-		border: solid rgba(0, 0, 0, 0.2);
+		border: solid rgba( 0, 0, 0, 0.2 );
 		border-width: 0 0 1px;
 		margin-bottom: 1em;
 		padding-bottom: 1em;
@@ -570,14 +569,13 @@
 		&:last-of-type {
 			margin-bottom: 0;
 
-			&:not(:first-of-type) {
+			&:not( :first-of-type ) {
 				border-bottom: 0;
 			}
 		}
 	}
 
-	@include media(tablet) {
-
+	@include media( tablet ) {
 		@for $i from 2 through 6 {
 			&.columns-#{ $i } article {
 				padding-right: calc( ( 16px * #{$i} ) / ( #{$i} - 1 ) );
@@ -592,11 +590,11 @@
 
 		&.is-grid article:last-of-type,
 		&.columns-1 article,
-		&.columns-2 article:nth-of-type(2n),
-		&.columns-3 article:nth-of-type(3n),
-		&.columns-4 article:nth-of-type(4n),
-		&.columns-5 article:nth-of-type(5n),
-		&.columns-6 article:nth-of-type(6n) {
+		&.columns-2 article:nth-of-type( 2n ),
+		&.columns-3 article:nth-of-type( 3n ),
+		&.columns-4 article:nth-of-type( 4n ),
+		&.columns-5 article:nth-of-type( 5n ),
+		&.columns-6 article:nth-of-type( 6n ) {
 			border: 0;
 		}
 	}
@@ -614,7 +612,9 @@
 
 /* "More" button & related elements styles */
 .wpnbha {
-	button, .loading, .error {
+	button,
+	.loading,
+	.error {
 		display: none;
 	}
 
@@ -638,8 +638,25 @@
 	}
 
 	&.has-more-button.is-error {
-		button, .error {
+		button,
+		.error {
 			display: block;
 		}
+	}
+}
+
+/* Prevent tree-shaking Loading and Error style rules */
+amp-script .wpnbha.has-more-button.is-loading {
+	button {
+		display: none;
+	}
+	.loading {
+		display: block;
+	}
+}
+amp-script .wpnbha.has-more-button.is-error {
+	button,
+	.error {
+		display: block;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds AMP compatibility for the Homepage Posts bock Load More button. 

### How to test the changes in this Pull Request:

1. Begin by verifying the block behaves exactly as it does on `master` in non-AMP requests.
2. Install AMP plugin, use Transitional mode.
3. View page with Homepage Posts block on it, switch to AMP request, verify identical behavior.
4. Test in pages with multiple Homepage Posts blocks. There should be no duplicate posts displayed after clicking Load More buttons.
5. Test in a variety of browsers.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?