### PR TITLE
Clean Up For 289

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -30,7 +30,6 @@ import {
 	RangeControl,
 	Toolbar,
 	ToggleControl,
-	Dashicon,
 	Placeholder,
 	Spinner,
 	BaseControl,
@@ -39,7 +38,6 @@ import {
 } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { addQueryArgs } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
 
 let IS_SUBTITLE_SUPPORTED_IN_THEME
@@ -119,7 +117,6 @@ class Edit extends Component {
 				minHeight / 5 + 'vh',
 		};
 
-		const authorNumber = post.newspack_author_info.length;
 		const postTitle = this.titleForPost( post );
 		return (
 			<article
@@ -234,14 +231,7 @@ class Edit extends Component {
 	);
 
 	renderInspectorControls = () => {
-		const {
-			attributes,
-			setAttributes,
-			latestPosts,
-			isSelected,
-			textColor,
-			setTextColor,
-		} = this.props;
+		const { attributes, setAttributes, latestPosts, textColor, setTextColor } = this.props;
 		const hasPosts = Array.isArray( latestPosts ) && latestPosts.length;
 
 		const {
@@ -249,7 +239,6 @@ class Edit extends Component {
 			specificPosts,
 			postsToShow,
 			categories,
-			sectionHeader,
 			columns,
 			showImage,
 			showCaption,
@@ -257,7 +246,6 @@ class Edit extends Component {
 			mobileStack,
 			minHeight,
 			moreButton,
-			moreButtonText,
 			showExcerpt,
 			showSubtitle,
 			typeScale,
@@ -270,7 +258,6 @@ class Edit extends Component {
 			specificMode,
 			tags,
 			tagExclusions,
-			url,
 		} = attributes;
 
 		const imageSizeOptions = [
@@ -495,24 +482,17 @@ class Edit extends Component {
 			setAttributes,
 			isSelected,
 			latestPosts,
-			hasPosts,
 			textColor,
 		} = this.props; // variables getting pulled out of props
 		const {
-			showExcerpt,
 			showSubtitle,
-			showDate,
 			showImage,
 			imageShape,
-			showAuthor,
-			showAvatar,
-			postsToShow,
 			postLayout,
 			mediaPosition,
 			moreButton,
 			moreButtonText,
 			columns,
-			categories,
 			typeScale,
 			imageScale,
 			mobileStack,

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -654,7 +654,7 @@ export default compose( [
 			specificPosts,
 			specificMode,
 		} = props.attributes;
-		const { getAuthors, getEntityRecords } = select( 'core' );
+		const { getEntityRecords } = select( 'core' );
 		const latestPostsQuery = pickBy(
 			specificMode && specificPosts && specificPosts.length
 				? {
@@ -670,9 +670,6 @@ export default compose( [
 				  },
 			value => ! isUndefined( value )
 		);
-		const postsListQuery = {
-			per_page: 50,
-		};
 		return {
 			latestPosts: getEntityRecords( 'postType', 'post', latestPostsQuery ),
 		};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In addition to the deduplication work, https://github.com/Automattic/newspack-blocks/pull/289 removes a few unused imports and variables that have been out of use for some time. To simplify 289 a bit I've  moved all the clean-up to  this PR.

### How to test the changes in this Pull Request:

Try the block, make sure everything works as before, with no breakage.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
