### PR TITLE
Fix patterns preview thumbnails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5456,6 +5456,12 @@
       "integrity": "sha512-b45c4x1+OvQm1f6egrBruO8eVF4bRVRZ8ojM1ttDcMi+K/qXfun3J6O8xXpSnA5eeNCZaJL3DhIk/aoNBbpwzw==",
       "dev": true
     },
+    "@wordpress/base-styles": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-1.7.0.tgz",
+      "integrity": "sha512-WobY7E2jcu6hALBf9JGzb/2kZb+kwL6AxgMg2ZedfsHxVZ1obf46jdTeKzIsALXNvjScw29q2krk9YIfNU/s/A==",
+      "dev": true
+    },
     "@wordpress/blob": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@semantic-release/changelog": "^5.0.0",
     "@semantic-release/git": "^9.0.0",
     "@wordpress/api-fetch": "^3.8.0",
+    "@wordpress/base-styles": "^1.7.0",
     "@wordpress/block-editor": "^3.4.0",
     "@wordpress/blocks": "^6.2.0",
     "@wordpress/components": "^8.5.0",

--- a/src/patterns/index.js
+++ b/src/patterns/index.js
@@ -56,13 +56,13 @@ class PatternsSidebar extends Component {
 									initialOpen={ true }
 									key={ patternGroupIndex }
 								>
-									<div className="block-editor-patterns newspack-patterns-block-styles">
+									<div className="newspack-block-patterns">
 										{ patternGroup.items &&
 											patternGroup.items.map(
 												( { image: image, content, title }, patternIndex ) => (
 													<div
 														key={ patternIndex }
-														className="block-editor-patterns__item"
+														className="newspack-block-patterns__item"
 														onClick={ () => this.insert( content ) }
 														onKeyDown={ event => {
 															if ( ENTER === event.keyCode || SPACE === event.keyCode ) {
@@ -74,10 +74,9 @@ class PatternsSidebar extends Component {
 														tabIndex="0"
 														aria-label={ title }
 													>
-														<div className="block-editor-patterns__item-preview">
+														<div className="newspack-block-patterns__item-preview">
 															<img src={ image } alt={ __( 'Preview', 'newspack-block' ) } />
 														</div>
-														<div className="block-editor-patterns__item-title">{ title }</div>
 													</div>
 												)
 											) }

--- a/src/patterns/style.scss
+++ b/src/patterns/style.scss
@@ -1,5 +1,5 @@
 @import '../shared/sass/colors';
-@import "~@wordpress/base-styles/colors";
+@import '~@wordpress/base-styles/colors';
 
 /**
  * Patterns

--- a/src/patterns/style.scss
+++ b/src/patterns/style.scss
@@ -1,18 +1,48 @@
 @import '../shared/sass/colors';
+@import "~@wordpress/base-styles/colors";
 
 /**
  * Patterns
  */
 
-.newspack-patterns-block-styles {
-	background: transparent;
-	padding: 0;
-	margin-bottom: -16px;
-
-	.block-editor-patterns__item-preview {
-		margin: 0;
-		padding: 3px 3px 0;
+.newspack-block-patterns {
+	&__item {
+		cursor: pointer;
+		margin: 0 0 16px;
 		width: 100%;
+
+		&:hover {
+			.newspack-block-patterns__item-preview {
+				border-color: $blue-medium-focus;
+			}
+		}
+
+		&:focus {
+			.newspack-block-patterns__item-preview {
+				box-shadow: inset 0 0 0 1px #fff, 0 0 0 1.5px $blue-medium-focus;
+			}
+		}
+
+		&:last-of-type {
+			margin-bottom: 0;
+		}
+	}
+
+	&__item-preview {
+		background: white;
+		border: 1px solid $light-gray-500;
+		border-radius: 2px;
+		padding: 2px;
+		width: 100%;
+
+		img {
+			display: block;
+		}
+	}
+
+	&__item-label {
+		padding: 4px 2px;
+		text-align: center;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Gutenberg 8.0 breaks the Newspack Patterns thumbnails because the class used was removed. So.. instead of relying on Gutenberg styles to display the patterns – since it's constantly evolving – this PR adds its own set of styles for the pattern thumbnails.

### How to test the changes in this Pull Request:

1. Enable Gutenberg < 8.0, check the patterns
2. Update to Gutenberg 8.0, check the patterns -- the styles should be missing
3. Switch to this branch and check the patterns -- we now have our own styles

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
