### PR TITLE
NHA: `More…` button improvements

### DIFF
--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -35,8 +35,8 @@
       "default": false
     },
     "moreButtonText": {
-	  "type": "string",
-	  "default": ""
+      "type": "string",
+      "default": ""
     },
     "showAuthor": {
       "type": "boolean",

--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -34,6 +34,10 @@
       "type": "boolean",
       "default": false
     },
+    "moreButtonText": {
+	  "type": "string",
+	  "default": ""
+    },
     "showAuthor": {
       "type": "boolean",
       "default": true

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -314,23 +314,12 @@ class Edit extends Component {
 						/>
 					) }
 					{ ! specificMode && (
-						<Fragment>
-							<ToggleControl
-								label={ __( 'Show "More" Button', 'newspack-blocks' ) }
-								checked={ moreButton }
-								onChange={ () => setAttributes( { moreButton: ! moreButton } ) }
-								help={ __('Only available for non-AMP requests.', 'newspack-blocks') }
-							/>
-
-							{ moreButton && (
-								<TextControl
-									value={ moreButtonText }
-									label={ __( 'Button text', 'newspack-blocks' ) }
-									onChange={ ( moreButtonText ) => setAttributes( { moreButtonText } ) }
-									placeholder={ __( 'Load more posts', 'newspack-blocks' ) }
-								/>
-							) }
-						</Fragment>
+						<ToggleControl
+							label={ __( 'Show "More" Button', 'newspack-blocks' ) }
+							checked={ moreButton }
+							onChange={ () => setAttributes( { moreButton: ! moreButton } ) }
+							help={ __( 'Only available for non-AMP requests.', 'newspack-blocks' ) }
+						/>
 					) }
 				</PanelBody>
 				<PanelBody title={ __( 'Featured Image Settings', 'newspack-blocks' ) }>
@@ -617,12 +606,14 @@ class Edit extends Component {
 				{ ! specificMode && latestPosts && moreButton && (
 					<div className="editor-styles-wrapper">
 						<div className="wp-block-button">
-							<button className="wp-block-button__link" type="button">
-								{ moreButtonText && moreButtonText.length
-									? moreButtonText
-									: __( 'Load more posts', 'newspack-blocks' )
-								}
-							</button>
+							<RichText
+								placeholder={ __( 'Load more posts', 'newspack-blocks' ) }
+								value={ moreButtonText }
+								onChange={ value => setAttributes( { moreButtonText: value } ) }
+								className="wp-block-button__link"
+								keepPlaceholderOnFocus
+								allowedFormats={ [] }
+							/>
 						</div>
 					</div>
 				) }

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -601,9 +601,14 @@ class Edit extends Component {
 				</div>
 
 				{ ! specificMode && latestPosts && moreButton && (
-					<button className="button" type="button">
-						{ __( 'More…', 'newspack-blocks' ) }
-					</button>
+					<div className="editor-styles-wrapper">
+						<button
+							className="wp-block-button__link"
+							type="button"
+						>
+							{ __( 'More…', 'newspack-blocks' ) }
+						</button>
+					</div>
 				) }
 
 				<BlockControls>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -477,6 +477,7 @@ class Edit extends Component {
 			postLayout,
 			mediaPosition,
 			moreButton,
+			moreButtonText,
 			columns,
 			categories,
 			typeScale,
@@ -602,12 +603,14 @@ class Edit extends Component {
 
 				{ ! specificMode && latestPosts && moreButton && (
 					<div className="editor-styles-wrapper">
-						<button
-							className="wp-block-button__link"
-							type="button"
-						>
-							{ __( 'More…', 'newspack-blocks' ) }
-						</button>
+						<div className="wp-block-button">
+							<button className="wp-block-button__link" type="button">
+								{ moreButtonText && moreButtonText.length
+									? moreButtonText
+									: __( 'Load more articles', 'newspack-blocks' )
+								}
+							</button>
+						</div>
 					</div>
 				) }
 

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -30,6 +30,7 @@ import {
 	BaseControl,
 	Path,
 	SVG,
+	TextControl,
 } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
@@ -238,6 +239,7 @@ class Edit extends Component {
 			mobileStack,
 			minHeight,
 			moreButton,
+			moreButtonText,
 			showExcerpt,
 			typeScale,
 			showDate,
@@ -312,12 +314,23 @@ class Edit extends Component {
 						/>
 					) }
 					{ ! specificMode && (
-						<ToggleControl
-							label={ __( 'Show "More" Button', 'newspack-blocks' ) }
-							checked={ moreButton }
-							onChange={ () => setAttributes( { moreButton: ! moreButton } ) }
-							help={ __( 'Only available for non-AMP requests.', 'newspack-blocks' ) }
-						/>
+						<div>
+							<ToggleControl
+								label={ __( 'Show "More" Button', 'newspack-blocks' ) }
+								checked={ moreButton }
+								onChange={ () => setAttributes( { moreButton: ! moreButton } ) }
+								help={ __('Only available for non-AMP requests.', 'newspack-blocks') }
+							/>
+
+							{ moreButton && (
+								<TextControl
+									value={ moreButtonText }
+									label={ __( 'Button description', 'newspack-blocks' ) }
+									onChange={ ( moreButtonText ) => setAttributes( { moreButtonText } ) }
+									placeholder={ __( 'Load more articles', 'newspack-blocks' ) }
+								/>
+							) }
+						</div>
 					) }
 				</PanelBody>
 				<PanelBody title={ __( 'Featured Image Settings', 'newspack-blocks' ) }>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -314,7 +314,7 @@ class Edit extends Component {
 						/>
 					) }
 					{ ! specificMode && (
-						<div>
+						<Fragment>
 							<ToggleControl
 								label={ __( 'Show "More" Button', 'newspack-blocks' ) }
 								checked={ moreButton }
@@ -330,7 +330,7 @@ class Edit extends Component {
 									placeholder={ __( 'Load more posts', 'newspack-blocks' ) }
 								/>
 							) }
-						</div>
+						</Fragment>
 					) }
 				</PanelBody>
 				<PanelBody title={ __( 'Featured Image Settings', 'newspack-blocks' ) }>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -325,9 +325,9 @@ class Edit extends Component {
 							{ moreButton && (
 								<TextControl
 									value={ moreButtonText }
-									label={ __( 'Button description', 'newspack-blocks' ) }
+									label={ __( 'Button text', 'newspack-blocks' ) }
 									onChange={ ( moreButtonText ) => setAttributes( { moreButtonText } ) }
-									placeholder={ __( 'Load more articles', 'newspack-blocks' ) }
+									placeholder={ __( 'Load more posts', 'newspack-blocks' ) }
 								/>
 							) }
 						</div>
@@ -620,7 +620,7 @@ class Edit extends Component {
 							<button className="wp-block-button__link" type="button">
 								{ moreButtonText && moreButtonText.length
 									? moreButtonText
-									: __( 'Load more articles', 'newspack-blocks' )
+									: __( 'Load more posts', 'newspack-blocks' )
 								}
 							</button>
 						</div>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -30,7 +30,6 @@ import {
 	BaseControl,
 	Path,
 	SVG,
-	TextControl,
 } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -120,10 +120,10 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				?>
 				<button type="button" data-load-more-btn data-load-more-url="<?php echo esc_url( $articles_rest_url ); ?>">
 				<?php
-				if ( isset( $attributes['moreButtonText'] ) && ! empty( $attributes['moreButtonText'] ) ) {
+				if ( ! empty( $attributes['moreButtonText'] ) ) {
 					echo esc_html( $attributes['moreButtonText'] );
 				} else {
-					esc_html_e( 'Load more articles', 'newspack-blocks' );
+					esc_html_e( 'Load more posts', 'newspack-blocks' );
 				}
 				?>
 				</button>

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -119,7 +119,13 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 			if ( ! Newspack_Blocks::is_amp() && $has_more_pages && boolval( $attributes['moreButton'] ) ) :
 				?>
 				<button type="button" data-load-more-btn data-load-more-url="<?php echo esc_url( $articles_rest_url ); ?>">
-					<?php _e( 'Load more articles', 'newspack-blocks' ); ?>
+				<?php
+				if ( isset( $attributes['moreButtonText'] ) && ! empty( $attributes['moreButtonText'] ) ) {
+					echo esc_html( $attributes['moreButtonText'] );
+				} else {
+					esc_html_e( 'Load more articles', 'newspack-blocks' );
+				}
+				?>
 				</button>
 				<p data-load-more-loading-text hidden>
 					<?php _e( 'Loading...', 'newspack-blocks' ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR implements several improvements to the `More…` button:

* Adds the needed CSS classes in order to try to show the button visually equivalent in both sides (Frontend and Editor canvas)

* Set the same button-text in both sides

* Default text: `Load more articles`. It's debatable and easily changeable.

* Be able to set a custom text for the button.

Closes #275 

## Testing the Styles
Check styles on both sides.

**BEFORE**

**Editor Canvas (Twenty Twenty)**
<img src="https://user-images.githubusercontent.com/77539/70643110-70742080-1c0e-11ea-9e91-45caf491e402.png" width="400px" />

**Frontend (Twenty Twenty)**
<img src="https://user-images.githubusercontent.com/77539/70643169-884ba480-1c0e-11ea-8231-59861698b698.png" width="400px" />

**AFTER**

**Editor Canvas (Twenty Nineteen)**
<img src="https://user-images.githubusercontent.com/77539/70651800-8211f400-1c1f-11ea-9831-b6caed0d004e.png" width="400px" />

**Frontend (Twenty Twenty)**
Same as **before**

**Editor Canvas (Twenty Nineteen)**

<img src="https://user-images.githubusercontent.com/77539/70650151-8ab4fb00-1c1c-11ea-9b1e-5c531519e68b.png" width="400px" />

**Frontend (Twenty Nineteen)**

<img src="https://user-images.githubusercontent.com/77539/70649951-25f9a080-1c1c-11ea-81e0-5128c90b5cca.png" width="400px" />

**Editor Canvas (Maywood)**
<img src="https://user-images.githubusercontent.com/77539/70651537-00ba6180-1c1f-11ea-868c-deac83ede1bc.png" width="400px" />

**Frontend (Twenty Maywood)**
<img src="https://user-images.githubusercontent.com/77539/70651588-1b8cd600-1c1f-11ea-9c80-a5aa6501bc92.png" width="400px" />

## Testing button custom text

* Confirm that an additional field appears when it enables the `Show "More" Button` 
<img src="https://user-images.githubusercontent.com/77539/70650265-c94ab580-1c1c-11ea-907f-67d9cf9767b2.png" width="400px" />

* Editing the `Button description` filed should update the button text on the fly.
<img src="https://user-images.githubusercontent.com/77539/70650358-eed7bf00-1c1c-11ea-8d88-50d2eb9f998b.png" width="500px" />


* Save and confirm that the custom text is propagated in the frontend page.

<img src="https://user-images.githubusercontent.com/77539/70650512-39593b80-1c1d-11ea-83a9-4e3645c94dd5.png" width="400px" />

* Finally, confirm that an empty value sets the default text
<img src="https://user-images.githubusercontent.com/77539/70651252-770a9400-1c1e-11ea-8185-f7222bbfbbb7.png" width="600px" />
