### PR TITLE
Fix AMP Load More Grid View

### DIFF
--- a/amp/homepage-articles/view.js
+++ b/amp/homepage-articles/view.js
@@ -1,6 +1,6 @@
 let isFetching = false;
 let isEndOfData = false;
-buildLoadMoreHandler( document.querySelector( '.wp-block-newspack-blocks-homepage-articles') );
+buildLoadMoreHandler( document.querySelector( '.wp-block-newspack-blocks-homepage-articles' ) );
 function buildLoadMoreHandler( blockWrapperEl ) {
 	const btnEl = blockWrapperEl.querySelector( '[data-next]' );
 	if ( ! btnEl ) {
@@ -26,10 +26,11 @@ function buildLoadMoreHandler( blockWrapperEl ) {
 				} );
 			} );
 			if ( isPostsDataValid( data ) ) {
-				const postsHTML = data.items.map( item => item.html ).join( '' );
-				const ampLayout = document.createElement( 'amp-layout' );
-				ampLayout.innerHTML = postsHTML;
-				postsContainerEl.appendChild( ampLayout );
+				data.items.forEach( item => {
+					const tempDIV = document.createElement( 'div' );
+					tempDIV.innerHTML = item.html.trim();
+					postsContainerEl.appendChild( tempDIV.childNodes[ 0 ] );
+				} );
 				if ( data.next ) {
 					btnEl.setAttribute( 'data-next', data.next );
 				}
@@ -40,7 +41,7 @@ function buildLoadMoreHandler( blockWrapperEl ) {
 				isFetching = false;
 				blockWrapperEl.classList.remove( 'is-loading' );
 			}
-		};
+		}
 		function onError() {
 			isFetching = false;
 			blockWrapperEl.classList.remove( 'is-loading' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The AMP implementation of the Load More button wraps dynamically loaded articles in an `amp-layout` element. This works fine for list view, but in grid view the additional layer of hierarchy breaks the flexbox layout. This PR resolves the problem by removing the wrapper and inserting the `article` tags directly into the container.

Closes https://github.com/Automattic/newspack-blocks/issues/366 .

### How to test the changes in this Pull Request:

1. Install/Activate the AMP plugin, switch to Transitional mode.
2. With this branch checked out, add a Homepage Posts block to a post or page.
3. Click the Grid View icon.
4. Preview the post/page. 
5. In non-AMP, click Load More, observe the results.
6. Switch to AMP, click Load More, verify the results look the same.
7. Try the same with a variety of other block settings, verify the results are equivalent in AMP and non-AMP requests.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
