### PR TITLE
Load More Script Improvements

### DIFF
--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -42,7 +42,7 @@ call_user_func(
 			}
 		}
 		?>
-	<article data-homepage-articles-post-id="<?php the_id(); ?>"
+	<article data-post-id="<?php the_id(); ?>"
 		<?php if ( has_post_thumbnail() ) : ?>
 		class="post-has-image"
 		<?php endif; ?>

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -42,7 +42,7 @@ call_user_func(
 			}
 		}
 		?>
-	<article data-post-id="<?php the_id(); ?>"
+	<article data-homepage-articles-post-id="<?php the_id(); ?>"
 		<?php if ( has_post_thumbnail() ) : ?>
 		class="post-has-image"
 		<?php endif; ?>

--- a/src/blocks/homepage-articles/view.js
+++ b/src/blocks/homepage-articles/view.js
@@ -15,7 +15,7 @@ const fetchRetryCount = 3;
  * Load More Button Handling
  */
 
-document.querySelectorAll( '.wp-block-newspack-blocks-homepage-articles.has-load-more-button' ).forEach( attachLoadMoreHandler );
+document.querySelectorAll( '.wp-block-newspack-blocks-homepage-articles[data-has-load-more-button]' ).forEach( attachLoadMoreHandler );
 
 /**
  * Attaches an event handler to the Load more button.

--- a/src/blocks/homepage-articles/view.js
+++ b/src/blocks/homepage-articles/view.js
@@ -15,20 +15,20 @@ const fetchRetryCount = 3;
  * Load More Button Handling
  */
 
-document.querySelectorAll( '[data-load-more-btn]' ).forEach( attachLoadMoreHandler );
+document.querySelectorAll( '.wp-block-newspack-blocks-homepage-articles.has-load-more-button' ).forEach( attachLoadMoreHandler );
 
 /**
  * Attaches an event handler to the Load more button.
  * @param {DOMElement} btnEl the button that was clicked
  */
-function attachLoadMoreHandler( btnEl ) {
-	if ( ! btnEl ) {
+function attachLoadMoreHandler( blockEl ) {
+
+	if ( ! blockEl ) {
 		return null;
 	}
 
-	const handler = buildLoadMoreHandler( btnEl );
+	buildLoadMoreHandler( blockEl );
 
-	btnEl.addEventListener( 'click', handler );
 }
 
 /**
@@ -38,9 +38,11 @@ function attachLoadMoreHandler( btnEl ) {
  *
  * @param {DOMElement} btnEl the button that was clicked
  */
-function buildLoadMoreHandler( btnEl ) {
-	// Set elements from scope determined by the clicked "Load more" button.
-	const blockWrapperEl = btnEl.parentElement; // scope root element
+function buildLoadMoreHandler( blockWrapperEl ) {
+	const btnEl = blockWrapperEl.querySelector( 'button[data-load-more-btn]' );
+	if ( ! btnEl ) {
+		return;
+	}
 	const postsContainerEl = blockWrapperEl.querySelector( '[data-posts-container]' );
 	const loadingEl = blockWrapperEl.querySelector( '[data-load-more-loading-text]' );
 	const errorEl = blockWrapperEl.querySelector( '[data-load-more-error-text]' );
@@ -49,7 +51,7 @@ function buildLoadMoreHandler( btnEl ) {
 	let isFetching = false;
 	let isEndOfData = false;
 
-	return () => {
+	btnEl.addEventListener( 'click', () => {
 		// Early return if still fetching or no more posts to render.
 		if ( isFetching || isEndOfData ) {
 			return false;
@@ -106,7 +108,7 @@ function buildLoadMoreHandler( btnEl ) {
 			showEl( errorEl );
 			showEl( btnEl );
 		}
-	};
+	} );
 }
 
 /**

--- a/src/blocks/homepage-articles/view.js
+++ b/src/blocks/homepage-articles/view.js
@@ -27,7 +27,9 @@ document
  */
 function buildLoadMoreHandler( blockWrapperEl ) {
 	const btnEl = blockWrapperEl.querySelector( '[data-next]' );
-	if ( ! btnEl ) return;
+	if ( ! btnEl ) {
+		return;
+	}
 	const postsContainerEl = blockWrapperEl.querySelector( '[data-posts]' );
 
 	// Set initial state flags.

--- a/src/blocks/homepage-articles/view.js
+++ b/src/blocks/homepage-articles/view.js
@@ -15,21 +15,7 @@ const fetchRetryCount = 3;
  * Load More Button Handling
  */
 
-document.querySelectorAll( '.wp-block-newspack-blocks-homepage-articles[data-has-load-more-button]' ).forEach( attachLoadMoreHandler );
-
-/**
- * Attaches an event handler to the Load more button.
- * @param {DOMElement} btnEl the button that was clicked
- */
-function attachLoadMoreHandler( blockEl ) {
-
-	if ( ! blockEl ) {
-		return null;
-	}
-
-	buildLoadMoreHandler( blockEl );
-
-}
+document.querySelectorAll( '.wp-block-newspack-blocks-homepage-articles[data-has-load-more-button]' ).forEach( buildLoadMoreHandler );
 
 /**
  * Builds a function to handle clicks on the load more button.

--- a/src/blocks/homepage-articles/view.js
+++ b/src/blocks/homepage-articles/view.js
@@ -44,8 +44,6 @@ function buildLoadMoreHandler( blockWrapperEl ) {
 		return;
 	}
 	const postsContainerEl = blockWrapperEl.querySelector( '[data-posts-container]' );
-	const loadingEl = blockWrapperEl.querySelector( '[data-load-more-loading-text]' );
-	const errorEl = blockWrapperEl.querySelector( '[data-load-more-error-text]' );
 
 	// Set initial state flags.
 	let isFetching = false;
@@ -59,10 +57,8 @@ function buildLoadMoreHandler( blockWrapperEl ) {
 
 		isFetching = true;
 
-		// Set elements visibility for fetching state.
-		hideEl( btnEl );
-		hideEl( errorEl );
-		showEl( loadingEl );
+		blockWrapperEl.classList.remove( 'is-error' );
+		blockWrapperEl.classList.add( 'is-loading' );
 
 		const requestURL = new URL( btnEl.getAttribute( btnURLAttr ) );
 
@@ -86,27 +82,23 @@ function buildLoadMoreHandler( blockWrapperEl ) {
 			if ( data.next ) {
 				// Save next URL as button's attribute.
 				btnEl.setAttribute( btnURLAttr, data.next );
-
-				// Unhide button since there are more posts available.
-				showEl( btnEl );
 			}
 
 			if ( ! data.items.length || ! data.next ) {
 				isEndOfData = true;
+				blockWrapperEl.classList.add( 'is-end-of-data' );
 			}
 
 			isFetching = false;
 
-			hideEl( loadingEl );
+			blockWrapperEl.classList.remove( 'is-loading' );
 		}
 
 		function onError() {
 			isFetching = false;
 
-			// Display error message and keep the button visible to enable retrying.
-			hideEl( loadingEl );
-			showEl( errorEl );
-			showEl( btnEl );
+			blockWrapperEl.classList.remove( 'is-loading' );
+			blockWrapperEl.classList.add( 'is-error' );
 		}
 	} );
 }
@@ -205,26 +197,6 @@ function isPostsDataValid( data ) {
 	}
 
 	return isValid;
-}
-
-/**
- * Hides given DOM element.
- *
- * @param {DOMElement} el
- */
-function hideEl( el ) {
-	el.style.display = 'none';
-	el.setAttribute( 'hidden', '' );
-}
-
-/**
- * Unhides given DOM element.
- *
- * @param {DOMElement} el
- */
-function showEl( el ) {
-	el.style.display = '';
-	el.removeAttribute( 'hidden' );
 }
 
 /**

--- a/src/blocks/homepage-articles/view.js
+++ b/src/blocks/homepage-articles/view.js
@@ -15,7 +15,9 @@ const fetchRetryCount = 3;
  * Load More Button Handling
  */
 
-document.querySelectorAll( '.wp-block-newspack-blocks-homepage-articles[data-has-load-more-button]' ).forEach( buildLoadMoreHandler );
+document
+	.querySelectorAll( '.wp-block-newspack-blocks-homepage-articles.has-more-button' )
+	.forEach( buildLoadMoreHandler );
 
 /**
  * Builds a function to handle clicks on the load more button.
@@ -94,7 +96,9 @@ function buildLoadMoreHandler( blockWrapperEl ) {
  */
 function getRenderedPostsIds() {
 	const postEls = document.querySelectorAll( 'article[data-homepage-articles-post-id]' );
-	const postIds = Array.from( postEls ).map( el => el.getAttribute( 'data-homepage-articles-post-id' ) );
+	const postIds = Array.from( postEls ).map( el =>
+		el.getAttribute( 'data-homepage-articles-post-id' )
+	);
 
 	return [ ...new Set( postIds ) ]; // Make values unique with Set
 }

--- a/src/blocks/homepage-articles/view.js
+++ b/src/blocks/homepage-articles/view.js
@@ -8,7 +8,6 @@
  */
 import './view.scss';
 
-const btnURLAttr = 'data-load-more-url';
 const fetchRetryCount = 3;
 
 /**
@@ -27,11 +26,9 @@ document
  * @param {DOMElement} btnEl the button that was clicked
  */
 function buildLoadMoreHandler( blockWrapperEl ) {
-	const btnEl = blockWrapperEl.querySelector( 'button[data-load-more-btn]' );
-	if ( ! btnEl ) {
-		return;
-	}
-	const postsContainerEl = blockWrapperEl.querySelector( '[data-posts-container]' );
+	const btnEl = blockWrapperEl.querySelector( '[data-next]' );
+	if ( ! btnEl ) return;
+	const postsContainerEl = blockWrapperEl.querySelector( '[data-posts]' );
 
 	// Set initial state flags.
 	let isFetching = false;
@@ -48,7 +45,7 @@ function buildLoadMoreHandler( blockWrapperEl ) {
 		blockWrapperEl.classList.remove( 'is-error' );
 		blockWrapperEl.classList.add( 'is-loading' );
 
-		const requestURL = new URL( btnEl.getAttribute( btnURLAttr ) );
+		const requestURL = new URL( btnEl.getAttribute( 'data-next' ) );
 
 		// Set currenty rendered posts' IDs as a query param (e.g. exclude_ids=1,2,3)
 		requestURL.searchParams.set( 'exclude_ids', getRenderedPostsIds().join( ',' ) );
@@ -69,12 +66,12 @@ function buildLoadMoreHandler( blockWrapperEl ) {
 
 			if ( data.next ) {
 				// Save next URL as button's attribute.
-				btnEl.setAttribute( btnURLAttr, data.next );
+				btnEl.setAttribute( 'data-next', data.next );
 			}
 
 			if ( ! data.items.length || ! data.next ) {
 				isEndOfData = true;
-				blockWrapperEl.classList.add( 'is-end-of-data' );
+				blockWrapperEl.classList.remove( 'has-more-button' );
 			}
 
 			isFetching = false;
@@ -95,10 +92,10 @@ function buildLoadMoreHandler( blockWrapperEl ) {
  * Returns unique IDs for posts that are currently in the DOM.
  */
 function getRenderedPostsIds() {
-	const postEls = document.querySelectorAll( 'article[data-homepage-articles-post-id]' );
-	const postIds = Array.from( postEls ).map( el =>
-		el.getAttribute( 'data-homepage-articles-post-id' )
+	const postEls = document.querySelectorAll(
+		'.wp-block-newspack-blocks-homepage-articles [data-post-id]'
 	);
+	const postIds = Array.from( postEls ).map( el => el.getAttribute( 'data-post-id' ) );
 
 	return [ ...new Set( postIds ) ]; // Make values unique with Set
 }

--- a/src/blocks/homepage-articles/view.js
+++ b/src/blocks/homepage-articles/view.js
@@ -107,8 +107,8 @@ function buildLoadMoreHandler( blockWrapperEl ) {
  * Returns unique IDs for posts that are currently in the DOM.
  */
 function getRenderedPostsIds() {
-	const postEls = document.querySelectorAll( 'article[data-post-id]' );
-	const postIds = Array.from( postEls ).map( el => el.getAttribute( 'data-post-id' ) );
+	const postEls = document.querySelectorAll( 'article[data-homepage-articles-post-id]' );
+	const postIds = Array.from( postEls ).map( el => el.getAttribute( 'data-homepage-articles-post-id' ) );
 
 	return [ ...new Set( postIds ) ]; // Make values unique with Set
 }

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -87,7 +87,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 			class="<?php echo esc_attr( $classes ); ?><?php echo( $has_more_button ? 'has-more-button' : '' ) ?>"
 			style="<?php echo esc_attr( $styles ); ?>"
 			>
-			<div data-posts-container>
+			<div data-posts>
 				<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
 					<h2 class="article-section-title">
 						<span><?php echo wp_kses_post( $attributes['sectionHeader'] ); ?></span>
@@ -124,7 +124,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 			if ( $has_more_button ) :
 				?>
-				<button type="button" data-load-more-btn data-load-more-url="<?php echo esc_url( $articles_rest_url ); ?>">
+				<button type="button" data-next="<?php echo esc_url( $articles_rest_url ); ?>">
 				<?php
 				if ( ! empty( $attributes['moreButtonText'] ) ) {
 					echo esc_html( $attributes['moreButtonText'] );
@@ -133,10 +133,10 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				}
 				?>
 				</button>
-				<p data-load-more-loading-text>
+				<p class="loading">
 					<?php _e( 'Loading...', 'newspack-blocks' ); ?>
 				</p>
-				<p data-load-more-error-text>
+				<p class="error">
 					<?php _e( 'Something went wrong. Please refresh the page and/or try again.', 'newspack-blocks' ); ?>
 				</p>
 			<?php endif; ?>

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -80,11 +80,15 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 	$has_more_button = ! Newspack_Blocks::is_amp() && $has_more_pages && boolval( $attributes['moreButton'] );
 
+	if ( $has_more_button ) {
+		$classes .= ' has-more-button';
+	}
+
 	ob_start();
 
 	if ( $article_query->have_posts() ) : ?>
 		<div
-			class="<?php echo esc_attr( $classes ); ?><?php echo( $has_more_button ? 'has-more-button' : '' ) ?>"
+			class="<?php echo esc_attr( $classes ); ?>"
 			style="<?php echo esc_attr( $styles ); ?>"
 			>
 			<div data-posts>

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -80,14 +80,16 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 	$has_load_more_button = ! Newspack_Blocks::is_amp() && $has_more_pages && boolval( $attributes['moreButton'] );
 
-	if ( $has_load_more_button ) {
-		$classes .= ' has-load-more-button';
-	}
-
 	ob_start();
 
 	if ( $article_query->have_posts() ) : ?>
-		<div  class="<?php echo esc_attr( $classes ); ?>" style="<?php echo esc_attr( $styles ); ?>">
+		<div
+			class="<?php echo esc_attr( $classes ); ?>"
+			style="<?php echo esc_attr( $styles ); ?>"
+			<?php if ( $has_load_more_button ) : ?>
+				data-has-load-more-button
+			<?php endif; ?>
+			>
 			<div data-posts-container>
 				<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
 					<h2 class="article-section-title">
@@ -134,10 +136,10 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				}
 				?>
 				</button>
-				<p data-load-more-loading-text class='homepage-articles-load-more-loading'>
+				<p data-load-more-loading-text>
 					<?php _e( 'Loading...', 'newspack-blocks' ); ?>
 				</p>
-				<p data-load-more-error-text class='homepage-articles-load-more-error'>
+				<p data-load-more-error-text>
 					<?php _e( 'Something went wrong. Please refresh the page and/or try again.', 'newspack-blocks' ); ?>
 				</p>
 			<?php endif; ?>

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -134,10 +134,10 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				}
 				?>
 				</button>
-				<p data-load-more-loading-text hidden>
+				<p data-load-more-loading-text class='homepage-articles-load-more-loading'>
 					<?php _e( 'Loading...', 'newspack-blocks' ); ?>
 				</p>
-				<p data-load-more-error-text hidden>
+				<p data-load-more-error-text class='homepage-articles-load-more-error'>
 					<?php _e( 'Something went wrong. Please refresh the page and/or try again.', 'newspack-blocks' ); ?>
 				</p>
 			<?php endif; ?>

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -78,17 +78,14 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 	$has_more_pages = ( ++$page ) <= $article_query->max_num_pages;
 
-	$has_load_more_button = ! Newspack_Blocks::is_amp() && $has_more_pages && boolval( $attributes['moreButton'] );
+	$has_more_button = ! Newspack_Blocks::is_amp() && $has_more_pages && boolval( $attributes['moreButton'] );
 
 	ob_start();
 
 	if ( $article_query->have_posts() ) : ?>
 		<div
-			class="<?php echo esc_attr( $classes ); ?>"
+			class="<?php echo esc_attr( $classes ); ?><?php echo( $has_more_button ? 'has-more-button' : '' ) ?>"
 			style="<?php echo esc_attr( $styles ); ?>"
-			<?php if ( $has_load_more_button ) : ?>
-				data-has-load-more-button
-			<?php endif; ?>
 			>
 			<div data-posts-container>
 				<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
@@ -125,7 +122,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 			 * @see https://wp.me/paYJgx-jW
 			 */
 
-			if ( $has_load_more_button ) :
+			if ( $has_more_button ) :
 				?>
 				<button type="button" data-load-more-btn data-load-more-url="<?php echo esc_url( $articles_rest_url ); ?>">
 				<?php

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -74,6 +74,16 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 		rest_url( '/newspack-blocks/v1/articles' )
 	);
 
+	$page = $article_query->paged ?? 1;
+
+	$has_more_pages = ( ++$page ) <= $article_query->max_num_pages;
+
+	$has_load_more_button = ! Newspack_Blocks::is_amp() && $has_more_pages && boolval( $attributes['moreButton'] );
+
+	if ( $has_load_more_button ) {
+		$classes .= ' has-load-more-button';
+	}
+
 	ob_start();
 
 	if ( $article_query->have_posts() ) : ?>
@@ -112,11 +122,8 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 			 * @see https://github.com/Automattic/newspack-blocks/pull/226#issuecomment-558695909
 			 * @see https://wp.me/paYJgx-jW
 			 */
-			$page = $article_query->paged ?? 1;
 
-			$has_more_pages = ( ++$page ) <= $article_query->max_num_pages;
-
-			if ( ! Newspack_Blocks::is_amp() && $has_more_pages && boolval( $attributes['moreButton'] ) ) :
+			if ( $has_load_more_button ) :
 				?>
 				<button type="button" data-load-more-btn data-load-more-url="<?php echo esc_url( $articles_rest_url ); ?>">
 				<?php

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -557,7 +557,7 @@
 		}
 	}
 
-	.homepage-articles-load-more-loading, .homepage-articles-load-more-error {
+	[data-load-more-loading-text], [data-load-more-error-text] {
 		display: none;
 	}
 
@@ -565,11 +565,11 @@
 		display: none;
 	}
 
-	&.is-loading .homepage-articles-load-more-loading {
+	&.is-loading [data-load-more-loading-text] {
 		display: block;
 	}
 
-	&.is-error .homepage-articles-load-more-error {
+	&.is-error [data-load-more-error-text] {
 		display: block;
 	}
 }

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -556,22 +556,6 @@
 			}
 		}
 	}
-
-	[data-load-more-loading-text], [data-load-more-error-text] {
-		display: none;
-	}
-
-	&.is-loading button, &.is-end-of-data button {
-		display: none;
-	}
-
-	&.is-loading [data-load-more-loading-text] {
-		display: block;
-	}
-
-	&.is-error [data-load-more-error-text] {
-		display: block;
-	}
 }
 
 /* Block styles */
@@ -625,5 +609,33 @@
 		margin-bottom: 0;
 		line-height: 1.4em;
 		font-style: italic;
+	}
+}
+
+/* "More" button & related elements styles */
+.wpnbha {
+	button, .loading, .error {
+		display: none;
+	}
+
+	&.has-more-button {
+		button {
+			display: block;
+		}
+	}
+
+	&.has-more-button.is-loading {
+		button {
+			display: none;
+		}
+		.loading {
+			display: block;
+		}
+	}
+
+	&.has-more-button.is-error {
+		button, .error {
+			display: block;
+		}
 	}
 }

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -618,6 +618,10 @@
 		display: none;
 	}
 
+	button {
+		margin-top: 1em;
+	}
+
 	&.has-more-button {
 		button {
 			display: block;

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -556,6 +556,22 @@
 			}
 		}
 	}
+
+	.homepage-articles-load-more-loading, .homepage-articles-load-more-error {
+		display: none;
+	}
+
+	&.is-loading button, &.is-end-of-data button {
+		display: none;
+	}
+
+	&.is-loading .homepage-articles-load-more-loading {
+		display: block;
+	}
+
+	&.is-error .homepage-articles-load-more-error {
+		display: block;
+	}
 }
 
 /* Block styles */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

- Following up [this comment](https://github.com/Automattic/newspack-blocks/pull/263#discussion_r357091226), improved block's selector scope by adding a unique selector for the block (parent) element. This is needed to be sure the global selectors we use don't accidentally catch other elements on the page.
- Added some margin to button element to improve default visuals a bit.

   Before (`Twenty Twenty`):
   
   <img width="325" alt="Screenshot 2019-12-16 13 23 13" src="https://user-images.githubusercontent.com/1451471/70906684-3d170480-2007-11ea-97f0-8f0aed6e8426.png">

   After:
   
   <img width="317" alt="Screenshot 2019-12-16 13 18 01" src="https://user-images.githubusercontent.com/1451471/70906555-edd0d400-2006-11ea-93a0-96eaeedf8566.png">

### How to test the changes in this Pull Request:

Apart from the `top-margin` added to the `Load More Posts` button, there should not be any other noticeable changes. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?