### PR TITLE
Remove lexical declaration inside case

### DIFF
--- a/src/blocks/homepage-articles/store.js
+++ b/src/blocks/homepage-articles/store.js
@@ -95,11 +95,10 @@ const getQueryBlocksInOrder = blocks =>
 const reducer = ( state = initialState, action ) => {
 	switch ( action.type ) {
 		case UPDATE_BLOCKS:
-			const updateBlocksState = {
+			return {
 				...state,
 				queryBlocks: getQueryBlocksInOrder( action.blocks ),
 			};
-			return updateBlocksState;
 		case MARK_POSTS_DISPLAYED:
 			return {
 				...state,

--- a/src/blocks/homepage-articles/store.js
+++ b/src/blocks/homepage-articles/store.js
@@ -1,6 +1,16 @@
-import { registerStore, select, subscribe, dispatch } from '@wordpress/data';
+/**
+ * External dependencies
+ */
 import { uniq } from 'lodash';
 
+/**
+ * WordPress dependencies
+ */
+import { registerStore, select, subscribe, dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
 import metadata from './block.json';
 
 const { name } = metadata;
@@ -42,7 +52,7 @@ const actions = {
 
 /**
  * @typedef Block A Gutenberg editor block
- * @type {Object}
+ * @type {object}
  * @typedef uuid Unique id
  * @type {string}
  */
@@ -52,7 +62,7 @@ const actions = {
  *
  * @param {Block[]} orderedBlocks Ordered Blocks
  * @param {uuid} clientId client id
- * @return {Block[]} blocks
+ * @returns {Block[]} blocks
  */
 const blocksBefore = ( orderedBlocks, clientId ) => {
 	const ourBlockIdx = orderedBlocks.findIndex( b => b.clientId === clientId );
@@ -81,7 +91,7 @@ const selectors = {
  * that PHP will render them.
  *
  * @param {Block[]} blocks any blocks
- * @return {Block[]} ordered newspack-blocks/query blocks
+ * @returns {Block[]} ordered newspack-blocks/query blocks
  */
 const getQueryBlocksInOrder = blocks =>
 	blocks.flatMap( block => {


### PR DESCRIPTION

Fix up store return - it is causing lint errors when trying to deploy FSE on dotcom.

Too many things are interwined, but regardless, the fix is to just return the thing in the case statement instead of defining a new variable and then return.

For reference, here's the lint rule being triggered on commit: 
https://eslint.org/docs/rules/no-case-declarations

