### PR TITLE
Fix issue with author avatar link getting stripped out

### DIFF
--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -98,6 +98,9 @@ call_user_func(
 										'srcset' => true,
 									),
 									'noscript' => array(),
+									'a' => array(
+										'href'  => true,
+									),
 								)
 							);
 						endif;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The link around the author avatar is getting stripped out; this issue was introduced in #261.

### How to test the changes in this Pull Request:

1. Add an article block to a page.
2. Hover over the author avatar; notice that the image no longer has a link.
3. Apply the PR.
4. Confirm that the image now has a link, and it points to the author's archive page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
