### PR TITLE
Homepage Posts: fix broken author URL on WP.com

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -217,13 +217,18 @@ function newspack_blocks_format_byline( $author_info ) {
 				$index ++;
 				$penultimate = count( $author_info ) - 2;
 
+				$get_author_posts_url = get_author_posts_url( $author->ID );
+				if ( function_exists( 'coauthors_posts_links' ) ) {
+					$get_author_posts_url = get_author_posts_url( $author->ID, $author->user_nicename );
+				}
+
 				return array_merge(
 					$accumulator,
 					[
 						sprintf(
 							/* translators: 1: author link. 2: author name. 3. variable seperator (comma, 'and', or empty) */
 							'<span class="author vcard"><a class="url fn n" href="%1$s">%2$s</a></span>',
-							esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ),
+							esc_url( $get_author_posts_url ),
 							esc_html( $author->display_name )
 						),
 						( $index < $penultimate ) ? ', ' : '',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

It looks like changes in #372 -- to make sure authors archive links worked when using the Co-Authors Plus plugin -- is not loved by WP.com. This PR reworks that approach a bit, so we're adding passing `$author->user_nicename` to `get_author_posts_url()` when the plugin is enabled, and only passing `$author->ID` otherwise.

Note: A WP.com sandbox will be needed to test this fully.

Closes #401.

### How to test the changes in this Pull Request:

1. Follow the steps outlined in #372 to confirm that this functionality still works as expected on self-hosted sites.
2. On a WP.com sandbox, add the Blog Posts block, and try clicking on the Author link. Note that it's using the user nice name, not the actual URL.
3. In the sandbox's plugins directory, copy-paste the same changes into the full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/view.php file. This would be replacing lines 220-232 with the following:

```
$get_author_posts_url = get_author_posts_url( $author->ID );
if ( function_exists( 'coauthors_posts_links' ) ) {
	$get_author_posts_url = get_author_posts_url( $author->ID, $author->user_nicename );
}

return array_merge(
	$accumulator,
	[
		sprintf(
			/* translators: 1: author link. 2: author name. 3. variable seperator (comma, 'and', or empty) */
			'<span class="author vcard"><a class="url fn n" href="%1$s">%2$s</a></span>',
			esc_url( $get_author_posts_url ),
			esc_html( $author->display_name )
		),
		( $index < $penultimate ) ? ', ' : '',
		( count( $author_info ) > 1 && $penultimate === $index ) ? esc_html_x( ' and ', 'post author', 'newspack-blocks' ) : '',
	]
);
```

4. Confirm that the author links in your block now work.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
