### PR TITLE
fix: byline, avatar and date in carousel block

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -164,6 +164,10 @@ class Newspack_Blocks_API {
 				} else {
 					$author_avatar = coauthors_get_avatar( $author, 48 );
 				}
+				$author_link = null;
+				if ( function_exists( 'coauthors_posts_links' ) ) {
+					$author_link = get_author_posts_url( $author->ID, $author->user_nicename );
+				}
 				$author_data[] = array(
 					/* Get the author name */
 					'display_name' => esc_html( $author->display_name ),
@@ -171,6 +175,8 @@ class Newspack_Blocks_API {
 					'avatar'       => wp_kses_post( $author_avatar ),
 					/* Get the author ID */
 					'id'           => $author->ID,
+					/* Get the author Link */
+					'author_link'  => $author_link,
 				);
 			}
 		else :
@@ -181,6 +187,8 @@ class Newspack_Blocks_API {
 				'avatar'       => get_avatar( $object['author'], 48 ),
 				/* Get the author ID */
 				'id'           => $object['author'],
+				/* Get the author Link */
+				'author_link'  => get_author_posts_url( $object['author'] ),
 			);
 		endif;
 

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -5,19 +5,20 @@
  */
 import QueryControls from '../../components/query-controls';
 import createSwiper from './create-swiper';
-import classnames from 'classnames';
+import { formatAvatars, formatByline } from '../../shared/js/utils';
 
 /**
  * External dependencies
  */
 import { isUndefined, pickBy } from 'lodash';
-import moment from 'moment';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, createRef, Fragment, RawHTML } from '@wordpress/element';
+import { dateI18n, __experimentalGetSettings } from '@wordpress/date';
+import { Component, createRef, Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/editor';
 import {
 	PanelBody,
@@ -78,6 +79,7 @@ class Edit extends Component {
 			{}
 		);
 	}
+
 	render() {
 		const { attributes, className, setAttributes, latestPosts } = this.props;
 		const { autoPlayState } = this.state;
@@ -99,7 +101,7 @@ class Edit extends Component {
 			'swiper-container',
 			autoplay && autoPlayState && 'wp-block-newspack-blocks-carousel__autoplay-playing'
 		);
-
+		const dateFormat = __experimentalGetSettings().formats.date;
 		return (
 			<Fragment>
 				<div className={ classes } ref={ this.carouselRef }>
@@ -133,26 +135,13 @@ class Edit extends Component {
 														<a href="#">{ decodeEntities( post.title.rendered.trim() ) }</a>
 													</h3>
 													<div className="entry-meta">
-														{ showAuthor && showAvatar && post.newspack_author_info.avatar && (
-															<span className="avatar author-avatar" key="author-avatar">
-																<RawHTML>{ post.newspack_author_info.avatar }</RawHTML>
-															</span>
-														) }
-														{ showAuthor && (
-															<span className="byline">
-																{ __( 'by' ) }{' '}
-																<span className="author vcard">
-																	<a className="url fn n" href="#">
-																		{ post.newspack_author_info.display_name }
-																	</a>
-																</span>
-															</span>
-														) }
+														{ showAuthor &&
+															showAvatar &&
+															formatAvatars( post.newspack_author_info ) }
+														{ showAuthor && formatByline( post.newspack_author_info ) }
 														{ showDate && (
 															<time className="entry-date published" key="pub-date">
-																{ moment( post.date_gmt )
-																	.local()
-																	.format( 'MMMM DD, Y' ) }
+																{ dateI18n( dateFormat, post.date_gmt ) }
 															</time>
 														) }
 													</div>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -6,6 +6,7 @@
 import QueryControls from '../../components/query-controls';
 import { STORE_NAMESPACE } from './store';
 import { isBlogPrivate, isSpecificPostModeActive, queryCriteriaFromAttributes } from './utils';
+import { formatAvatars, formatByline } from '../../shared/js/utils';
 
 /**
  * External dependencies
@@ -15,7 +16,7 @@ import classNames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { dateI18n, __experimentalGetSettings } from '@wordpress/date';
 import { Component, Fragment, RawHTML } from '@wordpress/element';
 import {
@@ -178,8 +179,8 @@ class Edit extends Component {
 						</RawHTML>
 					) }
 					<div className="entry-meta">
-						{ showAuthor && showAvatar && this.formatAvatars( post.newspack_author_info ) }
-						{ showAuthor && this.formatByline( post.newspack_author_info ) }
+						{ showAuthor && showAvatar && formatAvatars( post.newspack_author_info ) }
+						{ showAuthor && formatByline( post.newspack_author_info ) }
 						{ showDate && (
 							<time className="entry-date published" key="pub-date">
 								{ dateI18n( dateFormat, post.date_gmt ) }
@@ -202,35 +203,6 @@ class Edit extends Component {
 			return decodeEntities( post.title.rendered.trim() );
 		}
 	};
-
-	formatAvatars = authorInfo =>
-		authorInfo.map( author => (
-			<span className="avatar author-avatar" key={ author.id }>
-				<a className="url fn n" href="#">
-					<RawHTML>{ author.avatar }</RawHTML>
-				</a>
-			</span>
-		) );
-
-	formatByline = authorInfo => (
-		<span className="byline">
-			{ _x( 'by', 'post author', 'newspack-blocks' ) }{' '}
-			{ authorInfo.reduce( ( accumulator, author, index ) => {
-				return [
-					...accumulator,
-					<span className="author vcard" key={ author.id }>
-						<a className="url fn n" href="#">
-							{ author.display_name }
-						</a>
-					</span>,
-					index < authorInfo.length - 2 && ', ',
-					authorInfo.length > 1 &&
-						index === authorInfo.length - 2 &&
-						_x( ' and ', 'post author', 'newspack-blocks' ),
-				];
-			}, [] ) }
-		</span>
-	);
 
 	renderInspectorControls = () => {
 		const { attributes, setAttributes, textColor, setTextColor } = this.props;

--- a/src/shared/js/utils.js
+++ b/src/shared/js/utils.js
@@ -7,7 +7,7 @@ import { RawHTML } from '@wordpress/element';
 export const formatAvatars = authorInfo =>
 	authorInfo.map( author => (
 		<span className="avatar author-avatar" key={ author.id }>
-			<a className="url fn n" href="#">
+			<a className="url fn n" href={ author.author_link }>
 				<RawHTML>{ author.avatar }</RawHTML>
 			</a>
 		</span>
@@ -20,7 +20,7 @@ export const formatByline = authorInfo => (
 			return [
 				...accumulator,
 				<span className="author vcard" key={ author.id }>
-					<a className="url fn n" href="#">
+					<a className="url fn n" href={ author.author_link }>
 						{ author.display_name }
 					</a>
 				</span>,

--- a/src/shared/js/utils.js
+++ b/src/shared/js/utils.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { _x } from '@wordpress/i18n';
+import { RawHTML } from '@wordpress/element';
+
+export const formatAvatars = authorInfo =>
+	authorInfo.map( author => (
+		<span className="avatar author-avatar" key={ author.id }>
+			<a className="url fn n" href="#">
+				<RawHTML>{ author.avatar }</RawHTML>
+			</a>
+		</span>
+	) );
+
+export const formatByline = authorInfo => (
+	<span className="byline">
+		{ _x( 'by', 'post author', 'newspack-blocks' ) }{' '}
+		{ authorInfo.reduce( ( accumulator, author, index ) => {
+			return [
+				...accumulator,
+				<span className="author vcard" key={ author.id }>
+					<a className="url fn n" href="#">
+						{ author.display_name }
+					</a>
+				</span>,
+				index < authorInfo.length - 2 && ', ',
+				authorInfo.length > 1 &&
+					index === authorInfo.length - 2 &&
+					_x( ' and ', 'post author', 'newspack-blocks' ),
+			];
+		}, [] ) }
+	</span>
+);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The byline and avatar display logic in Homepage Posts has changed since Carousel was first introduced. This brings the two in sync, extracting the handling of both to a shared utilities file.

Closes https://github.com/Automattic/newspack-blocks/issues/445

### How to test the changes in this Pull Request:

1. Add Carousel block to the editor, verify author, avatar and date display.
2. Publish the post and verify the display is the same. 
3. Add one or more Homepage Posts blocks, verify the byline/date/avatar display is unchanged.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
