### PR TITLE
CI: fix build on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,11 +9,6 @@ jobs:
       # specify the version you desire here
       - image: circleci/node:12
 
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
-
     working_directory: ~/repo
 
     steps:
@@ -26,7 +21,7 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
 
-      - run: npm install
+      - run: npm ci
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,18 @@
-version: 2
+version: 2.1
+
+commands:
+  checkout_code:
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/
 
 jobs:
   build:
     docker:
       - image: circleci/node:12
     steps:
-      - checkout
-      - attach_workspace:
-          at: ~/
+      - checkout_code
       - run:
           name: Install dependencies
           command: npm ci
@@ -23,9 +28,7 @@ jobs:
     docker:
       - image: circleci/node:12
     steps:
-      - checkout
-      - attach_workspace:
-          at: ~/
+      - checkout_code
       - run:
           name: Run Linter
           command: npm run lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,32 +1,49 @@
-# Javascript Node CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-javascript/ for more details
-#
 version: 2
+
 jobs:
   build:
     docker:
-      # specify the version you desire here
       - image: circleci/node:12
-
-    working_directory: ~/repo
-
     steps:
       - checkout
 
-      # Download and cache dependencies
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "package.json" }}
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
 
-      - run: npm ci
+      - run:
+          name: Install dependencies
+          command: npm ci
 
       - save_cache:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
 
-      # run linting!
-      - run: npm run lint
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - project
+
+  lint:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Run Linter
+          command: npm run lint
+
+## Workflows
+workflows:
+  version: 2
+  quality_assurance:
+    jobs:
+      - build
+      - lint:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           command: npm ci
       - run:
           name: Prune node_modules before persisting
-          command: curl -sfL https://install.goreleaser.com/github.com/tj/node-prune.sh | bash
+          command: curl -sfL https://install.goreleaser.com/github.com/tj/node-prune.sh | bash && ./bin/node-prune
       - persist_to_workspace:
           root: ~/
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,22 +6,11 @@ jobs:
       - image: circleci/node:12
     steps:
       - checkout
-
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
+      - attach_workspace:
+          at: ~/
       - run:
           name: Install dependencies
           command: npm ci
-
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
-
       - persist_to_workspace:
           root: ~/
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,6 @@ jobs:
       - run:
           name: Install dependencies
           command: npm ci
-      - run:
-          name: Prune node_modules before persisting
-          command: curl -sfL https://install.goreleaser.com/github.com/tj/node-prune.sh | bash && ./bin/node-prune
       - persist_to_workspace:
           root: ~/
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ jobs:
       - run:
           name: Install dependencies
           command: npm ci
+      - run:
+          name: Prune node_modules before persisting
+          command: curl -sfL https://install.goreleaser.com/github.com/tj/node-prune.sh | bash
       - persist_to_workspace:
           root: ~/
           paths:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6747,7 +6747,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -9733,7 +9733,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true
+      "optional": true
     },
     "fill-range": {
       "version": "4.0.0",
@@ -9961,7 +9961,7 @@
       "version": "1.2.11",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
       "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "bindings": "^1.5.0",
         "nan": "^2.12.1",
@@ -9971,22 +9971,22 @@
         "abbrev": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -9995,12 +9995,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10009,32 +10009,32 @@
         "chownr": {
           "version": "1.1.3",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "debug": {
           "version": "3.2.6",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -10042,22 +10042,22 @@
         "deep-extend": {
           "version": "0.6.0",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "fs-minipass": {
           "version": "1.2.7",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.6.0"
           }
@@ -10065,12 +10065,12 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -10085,7 +10085,7 @@
         "glob": {
           "version": "7.1.6",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -10098,12 +10098,12 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -10111,7 +10111,7 @@
         "ignore-walk": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
@@ -10119,7 +10119,7 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -10128,17 +10128,17 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10146,12 +10146,12 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -10159,12 +10159,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10173,7 +10173,7 @@
         "minizlib": {
           "version": "1.3.3",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.9.0"
           }
@@ -10181,7 +10181,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10189,12 +10189,12 @@
         "ms": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "needle": {
           "version": "2.4.0",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
@@ -10204,7 +10204,7 @@
         "node-pre-gyp": {
           "version": "0.14.0",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
@@ -10221,7 +10221,7 @@
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -10230,7 +10230,7 @@
         "npm-bundled": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
@@ -10238,12 +10238,12 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.7",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1"
@@ -10252,7 +10252,7 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -10263,17 +10263,17 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -10281,17 +10281,17 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -10300,17 +10300,17 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -10321,14 +10321,14 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true,
-              "dev": true
+              "optional": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -10342,7 +10342,7 @@
         "rimraf": {
           "version": "2.7.1",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -10350,37 +10350,37 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "sax": {
           "version": "1.2.4",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "semver": {
           "version": "5.7.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10390,7 +10390,7 @@
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -10398,7 +10398,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10406,12 +10406,12 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "tar": {
           "version": "4.4.13",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -10425,12 +10425,12 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
@@ -10438,12 +10438,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         }
       }
     },
@@ -13941,8 +13941,7 @@
     "nan": {
       "version": "2.13.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
-      "dev": true
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -16107,15 +16106,6 @@
           "integrity": "sha512-vPmXtExk6AV7F5l2N5jW4LhbhZZPPN+xOK8x/+EgSXsXoawuo19Iqa+9nYMwrltsi6nl0rMKiROA/SAfG2OgUw==",
           "dev": true
         }
-      }
-    },
-    "prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "dev": true,
-      "requires": {
-        "fast-diff": "^1.1.2"
       }
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "eslint-plugin-jsdoc": "^20.0.0",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.17.0",
-    "fsevents": "^1.2.11",
     "grunt": "^0.4.5",
     "grunt-wp-i18n": "^0.5.4",
     "grunt-wp-readme-to-markdown": "^1.0.0",
@@ -76,5 +75,8 @@
   "license": "GPL-3.0-or-later",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-blocks/issues"
+  },
+  "optionalDependencies": {
+    "fsevents": "^1.2.11"
   }
 }


### PR DESCRIPTION
Fix after #333 - `fsevents` is a MacOS only package, so it won't run on Linux machines. 

Also:

1. changes `npm install` to `npm ci` for efficiency:
> It can be significantly faster than a regular npm install by skipping certain user-oriented features.

https://docs.npmjs.com/cli/ci

2. run in workflow, so that linting job is reported separately (and it will be possible to report testing and then release in that manner):

![image](https://user-images.githubusercontent.com/7383192/72750030-fbf0b200-3bbb-11ea-9ed6-9d277935caf7.png)

Note that the linting [will fail](https://app.circleci.com/jobs/github/Automattic/newspack-blocks/40) due to linting errors, but these will be fixed in a separate PR