### PR TITLE
Bump version for release

### DIFF
--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -7,14 +7,14 @@
  * Author URI:      https://newspack.blog/
  * Text Domain:     newspack-blocks
  * Domain Path:     /languages
- * Version:         1.0.0-alpha.26
+ * Version:         1.0.0-alpha.27
  *
  * @package         Newspack_Blocks
  */
 
 define( 'NEWSPACK_BLOCKS__BLOCKS_DIRECTORY', 'dist/' );
 define( 'NEWSPACK_BLOCKS__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
-define( 'NEWSPACK_BLOCKS__VERSION', '1.0.0-alpha.26' );
+define( 'NEWSPACK_BLOCKS__VERSION', '1.0.0-alpha.27' );
 
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'class-newspack-blocks.php';
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'class-newspack-blocks-api.php';


### PR DESCRIPTION
Note: https://github.com/Automattic/newspack-blocks/pull/362 should be merged before the actual release, but bumping the version won't hurt anything.