### PR TITLE
Columns styles: Update editor selector for reordering columns

### DIFF
--- a/src/block-styles/core/columns/editor.scss
+++ b/src/block-styles/core/columns/editor.scss
@@ -1,7 +1,7 @@
 @import '../../../shared/sass/variables';
 @import '../../../shared/sass/mixins';
 
-.wp-block .wp-block-columns {
+.wp-block-columns {
 	@include media( mobile ) {
 		&[class*='is-style-first-col-to'] [data-type='core/column'] {
 			margin-left: 46px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes the `.wp-block` class from the selectors for the Columns block styles in the editor. At some point, this container was removed from from the block markup, but! It does exist on the block itself. So when the block is nested in another -- like the group block, like you'd see with the Newspack block patterns -- the preview displays as expected.

Closes #434.

### How to test the changes in this Pull Request:

1. Add a column block to the editor with 2-3 columns.
2. In each column, add a paragraph block that labels the order - for example, Column 1, Column 2:

<img width="1242" alt="image" src="https://user-images.githubusercontent.com/177561/80058069-1dc04480-84dd-11ea-872c-8a9d309d2164.png">

3. Select the 'first column to second' block style.
4. Note the preview isn't updated:

<img width="1242" alt="image" src="https://user-images.githubusercontent.com/177561/80058070-20229e80-84dd-11ea-95b9-2616158519f4.png">

5. Apply the PR and run `npm run build`
6. Refresh the editor and confirm that the block style is now previewing correctly:

<img width="1213" alt="image" src="https://user-images.githubusercontent.com/177561/80058404-02096e00-84de-11ea-8e94-081c4a72cf57.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
