### PR TITLE
NHA: Add styles to hide `.updated` class

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -190,6 +190,10 @@
 		.byline:not(:last-child) {
 			margin-right: 1.5em;
 		}
+
+		.updated:not(.published) {
+			display: none;
+		}
 	}
 
 	.avatar {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Many themes output both a 'published' and 'updated' time for posts, and hide the latter.

The NHA block does this too, but it has relied on the theme hiding the updated time. Because of this, it's visible with themes that don't (like Twenty Twenty). This PR adds styles to hide it to the block.

Closes #283.

### How to test the changes in this Pull Request:

1. Switch to a theme that doesn't hide the `.updated` class (like Twenty Twenty).
2. Add a Homepage Block to a page.
3. Pick a post displayed by the block that was published earlier than today, and edit it. Save and publish.
4. View the block on the front end; you should see two dates, like in the first post below:

![image](https://user-images.githubusercontent.com/177561/70672818-41bd7080-1c35-11ea-94db-9ed6cf12a282.png)

5. Apply the PR and run `npm run build`.
6. Confirm that the second date no longer displays, and only the one representing when the post was originally published is shown:

![image](https://user-images.githubusercontent.com/177561/70672793-30746400-1c35-11ea-8fd5-cb0e5dc1b83a.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
