### PR TITLE
Linting: use lint-staged for JS pre-commit linting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "extra": {
     "hooks": {
       "pre-commit": [
-        "./vendor/xwp/wp-dev-lib/scripts/pre-commit && ./node_modules/.bin/lint-staged"
+        "DEV_LIB_SKIP=eslint ./vendor/xwp/wp-dev-lib/scripts/pre-commit && ./node_modules/.bin/lint-staged"
       ],
       "commit-msg": [
         "cat $1 | ./node_modules/.bin/commitlint"

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "build": "calypso-build --config='./webpack.config.js'",
     "lint": "npm-run-all --parallel lint:*",
     "lint:js": "eslint --ext .js,.jsx src",
+    "lint:js:staged": "eslint --ext .js,.jsx",
     "format:js": "prettier 'src/**/*.{js,jsx}' --write",
     "lint:scss": "stylelint \"**/*.scss\" --syntax scss",
     "format:scss": "prettier --write 'src/**/*.scss'",
@@ -74,7 +75,8 @@
     "release:archive": "run-p \"clean\" && NODE_ENV=production run-p \"build\" && mkdir -p assets/release && zip -r assets/release/newspack-blocks.zip . -x node_modules/\\* .git/\\* .github/\\* .gitignore .DS_Store vendor/\\*"
   },
   "lint-staged": {
-    "*.scss": "npm run lint:scss:staged"
+    "*.scss": "npm run lint:scss:staged",
+    "*.js": "npm run lint:js:staged"
   },
   "release": {
     "prepare": [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

`xwd-dev-lib` lints files in a tmp directory - with changed files only - which makes [`import/no-unresolved`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md) rule fail at times, as not all files are present. 
This PR relieves `xwp-dev-lib` of linting JS files and makes it so that JS is linted with [`lint-staged`](https://github.com/okonet/lint-staged) tool.

## Important

Git hooks need to be updated after these changes: `./vendor/bin/cghooks update`

### How to test the changes in this Pull Request:

1. Update git hooks - `./vendor/bin/cghooks update`
2. Change a JS file so that it's broken (would not pass linting)
3. Try to commit the change. See that it fails and error message from Eslint is output. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->