### PR TITLE
Carousel: Remove post modified time

### DIFF
--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -136,20 +136,13 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 							<?php
 							endif;
 
-						if ( $attributes['showDate'] ) {
-							$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
-							if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
-								$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
-							}
-							$time_string = sprintf(
-								$time_string,
-								esc_attr( get_the_date( DATE_W3C ) ),
-								esc_html( get_the_date() ),
-								esc_attr( get_the_modified_date( DATE_W3C ) ),
-								esc_html( get_the_modified_date() )
-							);
-							echo $time_string; // phpcs:ignore
-						}
+							if ( $attributes['showDate'] ) :
+								printf(
+									'<time class="entry-date published" datetime="%1$s">%2$s</time>',
+									esc_attr( get_the_date( DATE_W3C ) ),
+									esc_html( get_the_date() )
+								);
+							endif;
 						?>
 					</div><!-- .entry-meta -->
 				</div><!-- .entry-wrapper -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes post updated time element to accomodate themes that doon't fully support microformats.
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #452.

### How to test the changes in this Pull Request:

1. Have two or more posts with featured images
2. Update one of the posts with new content
3. Add the articles carousel to a page
4. Publish the page 
5. Visit the page and see that the post in the carousel doesn't show a repeated date
