### PR TITLE
Homepage Posts: Reduce padding for 'image behind' style

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -302,9 +302,13 @@
 			}
 
 			.entry-wrapper {
-				padding: 2em;
+				padding: 2em 1em;
 				position: relative;
 				z-index: 2;
+
+				@include media( desktop ) {
+					padding: 2em 1.5em;
+				}
 			}
 
 			.entry-wrapper,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR tightens up the padding a bit on the Homepage Posts, when using the 'image behind' option. I noticed when recreating one of the layouts on a staging site that, when this block is nested in a column block, it can get really squishy on tablet-ish sized screens. 

This PR doesn't fully resolve the issue -- there's just not enough space. I think it would make sense to look at adding a 'little-to-no gutter' style for the Columns block as well, after #325 lands. 

Closes #320 (not sure where I got the number used in the branch name!)

### How to test the changes in this Pull Request:

1. Copy-paste [this test content](https://cloudup.com/c3uK2-EEtdI) into the editor.
2. Make sure most of the posts displayed have a featured image, and a couple also have a caption for that featured image.
3. View on the front end at desktop, tablet-ish and mobile-ish sizes:

![image](https://user-images.githubusercontent.com/177561/72459624-07894680-3780-11ea-962d-12f87d9423e3.png)

![image](https://user-images.githubusercontent.com/177561/72459655-140d9f00-3780-11ea-8f29-1dcbc9a48a9e.png)

![image](https://user-images.githubusercontent.com/177561/72459640-0e17be00-3780-11ea-9793-a978f19da7de.png)

4. Apply the PR and run `npm run build`
5. Confirm at the above screen-sizes the padding is reduced a bit:

![image](https://user-images.githubusercontent.com/177561/72459533-d577e480-377f-11ea-91be-4f79ddee2eec.png)

![image](https://user-images.githubusercontent.com/177561/72459550-e0cb1000-377f-11ea-8cee-ec44b4dc041e.png)

![image](https://user-images.githubusercontent.com/177561/72459565-ed4f6880-377f-11ea-8cd9-12b44b176e5a.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
