### PR TITLE
Resolve React Errors

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -169,6 +169,8 @@ class Newspack_Blocks_API {
 					'display_name' => esc_html( $author->display_name ),
 					/* Get the author avatar */
 					'avatar'       => wp_kses_post( $author_avatar ),
+					/* Get the author ID */
+					'id'           => $author->ID,
 				);
 			}
 		else :
@@ -177,6 +179,8 @@ class Newspack_Blocks_API {
 				'display_name' => get_the_author_meta( 'display_name', $object['author'] ),
 				/* Get the author avatar */
 				'avatar'       => get_avatar( $object['author'], 48 ),
+				/* Get the author ID */
+				'id'           => $author->ID,
 			);
 		endif;
 

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -187,9 +187,9 @@ class Edit extends Component {
 
 	formatAvatars = authorInfo =>
 		authorInfo.map( author => (
-			<span className="avatar author-avatar">
+			<span className="avatar author-avatar" key={ author.id }>
 				<a className="url fn n" href="#">
-					<RawHTML key={ author.id }>{ author.avatar }</RawHTML>
+					<RawHTML>{ author.avatar }</RawHTML>
 				</a>
 			</span>
 		) );

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -15,7 +15,13 @@ import moment from 'moment';
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment, RawHTML } from '@wordpress/element';
-import { InspectorControls, RichText, BlockControls } from '@wordpress/editor';
+import {
+	BlockControls,
+	InspectorControls,
+	PanelColorSettings,
+	RichText,
+	withColors,
+} from '@wordpress/block-editor';
 import {
 	Button,
 	ButtonGroup,
@@ -35,7 +41,6 @@ import { withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { addQueryArgs } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
-import { PanelColorSettings, withColors } from '@wordpress/block-editor';
 
 /**
  * Module Constants

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -360,6 +360,7 @@ class Edit extends Component {
 													isPrimary={ isCurrent }
 													aria-pressed={ isCurrent }
 													aria-label={ option.label }
+													key={ option.value }
 													onClick={ () => setAttributes( { imageScale: option.value } ) }
 												>
 													{ option.shortName }

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -157,6 +157,7 @@ class QueryControls extends Component {
 		return [
 			enableSpecific && (
 				<ToggleControl
+					key='specificMode'
 					checked={ specificMode }
 					onChange={ onSpecificModeChange }
 					label={ __( 'Choose specific stories', 'newspack-blocks' ) }
@@ -164,6 +165,7 @@ class QueryControls extends Component {
 			),
 			specificMode && (
 				<AutocompleteTokenField
+					key='posts'
 					tokens={ specificPosts || [] }
 					onChange={ onSpecificPostsChange }
 					fetchSuggestions={ this.fetchPostSuggestions }
@@ -171,9 +173,10 @@ class QueryControls extends Component {
 					label={ __( 'Posts', 'newspack-blocks' ) }
 				/>
 			),
-			! specificMode && <BaseControl { ...this.props } />,
+			! specificMode && <BaseControl key='queryControls' { ...this.props } />,
 			! specificMode && onAuthorsChange && (
 				<AutocompleteTokenField
+					key='authors'
 					tokens={ authors || [] }
 					onChange={ onAuthorsChange }
 					fetchSuggestions={ this.fetchAuthorSuggestions }
@@ -183,6 +186,7 @@ class QueryControls extends Component {
 			),
 			! specificMode && onCategoriesChange && (
 				<AutocompleteTokenField
+					key='categories'
 					tokens={ categories || [] }
 					onChange={ onCategoriesChange }
 					fetchSuggestions={ this.fetchCategorySuggestions }
@@ -192,6 +196,7 @@ class QueryControls extends Component {
 			),
 			! specificMode && onTagsChange && (
 				<AutocompleteTokenField
+					key='tags'
 					tokens={ tags || [] }
 					onChange={ onTagsChange }
 					fetchSuggestions={ this.fetchTagSuggestions }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR cleans up a few React errors and warnings that have been in the codebase for awhile. These include missing `key` attributes and the use of deprecated `@wordpress/editor`. The console won't be completely clean as there are a number of other warnings and errors that aren't related to the block. 

### How to test the changes in this Pull Request:

1. Checkout `master`, build the block `npm start`. 
2. Add a few blocks to a Page or Post and interact with them.
3. In the developer console observe numerous instances of:

```
Warning: Each child in a list should have a unique "key" prop
```

and

```
wp.editor.RichText.isEmpty is deprecated. Please use wp.blockEditor.RichText.isEmpty instead.
```
4. Check out `fix/react-errors`, rebuild, and reload the page in the editor.
5. Observe these errors are gone. As noted above there may be other errors unrelated to this block such as `Warning: Legacy context API has been detected within a strict-mode tree:`, `Warning: componentWillReceiveProps has been renamed, and is not recommended for use.`, `Warning: Unknown event handler property `onButtonClick`. It will be ignored.`, and ``wp.data.select( 'core/editor' ).getSelectedBlock` is deprecated. Please use `wp.data.select( 'core/block-editor' ).getSelectedBlock` instead. `
6. Verify all other block functionality is intact and unchanged.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
