### PR TITLE
fix: carousel image being distorted

### DIFF
--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -191,6 +191,10 @@
 	/* Swiper Slide */
 	.swiper-slide {
 		height: auto;
+
+		.post-thumbnail img {
+			object-fit: cover;
+		}
 	}
 
 	/* Image styles */

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -191,6 +191,7 @@
 	/* Swiper Slide */
 	.swiper-slide {
 		height: auto;
+		max-height: 75vh;
 
 		.post-thumbnail img {
 			object-fit: cover;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Use `object-fit: cover` to keep the correct ratio.

_Note: This won't work for anyone using IE11._

Closes #460

### How to test the changes in this Pull Request:

1. Replicate #460
2. Switch to this branch
3. Refresh your carousel

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
