### PR TITLE
Prevent label collisions when multiple Donate blocks are on the same page

### DIFF
--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -38,6 +38,9 @@ class Edit extends Component {
 				year: 0,
 			},
 			error: '',
+			uid: Math.random()
+				.toString( 16 )
+				.slice( 2 ), // Unique identifier to prevent collisions with other Donate blocks' labels.
 		};
 	}
 	componentDidMount() {
@@ -138,6 +141,7 @@ class Edit extends Component {
 
 	renderUntieredForm() {
 		const { className } = this.props;
+		const { uid } = this.state;
 		const { currencySymbol, customDonationAmounts, selectedFrequency } = this.blockData();
 
 		const frequencies = {
@@ -155,12 +159,12 @@ class Edit extends Component {
 								<input
 									type="radio"
 									onClick={ () => this.setState( { selectedFrequency: frequencySlug } ) }
-									id={ 'newspack-donate-' + frequencySlug }
+									id={ 'newspack-donate-' + frequencySlug + '-' + uid }
 									name="donation_frequency"
 									checked={ frequencySlug === selectedFrequency }
 								/>
 								<label
-									htmlFor={ 'newspack-donate-' + frequencySlug }
+									htmlFor={ 'newspack-donate-' + frequencySlug + '-' + uid }
 									className="donation-frequency-label"
 								>
 									{ frequencies[ frequencySlug ] }
@@ -168,7 +172,7 @@ class Edit extends Component {
 								<div className="input-container">
 									<label
 										className="donate-label"
-										htmlFor={ 'newspack-' + frequencySlug + '-untiered-input' }
+										htmlFor={ 'newspack-' + frequencySlug + '-' + uid + '-untiered-input' }
 									>
 										{ __( 'Donation amount', 'newspack-blocks' ) }
 									</label>
@@ -180,7 +184,7 @@ class Edit extends Component {
 											value={ this.formatCurrencyWithoutSymbol(
 												customDonationAmounts[ frequencySlug ]
 											) }
-											id={ 'newspack-' + frequencySlug + '-untiered-input' }
+											id={ 'newspack-' + frequencySlug + '-' + uid + '-untiered-input' }
 										/>
 									</div>
 								</div>
@@ -200,6 +204,7 @@ class Edit extends Component {
 
 	renderTieredForm() {
 		const { className } = this.props;
+		const { uid } = this.state;
 		const {
 			activeTier,
 			currencySymbol,
@@ -223,12 +228,12 @@ class Edit extends Component {
 									<input
 										type="radio"
 										onClick={ () => this.setState( { selectedFrequency: frequencySlug } ) }
-										id={ 'newspack-donate-' + frequencySlug }
+										id={ 'newspack-donate-' + frequencySlug + '-' + uid }
 										name="donation_frequency"
 										checked={ frequencySlug === selectedFrequency }
 									/>
 									<label
-										htmlFor={ 'newspack-donate-' + frequencySlug }
+										htmlFor={ 'newspack-donate-' + frequencySlug + '-' + uid }
 										className="donation-frequency-label"
 									>
 										{ frequencies[ frequencySlug ] }
@@ -240,12 +245,12 @@ class Edit extends Component {
 												<input
 													type="radio"
 													onClick={ () => this.setState( { activeTier: index } ) }
-													id={ 'newspack-tier-' + frequencySlug + '-' + index }
+													id={ 'newspack-tier-' + frequencySlug + '-' + uid + '-' + index }
 													checked={ index === activeTier }
 												/>
 												<label
 													className="tier-select-label"
-													htmlFor={ 'newspack-tier-' + frequencySlug + '-' + index }
+													htmlFor={ 'newspack-tier-' + frequencySlug + '-' + uid + '-' + index }
 												>
 													{ this.formatCurrency(
 														'year' === frequencySlug || 'once' === frequencySlug
@@ -261,18 +266,18 @@ class Edit extends Component {
 												type="radio"
 												onClick={ () => this.setState( { activeTier: 'other' } ) }
 												className="other-input"
-												id={ 'newspack-tier-' + frequencySlug + '-other' }
+												id={ 'newspack-tier-' + frequencySlug + '-' + uid + '-other' }
 												checked={ 'other' === activeTier }
 											/>
 											<label
 												className="tier-select-label"
-												htmlFor={ 'newspack-tier-' + frequencySlug + '-other' }
+												htmlFor={ 'newspack-tier-' + frequencySlug + '-' + uid + '-other' }
 											>
 												{ __( 'Other', 'newspack-blocks' ) }
 											</label>
 											<label
 												className="other-donate-label"
-												htmlFor={ 'newspack-tier-' + frequencySlug + '-other-input' }
+												htmlFor={ 'newspack-tier-' + frequencySlug + '-' + uid + '-other-input' }
 											>
 												{ __( 'Donation amount', 'newspack-blocks' ) }
 											</label>
@@ -282,7 +287,7 @@ class Edit extends Component {
 													type="number"
 													onChange={ evt => this.handleCustomDonationChange( evt, frequencySlug ) }
 													value={ customDonationAmounts[ frequencySlug ] }
-													id={ 'newspack-tier-' + frequencySlug + '-other-input' }
+													id={ 'newspack-tier-' + frequencySlug + '-' + uid + '-other-input' }
 												/>
 											</div>
 										</div>

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -38,6 +38,8 @@ function newspack_blocks_render_block_donate( $attributes ) {
 	$selected_frequency = 'month';
 	$suggested_amounts  = $settings['suggestedAmounts'];
 
+	$uid = rand(); // Unique identifier to prevent labels colliding with other instances of Donate block.
+
 	ob_start();
 
 	/**
@@ -62,12 +64,12 @@ function newspack_blocks_render_block_donate( $attributes ) {
 							<input
 								type='radio'
 								value='<?php echo esc_attr( $frequency_slug ); ?>'
-								id='newspack-donate-<?php echo esc_attr( $frequency_slug ); ?>'
+								id='newspack-donate-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>'
 								name='donation_frequency'
 								<?php checked( $selected_frequency, $frequency_slug ); ?>
 							/>
 							<label
-								for='newspack-donate-<?php echo esc_attr( $frequency_slug ); ?>'
+								for='newspack-donate-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>'
 								class='donation-frequency-label'
 							>
 								<?php echo esc_html( $frequency_name ); ?>
@@ -75,7 +77,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 							<div class='input-container'>
 								<label
 									class='donate-label'
-									for='newspack-<?php echo esc_attr( $frequency_slug ); ?>-untiered-input'
+									for='newspack-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-untiered-input'
 								>
 									<?php echo esc_html__( 'Donation amount', 'newspack-blocks' ); ?>
 								</label>
@@ -87,7 +89,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 										type='number'
 										name='donation_value_<?php echo esc_attr( $frequency_slug ); ?>_untiered'
 										value='<?php echo esc_attr( $formatted_amount ); ?>'
-										id='newspack-<?php echo esc_attr( $frequency_slug ); ?>-untiered-input'
+										id='newspack-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-untiered-input'
 									/>
 								</div>
 							</div>
@@ -118,12 +120,12 @@ function newspack_blocks_render_block_donate( $attributes ) {
 								<input
 									type='radio'
 									value='<?php echo esc_attr( $frequency_slug ); ?>'
-									id='newspack-donate-<?php echo esc_attr( $frequency_slug ); ?>'
+									id='newspack-donate-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>'
 									name='donation_frequency'
 									<?php checked( $selected_frequency, $frequency_slug ); ?>
 								/>
 								<label
-									for='newspack-donate-<?php echo esc_attr( $frequency_slug ); ?>'
+									for='newspack-donate-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>'
 									class='donation-frequency-label'
 								>
 									<?php echo esc_html( $frequency_name ); ?>
@@ -140,12 +142,12 @@ function newspack_blocks_render_block_donate( $attributes ) {
 												type='radio'
 												name='donation_value_<?php echo esc_attr( $frequency_slug ); ?>'
 												value='<?php echo esc_attr( $amount ); ?>'
-												id='newspack-tier-<?php echo esc_attr( $frequency_slug ); ?>-<?php echo (int) $index; ?>'
+												id='newspack-tier-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-<?php echo (int) $index; ?>'
 												<?php checked( 1, $index ); ?>
 											/>
 											<label
 												class='tier-select-label'
-												for='newspack-tier-<?php echo esc_attr( $frequency_slug ); ?>-<?php echo (int) $index; ?>'
+												for='newspack-tier-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-<?php echo (int) $index; ?>'
 											>
 												<?php echo esc_html( $formatted_amount ); ?>
 											</label>
@@ -159,17 +161,17 @@ function newspack_blocks_render_block_donate( $attributes ) {
 											class='other-input'
 											name='donation_value_<?php echo esc_attr( $frequency_slug ); ?>'
 											value='other'
-											id='newspack-tier-<?php echo esc_attr( $frequency_slug ); ?>-other'
+											id='newspack-tier-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-other'
 										/>
 										<label
 											class='tier-select-label'
-											for='newspack-tier-<?php echo esc_attr( $frequency_slug ); ?>-other'
+											for='newspack-tier-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-other'
 										>
 											<?php echo esc_html__( 'Other', 'newspack-blocks' ); ?>
 										</label>
 										<label
 											class='other-donate-label'
-											for='newspack-tier-<?php echo esc_attr( $frequency_slug ); ?>-other-input'
+											for='newspack-tier-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-other-input'
 										>
 											<?php echo esc_html__( 'Donation amount', 'newspack-blocks' ); ?>
 										</label>
@@ -181,7 +183,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 												type='number'
 												name='donation_value_<?php echo esc_attr( $frequency_slug ); ?>_other'
 												value='<?php echo esc_attr( $amount ); ?>'
-												id='newspack-tier-<?php echo esc_attr( $frequency_slug ); ?>-other-input'
+												id='newspack-tier-<?php echo esc_attr( $frequency_slug . '-' . $uid  ); ?>-other-input'
 											/>
 										</div>
 									</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #86 

When multiple Donate blocks were present on the same page the `label` elements for the 2nd+ Donate block controlled the `radio` inputs in the first block since they all had the same ID. I've added a UID to the labels/inputs to prevent this issue.

### How to test the changes in this Pull Request:

1. Add multiple Donate blocks to a page (test with tiered and untiered Donate blocks since they each have separate rendering).
2. In the editor, you should be able to toggle the frequencies of the 2nd+ Donate block without affecting the topmost Donate block.
3. On the frontend, you should be able to toggle the frequencies of the 2nd+ Donate block without affecting the topmost Donate block.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
