### PR TITLE
Carousel: Make block name filterable

### DIFF
--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -259,7 +259,7 @@ function newspack_blocks_carousel_block_autoplay_ui( $block_ordinal = 0 ) {
  */
 function newspack_blocks_register_carousel() {
 	register_block_type(
-		'newspack-blocks/carousel',
+		apply_filters( 'newspack_blocks_block_name', 'newspack-blocks/carousel' ),
 		array(
 			'attributes'      => array(
 				'className'    => array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Makes the block name filterable, similar to Homepage Articles.

This allows third party consumers to replace the name in different contexts.

See #248.

 
### How to test the changes in this Pull Request:

1. Create a post with the Carousel block.
2. Preview the post and make sure the block still shows up.
