### PR TITLE
Exclude  IDs In Load More Posts Endpoint

### DIFF
--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * WP_REST_Newspack_Articles_Controller file.
+ *
+ * @package WordPress
  */
 
 /**
@@ -101,17 +103,24 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 		if ( $next_page <= $article_query->max_num_pages ) {
 			$next_url = add_query_arg(
 				array_merge(
-					array_map( function( $attribute ) { return $attribute === false ? '0' : $attribute; }, $attributes ),
+					array_map(
+						function( $attribute ) {
+							return false === $attribute ? '0' : $attribute;
+						},
+						$attributes
+					),
 					[ 'page' => $next_page ] // phpcs:ignore PHPCompatibility.Syntax.NewShortArray.Found
 				),
 				rest_url( '/newspack-blocks/v1/articles' )
 			);
 		}
 
-		return rest_ensure_response( [
-			'items' => $items,
-			'next'  => $next_url,
-		] );
+		return rest_ensure_response(
+			[
+				'items' => $items,
+				'next'  => $next_url,
+			]
+		);
 	}
 
 	/**
@@ -122,9 +131,10 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 	public function get_attribute_schema() {
 		if ( empty( $this->attribute_schema ) ) {
 			$block_json = json_decode(
-				file_get_contents( __DIR__ . '/block.json' ),
+				file_get_contents( __DIR__ . '/block.json' ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 				true
 			);
+
 			$this->attribute_schema = array_merge(
 				$block_json['attributes'],
 				[


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds support  for an  `exclude_ids` parameter. As with the normal rendering logic, this avoids using `post__not_in` logic and instead queries for more posts than were requested and sorts out which to return in PHP logic. This is related to  https://github.com/Automattic/newspack-blocks/pull/263, which tacks on an array of all visible posts so they will be excluded.

### How to test the changes in this Pull Request:

This one is a little tough to test without https://github.com/Automattic/newspack-blocks/pull/263. Here's one approach:

1. Branch switch to `update/load-more-with-post-ids`.
2. Add several `Homepage Posts`blocks, and switch on `Show "More" Button`.
3. Publish and view the post.
4. With web inspector open to Network->XHR tab (Chrome), click the `Load More Posts` button.
5. You should see requests that look something like this: `https://newspack1.ngrok.io/wp-json/newspack-blocks/v1/articles?showExcerpt=0&postsToShow=2&typeScale=1&sectionHeader=Latest%20News&textColor=secondary-variation&className=&showDate=1&showImage=1&showCaption=0&imageShape=landscape&minHeight=0&moreButton=0&showAuthor=1&showAvatar=1&showCategory=0&postLayout=list&columns=3&mediaPosition=top&imageScale=3&mobileStack=0&specificMode=0&customTextColor=&singleMode=0&page=2&exclude_ids=5466%2C5464%2C5462%2C5460&_locale=user`. Double-click to open the endpoint in a new window.
6. Branch switch to `add/load-more-endpoint-exclude-ids` and reload the request. 
7. The results should now exclude any posts that are visible on  the page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
