### PR TITLE
Article Block: Fix issue with author link not working

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -204,7 +204,7 @@ function newspack_blocks_format_byline( $author_info ) {
 						sprintf(
 							/* translators: 1: author link. 2: author name. 3. variable seperator (comma, 'and', or empty) */
 							'<span class="author vcard"><a class="url fn n" href="%1$s">%2$s</a></span>',
-							esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ),
+							esc_url( get_author_posts_url( $author->ID ) ),
 							esc_html( $author->display_name )
 						),
 						( $index < $penultimate ) ? ', ' : '',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue where the author name wasn't linked to the correct location when the Co-Authors Plus plugin is deactivated. 

Closes https://github.com/Automattic/newspack-theme/issues/623.

### How to test the changes in this Pull Request:

1. Add an article block to the homepage; make sure at least one author that displays has a two word display name, or their display name and username/slug are different.
2. Deactivate the Co-Authors Plus plugin, if active.
3. Click on one of the author links; note the URL it tries to go to is their nice name, rather than their slug:

![image](https://user-images.githubusercontent.com/177561/70470235-6ff94f80-1a7f-11ea-9444-54b8f59f62d3.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the link now works:

![image](https://user-images.githubusercontent.com/177561/70470163-4e986380-1a7f-11ea-8bdd-8a615d20919d.png)

6. Turn back on the Co-Authors Plus plugin and confirm the link still works.
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
