### PR TITLE
Group Block style: Add border option to group block

### DIFF
--- a/src/block-styles/core/group/editor.scss
+++ b/src/block-styles/core/group/editor.scss
@@ -1,3 +1,6 @@
+@import '../../../shared/sass/variables';
+@import '../../../shared/sass/mixins';
+
 .block-editor-block-list__layout
 	.block-editor-block-list__block[data-align='left']
 	.block-editor-block-list__block-edit
@@ -7,4 +10,14 @@
 	.block-editor-block-list__block-edit
 	.block-editor-block-list__block-edit {
 	float: none;
+}
+
+.wp-block-group {
+	&.is-style-border {
+		border: 1px solid $color__border;
+
+		&:not( .has-background ) {
+			padding: 20px 30px;
+		}
+	}
 }

--- a/src/block-styles/core/group/index.js
+++ b/src/block-styles/core/group/index.js
@@ -2,7 +2,9 @@
  * External dependencies
  */
 import { addFilter } from '@wordpress/hooks';
+import { registerBlockStyle } from '@wordpress/blocks';
 import './editor.scss';
+
 addFilter( 'blocks.registerBlockType', 'newspack-blocks', ( settings, name ) => {
 	if ( name === 'core/group' ) {
 		const { supports } = settings;
@@ -15,4 +17,9 @@ addFilter( 'blocks.registerBlockType', 'newspack-blocks', ( settings, name ) => 
 		}
 	}
 	return settings;
+} );
+
+registerBlockStyle( 'core/group', {
+	name: 'border',
+	label: 'Border',
 } );

--- a/src/block-styles/core/group/view.scss
+++ b/src/block-styles/core/group/view.scss
@@ -1,0 +1,12 @@
+@import '../../../shared/sass/variables';
+@import '../../../shared/sass/mixins';
+
+.wp-block-group {
+	&.is-style-border {
+		border: 1px solid $color__border;
+
+		&:not( .has-background ) {
+			padding: 20px 30px;
+		}
+	}
+}

--- a/src/block-styles/view.js
+++ b/src/block-styles/view.js
@@ -2,3 +2,4 @@
  * Internal dependencies
  */
 import './core/columns/view.scss';
+import './core/group/view.scss';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a border style to the group block, a request that's come up a couple times.

It will need to be paired with border-related styles in the theme as well, to make sure some of the child themes (specifically, Nelson, Katharine and Joseph) are using their border styles on this block, too.

Closes #195.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. In the editor, add a group block, and confirm there is a 'borders' style. Apply it to your block:

![image](https://user-images.githubusercontent.com/177561/81219802-2f9def00-8f95-11ea-9812-4e3fb247437d.png)

3. View in the editor, and confirm a border has been added, as well as padding (it's equal to how much padding is added when you add a background colour to that block):

![image](https://user-images.githubusercontent.com/177561/81219824-36c4fd00-8f95-11ea-841f-0a8fa0d0e7e4.png)

4. View on the front-end and confirm the border has been added:

![image](https://user-images.githubusercontent.com/177561/81219951-6bd14f80-8f95-11ea-9809-2643574fce6f.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
