### PR TITLE
Use Swiper In Non-AMP Contexts

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -86,6 +86,14 @@ class Newspack_Blocks_API {
 			return false;
 		}
 
+		// Large image.
+		$feat_img_array_large        = wp_get_attachment_image_src(
+			$object['featured_media'],
+			'large',
+			false
+		);
+		$featured_image_set['large'] = $feat_img_array_large[0];
+
 		// Landscape image.
 		$landscape_size = Newspack_Blocks::image_size_for_orientation( 'landscape' );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6900,22 +6900,25 @@
       }
     },
     "@wordpress/dom-ready": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.5.1.tgz",
-      "integrity": "sha512-HPEPWdShm/xJjQJVOOWpehvt4wtK0W5D/X0wpLfWAQjPOsTMTKnlRsRL3vTjIlgTrVZan1rv+3ZJv7AwH/1U5g==",
-      "dev": true,
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.9.0.tgz",
+      "integrity": "sha512-2egz1f4LaLeeSPTsWUgvgerNUbV9A++x/YWBGiF8t/bC7KX1n4mqexQRihfuofvpBxlkalIJEXxka3pzrD1XHA==",
       "requires": {
-        "@babel/runtime": "^7.4.4"
+        "@babel/runtime": "^7.9.2"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.7.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
-          "integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
-          "dev": true,
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+          "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
           "requires": {
-            "regenerator-runtime": "^0.13.2"
+            "regenerator-runtime": "^0.13.4"
           }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@wordpress/compose": "^3.9.0",
     "@wordpress/data": "^4.11.0",
     "@wordpress/date": "^3.7.0",
+    "@wordpress/dom-ready": "^2.9.0",
     "@wordpress/edit-post": "^3.13.0",
     "@wordpress/hooks": "^2.6.0",
     "@wordpress/html-entities": "^2.5.0",

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -119,7 +119,7 @@ class Edit extends Component {
 												<figure className="post-thumbnail">
 													{ post.newspack_featured_image_src && (
 														<a href="#" rel="bookmark">
-															<img src={ post.newspack_featured_image_src.landscape } alt="" />
+															<img src={ post.newspack_featured_image_src.large } alt="" />
 														</a>
 													) }
 												</figure>

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -16,7 +16,62 @@ if ( typeof window !== 'undefined' ) {
 		);
 		blocksArray.forEach( block => {
 			const container = block.querySelector( '.swiper-container' );
-			createSwiper( container );
+			const params = Array.from( block.classList ).reduce(
+				( accumulator, className ) => {
+					const prefix = 'wp-block-newspack-carousel__param-';
+					if ( 0 === className.indexOf( prefix ) ) {
+						const a = className.split( prefix );
+						const b = a[ a.length - 1 ].split( '-' );
+						accumulator[ b[ 0 ] ] = b[ 1 ];
+					}
+					return accumulator;
+				},
+				{ autoplay: false, delay: 0 }
+			);
+			const els = {
+				prev: block.querySelector( '.swiper-button-prev' ),
+				next: block.querySelector( '.swiper-button-next' ),
+				pagination: block.querySelector( '.swiper-pagination-bullets' ),
+				pause: block.querySelector( '.swiper-button-pause' ),
+				play: block.querySelector( '.swiper-button-play' ),
+			};
+			const swiperConfig = {
+				autoplay: parseInt( params.autoplay )
+					? {
+							delay: parseInt( params.delay ) * 1000,
+							disableOnInteraction: false,
+					  }
+					: false,
+				effect: 'slide',
+				initialSlide: 0,
+				loop: true,
+				navigation: {
+					nextEl: els.next,
+					prevEl: els.prev,
+				},
+				pagination: {
+					clickable: true,
+					el: els.pagination,
+					type: 'bullets',
+				},
+				on: {
+					init() {
+						if ( els.pause ) {
+							els.pause.addEventListener( 'click', () => {
+								this.autoplay.stop();
+								block.classList.remove( 'wp-block-newspack-blocks-carousel__autoplay-playing' );
+							} );
+						}
+						if ( els.play ) {
+							els.play.addEventListener( 'click', () => {
+								this.autoplay.start();
+								block.classList.add( 'wp-block-newspack-blocks-carousel__autoplay-playing' );
+							} );
+						}
+					},
+				},
+			};
+			createSwiper( container, swiperConfig );
 		} );
 	} );
 }

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -1,7 +1,22 @@
-//alert( "hello!");
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
 
 /**
- * Style dependencies
+ * Internal dependencies
  */
-
+import createSwiper from './create-swiper';
 import './view.scss';
+
+if ( typeof window !== 'undefined' ) {
+	domReady( () => {
+		const blocksArray = Array.from(
+			document.querySelectorAll( '.wp-block-newspack-blocks-carousel' )
+		);
+		blocksArray.forEach( block => {
+			const container = block.querySelector( '.swiper-container' );
+			createSwiper( container );
+		} );
+	} );
+}

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -16,18 +16,6 @@ if ( typeof window !== 'undefined' ) {
 		);
 		blocksArray.forEach( block => {
 			const container = block.querySelector( '.swiper-container' );
-			const params = Array.from( block.classList ).reduce(
-				( accumulator, className ) => {
-					const prefix = 'wp-block-newspack-carousel__param-';
-					if ( 0 === className.indexOf( prefix ) ) {
-						const a = className.split( prefix );
-						const b = a[ a.length - 1 ].split( '-' );
-						accumulator[ b[ 0 ] ] = b[ 1 ];
-					}
-					return accumulator;
-				},
-				{ autoplay: false, delay: 0 }
-			);
 			const els = {
 				prev: block.querySelector( '.swiper-button-prev' ),
 				next: block.querySelector( '.swiper-button-next' ),
@@ -35,10 +23,12 @@ if ( typeof window !== 'undefined' ) {
 				pause: block.querySelector( '.swiper-button-pause' ),
 				play: block.querySelector( '.swiper-button-play' ),
 			};
+			const autoplay = parseInt( block.dataset.autoplay ) ? true : false;
+			const delay = parseInt( block.dataset.autoplay_delay ) * 1000;
 			const swiperConfig = {
-				autoplay: parseInt( params.autoplay )
+				autoplay: autoplay
 					? {
-							delay: parseInt( params.delay ) * 1000,
+							delay,
 							disableOnInteraction: false,
 					  }
 					: false,

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -26,10 +26,6 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 	$other = array();
 	if ( $autoplay ) {
 		$other[] = 'wp-block-newspack-blocks-carousel__autoplay-playing';
-		if ( ! $is_amp ) {
-			$other[] = 'wp-block-newspack-carousel__param-autoplay-1';
-			$other[] = 'wp-block-newspack-carousel__param-delay-' . esc_attr( $delay );
-		}
 	}
 	$classes = Newspack_Blocks::block_classes( 'carousel', $attributes, $other );
 
@@ -209,11 +205,18 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 		);
 		$autoplay_ui = $autoplay ? newspack_blocks_carousel_block_autoplay_ui( $newspack_blocks_carousel_id ) : '';
 	}
+	$data_attributes = [];
+
+	if ( $autoplay && ! $is_amp ) {
+		$data_attributes[] = 'data-autoplay=1';
+		$data_attributes[] = sprintf( 'data-autoplay_delay=%s', esc_attr( $delay ) );
+	}
 	Newspack_Blocks::enqueue_view_assets( 'carousel' );
 	return sprintf(
-		'<div class="%1$s" id="wp-block-newspack-carousel__%2$d">%3$s%4$s%5$s</div>',
+		'<div class="%1$s" id="wp-block-newspack-carousel__%2$d" %3$s>%4$s%5$s%6$s</div>',
 		esc_attr( $classes ),
 		absint( $newspack_blocks_carousel_id ),
+		esc_attr( implode( ' ', $data_attributes ) ),
 		$carousel,
 		$autoplay_ui,
 		$selector

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -26,6 +26,10 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 	$other = array();
 	if ( $autoplay ) {
 		$other[] = 'wp-block-newspack-blocks-carousel__autoplay-playing';
+		if ( ! $is_amp ) {
+			$other[] = 'wp-block-newspack-carousel__param-autoplay-1';
+			$other[] = 'wp-block-newspack-carousel__param-delay-' . esc_attr( $delay );
+		}
 	}
 	$classes = Newspack_Blocks::block_classes( 'carousel', $attributes, $other );
 
@@ -174,12 +178,12 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 		);
 	}
 	if ( $is_amp ) {
-		$selector = sprintf(
+		$selector    = sprintf(
 			'<amp-selector id="wp-block-newspack-carousel__amp-pagination__%1$d" class="swiper-pagination-bullets amp-pagination" on="select:wp-block-newspack-carousel__amp-carousel__%1$d.goToSlide(index=event.targetOption)" layout="container">%2$s</amp-selector>',
 			absint( $newspack_blocks_carousel_id ),
 			implode( '', $buttons )
 		);
-		$carousel = sprintf(
+		$carousel    = sprintf(
 			'<amp-carousel width="4" height="3" layout="responsive" type="slides" data-next-button-aria-label="%1$s" data-prev-button-aria-label="%2$s" controls loop %3$s id="wp-block-newspack-carousel__amp-carousel__%4$s" on="slideChange:wp-block-newspack-carousel__amp-pagination__%4$s.toggle(index=event.index, value=true)">%5$s</amp-carousel>',
 			esc_attr__( 'Next Slide', 'newspack-blocks' ),
 			esc_attr__( 'Previous Slide', 'newspack-blocks' ),
@@ -187,15 +191,23 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 			absint( $newspack_blocks_carousel_id ),
 			$slides
 		);
+		$autoplay_ui = $autoplay ? newspack_blocks_carousel_block_autoplay_ui_amp( $newspack_blocks_carousel_id ) : '';
 	} else {
-		$selector = sprintf(
+		$selector    = sprintf(
 			'<div class="swiper-pagination-bullets amp-pagination">%s</div>',
 			implode( '', $buttons )
 		);
-		$carousel = sprintf(
-			'<div class="swiper-container"><div class="swiper-wrapper">%s</div></div>',
-			$slides
+		$navigation  = sprintf(
+			'<a class="swiper-button swiper-button-prev" role="button" aria-label="%s"></a><a class="swiper-button swiper-button-next" role="button" aria-labvel="%s"></a>',
+			esc_attr__( 'Previous Slide', 'newspack-blocks' ),
+			esc_attr__( 'Next Slide', 'newspack-blocks' )
 		);
+		$carousel    = sprintf(
+			'<div class="swiper-container"><div class="swiper-wrapper">%s</div>%s</div>',
+			$slides,
+			$navigation
+		);
+		$autoplay_ui = $autoplay ? newspack_blocks_carousel_block_autoplay_ui( $newspack_blocks_carousel_id ) : '';
 	}
 	Newspack_Blocks::enqueue_view_assets( 'carousel' );
 	return sprintf(
@@ -203,19 +215,34 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 		esc_attr( $classes ),
 		absint( $newspack_blocks_carousel_id ),
 		$carousel,
-		$autoplay ? newspack_blocks_carousel_block_autoplay_ui( $newspack_blocks_carousel_id ) : '',
+		$autoplay_ui,
 		$selector
 	);
 }
 
 /**
- * Generate autoplay play/pause UI.
+ * Generate autoplay play/pause UI for non-AMP requests.
  *
  * @param int $block_ordinal The ordinal number of the block, used in unique ID.
  *
  * @return string Autoplay UI markup.
  */
 function newspack_blocks_carousel_block_autoplay_ui( $block_ordinal = 0 ) {
+	return sprintf(
+		'<a aria-label="%s" class="swiper-button swiper-button-pause" role="button"></a><a aria-label="%s" class="swiper-button swiper-button-play" role="button"></a>',
+		esc_attr__( 'Pause Slideshow', 'newspack-blocks' ),
+		esc_attr__( 'Play Slideshow', 'newspack-blocks' )
+	);
+}
+
+/**
+ * Generate autoplay play/pause UI for AMP requests.
+ *
+ * @param int $block_ordinal The ordinal number of the block, used in unique ID.
+ *
+ * @return string Autoplay UI markup.
+ */
+function newspack_blocks_carousel_block_autoplay_ui_amp( $block_ordinal = 0 ) {
 	$block_id        = sprintf(
 		'wp-block-newspack-carousel__%d',
 		absint( $block_ordinal )

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -13,39 +13,6 @@
  * @return string Returns the post content with latest posts added.
  */
 function newspack_blocks_render_block_carousel( $attributes ) {
-	if ( ! wp_script_is( 'amp-runtime', 'registered' ) ) {
-		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
-		wp_register_script(
-			'amp-runtime',
-			'https://cdn.ampproject.org/v0.js',
-			null,
-			null,
-			true
-		);
-	}
-	if ( ! wp_script_is( 'amp-carousel', 'registered' ) ) {
-		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
-		wp_register_script(
-			'amp-carousel',
-			'https://cdn.ampproject.org/v0/amp-carousel-latest.js',
-			array( 'amp-runtime' ),
-			null,
-			true
-		);
-	}
-	if ( ! wp_script_is( 'amp-selector', 'registered' ) ) {
-		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
-		wp_register_script(
-			'amp-selector',
-			'https://cdn.ampproject.org/v0/amp-selector-latest.js',
-			array( 'amp-runtime' ),
-			null,
-			true
-		);
-	}
-
-	wp_enqueue_script( 'amp-carousel' );
-	wp_enqueue_script( 'amp-selector' );
 	static $newspack_blocks_carousel_id = 0;
 	$newspack_blocks_carousel_id++;
 	$autoplay      = isset( $attributes['autoplay'] ) ? $attributes['autoplay'] : false;

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -33,7 +33,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 	}
 	$classes = Newspack_Blocks::block_classes( 'carousel', $attributes, $other );
 
-	$args          = array(
+	$args = array(
 		'posts_per_page'      => $posts_to_show,
 		'post_status'         => 'publish',
 		'suppress_filters'    => false,
@@ -140,21 +140,21 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 							<?php
 							endif;
 
-							if ( $attributes['showDate'] ) {
-								$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
-								if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
-									$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
-								}
-								$time_string = sprintf(
-									$time_string,
-									esc_attr( get_the_date( DATE_W3C ) ),
-									esc_html( get_the_date() ),
-									esc_attr( get_the_modified_date( DATE_W3C ) ),
-									esc_html( get_the_modified_date() )
-								);
-								echo $time_string; // WPCS: XSS OK.
+						if ( $attributes['showDate'] ) {
+							$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
+							if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
+								$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
 							}
-							?>
+							$time_string = sprintf(
+								$time_string,
+								esc_attr( get_the_date( DATE_W3C ) ),
+								esc_html( get_the_date() ),
+								esc_attr( get_the_modified_date( DATE_W3C ) ),
+								esc_html( get_the_modified_date() )
+							);
+							echo $time_string; // phpcs:ignore
+						}
+						?>
 					</div><!-- .entry-meta -->
 				</div><!-- .entry-wrapper -->
 			</article>

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -80,9 +80,11 @@
 		margin: 0;
 		height: 100%;
 		padding: 0;
+		a,
 		img {
-			width: 100%;
+			display: block;
 			height: 100%;
+			width: 100%;
 		}
 	}
 	p {
@@ -119,7 +121,6 @@
 			width: 24px;
 		}
 	}
-
 	.swiper-button,
 	.amp-carousel-button {
 		background-color: rgba( black, 0.5 );
@@ -155,19 +156,20 @@
 			display: block;
 		}
 	}
-
+	.swiper-button-next,
+	.swiper-button-prev {
+		margin-top: -24px;
+	}
 	.amp-carousel-button-next,
 	.swiper-button-next {
 		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M5.88%204.12L13.76%2012l-7.88%207.88L8%2022l10-10L8%202z'%20fill='white'/%3E%3Cpath%20fill='none'%20d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
 		left: auto;
 		right: 1.5em;
 	}
-
 	.amp-carousel-button-prev,
 	.swiper-button-prev {
 		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M18%204.12L10.12%2012%2018%2019.88%2015.88%2022l-10-10%2010-10z'%20fill='white'/%3E%3Cpath%20fill='none'%20d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
 	}
-
 	.amp-carousel-button-pause,
 	.amp-carousel-button-play,
 	.swiper-button-pause,
@@ -194,7 +196,6 @@
 	/* Headings */
 	.entry-title {
 		margin: 0 0 0.25em;
-
 		a {
 			color: inherit;
 			text-decoration: none;
@@ -207,7 +208,6 @@
 		flex-wrap: wrap;
 		align-items: center;
 		margin-top: 0.5em;
-
 		.byline:not( :last-child ) {
 			margin-right: 1.5em;
 		}
@@ -217,7 +217,6 @@
 		font-size: 0.6em;
 		font-weight: bold;
 		margin: 0 0 0.5em;
-
 		a {
 			text-decoration: none;
 		}

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -112,6 +112,7 @@
 			box-shadow: 0 0 0 2px white, 0 0 0 4px black;
 			outline: 0;
 		}
+		&.swiper-pagination-bullet-active,
 		&[selected] {
 			opacity: 1;
 			outline: 0;
@@ -119,6 +120,7 @@
 		}
 	}
 
+	.swiper-button,
 	.amp-carousel-button {
 		background-color: rgba( black, 0.5 );
 		background-position: center;
@@ -143,7 +145,9 @@
 		}
 	}
 	.amp-carousel-button-next,
-	.amp-carousel-button-prev {
+	.amp-carousel-button-prev,
+	.swiper-button-next,
+	.swiper-button-prev {
 		left: 1.5em;
 		display: none;
 
@@ -151,16 +155,23 @@
 			display: block;
 		}
 	}
-	.amp-carousel-button-next {
+
+	.amp-carousel-button-next,
+	.swiper-button-next {
 		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M5.88%204.12L13.76%2012l-7.88%207.88L8%2022l10-10L8%202z'%20fill='white'/%3E%3Cpath%20fill='none'%20d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
 		left: auto;
 		right: 1.5em;
 	}
-	.amp-carousel-button-prev {
+
+	.amp-carousel-button-prev,
+	.swiper-button-prev {
 		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M18%204.12L10.12%2012%2018%2019.88%2015.88%2022l-10-10%2010-10z'%20fill='white'/%3E%3Cpath%20fill='none'%20d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
 	}
+
+	.amp-carousel-button-pause,
 	.amp-carousel-button-play,
-	.amp-carousel-button-pause {
+	.swiper-button-pause,
+	.swiper-button-play {
 		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M6%2019h4V5H6v14zm8-14v14h4V5h-4z'%20fill='white'/%3E%3Cpath%20d='M0%200h24v24H0z'%20fill='none'/%3E%3C/svg%3E" );
 		display: none;
 		margin-top: 0;
@@ -170,7 +181,8 @@
 		transform: none;
 		z-index: 1;
 	}
-	.amp-carousel-button-play {
+	.amp-carousel-button-play,
+	.swiper-button-play {
 		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M8%205v14l11-7z'%20fill='white'/%3E%3Cpath%20d='M0 0h24v24H0z'%20fill='none'/%3E%3C/svg%3E" );
 	}
 
@@ -200,7 +212,6 @@
 			margin-right: 1.5em;
 		}
 	}
-
 	.cat-links {
 		color: inherit;
 		font-size: 0.6em;
@@ -211,18 +222,21 @@
 			text-decoration: none;
 		}
 	}
-
 	.avatar {
 		border-radius: 100%;
 		display: block;
 		margin-right: 0.5em;
 	}
 	&.wp-block-newspack-blocks-carousel__autoplay-playing .amp-carousel-button-pause,
-	.amp-carousel-button-play {
+	&.wp-block-newspack-blocks-carousel__autoplay-playing .swiper-button-pause,
+	.amp-carousel-button-play,
+	.swiper-button-play {
 		display: block;
 	}
 	&.wp-block-newspack-blocks-carousel__autoplay-playing .amp-carousel-button-play,
-	.amp-carousel-button-pause {
+	&.wp-block-newspack-blocks-carousel__autoplay-playing .swiper-button-play,
+	.amp-carousel-button-pause,
+	.swiper-button-pause {
 		display: none;
 	}
 }

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -188,6 +188,11 @@
 		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M8%205v14l11-7z'%20fill='white'/%3E%3Cpath%20d='M0 0h24v24H0z'%20fill='none'/%3E%3C/svg%3E" );
 	}
 
+	/* Swiper Slide */
+	.swiper-slide {
+		height: auto;
+	}
+
 	/* Image styles */
 	figcaption {
 		font-size: $font__size-xxs;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Originally the Carousel block took an experimental approach using an AMP component in AMP and non-AMP contexts, effectively treating AMP as a general-use components library. This is an unsupported use case, and although it has worked so far, there could be unexpected side effects. The block is being adapted for use on WordPress.com, which multiplies these risks. This PR reworks the front end rendering so that `amp-component` is used in AMP requests and [Swiper](https://swiperjs.com/) is used in non-AMP. 

Closes https://github.com/Automattic/newspack-blocks/issues/449
Closes https://github.com/Automattic/newspack-blocks/issues/442

### How to test the changes in this Pull Request:

_Note: If Newspack Pop-ups is active, deactivate it. Pop-ups also enqueues AMP scripts in non-AMP requests so it confuses testing and verification of this branch._

1. Put the AMP plugin into Transitional mode. 
2. Add one or more Carousel blocks to a post, publish and view.
3. Alternate between AMP and non-AMP requests. The two should be near identical. 
4. Test all Carousel features, and test with a variety of posts with and without featured images.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
