### PR TITLE
improvement: make the carousel block args filterable

### DIFF
--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -260,62 +260,66 @@ function newspack_blocks_carousel_block_autoplay_ui( $block_ordinal = 0 ) {
 function newspack_blocks_register_carousel() {
 	register_block_type(
 		apply_filters( 'newspack_blocks_block_name', 'newspack-blocks/carousel' ),
-		array(
-			'attributes'      => array(
-				'className'    => array(
-					'type' => 'string',
-				),
-				'postsToShow'  => array(
-					'type'    => 'integer',
-					'default' => 3,
-				),
-				'authors'      => array(
-					'type'    => 'array',
-					'default' => array(),
-					'items'   => array(
-						'type' => 'integer',
+		apply_filters(
+			'newspack_blocks_block_args',
+			array(
+				'attributes'      => array(
+					'className'    => array(
+						'type' => 'string',
+					),
+					'postsToShow'  => array(
+						'type'    => 'integer',
+						'default' => 3,
+					),
+					'authors'      => array(
+						'type'    => 'array',
+						'default' => array(),
+						'items'   => array(
+							'type' => 'integer',
+						),
+					),
+					'categories'   => array(
+						'type'    => 'array',
+						'default' => array(),
+						'items'   => array(
+							'type' => 'integer',
+						),
+					),
+					'tags'         => array(
+						'type'    => 'array',
+						'default' => array(),
+						'items'   => array(
+							'type' => 'integer',
+						),
+					),
+					'autoplay'     => array(
+						'type'    => 'boolean',
+						'default' => false,
+					),
+					'delay'        => array(
+						'type'    => 'integer',
+						'default' => 5,
+					),
+					'showAuthor'   => array(
+						'type'    => 'boolean',
+						'default' => true,
+					),
+					'showAvatar'   => array(
+						'type'    => 'boolean',
+						'default' => true,
+					),
+					'showCategory' => array(
+						'type'    => 'boolean',
+						'default' => false,
+					),
+					'showDate'     => array(
+						'type'    => 'boolean',
+						'default' => true,
 					),
 				),
-				'categories'   => array(
-					'type'    => 'array',
-					'default' => array(),
-					'items'   => array(
-						'type' => 'integer',
-					),
-				),
-				'tags'         => array(
-					'type'    => 'array',
-					'default' => array(),
-					'items'   => array(
-						'type' => 'integer',
-					),
-				),
-				'autoplay'     => array(
-					'type'    => 'boolean',
-					'default' => false,
-				),
-				'delay'        => array(
-					'type'    => 'integer',
-					'default' => 5,
-				),
-				'showAuthor'   => array(
-					'type'    => 'boolean',
-					'default' => true,
-				),
-				'showAvatar'   => array(
-					'type'    => 'boolean',
-					'default' => true,
-				),
-				'showCategory' => array(
-					'type'    => 'boolean',
-					'default' => false,
-				),
-				'showDate'     => array(
-					'type'    => 'boolean',
-					'default' => true,
-				),
+				'render_callback' => 'newspack_blocks_render_block_carousel',
 			),
-			'render_callback' => 'newspack_blocks_render_block_carousel',
+			'carousel'
 		)
 	);
 }


### PR DESCRIPTION
#239 # All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:

It applies a filter to the carousel block in order to be able to pass custom arguments to it.

### How to test the changes in this Pull Request:

It shouldn't change the current behavior of the carousel block. Simply confirm that it's still working as expected after applying these changes. If you'd like to go forward, add a function to the hook and test it runs:

```php
function block_arguments( $name, $args ) {
  // $name contains the block name
  // $args -> the block arguments :smart:
};

add_filter( 'newspack_blocks_block_args',  'block_arguments', 10, 2 );
```