### PR TITLE
Handle Post Title As String

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -109,7 +109,7 @@ class Edit extends Component {
 		};
 
 		const authorNumber = post.newspack_author_info.length;
-
+		const postTitle =  this.titleForPost( post );
 		return (
 			<article
 				className={ post.newspack_featured_image_src ? 'post-has-image' : null }
@@ -145,11 +145,11 @@ class Edit extends Component {
 					) }
 					{ RichText.isEmpty( sectionHeader ) ? (
 						<h2 className="entry-title" key="title">
-							<a href="#">{ decodeEntities( post.title.rendered.trim() ) }</a>
+							<a href="#">{ postTitle }</a>
 						</h2>
 					) : (
 						<h3 className="entry-title" key="title">
-							<a href="#">{ decodeEntities( post.title.rendered.trim() ) }</a>
+							<a href="#">{ postTitle }</a>
 						</h3>
 					) }
 					{ showExcerpt && (
@@ -171,6 +171,18 @@ class Edit extends Component {
 				</div>
 			</article>
 		);
+	};
+
+	titleForPost = post => {
+		if ( ! post.title ) {
+			return '';
+		}
+		if ( typeof post.title === 'string' ) {
+			return decodeEntities( post.title.trim() );
+		}
+		if ( typeof post.title === 'object' && post.title.rendered ) {
+			return decodeEntities( post.title.rendered.trim() );
+		}
 	};
 
 	formatAvatars = authorInfo =>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -109,7 +109,7 @@ class Edit extends Component {
 		};
 
 		const authorNumber = post.newspack_author_info.length;
-		const postTitle =  this.titleForPost( post );
+		const postTitle = this.titleForPost( post );
 		return (
 			<article
 				className={ post.newspack_featured_image_src ? 'post-has-image' : null }
@@ -252,27 +252,33 @@ class Edit extends Component {
 		} = attributes;
 
 		const imageSizeOptions = [
-		{
-			value: 1,
-			label: /* translators: label for small size option */ __( 'Small', 'newspack-blocks' ),
-			shortName: /* translators: abbreviation for small size */ __( 'S', 'newspack-blocks' ),
-		},
-		{
-			value: 2,
-			label: /* translators: label for medium size option */ __( 'Medium', 'newspack-blocks' ),
-			shortName: /* translators: abbreviation for medium size */ __( 'M', 'newspack-blocks' ),
-		},
-		{
-			value: 3,
-			label: /* translators: label for large size option */ __( 'Large', 'newspack-blocks' ),
-			shortName: /* translators: abbreviation for large size */ __( 'L', 'newspack-blocks' ),
-		},
-		{
-			value: 4,
-			label: /* translators: label for extra large size option */ __( 'Extra Large', 'newspack-blocks' ),
-			shortName: /* translators: abbreviation for extra large size */ __( 'XL', 'newspack-blocks' ),
-		},
-	];
+			{
+				value: 1,
+				label: /* translators: label for small size option */ __( 'Small', 'newspack-blocks' ),
+				shortName: /* translators: abbreviation for small size */ __( 'S', 'newspack-blocks' ),
+			},
+			{
+				value: 2,
+				label: /* translators: label for medium size option */ __( 'Medium', 'newspack-blocks' ),
+				shortName: /* translators: abbreviation for medium size */ __( 'M', 'newspack-blocks' ),
+			},
+			{
+				value: 3,
+				label: /* translators: label for large size option */ __( 'Large', 'newspack-blocks' ),
+				shortName: /* translators: abbreviation for large size */ __( 'L', 'newspack-blocks' ),
+			},
+			{
+				value: 4,
+				label: /* translators: label for extra large size option */ __(
+					'Extra Large',
+					'newspack-blocks'
+				),
+				shortName: /* translators: abbreviation for extra large size */ __(
+					'XL',
+					'newspack-blocks'
+				),
+			},
+		];
 
 		return (
 			<Fragment>
@@ -310,7 +316,7 @@ class Edit extends Component {
 							label={ __( 'Show "More" Button', 'newspack-blocks' ) }
 							checked={ moreButton }
 							onChange={ () => setAttributes( { moreButton: ! moreButton } ) }
-							help={ __('Only available for non-AMP requests.', 'newspack-blocks') }
+							help={ __( 'Only available for non-AMP requests.', 'newspack-blocks' ) }
 						/>
 					) }
 				</PanelBody>
@@ -345,7 +351,7 @@ class Edit extends Component {
 							<BaseControl label={ __( 'Featured Image Size', 'newspack-blocks' ) }>
 								<PanelRow>
 									<ButtonGroup aria-label={ __( 'Featured Image Size', 'newspack-blocks' ) }>
-										{ imageSizeOptions.map( ( option ) => {
+										{ imageSizeOptions.map( option => {
 											const isCurrent = imageScale === option.value;
 											return (
 												<Button
@@ -614,14 +620,21 @@ class Edit extends Component {
 export default compose( [
 	withColors( { textColor: 'color' } ),
 	withSelect( ( select, props ) => {
-		const { postsToShow, authors, categories, tags, specificPosts, specificMode } = props.attributes;
+		const {
+			postsToShow,
+			authors,
+			categories,
+			tags,
+			specificPosts,
+			specificMode,
+		} = props.attributes;
 		const { getAuthors, getEntityRecords } = select( 'core' );
 		const latestPostsQuery = pickBy(
 			specificMode && specificPosts && specificPosts.length
 				? {
-					include: specificPosts,
-					orderby: 'include'
-				}
+						include: specificPosts,
+						orderby: 'include',
+				  }
 				: {
 						per_page: postsToShow,
 						categories,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As reported in https://github.com/Automattic/newspack-blocks/issues/277, if a Post contains an instance of a block which displays the  current Post, editing the Post title causes the block to break. Normally `post.title` is an object, but after an edit to the current post it comes back as a simple string. The change in this PR accounts for this situation.

Closes https://github.com/Automattic/newspack-blocks/issues/277.

### How to test the changes in this Pull Request:

1. Create a post, save and publish.
2. Add Homepage Posts block. Observe the top Post shown is the  current one.
3. Edit the title of the current Post  and save. 
4. Observe the block reflects the title change and doesn't crash.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
