### PR TITLE
Handle Post Subtitle

### DIFF
--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -44,3 +44,20 @@ function newspack_blocks_plugin_textdomain() {
 	load_plugin_textdomain( 'newspack-blocks', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
 }
 add_action( 'plugins_loaded', 'newspack_blocks_plugin_textdomain' );
+
+
+/**
+ * Add global variable for theme supports detection.
+ *
+ * @action enqueue_block_editor_assets
+ */
+function newspack_blocks_post_subtitle_detection() {
+	wp_localize_script(
+		'newspack-blocks-editor',
+		'newspackIsPostSubtitleSupported',
+		array(
+			'post_subtitle' => get_theme_support( 'post-subtitle' ),
+		)
+	);
+}
+add_action( 'enqueue_block_editor_assets', 'newspack_blocks_post_subtitle_detection' );

--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -117,6 +117,10 @@
     "singleMode": {
       "type": "boolean",
       "default": false
+    },
+    "showSubtitle": {
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -410,16 +410,16 @@ class Edit extends Component {
 				<PanelBody title={ __( 'Post Control Settings', 'newspack-blocks' ) }>
 					<PanelRow>
 						<ToggleControl
-							label={ __( 'Show Excerpt', 'newspack-blocks' ) }
-							checked={ showExcerpt }
-							onChange={ () => setAttributes( { showExcerpt: ! showExcerpt } ) }
+							label={ __( 'Show Subtitle', 'newspack-blocks' ) }
+							checked={ showSubtitle }
+							onChange={ () => setAttributes( { showSubtitle: ! showSubtitle} ) }
 						/>
 					</PanelRow>
 					<PanelRow>
 						<ToggleControl
-							label={ __( 'Show Subtitle', 'newspack-blocks' ) }
-							checked={ showSubtitle }
-							onChange={ () => setAttributes( { showSubtitle: ! showSubtitle} ) }
+							label={ __( 'Show Excerpt', 'newspack-blocks' ) }
+							checked={ showExcerpt }
+							onChange={ () => setAttributes( { showExcerpt: ! showExcerpt } ) }
 						/>
 					</PanelRow>
 					<RangeControl

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -93,6 +93,7 @@ class Edit extends Component {
 			minHeight,
 			showCaption,
 			showExcerpt,
+			showSubtitle,
 			showAuthor,
 			showAvatar,
 			showDate,
@@ -156,6 +157,18 @@ class Edit extends Component {
 						<h3 className="entry-title" key="title">
 							<a href="#">{ postTitle }</a>
 						</h3>
+					) }
+					{ showSubtitle && (
+						<RawHTML
+							key="subtitle"
+							className={classNames(
+								'newspack-post-subtitle',
+								'newspack-post-subtitle--in-homepage-block',
+								RichText.isEmpty( sectionHeader ) && 'newspack-post-subtitle--small'
+							)}
+						>
+							{ post.meta.newspack_post_subtitle || '' }
+						</RawHTML>
 					) }
 					{ showExcerpt && (
 						<RawHTML key="excerpt" className="excerpt-contain">
@@ -245,6 +258,7 @@ class Edit extends Component {
 			moreButton,
 			moreButtonText,
 			showExcerpt,
+			showSubtitle,
 			typeScale,
 			showDate,
 			showAuthor,
@@ -401,6 +415,13 @@ class Edit extends Component {
 							onChange={ () => setAttributes( { showExcerpt: ! showExcerpt } ) }
 						/>
 					</PanelRow>
+					<PanelRow>
+						<ToggleControl
+							label={ __( 'Show Subtitle', 'newspack-blocks' ) }
+							checked={ showSubtitle }
+							onChange={ () => setAttributes( { showSubtitle: ! showSubtitle} ) }
+						/>
+					</PanelRow>
 					<RangeControl
 						className="type-scale-slider"
 						label={ __( 'Type Scale', 'newspack-blocks' ) }
@@ -475,6 +496,7 @@ class Edit extends Component {
 		} = this.props; // variables getting pulled out of props
 		const {
 			showExcerpt,
+			showSubtitle,
 			showDate,
 			showImage,
 			imageShape,

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -42,6 +42,11 @@ import { compose } from '@wordpress/compose';
 import { addQueryArgs } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
 
+let IS_SUBTITLE_SUPPORTED_IN_THEME
+if ( typeof window === 'object' && window.newspackIsPostSubtitleSupported && window.newspackIsPostSubtitleSupported.post_subtitle ) {
+	IS_SUBTITLE_SUPPORTED_IN_THEME = true
+}
+
 /**
  * Module Constants
  */
@@ -158,7 +163,7 @@ class Edit extends Component {
 							<a href="#">{ postTitle }</a>
 						</h3>
 					) }
-					{ showSubtitle && (
+					{ IS_SUBTITLE_SUPPORTED_IN_THEME && showSubtitle && (
 						<RawHTML
 							key="subtitle"
 							className={classNames(
@@ -408,13 +413,13 @@ class Edit extends Component {
 					) }
 				</PanelBody>
 				<PanelBody title={ __( 'Post Control Settings', 'newspack-blocks' ) }>
-					<PanelRow>
+					{IS_SUBTITLE_SUPPORTED_IN_THEME && <PanelRow>
 						<ToggleControl
 							label={ __( 'Show Subtitle', 'newspack-blocks' ) }
 							checked={ showSubtitle }
 							onChange={ () => setAttributes( { showSubtitle: ! showSubtitle} ) }
 						/>
-					</PanelRow>
+					</PanelRow>}
 					<PanelRow>
 						<ToggleControl
 							label={ __( 'Show Excerpt', 'newspack-blocks' ) }

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -166,11 +166,7 @@ class Edit extends Component {
 					{ IS_SUBTITLE_SUPPORTED_IN_THEME && showSubtitle && (
 						<RawHTML
 							key="subtitle"
-							className={classNames(
-								'newspack-post-subtitle',
-								'newspack-post-subtitle--in-homepage-block',
-								RichText.isEmpty( sectionHeader ) && 'newspack-post-subtitle--small'
-							)}
+							className="newspack-post-subtitle newspack-post-subtitle--in-homepage-block"
 						>
 							{ post.meta.newspack_post_subtitle || '' }
 						</RawHTML>

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -71,11 +71,18 @@ call_user_func(
 				</div>
 				<?php
 			endif;
-			if ( '' === $attributes['sectionHeader'] ) :
+
+			$is_section_header = '' === $attributes['sectionHeader'];
+			if ( $is_section_header ) :
 				the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
 			else :
 				the_title( '<h3 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h3>' );
 			endif;
+			?>
+			<div class="newspack-post-subtitle newspack-post-subtitle--in-homepage-block <?php echo $is_section_header ? 'newspack-post-subtitle--small' : '' ?>">
+				<?php echo get_post_meta(get_the_ID(), 'newspack_post_subtitle', true); ?>
+			</div>
+			<?php
 			if ( $attributes['showExcerpt'] ) :
 				the_excerpt();
 			endif;

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -79,9 +79,13 @@ call_user_func(
 				the_title( '<h3 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h3>' );
 			endif;
 			?>
-			<div class="newspack-post-subtitle newspack-post-subtitle--in-homepage-block <?php echo $is_section_header ? 'newspack-post-subtitle--small' : '' ?>">
-				<?php echo get_post_meta(get_the_ID(), 'newspack_post_subtitle', true); ?>
-			</div>
+			<?php
+			if ( $attributes['showSubtitle'] ) :
+				?>
+				<div class="newspack-post-subtitle newspack-post-subtitle--in-homepage-block <?php echo esc_html( $is_section_header ? 'newspack-post-subtitle--small' : '' ); ?>">
+					<?php echo esc_html( get_post_meta( get_the_ID(), 'newspack_post_subtitle', true ) ); ?>
+				</div>
+			<?php endif; ?>
 			<?php
 			if ( $attributes['showExcerpt'] ) :
 				the_excerpt();
@@ -95,7 +99,7 @@ call_user_func(
 							echo wp_kses(
 								newspack_blocks_format_avatars( $authors ),
 								array(
-									'img' => array(
+									'img'      => array(
 										'class'  => true,
 										'src'    => true,
 										'alt'    => true,
@@ -105,8 +109,8 @@ call_user_func(
 										'srcset' => true,
 									),
 									'noscript' => array(),
-									'a' => array(
-										'href'  => true,
+									'a'        => array(
+										'href' => true,
 									),
 								)
 							);

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -72,8 +72,7 @@ call_user_func(
 				<?php
 			endif;
 
-			$is_section_header = '' === $attributes['sectionHeader'];
-			if ( $is_section_header ) :
+			if ( '' === $attributes['sectionHeader'] ) :
 				the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
 			else :
 				the_title( '<h3 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h3>' );
@@ -82,7 +81,7 @@ call_user_func(
 			<?php
 			if ( $attributes['showSubtitle'] ) :
 				?>
-				<div class="newspack-post-subtitle newspack-post-subtitle--in-homepage-block <?php echo esc_html( $is_section_header ? 'newspack-post-subtitle--small' : '' ); ?>">
+				<div class="newspack-post-subtitle newspack-post-subtitle--in-homepage-block">
 					<?php echo esc_html( get_post_meta( get_the_ID(), 'newspack_post_subtitle', true ) ); ?>
 				</div>
 			<?php endif; ?>

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -342,15 +342,20 @@
 				width: 2.4em;
 			}
 		}
+	}
 
+	&.ts-10,
+	&.ts-9,
+	&.ts-8,
+	&.ts-7 {
+		.newspack-post-subtitle {
+			font-size: 1.4em;
+		}
 	}
 
 	&.ts-10 article {
 		.entry-title {
 			font-size: 2.6em;
-		}
-		.newspack-post-subtitle {
-			font-size: 2.3em;
 		}
 		@include media(tablet) {
 			.entry-title {
@@ -368,9 +373,6 @@
 		.entry-title {
 			font-size: 2.4em;
 		}
-		.newspack-post-subtitle {
-			font-size: 2.1em;
-		}
 		@include media(tablet) {
 			.entry-title {
 				font-size: 3.4em;
@@ -387,9 +389,6 @@
 		.entry-title {
 			font-size: 2.2em;
 		}
-		.newspack-post-subtitle {
-			font-size: 1.9em;
-		}
 		@include media(tablet) {
 			.entry-title {
 				font-size: 3.0em;
@@ -405,9 +404,6 @@
 	&.ts-7 article {
 		.entry-title {
 			font-size: 2em;
-		}
-		.newspack-post-subtitle {
-			font-size: 1.7em;
 		}
 		@include media( tablet) {
 			.entry-title {
@@ -477,9 +473,7 @@
 		.entry-title {
 			font-size: 1.0em;
 		}
-		.newspack-post-subtitle {
-			font-size: 0.8em;
-		}
+		.newspack-post-subtitle,
 		.entry-wrapper p {
 			font-size: 0.8em;
 		}
@@ -503,7 +497,7 @@
 			font-size: 0.8em;
 		}
 		.newspack-post-subtitle {
-			font-size: 0.6em;
+			font-size: 0.7em;
 		}
 		.entry-wrapper p,
 		.entry-meta {
@@ -528,7 +522,7 @@
 			font-size: 0.7em;
 		}
 		.newspack-post-subtitle {
-			font-size: 0.5em;
+			font-size: 0.7em;
 		}
 		.entry-meta {
 			font-size: 0.6em;
@@ -589,10 +583,9 @@
 /* Styles for the Subtitle, as part of the the Block */
 .newspack-post-subtitle {
 	&--in-homepage-block {
+		margin-top: 0.3em;
 		margin-bottom: 0;
+		line-height: 1.4em;
 		font-style: italic;
-	}
-	&--small {
-		font-size: 0.8em;
 	}
 }

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -349,6 +349,9 @@
 		.entry-title {
 			font-size: 2.6em;
 		}
+		.newspack-post-subtitle {
+			font-size: 2.3em;
+		}
 		@include media(tablet) {
 			.entry-title {
 				font-size: 3.6em;
@@ -364,6 +367,9 @@
 	&.ts-9 article {
 		.entry-title {
 			font-size: 2.4em;
+		}
+		.newspack-post-subtitle {
+			font-size: 2.1em;
 		}
 		@include media(tablet) {
 			.entry-title {
@@ -381,6 +387,9 @@
 		.entry-title {
 			font-size: 2.2em;
 		}
+		.newspack-post-subtitle {
+			font-size: 1.9em;
+		}
 		@include media(tablet) {
 			.entry-title {
 				font-size: 3.0em;
@@ -396,6 +405,9 @@
 	&.ts-7 article {
 		.entry-title {
 			font-size: 2em;
+		}
+		.newspack-post-subtitle {
+			font-size: 1.7em;
 		}
 		@include media( tablet) {
 			.entry-title {
@@ -417,6 +429,9 @@
 		.entry-title {
 			font-size: 1.7em;
 		}
+		.newspack-post-subtitle {
+			font-size: 1.4em;
+		}
 		@include media(tablet) {
 			.entry-title {
 				font-size: 2.0em;
@@ -436,6 +451,9 @@
 	&.ts-5 article {
 		.entry-title {
 			font-size: 1.4em;
+		}
+		.newspack-post-subtitle {
+			font-size: 1.2em;
 		}
 		@include media(tablet) {
 			.entry-title {
@@ -459,6 +477,9 @@
 		.entry-title {
 			font-size: 1.0em;
 		}
+		.newspack-post-subtitle {
+			font-size: 0.8em;
+		}
 		.entry-wrapper p {
 			font-size: 0.8em;
 		}
@@ -481,6 +502,9 @@
 		.entry-title {
 			font-size: 0.8em;
 		}
+		.newspack-post-subtitle {
+			font-size: 0.6em;
+		}
 		.entry-wrapper p,
 		.entry-meta {
 			font-size: 0.7em;
@@ -502,6 +526,9 @@
 		.entry-title,
 		.entry-wrapper p {
 			font-size: 0.7em;
+		}
+		.newspack-post-subtitle {
+			font-size: 0.5em;
 		}
 		.entry-meta {
 			font-size: 0.6em;

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -558,3 +558,14 @@
 		}
 	}
 }
+
+/* Styles for the Subtitle, as part of the the Block */
+.newspack-post-subtitle {
+	&--in-homepage-block {
+		margin-bottom: 0;
+		font-style: italic;
+	}
+	&--small {
+		font-size: 0.8em;
+	}
+}


### PR DESCRIPTION
This adds **post subtitle** (Automattic/newspack-theme#635) handling for Homepage Articles block. 

Post subtitle can now appear in the block:

![image](https://user-images.githubusercontent.com/7383192/71018530-f0135b00-20f8-11ea-9faa-2f454a8c2765.png)

And this can be toggled in the block settings:

![image](https://cdn-std.droplr.net/files/acc_887633/eISzuT)