### PR TITLE
Update the pattern's icon with Newspack logo

### DIFF
--- a/src/patterns/index.js
+++ b/src/patterns/index.js
@@ -12,14 +12,10 @@ import { registerPlugin } from '@wordpress/plugins';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 
 /**
- * Material UI dependencies.
- */
-import Icon from '@material-ui/icons/ViewQuilt';
-
-/**
  * Internal dependencies.
  */
 import './style.scss';
+import Icon from '../shared/js/newspack-icon';
 
 class PatternsSidebar extends Component {
 	state = {
@@ -97,7 +93,7 @@ class PatternsSidebar extends Component {
 						</PanelBody>
 					) }
 				</PluginSidebar>
-				<PluginSidebarMoreMenuItem target={ sidebarId } icon=<Icon />>
+				<PluginSidebarMoreMenuItem target={ sidebarId } icon={ <Icon /> }>
 					{ sidebarTitle }
 				</PluginSidebarMoreMenuItem>
 			</Fragment>

--- a/src/patterns/style.scss
+++ b/src/patterns/style.scss
@@ -1,3 +1,5 @@
+@import '../shared/sass/colors';
+
 /**
  * Patterns
  */
@@ -11,5 +13,23 @@
 		margin: 0;
 		padding: 3px;
 		width: 100%;
+	}
+}
+
+.edit-post-pinned-plugins {
+	.components-button.has-icon,
+	.components-icon-button {
+		&.is-toggled,
+		&.is-toggled:hover,
+		&.has-icon:hover,
+		&.has-icon:not( .is-toggled ) {
+			.newspack-icon__circle {
+				fill: $color__primary !important;
+			}
+
+			.newspack-icon__n {
+				fill: white !important;
+			}
+		}
 	}
 }

--- a/src/shared/js/newspack-icon.js
+++ b/src/shared/js/newspack-icon.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies.
+ */
+import { Path, SVG } from '@wordpress/components';
+
+/**
+ * External dependencies.
+ */
+import classnames from 'classnames';
+
+export default ( { size = 24, className } ) => (
+	<SVG
+		className={ classnames( 'newspack-icon', className ) }
+		width={ size }
+		height={ size }
+		viewBox="0 0 24 24"
+	>
+		<Path
+			className="newspack-icon__circle"
+			fill="#36f"
+			d="M12 24c6.627 0 12-5.373 12-12S18.627 0 12 0 0 5.373 0 12s5.372 12 12 12z"
+		/>
+		<Path
+			className="newspack-icon__n"
+			fill="#fff"
+			d="M17.241 12.467h-1.29l-.827-.843h2.117v.843zm0-2.483h-3.727l-.826-.843h4.553v.843zm0-2.483h-6.163l-.827-.843h6.99v.843zm0 9.841L6.76 6.658v10.684h2.588v-4.484l4.4 4.484h3.494z"
+		/>
+	</SVG>
+);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Gutenberg 7.7 introduces a pattern library that lives in the pinned sidebar. The icon is very similar to the one we use for the Newspack Patterns.
This PR replaces the Material icon with our logo.

### How to test the changes in this Pull Request:

1. Make sure you have Gutenberg 7.7+ installed.
2. Edit a page/post
3. Notice the 2 similar looking icons in the top right hand corner of the editor
4. Switch to this branch and refresh the page/post.
5. Is it any better? Is is less confusing?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
