### PR TITLE
Carousel: Use absolute path for style import

### DIFF
--- a/src/blocks/carousel/create-swiper.js
+++ b/src/blocks/carousel/create-swiper.js
@@ -3,7 +3,7 @@
  */
 import { merge } from 'lodash';
 import Swiper from 'swiper';
-import '../../../node_modules/swiper/dist/css/swiper.css';
+import 'swiper/dist/css/swiper.css';
 
 /**
  * @param {string} container Selector


### PR DESCRIPTION
See https://github.com/nolimits4web/swiper/issues/2745#issuecomment-412607428

Switching to this way of importing the stylesheet makes it independent from the folder structure this component is in. It's currently what's preventing this block from being added to Dotcom's FSE.

See https://github.com/Automattic/wp-calypso/pull/41423.

### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->
### How to test the changes in this Pull Request:

1. Build the blocks
2. Make sure styles are still loaded for the block.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
