### PR TITLE
Donate Block: Manual Mode

### DIFF
--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -337,7 +337,11 @@ class Edit extends Component {
 							value={ suggestedAmounts[ 0 ] }
 							onChange={ value =>
 								setAttributes( {
-									suggestedAmounts: [ this.sanitizeCurrencyInput( value ), suggestedAmounts[ 1 ], suggestedAmounts[ 2 ] ],
+									suggestedAmounts: [
+										this.sanitizeCurrencyInput( value ),
+										suggestedAmounts[ 1 ],
+										suggestedAmounts[ 2 ],
+									],
 								} )
 							}
 						/>
@@ -349,7 +353,11 @@ class Edit extends Component {
 							value={ suggestedAmounts[ 1 ] }
 							onChange={ value =>
 								setAttributes( {
-									suggestedAmounts: [suggestedAmounts[ 0 ], this.sanitizeCurrencyInput( value ), suggestedAmounts[ 2 ] ],
+									suggestedAmounts: [
+										suggestedAmounts[ 0 ],
+										this.sanitizeCurrencyInput( value ),
+										suggestedAmounts[ 2 ],
+									],
 								} )
 							}
 						/>
@@ -361,7 +369,11 @@ class Edit extends Component {
 							value={ suggestedAmounts[ 2 ] }
 							onChange={ value =>
 								setAttributes( {
-									suggestedAmounts: [ suggestedAmounts[ 0 ], suggestedAmounts[ 1 ], this.sanitizeCurrencyInput( value ) ],
+									suggestedAmounts: [
+										suggestedAmounts[ 0 ],
+										suggestedAmounts[ 1 ],
+										this.sanitizeCurrencyInput( value ),
+									],
 								} )
 							}
 						/>

--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -10,7 +10,14 @@ import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { Component, Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/editor';
-import { PanelBody, ExternalLink, Placeholder, Spinner } from '@wordpress/components';
+import {
+	PanelBody,
+	ExternalLink,
+	Placeholder,
+	Spinner,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
 
 class Edit extends Component {
 	constructor( props ) {
@@ -33,9 +40,23 @@ class Edit extends Component {
 			error: '',
 		};
 	}
-
 	componentDidMount() {
 		this.getSettings();
+	}
+
+	/* If block is in "manual" mode, override certain state properties with values stored in attributes */
+	blockData() {
+		const { attributes } = this.props;
+		const { manual } = attributes;
+		const data = { ...this.state, ...( manual ? attributes : {} ) };
+		if ( manual ) {
+			data.customDonationAmounts = {
+				once: data.tiered ? 12 * data.suggestedAmounts[ 1 ] : 12 * data.suggestedAmountUntiered,
+				month: data.tiered ? data.suggestedAmounts[ 1 ] : data.suggestedAmountUntiered,
+				year: data.tiered ? 12 * data.suggestedAmounts[ 1 ] : 12 * data.suggestedAmountUntiered,
+			};
+		}
+		return data;
 	}
 
 	getSettings() {
@@ -83,7 +104,7 @@ class Edit extends Component {
 
 	renderUntieredForm() {
 		const { className } = this.props;
-		const { currencySymbol, selectedFrequency, customDonationAmounts, error } = this.state;
+		const { currencySymbol, customDonationAmounts, error, selectedFrequency } = this.blockData();
 
 		const frequencies = {
 			once: __( 'One-time', 'newspack-blocks' ),
@@ -144,19 +165,18 @@ class Edit extends Component {
 	renderTieredForm() {
 		const { className } = this.props;
 		const {
-			suggestedAmounts,
-			currencySymbol,
 			activeTier,
-			selectedFrequency,
+			currencySymbol,
 			customDonationAmounts,
-		} = this.state;
+			selectedFrequency,
+			suggestedAmounts,
+		} = this.blockData();
 
 		const frequencies = {
 			once: __( 'One-time', 'newspack-blocks' ),
 			month: __( 'Monthly', 'newspack-blocks' ),
 			year: __( 'Annually', 'newspack-blocks' ),
 		};
-
 		return (
 			<div className={ classNames( className, 'tiered wpbnbd' ) }>
 				<form>
@@ -245,14 +265,16 @@ class Edit extends Component {
 		);
 	}
 
-	render() {
-		const { className } = this.props;
-		const { tiered, created, isLoading, error } = this.state;
+	renderPlaceholder() {
+		const { attributes } = this.props;
+		const { created, error, isLoading, manual } = this.blockData();
 
+		if ( manual ) {
+			return null;
+		}
 		if ( isLoading ) {
 			return <Placeholder icon={ <Spinner /> } />;
 		}
-
 		if ( error.length ) {
 			return (
 				<Placeholder
@@ -266,7 +288,6 @@ class Edit extends Component {
 				</Placeholder>
 			);
 		}
-
 		if ( ! created ) {
 			return (
 				<Placeholder
@@ -283,29 +304,120 @@ class Edit extends Component {
 				</Placeholder>
 			);
 		}
+	}
 
-		let form;
-		if ( ! tiered ) {
-			form = this.renderUntieredForm();
-		} else {
-			form = this.renderTieredForm();
+	renderForm() {
+		const { created, error, manual, tiered } = this.blockData();
+		if ( ! manual && ( error.length || ! created ) ) {
+			return null;
 		}
+		return tiered ? this.renderTieredForm() : this.renderUntieredForm();
+	}
 
+	renderManualControls() {
+		const { attributes, setAttributes } = this.props;
+		const { currencySymbol, suggestedAmounts, suggestedAmountUntiered, tiered } = this.blockData();
 		return (
 			<Fragment>
-				{ form }
+				<ToggleControl
+					key="tiered"
+					checked={ tiered }
+					onChange={ tiered => setAttributes( { tiered } ) }
+					label={ __( 'Tiered', 'newspack-blocks' ) }
+				/>
+				{ tiered && (
+					<Fragment>
+						<TextControl
+							key="low-tier"
+							label={ __( 'Low-tier' + ' (' + currencySymbol + ')' ) }
+							type="number"
+							step="0.01"
+							value={ suggestedAmounts[ 0 ] }
+							onChange={ value =>
+								setAttributes( {
+									suggestedAmounts: [ value, suggestedAmounts[ 1 ], suggestedAmounts[ 2 ] ],
+								} )
+							}
+						/>
+						<TextControl
+							key="mid-tier"
+							label={ __( 'Mid-tier' + ' (' + currencySymbol + ')' ) }
+							type="number"
+							step="0.01"
+							value={ suggestedAmounts[ 1 ] }
+							onChange={ value =>
+								setAttributes( {
+									suggestedAmounts: [ suggestedAmounts[ 0 ], value, suggestedAmounts[ 2 ] ],
+								} )
+							}
+						/>
+						<TextControl
+							key="hi-tier"
+							label={ __( 'Hi-tier' ) + ' (' + currencySymbol + ')' }
+							type="number"
+							step="0.01"
+							value={ suggestedAmounts[ 2 ] }
+							onChange={ value =>
+								setAttributes( {
+									suggestedAmounts: [ suggestedAmounts[ 0 ], suggestedAmounts[ 1 ], value ],
+								} )
+							}
+						/>
+					</Fragment>
+				) }
+				{ ! tiered && (
+					<TextControl
+						key="suggestedAmountUntiered"
+						label={ __( 'Suggested donation amount per month' )  + ' (' + currencySymbol + ')' }
+						type="number"
+						step="0.01"
+						value={ suggestedAmountUntiered }
+						onChange={ suggestedAmountUntiered =>
+							setAttributes( {
+								suggestedAmountUntiered,
+							} )
+						}
+					/>
+				) }
+			</Fragment>
+		);
+	}
+
+	render() {
+		const { attributes, setAttributes } = this.props;
+		const { manual } = this.blockData();
+		return (
+			<Fragment>
+				{ this.renderPlaceholder() }
+				{ this.renderForm() }
 				<InspectorControls>
 					<PanelBody title={ __( 'Donate Block', 'newspack-blocks' ) }>
-						<p>
-							{ __(
-								'The Donate Block allows you to collect donations from readers. The fields are automatically defined based on your donation settings.',
-								'newspack-blocks'
-							) }
-						</p>
-						<ExternalLink href="/wp-admin/admin.php?page=newspack-donations-wizard#/">
-							{ __( 'Edit donation settings.', 'newspack-blocks' ) }
-						</ExternalLink>
+						<ToggleControl
+							key="manual"
+							checked={ manual }
+							onChange={ manual => setAttributes( { manual } ) }
+							label={ __( 'Configure manually', 'newspack-blocks' ) }
+						/>
+						{ ! manual && (
+							<Fragment>
+								<p>
+									{ __(
+										'The Donate Block allows you to collect donations from readers. The fields are automatically defined based on your donation settings.',
+										'newspack-blocks'
+									) }
+								</p>
+
+								<ExternalLink href="/wp-admin/admin.php?page=newspack-donations-wizard#/">
+									{ __( 'Edit donation settings.', 'newspack-blocks' ) }
+								</ExternalLink>
+							</Fragment>
+						) }
 					</PanelBody>
+					{ manual && (
+						<PanelBody title={ __( 'Manual Settings', 'newspack-blocks' ) }>
+							{ this.renderManualControls() }
+						</PanelBody>
+					) }
 				</InspectorControls>
 			</Fragment>
 		);

--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -61,6 +61,16 @@ class Edit extends Component {
 
 	sanitizeCurrencyInput = amount => Math.max( 0, parseFloat( amount ).toFixed( 2 ) );
 
+	formatCurrencyWithoutSymbol = amount => {
+		const decimalPlaces = parseFloat( amount ) - parseInt( amount ) ? 2 : 0;
+		return parseFloat( amount ).toFixed( decimalPlaces );
+	}
+
+	formatCurrency = amount => {
+		const { currencySymbol } = this.blockData();
+		return currencySymbol + this.formatCurrencyWithoutSymbol( amount );
+	};
+
 	getSettings() {
 		const path = '/newspack/v1/wizard/newspack-donations-wizard/donation';
 
@@ -145,7 +155,7 @@ class Edit extends Component {
 										<input
 											type="number"
 											onChange={ evt => this.handleCustomDonationChange( evt, frequencySlug ) }
-											value={ customDonationAmounts[ frequencySlug ] }
+											value={ this.formatCurrencyWithoutSymbol( customDonationAmounts[ frequencySlug ] ) }
 											id={ 'newspack-' + frequencySlug + '-untiered-input' }
 										/>
 									</div>
@@ -213,10 +223,11 @@ class Edit extends Component {
 													className="tier-select-label"
 													htmlFor={ 'newspack-tier-' + frequencySlug + '-' + index }
 												>
-													{ currencySymbol +
-														( 'year' === frequencySlug || 'once' == frequencySlug
+													{ this.formatCurrency(
+														'year' === frequencySlug || 'once' == frequencySlug
 															? 12 * suggestedAmount
-															: suggestedAmount ) }
+															: suggestedAmount
+													) }
 												</label>
 											</div>
 										) ) }

--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -59,6 +59,8 @@ class Edit extends Component {
 		return data;
 	}
 
+	sanitizeCurrencyInput = amount => Math.max( 0, parseFloat( amount ).toFixed( 2 ) );
+
 	getSettings() {
 		const path = '/newspack/v1/wizard/newspack-donations-wizard/donation';
 
@@ -335,7 +337,7 @@ class Edit extends Component {
 							value={ suggestedAmounts[ 0 ] }
 							onChange={ value =>
 								setAttributes( {
-									suggestedAmounts: [ value, suggestedAmounts[ 1 ], suggestedAmounts[ 2 ] ],
+									suggestedAmounts: [ this.sanitizeCurrencyInput( value ), suggestedAmounts[ 1 ], suggestedAmounts[ 2 ] ],
 								} )
 							}
 						/>
@@ -347,7 +349,7 @@ class Edit extends Component {
 							value={ suggestedAmounts[ 1 ] }
 							onChange={ value =>
 								setAttributes( {
-									suggestedAmounts: [ suggestedAmounts[ 0 ], value, suggestedAmounts[ 2 ] ],
+									suggestedAmounts: [suggestedAmounts[ 0 ], this.sanitizeCurrencyInput( value ), suggestedAmounts[ 2 ] ],
 								} )
 							}
 						/>
@@ -359,7 +361,7 @@ class Edit extends Component {
 							value={ suggestedAmounts[ 2 ] }
 							onChange={ value =>
 								setAttributes( {
-									suggestedAmounts: [ suggestedAmounts[ 0 ], suggestedAmounts[ 1 ], value ],
+									suggestedAmounts: [ suggestedAmounts[ 0 ], suggestedAmounts[ 1 ], this.sanitizeCurrencyInput( value ) ],
 								} )
 							}
 						/>
@@ -368,13 +370,13 @@ class Edit extends Component {
 				{ ! tiered && (
 					<TextControl
 						key="suggestedAmountUntiered"
-						label={ __( 'Suggested donation amount per month' )  + ' (' + currencySymbol + ')' }
+						label={ __( 'Suggested donation amount per month' ) + ' (' + currencySymbol + ')' }
 						type="number"
 						step="0.01"
 						value={ suggestedAmountUntiered }
 						onChange={ suggestedAmountUntiered =>
 							setAttributes( {
-								suggestedAmountUntiered,
+								suggestedAmountUntiered: this.sanitizeCurrencyInput( suggestedAmountUntiered ),
 							} )
 						}
 					/>

--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -64,11 +64,33 @@ class Edit extends Component {
 	formatCurrencyWithoutSymbol = amount => {
 		const decimalPlaces = parseFloat( amount ) - parseInt( amount ) ? 2 : 0;
 		return parseFloat( amount ).toFixed( decimalPlaces );
-	}
+	};
 
 	formatCurrency = amount => {
 		const { currencySymbol } = this.blockData();
 		return currencySymbol + this.formatCurrencyWithoutSymbol( amount );
+	};
+
+	manualChanged = value => {
+		const { attributes, setAttributes } = this.props;
+		const { suggestedAmounts, suggestedAmountUntiered } = attributes;
+		setAttributes( { manual: value } );
+		if (
+			value &&
+			0 === suggestedAmountUntiered &&
+			0 === suggestedAmounts[ 0 ] &&
+			0 === suggestedAmounts[ 1 ] &&
+			0 === suggestedAmounts[ 2 ]
+		) {
+			setAttributes( {
+				suggestedAmounts: [
+					this.sanitizeCurrencyInput( this.state.suggestedAmounts[ 0 ] ),
+					this.sanitizeCurrencyInput( this.state.suggestedAmounts[ 1 ] ),
+					this.sanitizeCurrencyInput( this.state.suggestedAmounts[ 2 ] ),
+				],
+				suggestedAmountUntiered: this.sanitizeCurrencyInput( this.state.suggestedAmountUntiered ),
+			} );
+		}
 	};
 
 	getSettings() {
@@ -155,7 +177,9 @@ class Edit extends Component {
 										<input
 											type="number"
 											onChange={ evt => this.handleCustomDonationChange( evt, frequencySlug ) }
-											value={ this.formatCurrencyWithoutSymbol( customDonationAmounts[ frequencySlug ] ) }
+											value={ this.formatCurrencyWithoutSymbol(
+												customDonationAmounts[ frequencySlug ]
+											) }
 											id={ 'newspack-' + frequencySlug + '-untiered-input' }
 										/>
 									</div>
@@ -420,7 +444,7 @@ class Edit extends Component {
 						<ToggleControl
 							key="manual"
 							checked={ manual }
-							onChange={ manual => setAttributes( { manual } ) }
+							onChange={ this.manualChanged }
 							label={ __( 'Configure manually', 'newspack-blocks' ) }
 						/>
 						{ ! manual && (

--- a/src/blocks/donate/index.js
+++ b/src/blocks/donate/index.js
@@ -42,6 +42,21 @@ export const settings = {
 		className: {
 			type: 'string',
 		},
+		manual: {
+			type: 'boolean',
+		},
+		suggestedAmounts: {
+			type: 'array',
+			default: [ 0, 0, 0 ],
+		},
+		suggestedAmountUntiered: {
+			type: 'integer',
+			default: 0,
+		},
+		tiered: {
+			type: 'boolean',
+			default: true,
+		},
 	},
 	supports: {
 		html: false,

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -24,6 +24,11 @@ function newspack_blocks_render_block_donate( $attributes ) {
 		return '';
 	}
 
+	/* If block is in "manual" mode, override certain state properties with values stored in attributes */
+	if ( $attributes['manual'] ?? false ) {
+		$settings = array_merge( $settings, $attributes );
+	}
+
 	$frequencies = [
 		'once'  => __( 'One-time', 'newspack-blocks' ),
 		'month' => __( 'Monthly', 'newspack-blocks' ),
@@ -204,9 +209,23 @@ function newspack_blocks_register_donate() {
 		'newspack-blocks/donate',
 		array(
 			'attributes'      => array(
-				'className' => array(
+				'className'               => [
 					'type' => 'string',
-				),
+				],
+				'manual'                  => [
+					'type' => 'boolean',
+				],
+				'suggestedAmounts'        => [
+					'type'    => 'array',
+					'default' => [ 0, 0, 0 ],
+				],
+				'suggestedAmountUntiered' => [
+					'type' => 'integer',
+				],
+				'tiered'                  => [
+					'type'    => 'boolean',
+					'default' => true,
+				],
 			),
 			'render_callback' => 'newspack_blocks_render_block_donate',
 		)

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -45,7 +45,6 @@ function newspack_blocks_render_block_donate( $attributes ) {
 	 * Each frequency and tier option is a radio input, styled to look like a button.
 	 * As the radio inputs are checked/unchecked, fields are hidden/displayed using only CSS.
 	 */
-
 	if ( ! $settings['tiered'] ) :
 
 		?>
@@ -54,7 +53,10 @@ function newspack_blocks_render_block_donate( $attributes ) {
 				<input type='hidden' name='newspack_donate' value='1' />
 				<div class='wp-block-newspack-blocks-donate__options'>
 					<?php foreach ( $frequencies as $frequency_slug => $frequency_name ) : ?>
-						<?php $amount = 'year' === $frequency_slug || 'once' === $frequency_slug ? 12 * $settings['suggestedAmountUntiered'] : $settings['suggestedAmountUntiered']; ?>
+						<?php
+							$amount           = 'year' === $frequency_slug || 'once' === $frequency_slug ? 12 * $settings['suggestedAmountUntiered'] : $settings['suggestedAmountUntiered'];
+							$formatted_amount = number_format( $amount, floatval( $amount ) - intval( $amount ) ? 2 : 0 );
+						?>
 
 						<div class='wp-block-newspack-blocks-donate__frequency'>
 							<input
@@ -84,7 +86,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 									<input
 										type='number'
 										name='donation_value_<?php echo esc_attr( $frequency_slug ); ?>_untiered'
-										value='<?php echo esc_attr( $amount ); ?>'
+										value='<?php echo esc_attr( $formatted_amount ); ?>'
 										id='newspack-<?php echo esc_attr( $frequency_slug ); ?>-untiered-input'
 									/>
 								</div>
@@ -130,7 +132,10 @@ function newspack_blocks_render_block_donate( $attributes ) {
 								<div class='wp-block-newspack-blocks-donate__tiers'>
 									<?php foreach ( $suggested_amounts as $index => $suggested_amount ) : ?>
 										<div class='wp-block-newspack-blocks-donate__tier'>
-											<?php $amount = 'year' === $frequency_slug || 'once' === $frequency_slug ? 12 * $suggested_amount : $suggested_amount; ?>
+											<?php
+												$amount           = 'year' === $frequency_slug || 'once' === $frequency_slug ? 12 * $suggested_amount : $suggested_amount;
+												$formatted_amount = $settings['currencySymbol'] . number_format( $amount, floatval( $amount ) - intval( $amount ) ? 2 : 0 );
+											?>
 											<input
 												type='radio'
 												name='donation_value_<?php echo esc_attr( $frequency_slug ); ?>'
@@ -142,7 +147,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 												class='tier-select-label'
 												for='newspack-tier-<?php echo esc_attr( $frequency_slug ); ?>-<?php echo (int) $index; ?>'
 											>
-												<?php echo esc_html( $settings['currencySymbol'] . $amount ); ?>
+												<?php echo esc_html( $formatted_amount ); ?>
 											</label>
 										</div>
 									<?php endforeach; ?>
@@ -220,7 +225,7 @@ function newspack_blocks_register_donate() {
 					'default' => [ 0, 0, 0 ],
 				],
 				'suggestedAmountUntiered' => [
-					'type' => 'integer',
+					'type' => 'number',
 				],
 				'tiered'                  => [
 					'type'    => 'boolean',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Normally the Donate block derives tiering and pricing data from the Newspack Plugin's Reader Revenue Wizard. In some circumstances publishers need to control these settings on a per-block basis. This PR adds a "Configure Manually" toggle to the Donate block's Inspector Controls. When switched on, the tiering and pricing of the block can be set manually. 

Closes https://github.com/Automattic/newspack-blocks/issues/308

<img width="1629" alt="Screen Shot 2019-12-22 at 5 48 36 PM" src="https://user-images.githubusercontent.com/1477002/71328385-760e1800-24e4-11ea-8125-6765cdbaebe7.png">

### How to test the changes in this Pull Request:

1. In Newspack Plugin be sure the Reader Revenue Wizard is fully configured (even in Manual mode the block gets the currency symbol and submission URL from the Wizard).
2. Add a Donate block to a page or post, then in the sidebar switch on "Configure Manually."
3. WIth Tiered Mode off verify there is one price field shown in the sidebar, and changing it updates the block. The MONTHLY amount should match the price field's value. ONE-TIME and ANNUALLY should be the value * 12.
4. Publish the block and verify the prices are the same on the front end.
5. Edit the post and switch Tiered on. Verify there are now three price fields and changing any updates the block.
6. Publish the block and verify the prices are the same on the front end.
7. Switch off "Configure manually," and verify the block reverts to settings from the Reader Revenue Wizard. Publish and verify these settings are seen in the front end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?