### PR TITLE
Fix Full Width Alignment

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -580,24 +580,26 @@ class Edit extends Component {
 						color: textColor.color,
 					} }
 				>
-					{ latestPosts && ( ! RichText.isEmpty( sectionHeader ) || isSelected ) && (
-						<RichText
-							onChange={ value => setAttributes( { sectionHeader: value } ) }
-							placeholder={ __( 'Write header…', 'newspack-blocks' ) }
-							value={ sectionHeader }
-							tagName="h2"
-							className="article-section-title"
-						/>
-					) }
-					{ latestPosts && ! latestPosts.length && (
-						<Placeholder>{ __( 'Sorry, no posts were found.', 'newspack-blocks' ) }</Placeholder>
-					) }
-					{ ! latestPosts && (
-						<Placeholder>
-							<Spinner />
-						</Placeholder>
-					) }
-					{ latestPosts && latestPosts.map( post => this.renderPost( post ) ) }
+					<div>
+						{ latestPosts && ( ! RichText.isEmpty( sectionHeader ) || isSelected ) && (
+							<RichText
+								onChange={ value => setAttributes( { sectionHeader: value } ) }
+								placeholder={ __( 'Write header…', 'newspack-blocks' ) }
+								value={ sectionHeader }
+								tagName="h2"
+								className="article-section-title"
+							/>
+						) }
+						{ latestPosts && ! latestPosts.length && (
+							<Placeholder>{ __( 'Sorry, no posts were found.', 'newspack-blocks' ) }</Placeholder>
+						) }
+						{ ! latestPosts && (
+							<Placeholder>
+								<Spinner />
+							</Placeholder>
+						) }
+						{ latestPosts && latestPosts.map( post => this.renderPost( post ) ) }
+					</div>
 				</div>
 
 				{ ! specificMode && latestPosts && moreButton && (

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -77,8 +77,8 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	ob_start();
 
 	if ( $article_query->have_posts() ) : ?>
-		<div>
-			<div data-posts-container class="<?php echo esc_attr( $classes ); ?>" style="<?php echo esc_attr( $styles ); ?>">
+		<div  class="<?php echo esc_attr( $classes ); ?>" style="<?php echo esc_attr( $styles ); ?>">
+			<div data-posts-container>
 				<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
 					<h2 class="article-section-title">
 						<span><?php echo wp_kses_post( $attributes['sectionHeader'] ); ?></span>

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -23,13 +23,15 @@
 	}
 
 	/* Column styles */
-	&.is-grid {
+	&.is-grid > div {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: space-between;
 		padding: 0;
 		list-style: none;
+	}
 
+	&.is-grid {
 		article {
 			flex-basis: 100%;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As reported in https://github.com/Automattic/newspack-blocks/issues/279 there has been a regression around the full-width alignment option due to the introduction of an additional `div` related to the Load More button. This PR resolves this by moving the classes and style up to the top-most div and fixing a styling issue created by the new hierarchy.

Closes https://github.com/Automattic/newspack-blocks/issues/279.

### How to test the changes in this Pull Request:

1. Switch to a theme that supports Full Width (e.g. Newspack Theme)
2. Create a post or page and add the Homepage Posts block. If you are using  the Newspack Theme switch to the `One Column` or  `One  Column (Wide)`  template.
3. Set the block to Full Width alignment.
4. Publish and view on the front end. 
5. Verify that the block is full width.

<img width="1831" alt="Screen Shot 2019-12-11 at 7 05 03 PM" src="https://user-images.githubusercontent.com/1477002/70671197-2cead800-1c49-11ea-94ed-5567c1f99bc1.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
