### PR TITLE
Carousel: Only query posts with thumbnails

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -253,11 +253,17 @@ class Newspack_Blocks_API {
 	 * @return array          $args    Filtered request parameters.
 	 */
 	public static function post_meta_request_params( $args, $request ) {
-		if ( ! empty( $request['meta_key'] ) && ! empty( $request['meta_value'] ) && ! empty( $request['meta_value'] ) ) {
+		$params = $request->get_params();
+
+		if (
+			'_thumbnail_id' === $params['meta_key'] &&
+			'0' === $params['meta_value_num'] &&
+			'>' === $params['meta_compare']
+		) {
 			// phpcs:disable WordPress.DB.SlowDBQuery
-			$args['meta_key']   = $request['meta_key'];
-			$args['meta_value'] = $request['meta_value'];
-			$args['meta_query'] = $request['meta_query'];
+			$args['meta_key']       = $params['meta_key'];
+			$args['meta_value_num'] = $params['meta_value_num'];
+			$args['meta_compare']   = $params['meta_compare'];
 			// phpcs:enable WordPress.DB.SlowDBQuery
 		}
 
@@ -267,4 +273,4 @@ class Newspack_Blocks_API {
 
 add_action( 'rest_api_init', array( 'Newspack_Blocks_API', 'register_rest_fields' ) );
 add_action( 'rest_api_init', array( 'Newspack_Blocks_API', 'register_video_playlist_endpoint' ) );
-add_filter( 'rest_post_query', array( 'Newspack_Blocks_API', 'post_meta_request_params' ), 10, 2 );
+//add_filter( 'rest_post_query', array( 'Newspack_Blocks_API', 'post_meta_request_params' ), 10, 2 );

--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -273,4 +273,4 @@ class Newspack_Blocks_API {
 
 add_action( 'rest_api_init', array( 'Newspack_Blocks_API', 'register_rest_fields' ) );
 add_action( 'rest_api_init', array( 'Newspack_Blocks_API', 'register_video_playlist_endpoint' ) );
-//add_filter( 'rest_post_query', array( 'Newspack_Blocks_API', 'post_meta_request_params' ), 10, 2 );
+add_filter( 'rest_post_query', array( 'Newspack_Blocks_API', 'post_meta_request_params' ), 10, 2 );

--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -256,6 +256,7 @@ class Newspack_Blocks_API {
 		$params = $request->get_params();
 
 		if (
+			isset( $params['meta_key'], $params['meta_value_num'], $params['meta_compare'] ) &&
 			'_thumbnail_id' === $params['meta_key'] &&
 			'0' === $params['meta_value_num'] &&
 			'>' === $params['meta_compare']

--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -244,7 +244,25 @@ class Newspack_Blocks_API {
 		$args = $request->get_params();
 		return new \WP_REST_Response( newspack_blocks_get_video_playlist( $args ), 200 );
 	}
+
+	/**
+	 * Adds meta query support to API rest endpoint.
+	 *
+	 * @param array           $args    Key value array of query var to query value.
+	 * @param WP_REST_Request $request The request used.
+	 * @return array          $args    Filtered request parameters.
+	 */
+	public static function post_meta_request_params( $args, $request ) {
+		// phpcs:disable WordPress.DB.SlowDBQuery
+		$args['meta_key']   = $request['meta_key'];
+		$args['meta_value'] = $request['meta_value'];
+		$args['meta_query'] = $request['meta_query'];
+		// phpcs:enable WordPress.DB.SlowDBQuery
+
+		return $args;
+	}
 }
 
 add_action( 'rest_api_init', array( 'Newspack_Blocks_API', 'register_rest_fields' ) );
 add_action( 'rest_api_init', array( 'Newspack_Blocks_API', 'register_video_playlist_endpoint' ) );
+add_filter( 'rest_post_query', array( 'Newspack_Blocks_API', 'post_meta_request_params' ), 10, 2 );

--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -253,11 +253,13 @@ class Newspack_Blocks_API {
 	 * @return array          $args    Filtered request parameters.
 	 */
 	public static function post_meta_request_params( $args, $request ) {
-		// phpcs:disable WordPress.DB.SlowDBQuery
-		$args['meta_key']   = $request['meta_key'];
-		$args['meta_value'] = $request['meta_value'];
-		$args['meta_query'] = $request['meta_query'];
-		// phpcs:enable WordPress.DB.SlowDBQuery
+		if ( ! empty( $request['meta_key'] ) && ! empty( $request['meta_value'] ) && ! empty( $request['meta_value'] ) ) {
+			// phpcs:disable WordPress.DB.SlowDBQuery
+			$args['meta_key']   = $request['meta_key'];
+			$args['meta_value'] = $request['meta_value'];
+			$args['meta_query'] = $request['meta_query'];
+			// phpcs:enable WordPress.DB.SlowDBQuery
+		}
 
 		return $args;
 	}

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -282,6 +282,9 @@ export default compose( [
 				categories,
 				author: authors,
 				tags,
+				meta_key: '_thumbnail_id',
+				meta_value_num: 0,
+				meta_compare: '>',
 			},
 			value => ! isUndefined( value )
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Not sure how smart it is to unilaterally open the posts endpoint up to meta queries. I suppose we could pass a custom parameter and "hard-code" the post thumbnail meta query based on that?

Regardless, with this change the carousel in the Editor will now contain the same posts as it does in the front-end. Currently it just displays X number of most recent posts and hopes they have featured images assigned to them.
### How to test the changes in this Pull Request:

1. Add the Carousel block in the editor and play with the post count attribute.
2. Make sure the carousel contains as many posts with thumbnails as you selected in the attribute
3. Double-check that posts on the Editor side are the same as in the front-end

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
