### PR TITLE
feat: update default carousel style for focused elements

### DIFF
--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -101,13 +101,18 @@
 		height: 16px;
 		opacity: 0.5;
 		transform: scale( 0.75 );
-		transition: opacity 250ms, transform 250ms;
+		transition: box-shadow 250ms, opacity 250ms, transform 250ms;
 		width: 16px;
 		border-radius: 100%;
 		padding: 0;
 		margin: 0 4px;
+		&:focus {
+			box-shadow: 0 0 0 2px white, 0 0 0 4px black;
+			outline: 0;
+		}
 		&[selected] {
 			opacity: 1;
+			outline: 0;
 			transform: scale( 1 );
 		}
 	}
@@ -124,15 +129,15 @@
 		height: 48px;
 		margin: 0;
 		padding: 0;
-		transition: background-color 250ms;
+		transition: background-color 250ms, box-shadow 250ms;
 		width: 48px;
 		&:focus,
 		&:hover {
 			background-color: rgba( 0, 0, 0, 0.75 );
 		}
 		&:focus {
-			outline: thin dotted white;
-			outline-offset: -4px;
+			box-shadow: inset 0 0 0 2px rgba( 0, 0, 0, 0.75 ), inset 0 0 0 4px white;
+			outline: 0;
 		}
 	}
 	.amp-carousel-button-next,

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -21,7 +21,7 @@
 			margin: 0 0 0.25em;
 		}
 	}
-	
+
 	.editor-rich-text {
 		width: 100%;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Tiny PR to clean the focus and select styles on the different buttons

### How to test the changes in this Pull Request:

1. Add a carousel block to a page/post
2. Notice the dotted navigation and left/right arrows when focused/selected
3. Switch to this branch
4. Refresh your page/post with the carousel and notice the differences

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
