### PR TITLE
Show/hide Load more button based on block attribute.

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -116,7 +116,8 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 			$has_more_pages = ( ++$page ) <= $article_query->max_num_pages;
 
-			if ( ! Newspack_Blocks::is_amp() && $has_more_pages ) : ?>
+			if ( ! Newspack_Blocks::is_amp() && $has_more_pages && boolval( $attributes['moreButton'] ) ) :
+				?>
 				<button type="button" data-load-more-btn data-load-more-url="<?php echo esc_url( $articles_rest_url ); ?>">
 					<?php _e( 'Load more articles', 'newspack-blocks' ); ?>
 				</button>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Hide/show the Load More button based on  value of the  `Show "More" Button` toggle.

Closes https://github.com/Automattic/newspack-blocks/issues/266.

### How to test the changes in this Pull Request:

1. On `master`, add a `Homepage Posts` block, keep `Show "More" Button` toggled off.
2. Publish and  view. Observe the `Load more articles`  button is visible.
3. Switch to this branch and try again. Observe the button is hidden.
4. Toggle the option on and Update post.
5. Observe the button is now visible.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
