### PR TITLE
Fix patterns sidebar background color since Gutenberg 7.9

### DIFF
--- a/src/patterns/style.scss
+++ b/src/patterns/style.scss
@@ -5,6 +5,7 @@
  */
 
 .newspack-patterns-block-styles {
+	background: transparent;
 	padding: 0;
 	margin-bottom: -16px;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR removes the pattern's background color introduced with Gutenberg 7.9

### How to test the changes in this Pull Request:

1. Make sure you have the latest version of Gutenberg
2. In a page/post try to add a new Pattern -- notice the grey background behind the list of patterns
3. Switch to this branch
4. Refresh -- grey background should be gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
