### PR TITLE
Fix Double-Encoded Load More URLs

### DIFF
--- a/src/blocks/homepage-articles/view.js
+++ b/src/blocks/homepage-articles/view.js
@@ -55,7 +55,7 @@ function buildLoadMoreHandler( blockWrapperEl ) {
 		const requestURL =
 			btnEl.getAttribute( 'data-next' ) + '&exclude_ids=' + getRenderedPostsIds().join( ',' );
 
-		fetchWithRetry( { url: encodeURI( requestURL ), onSuccess, onError }, fetchRetryCount );
+		fetchWithRetry( { url: requestURL, onSuccess, onError }, fetchRetryCount );
 
 		/**
 		 * @param {Object} data Post data


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Several recent issues have noted that posts displayed by clicking Load More do not adhere to the same query parameters as defined in the block. This is due to a double-encoding problem. The 'next' URL is encoded by PHP [here](https://github.com/Automattic/newspack-blocks/blob/master/src/blocks/homepage-articles/view.php#L129), then again by Javascript [here](https://github.com/Automattic/newspack-blocks/blob/master/src/blocks/homepage-articles/view.js#L58). This meant that parameters with special characters would be end up double-encoded. Any of the array parameters, like `categories[]` would end up mangled and therefore would be ignored by the endpoint rendering the Load More response. The Javascript encoding is present only in the non-AMP version, so this issue did not affect AMP pages. This is a regression dating back to [late January](https://github.com/Automattic/newspack-blocks/commit/2faed01269a5b47b8a4109a69884925377c0b004). However, it was only applied to WordPress.com in early March, so the period of time it was affecting WP.com is much shorter. Newspack customers tend to be in AMP standard mode so most would not have been affected (although the problem was reported on this page https://therivardreport.com/arts-culture/)

Resolved here by removing the URL encoding in Javascript. 

Closes https://github.com/Automattic/newspack-blocks/issues/411, https://github.com/Automattic/newspack-blocks/issues/392.

### How to test the changes in this Pull Request:

1. On `master`, create multiple (6) posts in the same category.
2. Switch AMP off, or go to Transitional mode.
3. Create a page with the Homepage Posts block. Set the count to 3, and select the category.
4. View the page (non-AMP), then click Load More. Verify the posts shown are not necessarily in the expected category.
5. Switch to this branch, and try again.
6. Verify the load more content is exactly as expected.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
