### PR TITLE
Homepage Posts: Improve Specific Posts UI

### DIFF
--- a/src/components/autocomplete-tokenfield.js
+++ b/src/components/autocomplete-tokenfield.js
@@ -26,7 +26,7 @@ class AutocompleteTokenField extends Component {
 			loading: false,
 		};
 
-		this.debouncedUpdateSuggestions = debounce( this.updateSuggestions, 500 )
+		this.debouncedUpdateSuggestions = debounce( this.updateSuggestions, 500 );
 	}
 
 	/**
@@ -41,16 +41,15 @@ class AutocompleteTokenField extends Component {
 		}
 
 		this.setState( { loading: true }, () => {
-			fetchSavedInfo( tokens )
-				.then( results => {
-					const { validValues }  = this.state;
+			fetchSavedInfo( tokens ).then( results => {
+				const { validValues } = this.state;
 
-					results.forEach( suggestion => {
-						validValues[ suggestion.value ] = suggestion.label;
-					} );
-
-					this.setState( { validValues, loading: false } );
+				results.forEach( suggestion => {
+					validValues[ suggestion.value ] = suggestion.label;
 				} );
+
+				this.setState( { validValues, loading: false } );
+			} );
 		} );
 	}
 
@@ -101,30 +100,32 @@ class AutocompleteTokenField extends Component {
 
 		this.setState( { loading: true }, () => {
 			const request = fetchSuggestions( input );
-			request.then( suggestions => { 
-				// A fetch Promise doesn't have an abort option. It's mimicked by
-				// comparing the request reference in on the instance, which is
-				// reset or deleted on subsequent requests or unmounting.
-				if ( this.suggestionsRequest !== request ) {
-					return;
-				}
+			request
+				.then( suggestions => {
+					// A fetch Promise doesn't have an abort option. It's mimicked by
+					// comparing the request reference in on the instance, which is
+					// reset or deleted on subsequent requests or unmounting.
+					if ( this.suggestionsRequest !== request ) {
+						return;
+					}
 
-				const { validValues }  = this.state;
-				const currentSuggestions = []
+					const { validValues } = this.state;
+					const currentSuggestions = [];
 
-				suggestions.forEach( suggestion => {
-					currentSuggestions.push( suggestion.label );
-					validValues[ suggestion.value ] = suggestion.label;
-				} );
-
-				this.setState( { suggestions: currentSuggestions, validValues, loading: false } );
-			} ).catch( () => {
-				if ( this.suggestionsRequest === request ) {
-					this.setState( {
-						loading: false,
+					suggestions.forEach( suggestion => {
+						currentSuggestions.push( suggestion.label );
+						validValues[ suggestion.value ] = suggestion.label;
 					} );
-				}
-			} );
+
+					this.setState( { suggestions: currentSuggestions, validValues, loading: false } );
+				} )
+				.catch( () => {
+					if ( this.suggestionsRequest === request ) {
+						this.setState( {
+							loading: false,
+						} );
+					}
+				} );
 
 			this.suggestionsRequest = request;
 		} );
@@ -158,7 +159,7 @@ class AutocompleteTokenField extends Component {
 		const { suggestions, loading } = this.state;
 
 		return (
-			<div className='autocomplete-tokenfield'>
+			<div className="autocomplete-tokenfield">
 				<FormTokenField
 					value={ this.getTokens() }
 					suggestions={ suggestions }

--- a/src/components/autocomplete-tokenfield.js
+++ b/src/components/autocomplete-tokenfield.js
@@ -155,7 +155,7 @@ class AutocompleteTokenField extends Component {
 	 * Render.
 	 */
 	render() {
-		const { label = '' } = this.props;
+		const { help, label = '' } = this.props;
 		const { suggestions, loading } = this.state;
 
 		return (
@@ -168,6 +168,7 @@ class AutocompleteTokenField extends Component {
 					label={ label }
 				/>
 				{ loading && <Spinner /> }
+				{ help && <p className="autocomplete-tokenfield__help">{ help }</p> }
 			</div>
 		);
 	}

--- a/src/components/autocomplete-tokenfield.scss
+++ b/src/components/autocomplete-tokenfield.scss
@@ -6,4 +6,13 @@
 		top: 2em;
 		right: 0;
 	}
+
+	/* Workaround for hard-coded help text in FormTokenField. */
+	.components-form-token-field > .components-form-token-field__help {
+		display: none;
+	}
+
+	.autocomplete-tokenfield__help {
+		font-style: italic;
+	}
 }

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -182,6 +182,7 @@ class QueryControls extends Component {
 					fetchSuggestions={ this.fetchPostSuggestions }
 					fetchSavedInfo={ this.fetchSavedPosts }
 					label={ __( 'Posts', 'newspack-blocks' ) }
+					help={ __( 'Begin typing post title, click autocomplete result to select.', 'newspack-blocks' ) }
 				/>
 			),
 			! specificMode && <BaseControl key="queryControls" { ...this.props } />,

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -171,7 +171,7 @@ class QueryControls extends Component {
 					key="specificMode"
 					checked={ specificMode }
 					onChange={ onSpecificModeChange }
-					label={ __( 'Choose specific stories', 'newspack-blocks' ) }
+					label={ __( 'Choose Specific Posts', 'newspack-blocks' ) }
 				/>
 			),
 			specificMode && (


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR improves two aspects of the Specific Posts UI:
- The feature toggle was labelled "Choose specific stories," not "Posts."
- Feedback indicated the post selection autocomplete interface was not immediately apparent, and help text would be useful. 

Closes https://github.com/Automattic/newspack-blocks/issues/310.

<img width="285" alt="Screen Shot 2019-12-24 at 9 54 43 AM" src="https://user-images.githubusercontent.com/1477002/71417566-027b2080-2634-11ea-8390-18fc968cd6d9.png">

### How to test the changes in this Pull Request:

1. Verify the field is labelled `Choose Specific Posts`
2. Toggle the field on and verify helper text below the input.
3. Verify Authors/Categories/Tags inputs no longer have help text beneath them.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
