### PR TITLE
Pass Block Name To Query Store

### DIFF
--- a/src/blocks/homepage-articles/editor.js
+++ b/src/blocks/homepage-articles/editor.js
@@ -6,4 +6,4 @@ import { name, settings } from '.';
 import { registerQueryStore } from './store';
 
 registerBlockType( `newspack-blocks/${ name }`, settings );
-registerQueryStore();
+registerQueryStore( `newspack-blocks/${ name }` );

--- a/src/blocks/homepage-articles/store.js
+++ b/src/blocks/homepage-articles/store.js
@@ -15,7 +15,6 @@ import metadata from './block.json';
 
 const { name } = metadata;
 export const STORE_NAMESPACE = name;
-const blockName = `newspack-blocks/${ name }`;
 
 const initialState = {
 	queryBlocks: [], // list of Query blocks in the order they are on the page
@@ -85,51 +84,50 @@ const selectors = {
 	},
 };
 
-/**
- * Returns an array of all newspack-blocks/query blocks in the order they are on
- * the page. This is needed to be able to show the editor blocks in the order
- * that PHP will render them.
- *
- * @param {Block[]} blocks any blocks
- * @returns {Block[]} ordered newspack-blocks/query blocks
- */
-const getQueryBlocksInOrder = blocks =>
-	blocks.flatMap( block => {
-		const queryBlocks = [];
-		if ( block.name === blockName ) {
-			queryBlocks.push( block );
+export const registerQueryStore = blockName => {
+	/**
+	 * Returns an array of all newspack-blocks/query blocks in the order they are on
+	 * the page. This is needed to be able to show the editor blocks in the order
+	 * that PHP will render them.
+	 *
+	 * @param {Block[]} blocks any blocks
+	 * @returns {Block[]} ordered newspack-blocks/query blocks
+	 */
+	const getQueryBlocksInOrder = blocks =>
+		blocks.flatMap( block => {
+			const queryBlocks = [];
+			if ( block.name === blockName ) {
+				queryBlocks.push( block );
+			}
+			return queryBlocks.concat( getQueryBlocksInOrder( block.innerBlocks ) );
+		} );
+
+	const reducer = ( state = initialState, action ) => {
+		switch ( action.type ) {
+			case UPDATE_BLOCKS:
+				return {
+					...state,
+					queryBlocks: getQueryBlocksInOrder( action.blocks ),
+				};
+			case MARK_POSTS_DISPLAYED:
+				return {
+					...state,
+					postsByBlock: {
+						...state.postsByBlock,
+						[ action.clientId ]: action.posts,
+					},
+				};
+			case MARK_SPECIFIC_POSTS_DISPLAYED:
+				return {
+					...state,
+					specificPostsByBlock: {
+						...state.specificPostsByBlock,
+						[ action.clientId ]: action.posts,
+					},
+				};
 		}
-		return queryBlocks.concat( getQueryBlocksInOrder( block.innerBlocks ) );
-	} );
-
-const reducer = ( state = initialState, action ) => {
-	switch ( action.type ) {
-		case UPDATE_BLOCKS:
-			return {
-				...state,
-				queryBlocks: getQueryBlocksInOrder( action.blocks ),
-			};
-		case MARK_POSTS_DISPLAYED:
-			return {
-				...state,
-				postsByBlock: {
-					...state.postsByBlock,
-					[ action.clientId ]: action.posts,
-				},
-			};
-		case MARK_SPECIFIC_POSTS_DISPLAYED:
-			return {
-				...state,
-				specificPostsByBlock: {
-					...state.specificPostsByBlock,
-					[ action.clientId ]: action.posts,
-				},
-			};
-	}
-	return state;
-};
-
-export const registerQueryStore = () => {
+		return state;
+	};
 	registerStore( STORE_NAMESPACE, {
 		reducer,
 		actions,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The query store maintains the block registration name in a hardcoded constant (https://github.com/Automattic/newspack-blocks/blob/master/src/blocks/homepage-articles/store.js#L18). This creates a problem for the Full-Site Editing plugin, which registers the block under a different name (`a8c/blog-posts`) . This branch allows the block name to be passed as a parameter when the store is registered.

### How to test the changes in this Pull Request:

There should be no visible changes in this branch. Verify that editor deduplication continues to work as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
