### PR TITLE
HA: Dumb down handling of exclude_ids

### DIFF
--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -107,8 +107,9 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 						$attributes
 					),
 					[
-						'page' => $next_page,
-						'amp'  => $request->get_param( 'amp' ),
+						'exclude_ids' => false,
+						'page'        => $next_page,
+						'amp'         => $request->get_param( 'amp' ),
 					]
 				),
 				rest_url( '/newspack-blocks/v1/articles' )

--- a/src/blocks/homepage-articles/view.js
+++ b/src/blocks/homepage-articles/view.js
@@ -51,7 +51,7 @@ function buildLoadMoreHandler( blockWrapperEl ) {
 		const requestURL =
 			btnEl.getAttribute( 'data-next' ) + '&exclude_ids=' + getRenderedPostsIds().join( ',' );
 
-		fetchWithRetry( { url: requestURL, onSuccess, onError }, fetchRetryCount );
+		fetchWithRetry( { url: encodeURI( requestURL ), onSuccess, onError }, fetchRetryCount );
 
 		/**
 		 * @param {Object} data Post data

--- a/src/blocks/homepage-articles/view.js
+++ b/src/blocks/homepage-articles/view.js
@@ -47,12 +47,11 @@ function buildLoadMoreHandler( blockWrapperEl ) {
 		blockWrapperEl.classList.remove( 'is-error' );
 		blockWrapperEl.classList.add( 'is-loading' );
 
-		const requestURL = new URL( btnEl.getAttribute( 'data-next' ) );
+		// Set currently rendered posts' IDs as a query param (e.g. exclude_ids=1,2,3)
+		const requestURL =
+			btnEl.getAttribute( 'data-next' ) + '&exclude_ids=' + getRenderedPostsIds().join( ',' );
 
-		// Set currenty rendered posts' IDs as a query param (e.g. exclude_ids=1,2,3)
-		requestURL.searchParams.set( 'exclude_ids', getRenderedPostsIds().join( ',' ) );
-
-		fetchWithRetry( { url: requestURL.toString(), onSuccess, onError }, fetchRetryCount );
+		fetchWithRetry( { url: requestURL, onSuccess, onError }, fetchRetryCount );
 
 		/**
 		 * @param {Object} data Post data


### PR DESCRIPTION
Fixes IE11 incompatibility with `URL` api.

### Changes proposed in this Pull Request:

UI will now always add all IDs of displayed posts, the endpoint will always remove it from its next url.
See https://github.com/Automattic/newspack-blocks/pull/338#issuecomment-576428130

### How to test the changes in this Pull Request:

1. Create a block instance with more button.
2. In the front-end, click the more button a few times, make sure the request URL looks sane and posts load as expected.
3. Make sure IE 11 works as expected.


