### PR TITLE
Try/cache rendered views

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -5,6 +5,8 @@
  * @package WordPress
  */
 
+require_once NEWSPACK_BLOCKS__PLUGIN_DIR . '/src/caching/class-newspack-blocks-cache.php';
+
 /**
  * Renders the `newspack-blocks/homepage-posts` block on server.
  *
@@ -14,6 +16,15 @@
  */
 function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	$article_query = new WP_Query( Newspack_Blocks::build_articles_query( $attributes ) );
+
+	$cache_key   = 'newspack_homepage_articles_query_attributes:' . print_r( $attributes, true );
+	$cache_group = 'newspack_blocks_homepage';
+	$content     = Newspack_Blocks_Cache::get( $cache_key, $cache_group );
+	if ( $content ) {
+		Newspack_Blocks::enqueue_view_assets( 'homepage-articles' );
+
+		return $content;
+	}
 
 	$classes = Newspack_Blocks::block_classes( 'homepage-articles', $attributes, [ 'wpnbha' ] );
 
@@ -153,6 +164,8 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 	$content = ob_get_clean();
 	Newspack_Blocks::enqueue_view_assets( 'homepage-articles' );
+
+	Newspack_Blocks_Cache::add( $cache_key, $content, $cache_group );
 
 	return $content;
 }

--- a/src/caching/class-newspack-blocks-cache.php
+++ b/src/caching/class-newspack-blocks-cache.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Newspack Blocks caching class file.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Class Newspack_Blocks_Cache.
+ *
+ * A central caching mechanism.
+ */
+class Newspack_Blocks_Cache {
+
+	/**
+	 * In seconds.
+	 */
+	const CACHE_EXPIRE = 600;
+
+	/**
+	 * Checks whether cache is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_caching_enabled() {
+		return defined( 'NEWSPACK_CACHE_BLOCKS' ) ? (bool) NEWSPACK_CACHE_BLOCKS : false;
+	}
+
+	/**
+	 * A wrapper for global function wp_cache_add.
+	 * Adds data to the cache, if the cache key doesn't already exist.
+	 *
+	 * @see WP_Object_Cache::add()
+	 *
+	 * @param int|string $key    The cache key to use for retrieval later.
+	 * @param mixed      $data   The data to add to the cache.
+	 * @param string     $group  Optional. The group to add the cache to. Enables the same key
+	 *                           to be used across groups. Default empty.
+	 * @param int        $expire Optional. When the cache data should expire, in seconds.
+	 *                           Default 0 (no expiration).
+	 *
+	 * @return bool True on success, false if cache key and group already exist.
+	 */
+	public static function add( $key, $data, $group = 'newspack', $expire = self::CACHE_EXPIRE ) {
+		if ( ! self::is_caching_enabled() ) {
+			return false;
+		}
+
+		return wp_cache_add( $key, $data, $group, $expire );
+	}
+
+	/**
+	 * A wrapper for global function wp_cache_get.
+	 * Retrieves the cache contents from the cache by key and group.
+	 *
+	 * @see WP_Object_Cache::get()
+	 *
+	 * @param int|string $key    The key under which the cache contents are stored.
+	 * @param string     $group  Optional. Where the cache contents are grouped. Default empty.
+	 * @return bool|mixed False on failure to retrieve contents or the cache contents on success.
+	 */
+	public static function get( $key, $group = 'newspack' ) {
+		if ( ! self::is_caching_enabled() ) {
+			return false;
+		}
+
+		return wp_cache_get( $key, $group );
+	}
+
+	/**
+	 * A wrapper for global function wp_cache_flush();
+	 * Removes all cache items.
+	 *
+	 * @see WP_Object_Cache::flush()
+	 *
+	 * @return bool True on success, false on failure.
+	 */
+	public static function flush() {
+		return wp_cache_flush();
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

A fully working example of simple server-side caching for query-intensive blocks block results.

Consists of:
- `Newspack_Blocks_Cache` class -- a super-simple static class serving as a central place to define caching. Advantages of having this class instead of using `wp_cache_get()` directly in code are three: 
  1. should we need to change the caching strategy/mechanism (memcache, Redis, disk, DB) all our other code will remain identical, we only update things in this class,
  2. this class checks whether custom caching is enabled ( `NEWSPACK_CACHE_BLOCKS` const in `wp-config.php` ), no need to repeatedly do those check in code where caching is used,
  3. minimizes lines to add in files where caching is used, and makes them look exactly the same throughout our code ( I mean the modifications to `view.php` in this particular PR ).
- `src/blocks/homepage-articles/view.php` -- here's a demonstration of what it takes to add caching to the code. This only adds caching to the Homepage Articles block. To add caching other places, we'd need to do the same in other views.


### How to test the changes in this Pull Request:

Please check if you agree with introducing this type of caching in Newspack Blocks. This PR shows what it takes to use server-side caching in `view.php` for Homepage Articles blocks. If it's thumbs up, we'd need to add the same lines of code in other places/views where we need caching.

Where to test:
- best to run this directly on an Atomic machine, I propose `hongkongfp-launch-performancetests.newspackstaging.com` since it's a realistic environment,
- note: I wasn't able to activate WP caching on my local VVV instance, and I'm still not sure why not;

How to test:
- edit the `wp-config.php` and add the following constants, the first two are WP standards, and the third lets us enable or disable the caching feature (we could move it into an Option, it would be just the same):
```
define( 'ENABLE_CACHE', true );
define( 'WP_CACHE', true );
define( 'NEWSPACK_CACHE_BLOCKS', true );
```
2. deploy these two files from the PR: the caching class, and the `view.php`,
3. since this PR applies caching to just one block (Homepage Articles), to experience the full significance of caching which would be seen if we introduced the same thing to other `view` files, make the current Home Page temporarily heavier, by using more elements. What I did was literally copied the current Home Page contents three times into the [the Home page](https://hongkongfp-launch-performancetests.newspackstaging.com/wp-admin/post.php?post=49&action=edit) (I also saved a backup of the original Home Page contents [here](https://hongkongfp-launch-performancetests.newspackstaging.com/wp-admin/post.php?post=256543&action=edit) so you can grab that source, and paste it three times into the actual Home Page),
4. first check the loading time in Inspector > Network: turn off caching by setting `NEWSPACK_CACHE_BLOCKS` in `wp-config.php` to `false`, and reload the home page (several times to let it "settle in"), and check how fast it loads before caching is used. Here's my results:
![scr_cache-off](https://user-images.githubusercontent.com/29167323/78714924-eff3d100-791c-11ea-897c-7a37f8e2f464.png)
5. next turn caching on by setting `NEWSPACK_CACHE_BLOCKS` to `true`. Reload the page several times (4, 5 times) to let the cache warm-up. Here's my results:
![scr_cache-on](https://user-images.githubusercontent.com/29167323/78714992-0863eb80-791d-11ea-8d5a-8c6ad52ec770.png)

Conclusion:
- this PR shows performance improvements by using custom server-side caching for demanding custom queries
- this is just an example **for one block**; if we added this same option to all our blocks, it would improve the performance much further -- we want to do that where we perform demanding WP_Query/SQL queries,
- the caching class super very simple (advantages of having this class instead of adding the caching code directly to `view` files was explained at the beginning of this PR), and it even contains the `flush()` function which could be triggered by a custom API endpoint -- so that we could introduce a flush button in our plugin, and this `flush` performs the equivalent of the CLI `wp cache flush`
- cache expire in seconds is currently defined in the cache class property, but might also be moved to a constant config.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
