### PR TITLE
Blog Posts Block: Prevent Date Being Hidden

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -212,8 +212,12 @@
 			margin-right: 1.5em;
 		}
 
-		.updated:not( .published ) {
+		.updated {
 			display: none;
+			
+			&.published {
+				display: block;
+			}
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

✔️Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
✔️Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
✔️Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
This fixes what I'm pretty sure the code attempts to do, but gets overrided with on WordPress.com themes, in regards to displaying the date.

Closes #405

### How to test the changes in this Pull Request:

1. Activate a free WordPress.com theme
2. Add the block and select showing the date
3. Get the `updated` class to be applied
4. Verify the date now displays

### Other information:

✔️Have you added an explanation of what your changes do and why you'd like us to include them?
❌Have you written new tests for your changes, as applicable?
❌ Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
