### PR TITLE
Remove Background Color Behind Load More Button in Editor

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -635,7 +635,7 @@ class Edit extends Component {
 				</div>
 
 				{ ! specificMode && latestPosts && moreButton && (
-					<div className="editor-styles-wrapper">
+					<div className="editor-styles-wrapper wpnbha__wp-block-button__wrapper">
 						<div className="wp-block-button">
 							<RichText
 								placeholder={ __( 'Load more posts', 'newspack-blocks' ) }

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -38,3 +38,7 @@
 		margin: 0.5em 0;
 	}
 }
+
+.editor-styles-wrapper.wpnbha__wp-block-button__wrapper {
+	background-color: transparent;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes background color from Load More button container in the editor.

Closes https://github.com/Automattic/newspack-blocks/issues/367 .

### How to test the changes in this Pull Request:

1. Switch to `master`.
2. Add Group block to a post.
3. Set Group block background color.
4. Add Homepage Posts block to the Group block.
5. Toggle Load More button on.
6. Observe background color behind the button.
7. Branch switch to `fix/load-more-button-bg-in-group-block`.
8. Refresh editor page.
9. Observe background is removed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
