### PR TITLE
Carousel: Add default class

### DIFF
--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -95,6 +95,7 @@ class Edit extends Component {
 		} = attributes;
 		const classes = classnames(
 			className,
+			'wp-block-newspack-blocks-carousel', // Default to make styles work for third-party consumers.
 			'swiper-container',
 			autoplay && autoPlayState && 'wp-block-newspack-blocks-carousel__autoplay-playing'
 		);


### PR DESCRIPTION
## Changes proposed in this Pull Request:
Adds the Editor-provided default class explicitly so styles still work when third party consumers replace the block name with their own.

### How to test the changes in this Pull Request:

1. Insert the block in the Editor and make sure the slider styles still work.

