### PR TITLE
Fix pattern sidebar to match Gutenberg patterns sidebar

### DIFF
--- a/src/patterns/index.js
+++ b/src/patterns/index.js
@@ -56,13 +56,13 @@ class PatternsSidebar extends Component {
 									initialOpen={ true }
 									key={ patternGroupIndex }
 								>
-									<div className="editor-block-styles block-editor-block-styles newspack-patterns-block-styles">
+									<div className="block-editor-patterns newspack-patterns-block-styles">
 										{ patternGroup.items &&
 											patternGroup.items.map(
 												( { image: image, content, title }, patternIndex ) => (
 													<div
 														key={ patternIndex }
-														className="editor-block-styles__item block-editor-block-styles__item"
+														className="block-editor-patterns__item"
 														onClick={ () => this.insert( content ) }
 														onKeyDown={ event => {
 															if ( ENTER === event.keyCode || SPACE === event.keyCode ) {
@@ -74,10 +74,10 @@ class PatternsSidebar extends Component {
 														tabIndex="0"
 														aria-label={ title }
 													>
-														<div className="editor-block-styles__item-preview block-editor-block-styles__item-preview">
+														<div className="block-editor-patterns__item-preview">
 															<img src={ image } alt={ __( 'Preview', 'newspack-block' ) } />
 														</div>
-														<div className="editor-block-styles__item-label block-editor-block-styles__item-label">
+														<div className="block-editor-patterns__item-title">
 															{ title }
 														</div>
 													</div>

--- a/src/patterns/index.js
+++ b/src/patterns/index.js
@@ -77,9 +77,7 @@ class PatternsSidebar extends Component {
 														<div className="block-editor-patterns__item-preview">
 															<img src={ image } alt={ __( 'Preview', 'newspack-block' ) } />
 														</div>
-														<div className="block-editor-patterns__item-title">
-															{ title }
-														</div>
+														<div className="block-editor-patterns__item-title">{ title }</div>
 													</div>
 												)
 											) }

--- a/src/patterns/style.scss
+++ b/src/patterns/style.scss
@@ -5,13 +5,12 @@
  */
 
 .newspack-patterns-block-styles {
-	.block-editor-block-styles__item {
-		padding-top: 6px;
-	}
+	padding: 0;
+	margin-bottom: -16px;
 
-	.block-editor-block-styles__item-preview {
+	.block-editor-patterns__item-preview {
 		margin: 0;
-		padding: 3px;
+		padding: 3px 3px 0;
 		width: 100%;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR tweaks the Newspack Patterns Sidebar so it looks similar to the Gutenberg Patterns Sidebar with 1-column items instead of 2.

Also 2 columns were returning visual issues on Safari 10.

![Screenshot 2020-03-30 at 16 45 02](https://user-images.githubusercontent.com/177929/77932714-d3fd8900-72a5-11ea-82fc-a3541a10c6d9.png)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Go to a page.
3. Open the Newspack Patterns. Open the Gutenberg Patterns. Do they kind of look similar?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
