### PR TITLE
Add rest fields only to edit context

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -18,9 +18,8 @@ class Newspack_Blocks_API {
 			array( 'post', 'page' ),
 			'newspack_featured_image_src',
 			array(
-				'get_callback'    => array( 'Newspack_Blocks_API', 'newspack_blocks_get_image_src' ),
-				'update_callback' => null,
-				'schema'          => null,
+				'get_callback' => array( 'Newspack_Blocks_API', 'newspack_blocks_get_image_src' ),
+				'schema'       => array( 'context' => array( 'edit' ) ),
 			)
 		);
 
@@ -28,9 +27,8 @@ class Newspack_Blocks_API {
 			array( 'post', 'page' ),
 			'newspack_featured_image_caption',
 			array(
-				'get_callback'    => array( 'Newspack_Blocks_API', 'newspack_blocks_get_image_caption' ),
-				'update_callback' => null,
-				'schema'          => null,
+				'get_callback' => array( 'Newspack_Blocks_API', 'newspack_blocks_get_image_caption' ),
+				'schema'       => array( 'context' => array( 'edit' ) ),
 			)
 		);
 
@@ -39,9 +37,8 @@ class Newspack_Blocks_API {
 			'post',
 			'newspack_author_info',
 			array(
-				'get_callback'    => array( 'Newspack_Blocks_API', 'newspack_blocks_get_author_info' ),
-				'update_callback' => null,
-				'schema'          => null,
+				'get_callback' => array( 'Newspack_Blocks_API', 'newspack_blocks_get_author_info' ),
+				'schema'       => array( 'context' => array( 'edit' ) ),
 			)
 		);
 
@@ -50,9 +47,8 @@ class Newspack_Blocks_API {
 			'post',
 			'newspack_category_info',
 			array(
-				'get_callback'    => array( 'Newspack_Blocks_API', 'newspack_blocks_get_primary_category' ),
-				'update_callback' => null,
-				'schema'          => null,
+				'get_callback' => array( 'Newspack_Blocks_API', 'newspack_blocks_get_primary_category' ),
+				'schema'       => array( 'context' => array( 'edit' ) ),
 			)
 		);
 	}

--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -15,41 +15,61 @@ class Newspack_Blocks_API {
 	 */
 	public static function register_rest_fields() {
 		register_rest_field(
-			array( 'post', 'page' ),
+			[ 'post', 'page' ],
 			'newspack_featured_image_src',
-			array(
-				'get_callback' => array( 'Newspack_Blocks_API', 'newspack_blocks_get_image_src' ),
-				'schema'       => array( 'context' => array( 'edit' ) ),
-			)
+			[
+				'get_callback' => [ 'Newspack_Blocks_API', 'newspack_blocks_get_image_src' ],
+				'schema'       => [
+					'context' => [
+						'edit',
+					],
+					'type'    => 'array',
+				],
+			]
 		);
 
 		register_rest_field(
-			array( 'post', 'page' ),
+			[ 'post', 'page' ],
 			'newspack_featured_image_caption',
-			array(
-				'get_callback' => array( 'Newspack_Blocks_API', 'newspack_blocks_get_image_caption' ),
-				'schema'       => array( 'context' => array( 'edit' ) ),
-			)
+			[
+				'get_callback' => [ 'Newspack_Blocks_API', 'newspack_blocks_get_image_caption' ],
+				'schema'       => [
+					'context' => [
+						'edit',
+					],
+					'type'    => 'string',
+				],
+			]
 		);
 
 		/* Add author info source */
 		register_rest_field(
 			'post',
 			'newspack_author_info',
-			array(
-				'get_callback' => array( 'Newspack_Blocks_API', 'newspack_blocks_get_author_info' ),
-				'schema'       => array( 'context' => array( 'edit' ) ),
-			)
+			[
+				'get_callback' => [ 'Newspack_Blocks_API', 'newspack_blocks_get_author_info' ],
+				'schema'       => [
+					'context' => [
+						'edit',
+					],
+					'type'    => 'array',
+				],
+			]
 		);
 
 		/* Add first category source */
 		register_rest_field(
 			'post',
 			'newspack_category_info',
-			array(
-				'get_callback' => array( 'Newspack_Blocks_API', 'newspack_blocks_get_primary_category' ),
-				'schema'       => array( 'context' => array( 'edit' ) ),
-			)
+			[
+				'get_callback' => [ 'Newspack_Blocks_API', 'newspack_blocks_get_primary_category' ],
+				'schema'       => [
+					'context' => [
+						'edit',
+					],
+					'type'    => 'string',
+				],
+			]
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Only adds custom rest fields for requests with the edit context.
Avoids adding those fields to public requests and only surfaces that information to authenticated users.
Fixes failing wp.com unit tests in D36572-code.

### How to test the changes in this Pull Request:

1. Make sure adding a Homepage Posts block still works and it displays all the usual information.
2. Check the `/wp/v2/posts` endpoint unauthenticated to not include these fields.
