### PR TITLE
Bump version for release

### DIFF
--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -7,14 +7,14 @@
  * Author URI:      https://newspack.blog/
  * Text Domain:     newspack-blocks
  * Domain Path:     /languages
- * Version:         1.0.0-alpha.22
+ * Version:         1.0.0-alpha.23
  *
  * @package         Newspack_Blocks
  */
 
 define( 'NEWSPACK_BLOCKS__BLOCKS_DIRECTORY', 'dist/' );
 define( 'NEWSPACK_BLOCKS__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
-define( 'NEWSPACK_BLOCKS__VERSION', '1.0.0-alpha.20' );
+define( 'NEWSPACK_BLOCKS__VERSION', '1.0.0-alpha.23' );
 
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'class-newspack-blocks.php';
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'class-newspack-blocks-api.php';


### PR DESCRIPTION
This PR bumps the version for the release. We should also be bumping the `NEWSPACK_BLOCKS__VERSION` constant too.