### PR TITLE
Make querySelectorAll loop IE11 compatible

### DIFF
--- a/src/blocks/homepage-articles/view.js
+++ b/src/blocks/homepage-articles/view.js
@@ -12,11 +12,14 @@ const fetchRetryCount = 3;
 
 /**
  * Load More Button Handling
+ *
+ * Calls Array.prototype.forEach for IE11 compatibility.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/NodeList
  */
-
-document
-	.querySelectorAll( '.wp-block-newspack-blocks-homepage-articles.has-more-button' )
-	.forEach( buildLoadMoreHandler );
+Array.prototype.forEach.call(
+	document.querySelectorAll( '.wp-block-newspack-blocks-homepage-articles.has-more-button' ),
+	buildLoadMoreHandler
+);
 
 /**
  * Builds a function to handle clicks on the load more button.


### PR DESCRIPTION
IE11 and other browsers don't implement `NodeList.forEach()`, so looping over `querySelectorAll()`'s return value causes errors there.

### Changes proposed in this Pull Request:

This PR attempts to fix it by using `Array.prototype.forEach` directly, as suggested in https://developer.mozilla.org/en-US/docs/Web/API/NodeList#Example

Fixes #332.
Fixes #315.



