### PR TITLE
Add a Placeholder align option and align center when loading

### DIFF
--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -106,9 +106,7 @@ class Edit extends Component {
 						<Placeholder>{ __( 'Sorry, no posts were found.' ) }</Placeholder>
 					) }
 					{ ! latestPosts && (
-						<Placeholder>
-							<Spinner />
-						</Placeholder>
+						<Placeholder icon={ <Spinner /> } className="component-placeholder__align-center" />
 					) }
 					{ latestPosts && (
 						<Fragment>

--- a/src/blocks/carousel/editor.scss
+++ b/src/blocks/carousel/editor.scss
@@ -1,3 +1,5 @@
+@import '../../shared/sass/placeholder';
+
 .wp-block-newspack-blocks-carousel {
 	.entry-title {
 		color: white;

--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -314,7 +314,7 @@ class Edit extends Component {
 			return null;
 		}
 		if ( isLoading ) {
-			return <Placeholder icon={ <Spinner /> } />;
+			return <Placeholder icon={ <Spinner /> } className="component-placeholder__align-center" />;
 		}
 		if ( error.length ) {
 			return (

--- a/src/blocks/donate/editor.scss
+++ b/src/blocks/donate/editor.scss
@@ -1,14 +1,17 @@
 @import '../../shared/sass/colors';
+@import '../../shared/sass/placeholder';
 
-.wp-block-newspack-blocks-donate button[type='submit'] {
-	background: $color__primary;
-	border: none;
-	border-radius: 5px;
-	box-sizing: border-box;
-	color: $color__background-body;
-	font-weight: bold;
-	outline: none;
-	line-height: 3em;
-	padding-left: 20px;
-	padding-right: 20px;
+.wp-block-newspack-blocks-donate {
+	button[type='submit'] {
+		background: $color__primary;
+		border: none;
+		border-radius: 5px;
+		box-sizing: border-box;
+		color: $color__background-body;
+		font-weight: bold;
+		outline: none;
+		line-height: 3em;
+		padding-left: 20px;
+		padding-right: 20px;
+	}
 }

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -628,9 +628,7 @@ class Edit extends Component {
 							<Placeholder>{ __( 'Sorry, no posts were found.', 'newspack-blocks' ) }</Placeholder>
 						) }
 						{ ! latestPosts && (
-							<Placeholder>
-								<Spinner />
-							</Placeholder>
+							<Placeholder icon={ <Spinner /> } className="component-placeholder__align-center" />
 						) }
 						{ latestPosts && latestPosts.map( post => this.renderPost( post ) ) }
 					</div>

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -1,4 +1,5 @@
 @import '../../shared/sass/variables';
+@import '../../shared/sass/placeholder';
 
 .type-scale-slider {
 	.dashicon {

--- a/src/shared/sass/_placeholder.scss
+++ b/src/shared/sass/_placeholder.scss
@@ -1,5 +1,5 @@
 .wp-block[data-type^='newspack-blocks/'] {
   .component-placeholder__align-center {
-    align-items: center;
+      align-items: center;
   }
 }

--- a/src/shared/sass/_placeholder.scss
+++ b/src/shared/sass/_placeholder.scss
@@ -1,5 +1,5 @@
 .wp-block[data-type^='newspack-blocks/'] {
-  .component-placeholder__align-center {
-    align-items: center;
-  }
+	.component-placeholder__align-center {
+		align-items: center;
+	}
 }

--- a/src/shared/sass/_placeholder.scss
+++ b/src/shared/sass/_placeholder.scss
@@ -1,5 +1,5 @@
 .wp-block[data-type^='newspack-blocks/'] {
   .component-placeholder__align-center {
-      align-items: center;
+    align-items: center;
   }
 }

--- a/src/shared/sass/_placeholder.scss
+++ b/src/shared/sass/_placeholder.scss
@@ -1,0 +1,5 @@
+.wp-block[data-type^="newspack-blocks/"] {
+  .component-placeholder__align-center {
+      align-items: center;
+  }
+}

--- a/src/shared/sass/_placeholder.scss
+++ b/src/shared/sass/_placeholder.scss
@@ -1,4 +1,4 @@
-.wp-block[data-type^="newspack-blocks/"] {
+.wp-block[data-type^='newspack-blocks/'] {
   .component-placeholder__align-center {
       align-items: center;
   }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

By adding a new shared SASS file we can control where we want to display the Placeholder content via a `component-placeholder__align-center` class.

This is particularly useful for the combo Placeholder + Spinner which looks odd when left-aligned (since G. 7.2.0)

See #329.

### How to test the changes in this Pull Request:

1. Load a post/page with the Home Articles, Carousel and Donation block.
2. Check the loading state. Spinner should be left aligned.
3. Switch to this branch.
4. Refresh your post/page.
5. Spinner should be centred.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
