### PR TITLE
Add Campaign field to Donate block

### DIFF
--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -50,7 +50,7 @@ class Edit extends Component {
 	/* If block is in "manual" mode, override certain state properties with values stored in attributes */
 	blockData() {
 		const { attributes } = this.props;
-		const { manual } = attributes;
+		const { manual, campaign } = attributes;
 		const data = { ...this.state, ...( manual ? attributes : {} ) };
 		if ( manual ) {
 			data.customDonationAmounts = {
@@ -59,6 +59,7 @@ class Edit extends Component {
 				year: data.tiered ? 12 * data.suggestedAmounts[ 1 ] : 12 * data.suggestedAmountUntiered,
 			};
 		}
+		data.campaign = campaign;
 		return data;
 	}
 
@@ -437,7 +438,8 @@ class Edit extends Component {
 	}
 
 	render() {
-		const { manual } = this.blockData();
+		const { setAttributes } = this.props;
+		const { manual, campaign } = this.blockData();
 		return (
 			<Fragment>
 				{ this.renderPlaceholder() }
@@ -470,6 +472,17 @@ class Edit extends Component {
 							{ this.renderManualControls() }
 						</PanelBody>
 					) }
+					<PanelBody title={ __( 'Advanced', 'newspack-blocks' ) }>
+						<TextControl
+							label={ __( 'Campaign ID', 'newspack-blocks' ) }
+							value={ campaign ? campaign : '' }
+							onChange={ value =>
+								setAttributes( {
+									campaign: value,
+								} )
+							}
+						/>
+					</PanelBody>
 				</InspectorControls>
 			</Fragment>
 		);

--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -472,7 +472,7 @@ class Edit extends Component {
 							{ this.renderManualControls() }
 						</PanelBody>
 					) }
-					<PanelBody title={ __( 'Advanced', 'newspack-blocks' ) }>
+					<PanelBody title={ __( 'Campaign', 'newspack-blocks' ) } initialOpen={ false }>
 						<TextControl
 							label={ __( 'Campaign ID', 'newspack-blocks' ) }
 							value={ campaign ? campaign : '' }

--- a/src/blocks/donate/index.js
+++ b/src/blocks/donate/index.js
@@ -55,6 +55,9 @@ export const settings = {
 			type: 'boolean',
 			default: true,
 		},
+		campaign: {
+			type: 'string',
+		},
 	},
 	supports: {
 		html: false,

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -38,6 +38,8 @@ function newspack_blocks_render_block_donate( $attributes ) {
 	$selected_frequency = 'month';
 	$suggested_amounts  = $settings['suggestedAmounts'];
 
+	$campaign = $attributes['campaign'] ?? false;
+
 	$uid = rand(); // Unique identifier to prevent labels colliding with other instances of Donate block.
 
 	ob_start();
@@ -102,6 +104,9 @@ function newspack_blocks_render_block_donate( $attributes ) {
 				<button type='submit'>
 					<?php echo esc_html__( 'Donate now!', 'newspack-blocks' ); ?>
 				</button>
+				<?php if ( $campaign ) : ?>
+					<input type='hidden' name='campaign' value='<?php echo esc_attr( $campaign ); ?>' />
+				<?php endif; ?>
 			</form>
 		</div>
 		<?php
@@ -199,6 +204,9 @@ function newspack_blocks_render_block_donate( $attributes ) {
 				<button type='submit'>
 					<?php echo esc_html__( 'Donate now!', 'newspack-blocks' ); ?>
 				</button>
+				<?php if ( $campaign ) : ?>
+					<input type='hidden' name='campaign' value='<?php echo esc_attr( $campaign ); ?>' />
+				<?php endif; ?>
 			</form>
 		</div>
 		<?php
@@ -233,6 +241,9 @@ function newspack_blocks_register_donate() {
 					'type'    => 'boolean',
 					'default' => true,
 				],
+				'campaign'                => [
+					'type'    => 'string',
+				]
 			),
 			'render_callback' => 'newspack_blocks_render_block_donate',
 		)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds a Campaign field to the Donate block. The field doesn't really do much on its own; it just renders a hidden `campaign` input on the Donate block's form. Other integrations (like NRH) can use this information when processing a submission from the Donate block to sync with Salesforce, and in the future this will be used as part of Newspack to connect with CRMs.

### How to test the changes in this Pull Request:

1. Add a Campaign to a Donate block:
<img width="1152" alt="Screen Shot 2020-01-24 at 10 49 54 AM" src="https://user-images.githubusercontent.com/7317227/73095603-d9021e80-3e97-11ea-8731-f098c51a90e2.png">

2. On the frontend, verify a hidden `campaign` input is rendered as part of the form:
<img width="439" alt="Screen Shot 2020-01-24 at 10 50 21 AM" src="https://user-images.githubusercontent.com/7317227/73095607-db647880-3e97-11ea-8c87-777f4ceafc37.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
