### PR TITLE
Improve Articles block selector scope (+add button margin)

### DIFF
--- a/src/blocks/homepage-articles/view.js
+++ b/src/blocks/homepage-articles/view.js
@@ -217,18 +217,25 @@ function isPostsDataValid( data ) {
 
 /**
  * Get DOM elements from the Homepage Articles block scope. Returns elements
- * from all blocks if parentBlock is not specified.
+ * from all HA blocks if parentBlock is not specified.
  *
  * @param {string} childSelector Selector of block's child element
  * @param {Element} [parentBlock] Parent block of queried child element
  * @returns {Element|Element[]} Element(s) from the block scope
  */
 function getBlockEl( childSelector, parentBlock ) {
+	const { blockSelector } = config;
+
 	if ( parentBlock ) {
-		return parentBlock.querySelector( childSelector );
+		// Check if it's a valid Homepage Articles block
+		if ( parentBlock.hasAttribute( blockSelector.replace( /\[|\]/g, '' ) ) ) {
+			return parentBlock.querySelector( childSelector );
+		}
+
+		return null;
 	}
 
-	return document.querySelectorAll( config.blockSelector + ' ' + childSelector );
+	return document.querySelectorAll( blockSelector + ' ' + childSelector );
 }
 
 /**

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -77,8 +77,8 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	ob_start();
 
 	if ( $article_query->have_posts() ) : ?>
-		<div  class="<?php echo esc_attr( $classes ); ?>" style="<?php echo esc_attr( $styles ); ?>">
-			<div data-posts-container>
+		<div class="<?php echo esc_attr( $classes ); ?>" style="<?php echo esc_attr( $styles ); ?>" data-wp-block-newspack-blocks-homepage-articles>
+			<div data-posts>
 				<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
 					<h2 class="article-section-title">
 						<span><?php echo wp_kses_post( $attributes['sectionHeader'] ); ?></span>
@@ -118,7 +118,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 			if ( ! Newspack_Blocks::is_amp() && $has_more_pages && boolval( $attributes['moreButton'] ) ) :
 				?>
-				<button type="button" data-load-more-btn data-load-more-url="<?php echo esc_url( $articles_rest_url ); ?>">
+				<button type="button" data-next="<?php echo esc_url( $articles_rest_url ); ?>">
 				<?php
 				if ( ! empty( $attributes['moreButtonText'] ) ) {
 					echo esc_html( $attributes['moreButtonText'] );
@@ -127,10 +127,10 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				}
 				?>
 				</button>
-				<p data-load-more-loading-text hidden>
+				<p data-loading hidden>
 					<?php _e( 'Loading...', 'newspack-blocks' ); ?>
 				</p>
-				<p data-load-more-error-text hidden>
+				<p data-error hidden>
 					<?php _e( 'Something went wrong. Please refresh the page and/or try again.', 'newspack-blocks' ); ?>
 				</p>
 			<?php endif; ?>

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -15,6 +15,10 @@
 		}
 	}
 
+	button {
+		margin-top: 1em;
+	}
+
 	/* Section header */
 	.article-section-title {
 		font-size: $font__size-sm;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

- Following up [this comment](https://github.com/Automattic/newspack-blocks/pull/263#discussion_r357091226), improved block's selector scope by adding a unique selector for the block (parent) element. This is needed to be sure the global selectors we use don't accidentally catch other elements on the page.
- Added some margin to button element to improve default visuals a bit.

   Before (`Twenty Twenty`):
   
   <img width="325" alt="Screenshot 2019-12-16 13 23 13" src="https://user-images.githubusercontent.com/1451471/70906684-3d170480-2007-11ea-97f0-8f0aed6e8426.png">

   After:
   
   <img width="317" alt="Screenshot 2019-12-16 13 18 01" src="https://user-images.githubusercontent.com/1451471/70906555-edd0d400-2006-11ea-93a0-96eaeedf8566.png">

### How to test the changes in this Pull Request:

Apart from the `top-margin` added to the `Load More Posts` button, there should not be any other noticeable changes. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?