### PR TITLE
Homepage Posts: Remove dynamic columns limit

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -40,15 +40,14 @@ import { withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
 
-let IS_SUBTITLE_SUPPORTED_IN_THEME
-if ( typeof window === 'object' && window.newspackIsPostSubtitleSupported && window.newspackIsPostSubtitleSupported.post_subtitle ) {
-	IS_SUBTITLE_SUPPORTED_IN_THEME = true
+let IS_SUBTITLE_SUPPORTED_IN_THEME;
+if (
+	typeof window === 'object' &&
+	window.newspackIsPostSubtitleSupported &&
+	window.newspackIsPostSubtitleSupported.post_subtitle
+) {
+	IS_SUBTITLE_SUPPORTED_IN_THEME = true;
 }
-
-/**
- * Module Constants
- */
-const MAX_POSTS_COLUMNS = 6;
 
 /* From https://material.io/tools/icons */
 const landscapeIcon = (
@@ -316,9 +315,7 @@ class Edit extends Component {
 							value={ columns }
 							onChange={ value => setAttributes( { columns: value } ) }
 							min={ 2 }
-							max={
-								! hasPosts ? MAX_POSTS_COLUMNS : Math.min( MAX_POSTS_COLUMNS, latestPosts.length )
-							}
+							max={ 6 }
 							required
 						/>
 					) }
@@ -399,13 +396,15 @@ class Edit extends Component {
 					) }
 				</PanelBody>
 				<PanelBody title={ __( 'Post Control Settings', 'newspack-blocks' ) }>
-					{IS_SUBTITLE_SUPPORTED_IN_THEME && <PanelRow>
-						<ToggleControl
-							label={ __( 'Show Subtitle', 'newspack-blocks' ) }
-							checked={ showSubtitle }
-							onChange={ () => setAttributes( { showSubtitle: ! showSubtitle} ) }
-						/>
-					</PanelRow>}
+					{ IS_SUBTITLE_SUPPORTED_IN_THEME && (
+						<PanelRow>
+							<ToggleControl
+								label={ __( 'Show Subtitle', 'newspack-blocks' ) }
+								checked={ showSubtitle }
+								onChange={ () => setAttributes( { showSubtitle: ! showSubtitle } ) }
+							/>
+						</PanelRow>
+					) }
 					<PanelRow>
 						<ToggleControl
 							label={ __( 'Show Excerpt', 'newspack-blocks' ) }
@@ -476,14 +475,7 @@ class Edit extends Component {
 		/**
 		 * Constants
 		 */
-		const {
-			attributes,
-			className,
-			setAttributes,
-			isSelected,
-			latestPosts,
-			textColor,
-		} = this.props; // variables getting pulled out of props
+		const { attributes, className, setAttributes, isSelected, latestPosts, textColor } = this.props; // variables getting pulled out of props
 		const {
 			showSubtitle,
 			showImage,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, if you set the Homepage Posts block to display as grid, you have an option to pick the number of columns you want to show. The maximum number of columns is six, or, if you have fewer posts than that (either based on the number of posts you've chosen to show, or the number of posts your query is returning), the maximum number of columns will be that. 

By default, the number of posts loaded is 3, so that's also your maximum number of columns.

This has been reported as confusing, and it also 'breaks' the ability to type in a column count value, since it gets "corrected" when you move focus away from the column field, and reset to the maximum.

This PR removes the restriction, so the maximum is always 6. Down the road, we should also improve the appearance of the columns when your column count is higher than your article count, but that should probably wait until #300 lands. (Right now, the columns are the same width, but spread out; they should probably all align left).

(There are some other code changes in this file, but they're coming from JS Prettifier).

Closes #305.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Add a Homepage Posts block to a page and switch it to 'grid' view.
3. Confirm that the default is still 3 columns.
4. Confirm you can increase the column count, even though you only have three articles:

![image](https://user-images.githubusercontent.com/177561/71382489-07d16000-258d-11ea-8adc-7475198fddbf.png)

5. Confirm other column settings work.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
