### PR TITLE
Homepage Posts, Article Carousel: Make sure content options don't affect blocks

### DIFF
--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -243,4 +243,16 @@
 	.swiper-button-pause {
 		display: none;
 	}
+
+	// Make sure Jetpack Content Options don't affect the block.
+	.posted-on,
+	.cat-links,
+	.tags-links,
+	.byline,
+	.author-avatar {
+		clip: auto;
+		height: auto;
+		position: relative;
+		width: auto;
+	}
 }

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -357,6 +357,18 @@
 			display: block;
 		}
 	}
+
+	// Make sure Jetpack Content Options don't affect the block.
+	.posted-on,
+	.cat-links,
+	.tags-links,
+	.byline,
+	.author-avatar {
+		clip: auto;
+		height: auto;
+		position: relative;
+		width: auto;
+	}
 }
 
 /*


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds styles to make sure Jetpack's Content Options won't hide the category, author byline or date in the Homepage Posts block and Article Carousel block, since each have their own controls to toggle those settings.

I'd originally fixed this for the Homepage Posts block in the Newspack Theme, but it makes more sense to tackle it in the block, since it could happen with other themes.

Should be tested with https://github.com/Automattic/newspack-theme/pull/919 (a PR removing the original fix from the Newspack theme), to make sure the block fix isn't coming from there. 

Closes #465.

### How to test the changes in this Pull Request:

1. Add a Homepage Posts block and Article Carousel to a page. For both, enable everything (author, date, category).
2. Navigate to Customizer > Content Options, and uncheck all the options under Post Details (Display Date, Display Author).
3. View the blocks on the front-end; note some elements are not displaying, like author name, category, and, for the article post block, date:

![image](https://user-images.githubusercontent.com/177561/81232205-5534f380-8fa9-11ea-9266-9a4185a01ba2.png)

![image](https://user-images.githubusercontent.com/177561/81232224-5d8d2e80-8fa9-11ea-81aa-f45f3a7c1b52.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the author, date, and category are all displaying, matching your block settings:

![image](https://user-images.githubusercontent.com/177561/81232297-7dbced80-8fa9-11ea-982f-65ec2bb06ec0.png)

![image](https://user-images.githubusercontent.com/177561/81232309-83b2ce80-8fa9-11ea-8139-e322c173a88e.png)

(Note: I have some contrast issues in the Article Carousel block that are being picked up from the Newspack theme, and will be fixed there).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
