### PR TITLE
Homepage Blocks: Fix grid display with and without borders

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -576,12 +576,42 @@
 		}
 	}
 
-	@include media( tablet ) {
+	@include media( mobile ) {
 		@for $i from 2 through 6 {
 			&.columns-#{ $i } article {
 				padding-right: calc( ( 16px * #{$i} ) / ( #{$i} - 1 ) );
 			}
 		}
+
+		&.columns-2,
+		&.columns-4,
+		&.columns-5 {
+			article {
+				border-width: 0;
+				&:nth-of-type(odd) {
+					border-width: 0 1px 0 0;
+				}
+			}
+		}
+
+		&.columns-3,
+		&.columns-6 {
+			article {
+				border-width: 0;
+
+				&:nth-of-type(3n+1),
+				&:nth-of-type(3n+2) {
+					border-width: 0 1px 0 0;
+				}
+			}
+		}
+
+		&.is-grid article:last-of-type {
+			border: 0;
+		}
+	}
+
+	@include media( tablet ) {
 
 		&.is-grid {
 			article {

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -56,14 +56,15 @@
 			flex-basis: calc( 50% - 16px );
 		}
 
-		&.columns-5 article:last-of-type:nth-child( odd ) {
-			flex-grow: 1;
+		&.columns-5 article:last-of-type {
+			flex-basis: 100%;
 		}
 	}
 
 	@include media( tablet ) {
 		@for $i from 2 through 6 {
-			&.columns-#{ $i } article {
+			&.columns-#{ $i } article,
+			&.columns-#{ $i } article:last-of-type {
 				flex-basis: calc( ( 100% / #{$i} ) - 16px );
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes some issue with the grid option for the article blocks, and how they work with the border styles.

Closes #284.

### How to test the changes in this Pull Request:

1. Copy-paste [this test content](https://cloudup.com/cbeiotXfh3p) into the editor. It include 10 copies of the article block: two with two columns, with and without borders; two with three columns, with and without borders, all the way up to six columns.
2. View the five column, bordered block on the front-end and note the odd spacing:

![image](https://user-images.githubusercontent.com/177561/71049896-a460b180-20f8-11ea-8c64-16d7c3b7c94b.png)

3. Shrink the browser window down to tablet-sized, and note the border placement on the blocks with borders -- even though there are still articles sitting side by side, the borders have now moved to the bottom of each article: 

![image](https://user-images.githubusercontent.com/177561/71049905-aa569280-20f8-11ea-8c65-cd16a0da475f.png)

![image](https://user-images.githubusercontent.com/177561/71049922-b5a9be00-20f8-11ea-8696-6f2245642907.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the five column block is now consistently spaced, and when viewed on tablet-sized screens:

![image](https://user-images.githubusercontent.com/177561/71049991-deca4e80-20f8-11ea-9488-0629a6c7c9a8.png)

6. View the other article blocks with borders on a tablet-sized window, and confirm that when articles sit side by side, they are separated by a vertical border, and no articles have borders underneath:

![image](https://user-images.githubusercontent.com/177561/71050051-04efee80-20f9-11ea-9d12-9c68e1132b3d.png)

![image](https://user-images.githubusercontent.com/177561/71050042-fe617700-20f8-11ea-80da-ae0de5dfab5f.png)

7. View the blocks on a mobile-sized screen. Confirm all of the blocks with the borders style have a bottom border on each of the articles, except the last one:

![image](https://user-images.githubusercontent.com/177561/71050086-218c2680-20f9-11ea-9582-7cf558442356.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
