### PR TITLE
Columns styles: Make sure nested columns don't inherit border styles

### DIFF
--- a/src/block-styles/core/columns/editor.scss
+++ b/src/block-styles/core/columns/editor.scss
@@ -22,7 +22,7 @@
 	}
 
 	&.is-style-borders {
-		[data-type="core/column"] {
+		& > .editor-inner-blocks > .editor-block-list__layout > [data-type="core/column"] {
 			border-bottom: 1px solid $color__border;
 			position: relative;
 

--- a/src/block-styles/core/columns/view.scss
+++ b/src/block-styles/core/columns/view.scss
@@ -39,7 +39,7 @@
 			max-width: calc(100% + 48px);
 			width: calc(100% + 48px);
 
-			.wp-block-column {
+			& > .wp-block-column {
 				margin-left: 24px;
 				margin-right: 24px;
 			}
@@ -52,7 +52,7 @@
 			max-width: calc(100% + 64px);
 			width: calc(100% + 64px);
 
-			.wp-block-column {
+			& > .wp-block-column {
 				margin-left: 32px;
 				margin-right: 32px;
 			}
@@ -60,7 +60,7 @@
 	}
 
 	&.is-style-borders {
-		.wp-block-column {
+		& > .wp-block-column {
 			position: relative;
 			margin-bottom: 64px;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**Note:** there will be a complementary theme PR to make sure this update doesn't break the border styles in style packs 3 and 5. This one should not be merged until that one is also ready to merge.

Edited to add: this is the related theme PR: https://github.com/Automattic/newspack-theme/pull/632

When you create a column block, give it the border styles, and nest a second column block inside of it, that second block incorrectly inherits those styles. This PR fixes that.

Closes #228.

### How to test the changes in this Pull Request:

1. On a page, add a column block and apply the border styles. Inside one of the cells, nest a second column block.
2. For testing regressions, also add a second column block with the border styles, but that's not nested.
3. Use any style pack but 3 and 5 (since they have different border styles, which this PR breaks).
4. Note in the first blocks that the nested columns block is also inheriting the border styles on the front-end and in the editor:

![image](https://user-images.githubusercontent.com/177561/70756915-b7d3dd00-1cf2-11ea-8256-fab34788ad15.png)

5. Apply the PR and run `npm run build`. 
6. Confirm that the nested columns block is no longer inheriting the styles:

![image](https://user-images.githubusercontent.com/177561/70756982-e2be3100-1cf2-11ea-9a60-321a25431d21.png)

7. Shrink down the browser window to make sure the borders under each column display where expected:

![image](https://user-images.githubusercontent.com/177561/70757372-2bc2b500-1cf4-11ea-84cd-53b4fc107a09.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
