### PR TITLE
Display subscribe pattern when Mailchimp is inactive

### DIFF
--- a/newspack-blocks-patterns.php
+++ b/newspack-blocks-patterns.php
@@ -375,9 +375,6 @@ add_filter(
 	'newspack_blocks_patterns',
 	function( $patterns, $post_type ) {
 		if ( in_array( $post_type, [ 'page', 'post', 'newspack_popups_cpt' ], true ) ) {
-			if ( ! function_exists( 'jetpack_mailchimp_verify_connection' ) || ! jetpack_mailchimp_verify_connection() ) {
-				return $patterns;
-			}
 			$decode = json_decode( file_get_contents( NEWSPACK_BLOCKS__PLUGIN_DIR . 'src/patterns/markup/subscribe/style-1.json'), true ); //phpcs:ignore
 			$patterns[] = [
 				'category' => __( 'Subscribe', 'newspack-blocks' ),
@@ -404,9 +401,6 @@ add_filter(
 	'newspack_blocks_patterns',
 	function( $patterns, $post_type ) {
 		if ( in_array( $post_type, [ 'page', 'post', 'newspack_popups_cpt' ], true ) ) {
-			if ( ! function_exists( 'jetpack_mailchimp_verify_connection' ) || ! jetpack_mailchimp_verify_connection() ) {
-				return $patterns;
-			}
 			$decode = json_decode( file_get_contents( NEWSPACK_BLOCKS__PLUGIN_DIR . 'src/patterns/markup/subscribe/style-2.json'), true ); //phpcs:ignore
 			$patterns[] = [
 				'category' => __( 'Subscribe', 'newspack-blocks' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This tiny PR makes sure that the Subscribe patterns are always being displayed and not just when Mailchimp is active. Because... how would you active Mailchimp if it's not available 🙄

### How to test the changes in this Pull Request:

1. On a site with Mailchimp not active, in a page, open the Newspack Patterns, do you see the Subscribe patterns? (you shouldn't)
2. Switch to this branch.
3. Try again (this time you should see the patterns)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
