### PR TITLE
Fix some issues with image handling

### DIFF
--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -11,6 +11,13 @@
 class Newspack_Blocks {
 
 	/**
+	 * Add hooks and filters.
+	 */
+	public static function init() {
+		add_action( 'after_setup_theme', [ __CLASS__, 'add_image_sizes' ] );
+	}
+
+	/**
 	 * Gather dependencies and paths needed for script enqueuing.
 	 *
 	 * @param string $script_path Path to the script relative to plugin root.
@@ -393,3 +400,4 @@ class Newspack_Blocks {
 		);
 	}
 }
+Newspack_Blocks::init();

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -267,6 +267,8 @@ class Newspack_Blocks {
 				return 'newspack-article-block-' . $orientation . '-' . $key;
 			}
 		}
+
+		return 'large';
 	}
 
 	/**

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -31,8 +31,6 @@ function newspack_articles_block_register_rest_routes() {
 }
 add_action( 'rest_api_init', 'newspack_articles_block_register_rest_routes' );
 
-add_action( 'after_setup_theme', array( 'Newspack_Blocks', 'add_image_sizes' ) );
-
 Newspack_Blocks::manage_view_scripts();
 add_action( 'enqueue_block_editor_assets', array( 'Newspack_Blocks', 'enqueue_block_editor_assets' ) );
 add_action( 'wp_enqueue_scripts', array( 'Newspack_Blocks', 'enqueue_block_styles_assets' ) );

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -18,7 +18,7 @@ call_user_func(
 			$styles = 'min-height: ' . $attributes['minHeight'] . 'vh; padding-top: ' . ( $attributes['minHeight'] / 5 ) . 'vh;';
 		}
 		$image_size = 'newspack-article-block-uncropped';
-		if ( 'uncropped' !== $attributes['imageShape'] ) {
+		if ( has_post_thumbnail() && 'uncropped' !== $attributes['imageShape'] ) {
 			$image_size = Newspack_Blocks::image_size_for_orientation( $attributes['imageShape'] );
 		}
 		$thumbnail_args = '';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #281. More info in my comment there.

This PR makes 3 small changes to fix image handling issues I noticed:
- https://github.com/Automattic/newspack-blocks/commit/2e8b905ec15c3ded35f7c82b5a8f1f4ac80c606f just saves a bunch of work looping through every possible thumbnail size on posts that don't have images.
- https://github.com/Automattic/newspack-blocks/commit/38b67ba46892184c1250c4ba282a62821388b61c fixes an issue where if an image doesn't match any Newspack thumbnails there is weird behavior around the class names output on the image. `large` seems like a reasonable fallback size.
- https://github.com/Automattic/newspack-blocks/commit/1e69dba87732600f3b84780645faf14a35e19868 moves things around so the image sizes will get registered in the FSE plugin.

### How to test the changes in this Pull Request:

There are definitely easier ways of testing this, but here's how I did it in a completely self-contained way free from any Newspack stuff that may influence the testing results:

1. Spin up a new Jurassic Ninja site. [Install the FSE plugin](https://wordpress.org/plugins/full-site-editing/).
2. Create a new post. Upload a featured image for the post.
3. On a page, add the Blog Posts block and give it the square or portrait crop. Observe the image cropping does not happen on the frontend. If you examine the image with the DOM inspector, you should see that it has class names like `size-` (with nothing after the dash).
4. Using Plugins > Plugin Editor, replace the contents of `full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/class-newspack-blocks.php` with [the updated version](https://raw.githubusercontent.com/Automattic/newspack-blocks/1e69dba87732600f3b84780645faf14a35e19868/class-newspack-blocks.php) from this PR. (Just do a complete copy of the new file contents and paste over the complete old file)
5. On the frontend, observe the previously uploaded featured image has a class name like `size-large` in the Blog Posts block. If you regenerate thumbnails or upload a new featured image it should have a class name like `size-newspack-article-block-square-large`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
