### PR TITLE
nha: add `blocks.transforms_from_name` filter

### DIFF
--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -5,9 +5,14 @@ import { Path, SVG } from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';
 
 /**
+ * WordPress dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+import { __, _x } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import edit from './edit';
 
 /**
@@ -59,14 +64,14 @@ export const settings = {
 				type: 'block',
 				blocks: [ 'core/latest-posts' ],
 				transform: ( {
-					displayPostContent,
-					displayPostDate,
-					postLayout,
-					columns,
-					postsToShow,
-					categories,
+				     displayPostContent,
+				     displayPostDate,
+				     postLayout,
+				     columns,
+				     postsToShow,
+				     categories,
 				} ) => {
-					return createBlock( 'newspack-blocks/homepage-articles', {
+					return createBlock( applyFilters( 'blocks.transforms_from_name', 'newspack-blocks/homepage-articles' ), {
 						showExcerpt: displayPostContent,
 						showDate: displayPostDate,
 						postLayout,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR adds a filter to the transform function from `core/latest-posts` block, in order to be able to change the block name.

### How to test the changes in this Pull Request:

These changes don't affect the current behaviour of the block, so just be sure that it still works as expected. Anyway, if you want to test it, you can define the transformation name adding a filter with this name:

```es6
function setBlockTransformationName( name ) {
	return name !== 'newspack-blocks/homepage-articles'
		? name
		: 'the-new-name-for-the-transformed-block`;
}

addFilter(
	'blocks.transforms_from_name',
	'set-transformed-block-name',
	setBlockTransformationName,
);
```