### PR TITLE
Articles Carousel: Improve accessibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7729,12 +7729,26 @@
       }
     },
     "@wordpress/escape-html": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.2.0.tgz",
-      "integrity": "sha512-IILebUBTFADag62cwxYcLFYoKeHRpDZiKwwhabiWd2sGoSdci1cqLxmLbE8iMcMQru7ALptQgQmhZcuX87DEwg==",
-      "dev": true,
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.8.0.tgz",
+      "integrity": "sha512-z7z+57nm9Dv3Hau0u3+17dJCbpWnh853VBF6JPID7rKnLPw2AOoRJtNHf4gLeBJTrG6M4cC8EG8Flarsuoxb2w==",
       "requires": {
-        "@babel/runtime": "^7.3.1"
+        "@babel/runtime": "^7.9.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+          "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        }
       }
     },
     "@wordpress/eslint-plugin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5399,23 +5399,26 @@
       }
     },
     "@wordpress/a11y": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.5.1.tgz",
-      "integrity": "sha512-aZidVNquAYrGopHLUr96vhX47kteAw41EC3zAsP2wxMkmTd2q2olCAaBo12a4rbj0JwNyw4Pq2uqis5hZVuMXw==",
-      "dev": true,
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.9.0.tgz",
+      "integrity": "sha512-1YBqy+yrAnCnQAayvQ6kx4O3vHq4EAyFh8UdNwbK0ZE4f+2Kzj/fD5QoICaTPl3vMzHb8ISeFyGFTxzqqBZh1g==",
       "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@wordpress/dom-ready": "^2.5.1"
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/dom-ready": "^2.9.0"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.7.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
-          "integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
-          "dev": true,
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+          "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
           "requires": {
-            "regenerator-runtime": "^0.13.2"
+            "regenerator-runtime": "^0.13.4"
           }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@wordpress/date": "^3.7.0",
     "@wordpress/dom-ready": "^2.9.0",
     "@wordpress/edit-post": "^3.13.0",
+    "@wordpress/escape-html": "^1.8.0",
     "@wordpress/hooks": "^2.6.0",
     "@wordpress/html-entities": "^2.5.0",
     "@wordpress/i18n": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "private": true,
   "dependencies": {
+    "@wordpress/a11y": "^2.9.0",
     "@wordpress/compose": "^3.9.0",
     "@wordpress/data": "^4.11.0",
     "@wordpress/date": "^3.7.0",

--- a/src/blocks/carousel/create-swiper.js
+++ b/src/blocks/carousel/create-swiper.js
@@ -14,13 +14,16 @@ import 'swiper/dist/css/swiper.css';
  * @param {HTMLElement} slide Slide DOM element
  */
 export function activateSlide( slide ) {
-	slide.ariaHidden = 'false';
+	slide.setAttribute( 'aria-hidden', 'false' );
+
 	/**
 	 * Calls Array.prototype.forEach for IE11 compatibility.
 	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/NodeList
 	 */
-	Array.prototype.forEach.call( slide.querySelectorAll( 'a' ), e => ( e.tabIndex = '0' ) );
+	Array.prototype.forEach.call( slide.querySelectorAll( 'a' ), el =>
+		el.removeAttribute( 'tabindex' )
+	);
 }
 
 /**
@@ -29,13 +32,15 @@ export function activateSlide( slide ) {
  * @param {HTMLElement} slide Slide DOM element
  */
 export function deactivateSlide( slide ) {
-	slide.ariaHidden = 'true';
+	slide.setAttribute( 'aria-hidden', 'true' );
 	/**
 	 * Calls Array.prototype.forEach for IE11 compatibility.
 	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/NodeList
 	 */
-	Array.prototype.forEach.call( slide.querySelectorAll( 'a' ), e => ( e.tabIndex = '-1' ) );
+	Array.prototype.forEach.call( slide.querySelectorAll( 'a' ), el =>
+		el.setAttribute( 'tabindex', '-1' )
+	);
 }
 
 /**

--- a/src/blocks/carousel/create-swiper.js
+++ b/src/blocks/carousel/create-swiper.js
@@ -2,15 +2,26 @@
  * External dependencies
  */
 import { merge } from 'lodash';
+import { speak } from '@wordpress/a11y';
 import { __, sprintf } from '@wordpress/i18n';
 import Swiper from 'swiper';
 import 'swiper/dist/css/swiper.css';
+
+export const activateSlide = slide => {
+	slide.ariaHidden = 'false';
+	slide.querySelectorAll( 'a' ).forEach( e => ( e.tabIndex = '0' ) );
+};
+
+export const deactivateSlide = slide => {
+	slide.ariaHidden = 'true';
+	slide.querySelectorAll( 'a' ).forEach( e => ( e.tabIndex = '-1' ) );
+};
 
 /**
  * @param {string} container Selector
  * @param {Object} params Params passed to Swiper
  */
-export default function createSwiper( container = '.swiper-container', params = {} ) {
+export const createSwiper = ( container = '.swiper-container', params = {} ) => {
 	const defaultParams = {
 		/**
 		 * Remove the messages, as we're announcing the slide content and number. These messages are overwriting the slide announcement.
@@ -42,7 +53,36 @@ export default function createSwiper( container = '.swiper-container', params = 
 		releaseFormElements: false,
 		setWrapperSize: true,
 		touchStartPreventDefault: false,
+		on: {
+			init() {
+				this.wrapperEl
+					.querySelectorAll( '.swiper-slide' )
+					.forEach( slide => deactivateSlide( slide ) );
+
+				// Set-up our active slide.
+				activateSlide( this.slides[ this.activeIndex ] );
+			},
+			slideChange() {
+				deactivateSlide( this.slides[ this.previousIndex ] );
+
+				activateSlide( this.slides[ this.activeIndex ] );
+
+				// If we're autoplaying, don't announce the slide change, as that would be supremely annoying.
+				if ( ! this.autoplay.running ) {
+					// Announce the contents of the slide.
+					speak(
+						`${ this.slides[ this.activeIndex ].innerHTML }, ${ sprintf(
+							/* translators: current slide number and the total number of slides */
+							__( 'Slide %s of %s', 'newspack-blocks' ),
+							this.realIndex + 1,
+							this.pagination.bullets.length
+						) }`,
+						'assertive'
+					);
+				}
+			},
+		},
 	};
 
 	return new Swiper( container, merge( {}, defaultParams, params ) );
-}
+};

--- a/src/blocks/carousel/create-swiper.js
+++ b/src/blocks/carousel/create-swiper.js
@@ -44,7 +44,8 @@ export function deactivateSlide( slide ) {
 
 /**
  * @param {Object} els Swiper elements
- * @param {Element} els.container Container element
+ * @param {Element} els.block Block element
+ * @param {Element} els.container Swiper container element
  * @param {Element} els.next Next button element
  * @param {Element} els.prev Previous button element
  * @param {Element} els.play Play button element
@@ -98,7 +99,7 @@ export function createSwiper( els, config = {} ) {
 						}
 
 						this.autoplay.stop();
-						els.container.classList.remove( 'wp-block-newspack-blocks-carousel__autoplay-playing' );
+						els.block.classList.remove( 'wp-block-newspack-blocks-carousel__autoplay-playing' );
 						speak( __( 'Paused', 'newspack-blocks' ), 'assertive' );
 						// Move focus to the play button.
 						els.play.focus();
@@ -111,7 +112,7 @@ export function createSwiper( els, config = {} ) {
 						}
 
 						this.autoplay.start();
-						els.container.classList.add( 'wp-block-newspack-blocks-carousel__autoplay-playing' );
+						els.block.classList.add( 'wp-block-newspack-blocks-carousel__autoplay-playing' );
 						speak( __( 'Playing', 'newspack-blocks' ), 'assertive' );
 						// Move focus to the pause button.
 						els.pause.focus();

--- a/src/blocks/carousel/create-swiper.js
+++ b/src/blocks/carousel/create-swiper.js
@@ -7,21 +7,41 @@ import { __, sprintf } from '@wordpress/i18n';
 import Swiper from 'swiper';
 import 'swiper/dist/css/swiper.css';
 
-export const activateSlide = slide => {
+/**
+ * Modifies attributes on slide HTML to make it accessible.
+ *
+ * @param {HTMLElement} slide Slide DOM element
+ */
+export function activateSlide( slide ) {
 	slide.ariaHidden = 'false';
-	slide.querySelectorAll( 'a' ).forEach( e => ( e.tabIndex = '0' ) );
-};
+	/**
+	 * Calls Array.prototype.forEach for IE11 compatibility.
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/NodeList
+	 */
+	Array.prototype.forEach.call( slide.querySelectorAll( 'a' ), e => ( e.tabIndex = '0' ) );
+}
 
-export const deactivateSlide = slide => {
+/**
+ * Modifies attributes on slide HTML to make it accessible.
+ *
+ * @param {HTMLElement} slide Slide DOM element
+ */
+export function deactivateSlide( slide ) {
 	slide.ariaHidden = 'true';
-	slide.querySelectorAll( 'a' ).forEach( e => ( e.tabIndex = '-1' ) );
-};
+	/**
+	 * Calls Array.prototype.forEach for IE11 compatibility.
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/NodeList
+	 */
+	Array.prototype.forEach.call( slide.querySelectorAll( 'a' ), e => ( e.tabIndex = '-1' ) );
+}
 
 /**
  * @param {string} container Selector
  * @param {Object} params Params passed to Swiper
  */
-export const createSwiper = ( container = '.swiper-container', params = {} ) => {
+export function createSwiper( container = '.swiper-container', params = {} ) {
 	const defaultParams = {
 		/**
 		 * Remove the messages, as we're announcing the slide content and number. These messages are overwriting the slide announcement.
@@ -85,4 +105,4 @@ export const createSwiper = ( container = '.swiper-container', params = {} ) => 
 	};
 
 	return new Swiper( container, merge( {}, defaultParams, params ) );
-};
+}

--- a/src/blocks/carousel/create-swiper.js
+++ b/src/blocks/carousel/create-swiper.js
@@ -3,6 +3,7 @@
  */
 import { merge } from 'lodash';
 import { speak } from '@wordpress/a11y';
+import { escapeHTML } from '@wordpress/escape-html';
 import { __, sprintf } from '@wordpress/i18n';
 import Swiper from 'swiper';
 import 'swiper/dist/css/swiper.css';
@@ -83,20 +84,31 @@ export function createSwiper( container = '.swiper-container', params = {} ) {
 				activateSlide( this.slides[ this.activeIndex ] );
 			},
 			slideChange() {
+				const currentSlide = this.slides[ this.activeIndex ];
+
 				deactivateSlide( this.slides[ this.previousIndex ] );
 
-				activateSlide( this.slides[ this.activeIndex ] );
+				activateSlide( currentSlide );
 
 				// If we're autoplaying, don't announce the slide change, as that would be supremely annoying.
 				if ( ! this.autoplay.running ) {
 					// Announce the contents of the slide.
+					const currentImage = currentSlide.querySelector( 'img' );
+					const alt = currentImage ? currentImage.alt : false;
+
+					const slideInfo = sprintf(
+						/* translators: current slide number and the total number of slides */
+						__( 'Slide %s of %s', 'newspack-blocks' ),
+						this.realIndex + 1,
+						this.pagination.bullets.length
+					);
+
 					speak(
-						`${ this.slides[ this.activeIndex ].innerHTML }, ${ sprintf(
-							/* translators: current slide number and the total number of slides */
-							__( 'Slide %s of %s', 'newspack-blocks' ),
-							this.realIndex + 1,
-							this.pagination.bullets.length
-						) }`,
+						escapeHTML(
+							`${ currentSlide.innerText }, 
+							${ alt ? sprintf( __( 'Image: %s, ', 'newspack-blocks' ), alt ) : '' }
+							${ slideInfo }`
+						),
 						'assertive'
 					);
 				}

--- a/src/blocks/carousel/create-swiper.js
+++ b/src/blocks/carousel/create-swiper.js
@@ -7,6 +7,8 @@ import { __, sprintf } from '@wordpress/i18n';
 import Swiper from 'swiper';
 import 'swiper/dist/css/swiper.css';
 
+const autoplayClassName = 'wp-block-newspack-blocks-carousel__autoplay-playing';
+
 /**
  * A helper for IE11-compatible iteration over NodeList elements.
  *
@@ -90,38 +92,28 @@ export default function createSwiper( els, config = {} ) {
 				) }</span></button>`;
 			},
 		},
-		preventClicksPropagation: false /* Necessary for normal block interactions */,
+		preventClicksPropagation: false, // Necessary for normal block interactions.
 		releaseFormElements: false,
 		setWrapperSize: true,
 		touchStartPreventDefault: false,
 		on: {
 			init() {
-				const autoplayClassName = 'wp-block-newspack-blocks-carousel__autoplay-playing';
-
-				if ( els.pause ) {
+				if ( config.autoplay ) {
 					els.pause.addEventListener( 'click', () => {
 						if ( this.destroyed ) {
 							return;
 						}
 
 						this.autoplay.stop();
-						els.block.classList.remove( autoplayClassName );
-						speak( __( 'Paused', 'newspack-blocks' ), 'assertive' );
-						// Move focus to the play button.
-						els.play.focus();
+						els.play.focus(); // Move focus to the play button.
 					} );
-				}
-				if ( els.play ) {
 					els.play.addEventListener( 'click', () => {
 						if ( this.destroyed ) {
 							return;
 						}
 
 						this.autoplay.start();
-						els.block.classList.add( autoplayClassName );
-						speak( __( 'Playing', 'newspack-blocks' ), 'assertive' );
-						// Move focus to the pause button.
-						els.pause.focus();
+						els.pause.focus(); // Move focus to the pause button.
 					} );
 				}
 
@@ -129,9 +121,19 @@ export default function createSwiper( els, config = {} ) {
 					deactivateSlide( slide )
 				);
 
-				// Set-up our active slide.
-				activateSlide( this.slides[ this.activeIndex ] );
+				activateSlide( this.slides[ this.activeIndex ] ); // Set-up our active slide.
 			},
+
+			autoplayStart() {
+				els.block.classList.add( autoplayClassName ); // Hide play & show pause button.
+				speak( __( 'Playing', 'newspack-blocks' ), 'assertive' );
+			},
+
+			autoplayStop() {
+				els.block.classList.remove( autoplayClassName ); // Hide pause & show play button.
+				speak( __( 'Paused', 'newspack-blocks' ), 'assertive' );
+			},
+
 			slideChange() {
 				const currentSlide = this.slides[ this.activeIndex ];
 
@@ -139,7 +141,10 @@ export default function createSwiper( els, config = {} ) {
 
 				activateSlide( currentSlide );
 
-				// If we're autoplaying, don't announce the slide change, as that would be supremely annoying.
+				/**
+				 * If we're autoplaying, don't announce the slide change, as that would
+				 * be supremely annoying.
+				 */
 				if ( ! this.autoplay.running ) {
 					// Announce the contents of the slide.
 					const currentImage = currentSlide.querySelector( 'img' );

--- a/src/blocks/carousel/create-swiper.js
+++ b/src/blocks/carousel/create-swiper.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { merge } from 'lodash';
+import { __, sprintf } from '@wordpress/i18n';
 import Swiper from 'swiper';
 import 'swiper/dist/css/swiper.css';
 
@@ -11,6 +12,11 @@ import 'swiper/dist/css/swiper.css';
  */
 export default function createSwiper( container = '.swiper-container', params = {} ) {
 	const defaultParams = {
+		/**
+		 * Remove the messages, as we're announcing the slide content and number. These messages are overwriting the slide announcement.
+		 */
+
+		a11y: false,
 		effect: 'slide',
 		grabCursor: true,
 		init: true,
@@ -24,6 +30,13 @@ export default function createSwiper( container = '.swiper-container', params = 
 			clickable: true,
 			el: '.swiper-pagination',
 			type: 'bullets',
+			renderBullet: ( index, className ) => {
+				// Use a custom render, as Swiper's render is inaccessible.
+				return `<button class="${ className }"><span>${ sprintf(
+					__( 'Slide %s', 'newspack-blocks' ),
+					index + 1
+				) }</span></button>`;
+			},
 		},
 		preventClicksPropagation: false /* Necessary for normal block interactions */,
 		releaseFormElements: false,

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { isUndefined, pickBy } from 'lodash';
+import { filter, isEqual, isUndefined, pickBy } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -48,8 +48,14 @@ class Edit extends Component {
 		const { attributes, latestPosts } = this.props;
 		const { autoplay, delay } = attributes;
 
+		/**
+		 * Check if:
+		 * - Latests posts have changed in any way
+		 * - The autoplay attribute has changed
+		 * - The delay attribute has changed
+		 */
 		if (
-			prevProps.latestPosts !== latestPosts ||
+			! isEqual( filter( prevProps.latestPosts, 'id' ), filter( latestPosts, 'id' ) ) ||
 			prevProps.attributes.autoplay !== autoplay ||
 			prevProps.attributes.delay !== delay
 		) {

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -48,12 +48,6 @@ class Edit extends Component {
 		const { attributes, latestPosts } = this.props;
 		const { autoplay, delay } = attributes;
 
-		/**
-		 * Check if:
-		 * - Latests posts have changed in any way
-		 * - The autoplay attribute has changed
-		 * - The delay attribute has changed
-		 */
 		if (
 			prevProps.latestPosts !== latestPosts ||
 			( prevProps.latestPosts &&

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 import QueryControls from '../../components/query-controls';
-import { createSwiper } from './create-swiper';
+import createSwiper from './create-swiper';
 import { formatAvatars, formatByline } from '../../shared/js/utils';
 
 /**

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { filter, isEqual, isUndefined, pickBy } from 'lodash';
+import { isEqual, isUndefined, pickBy } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -55,9 +55,11 @@ class Edit extends Component {
 		 * - The delay attribute has changed
 		 */
 		if (
-			! isEqual( filter( prevProps.latestPosts, 'id' ), filter( latestPosts, 'id' ) ) ||
-			prevProps.attributes.autoplay !== autoplay ||
-			prevProps.attributes.delay !== delay
+			prevProps.latestPosts !== latestPosts ||
+			( prevProps.latestPosts &&
+				latestPosts &&
+				prevProps.latestPosts.length !== latestPosts.length ) ||
+			! isEqual( prevProps.attributes, attributes )
 		) {
 			let initialSlide = 0;
 

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -150,29 +150,25 @@ class Edit extends Component {
 										)
 								) }
 							</div>
-							<a
+							<button
 								className="amp-carousel-button amp-carousel-button-prev swiper-button-prev"
 								ref={ this.btnPrevRef }
-								role="button"
 							/>
-							<a
+							<button
 								className="amp-carousel-button amp-carousel-button-next swiper-button-next"
 								ref={ this.btnNextRef }
-								role="button"
 							/>
 							{ autoplay && (
 								<Fragment>
-									<a
+									<button
 										className="amp-carousel-button-pause amp-carousel-button"
-										role="button"
 										onClick={ () => {
 											this.swiperInstance.autoplay.stop();
 											this.setState( { autoPlayState: false } );
 										} }
 									/>
-									<a
+									<button
 										className="amp-carousel-button-play amp-carousel-button"
-										role="button"
 										onClick={ () => {
 											this.swiperInstance.autoplay.start();
 											this.setState( { autoPlayState: true } );

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -63,6 +63,7 @@ class Edit extends Component {
 
 		this.swiperInstance = createSwiper(
 			{
+				block: this.carouselRef.current, // Editor uses the same wrapper for block and swiper container
 				container: this.carouselRef.current,
 				next: this.btnNextRef.current,
 				prev: this.btnPrevRef.current,

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 import QueryControls from '../../components/query-controls';
-import createSwiper from './create-swiper';
+import { createSwiper } from './create-swiper';
 import { formatAvatars, formatByline } from '../../shared/js/utils';
 
 /**
@@ -113,6 +113,24 @@ class Edit extends Component {
 					) }
 					{ latestPosts && (
 						<Fragment>
+							{ autoplay && (
+								<Fragment>
+									<button
+										className="amp-carousel-button-pause amp-carousel-button"
+										onClick={ () => {
+											this.swiperInstance.autoplay.stop();
+											this.setState( { autoPlayState: false } );
+										} }
+									/>
+									<button
+										className="amp-carousel-button-play amp-carousel-button"
+										onClick={ () => {
+											this.swiperInstance.autoplay.start();
+											this.setState( { autoPlayState: true } );
+										} }
+									/>
+								</Fragment>
+							) }
 							<div className="swiper-wrapper">
 								{ latestPosts.map(
 									post =>
@@ -158,24 +176,6 @@ class Edit extends Component {
 								className="amp-carousel-button amp-carousel-button-next swiper-button-next"
 								ref={ this.btnNextRef }
 							/>
-							{ autoplay && (
-								<Fragment>
-									<button
-										className="amp-carousel-button-pause amp-carousel-button"
-										onClick={ () => {
-											this.swiperInstance.autoplay.stop();
-											this.setState( { autoPlayState: false } );
-										} }
-									/>
-									<button
-										className="amp-carousel-button-play amp-carousel-button"
-										onClick={ () => {
-											this.swiperInstance.autoplay.start();
-											this.setState( { autoPlayState: true } );
-										} }
-									/>
-								</Fragment>
-							) }
 							<div
 								className="swiper-pagination-bullets amp-pagination"
 								ref={ this.paginationRef }

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -1,13 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid, jsx-a11y/anchor-has-content, jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus */
 
 /**
- * Internal dependencies
- */
-import QueryControls from '../../components/query-controls';
-import createSwiper from './create-swiper';
-import { formatAvatars, formatByline } from '../../shared/js/utils';
-
-/**
  * External dependencies
  */
 import { isUndefined, pickBy } from 'lodash';
@@ -32,6 +25,13 @@ import { withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
 
+/**
+ * Internal dependencies
+ */
+import QueryControls from '../../components/query-controls';
+import createSwiper from './create-swiper';
+import { formatAvatars, formatByline } from '../../shared/js/utils';
+
 class Edit extends Component {
 	constructor( props ) {
 		super( props );
@@ -44,39 +44,41 @@ class Edit extends Component {
 		this.paginationRef = createRef();
 	}
 
-	componentDidUpdate() {
+	componentDidUpdate( prevProps ) {
 		const { attributes, latestPosts } = this.props;
 		const { autoplay, delay } = attributes;
-		let initialSlide = 0;
 
 		if (
-			this.swiperInstance &&
-			latestPosts &&
-			this.swiperInstance.realIndex < latestPosts.length
+			prevProps.latestPosts !== latestPosts ||
+			prevProps.attributes.autoplay !== autoplay ||
+			prevProps.attributes.delay !== delay
 		) {
-			initialSlide = this.swiperInstance.realIndex;
-		}
+			let initialSlide = 0;
 
-		if ( this.swiperInstance ) {
-			this.swiperInstance.destroy( true, true );
-		}
-
-		this.swiperInstance = createSwiper(
-			{
-				block: this.carouselRef.current, // Editor uses the same wrapper for block and swiper container
-				container: this.carouselRef.current,
-				next: this.btnNextRef.current,
-				prev: this.btnPrevRef.current,
-				play: this.btnPlayRef.current,
-				pause: this.btnPauseRef.current,
-				pagination: this.paginationRef.current,
-			},
-			{
-				autoplay,
-				delay: delay * 1000,
-				initialSlide,
+			if ( this.swiperInstance ) {
+				if ( latestPosts && this.swiperInstance.realIndex < latestPosts.length ) {
+					initialSlide = this.swiperInstance.realIndex;
+				}
+				this.swiperInstance.destroy( true, true );
 			}
-		);
+
+			this.swiperInstance = createSwiper(
+				{
+					block: this.carouselRef.current, // Editor uses the same wrapper for block and swiper container
+					container: this.carouselRef.current,
+					next: this.btnNextRef.current,
+					prev: this.btnPrevRef.current,
+					play: this.btnPlayRef.current,
+					pause: this.btnPauseRef.current,
+					pagination: this.paginationRef.current,
+				},
+				{
+					autoplay,
+					delay: delay * 1000,
+					initialSlide,
+				}
+			);
+		}
 	}
 
 	render() {

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -62,22 +62,24 @@ class Edit extends Component {
 				this.swiperInstance.destroy( true, true );
 			}
 
-			this.swiperInstance = createSwiper(
-				{
-					block: this.carouselRef.current, // Editor uses the same wrapper for block and swiper container
-					container: this.carouselRef.current,
-					next: this.btnNextRef.current,
-					prev: this.btnPrevRef.current,
-					play: this.btnPlayRef.current,
-					pause: this.btnPauseRef.current,
-					pagination: this.paginationRef.current,
-				},
-				{
-					autoplay,
-					delay: delay * 1000,
-					initialSlide,
-				}
-			);
+			if ( latestPosts && latestPosts.length > 0 ) {
+				this.swiperInstance = createSwiper(
+					{
+						block: this.carouselRef.current, // Editor uses the same wrapper for block and swiper container
+						container: this.carouselRef.current,
+						next: this.btnNextRef.current,
+						prev: this.btnPrevRef.current,
+						play: this.btnPlayRef.current,
+						pause: this.btnPauseRef.current,
+						pagination: this.paginationRef.current,
+					},
+					{
+						autoplay,
+						delay: delay * 1000,
+						initialSlide,
+					}
+				);
+			}
 		}
 	}
 

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import domReady from '@wordpress/dom-ready';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -93,7 +93,14 @@ if ( typeof window !== 'undefined' ) {
 						// If we're autoplaying, don't announce the slide change, as that would be supremely annoying.
 						if ( ! this.autoplay.running ) {
 							// Announce the contents of the slide.
-							this.a11y.notify( this.slides[ this.activeIndex ].innerHTML );
+							this.a11y.notify(
+								`${ this.slides[ this.activeIndex ].innerHTML }, ${ sprintf(
+									/* translators: current slide number and the total number of slides */
+									__( 'Slide %s of %s', 'newspack-blocks' ),
+									this.realIndex + 1,
+									this.pagination.bullets.length
+								) }`
+							);
 						}
 					},
 				},

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -69,9 +69,15 @@ if ( typeof window !== 'undefined' ) {
 							} );
 						}
 
-						this.wrapperEl
-							.querySelectorAll( '.swiper-slide' )
-							.forEach( slide => deactivateSlide( slide ) );
+						/**
+						 * Calls Array.prototype.forEach for IE11 compatibility.
+						 *
+						 * @see https://developer.mozilla.org/en-US/docs/Web/API/NodeList
+						 */
+						Array.prototype.forEach.call(
+							this.wrapperEl.querySelectorAll( '.swiper-slide' ),
+							slide => deactivateSlide( slide )
+						);
 
 						// Set-up our active slide.
 						activateSlide( this.slides[ this.activeIndex ] );

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -59,8 +59,24 @@ if ( typeof window !== 'undefined' ) {
 							} );
 						}
 
-						// set tabindex to -1 on all focusable elements that are not the current slide
+						// Set tabindex to -1 on all focusable elements that are not the current slide.
 						this.wrapperEl.querySelectorAll( 'a' ).forEach( e => ( e.tabIndex = '-1' ) );
+
+						// Get the active slide's <a> and make them focusable again
+						this.slides[ this.activeIndex ]
+							.querySelectorAll( 'a' )
+							.forEach( e => ( e.tabIndex = '0' ) );
+					},
+					slideChange() {
+						// Get all the previous slides' <a> and set to tabIndex -1
+						this.slides[ this.previousIndex ]
+							.querySelectorAll( 'a' )
+							.forEach( e => ( e.tabIndex = '-1' ) );
+
+						// Get the active slide's <a> and make them focusable again
+						this.slides[ this.activeIndex ]
+							.querySelectorAll( 'a' )
+							.forEach( e => ( e.tabIndex = '0' ) );
 					},
 				},
 			};

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -26,6 +26,17 @@ if ( typeof window !== 'undefined' ) {
 			};
 			const autoplay = parseInt( block.dataset.autoplay ) ? true : false;
 			const delay = parseInt( block.dataset.autoplay_delay ) * 1000;
+
+			const activateSlide = slide => {
+				slide.ariaHidden = 'false';
+				slide.querySelectorAll( 'a' ).forEach( e => ( e.tabIndex = '0' ) );
+			};
+
+			const deactivateSlide = slide => {
+				slide.ariaHidden = 'true';
+				slide.querySelectorAll( 'a' ).forEach( e => ( e.tabIndex = '-1' ) );
+			};
+
 			const swiperConfig = {
 				autoplay: autoplay
 					? {
@@ -45,6 +56,7 @@ if ( typeof window !== 'undefined' ) {
 					el: els.pagination,
 					type: 'bullets',
 				},
+
 				on: {
 					init() {
 						if ( els.pause ) {
@@ -66,24 +78,17 @@ if ( typeof window !== 'undefined' ) {
 							} );
 						}
 
-						// Set tabindex to -1 on all focusable elements that are not the current slide.
-						this.wrapperEl.querySelectorAll( 'a' ).forEach( e => ( e.tabIndex = '-1' ) );
+						this.wrapperEl
+							.querySelectorAll( '.swiper-slide' )
+							.forEach( slide => deactivateSlide( slide ) );
 
-						// Get the active slide's <a> and make them focusable again
-						this.slides[ this.activeIndex ]
-							.querySelectorAll( 'a' )
-							.forEach( e => ( e.tabIndex = '0' ) );
+						// Set-up our active slide.
+						activateSlide( this.slides[ this.activeIndex ] );
 					},
 					slideChange() {
-						// Get all the previous slides' <a> and set to tabIndex -1.
-						this.slides[ this.previousIndex ]
-							.querySelectorAll( 'a' )
-							.forEach( e => ( e.tabIndex = '-1' ) );
+						deactivateSlide( this.slides[ this.previousIndex ] );
 
-						// Get the active slide's <a> and make them focusable again.
-						this.slides[ this.activeIndex ]
-							.querySelectorAll( 'a' )
-							.forEach( e => ( e.tabIndex = '0' ) );
+						activateSlide( this.slides[ this.activeIndex ] );
 
 						// If we're autoplaying, don't announce the slide change, as that would be supremely annoying.
 						if ( ! this.autoplay.running ) {

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import domReady from '@wordpress/dom-ready';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -50,12 +51,18 @@ if ( typeof window !== 'undefined' ) {
 							els.pause.addEventListener( 'click', () => {
 								this.autoplay.stop();
 								block.classList.remove( 'wp-block-newspack-blocks-carousel__autoplay-playing' );
+								this.a11y.notify( __( 'Paused' ) );
+								// Move focus to the play button.
+								els.play.focus();
 							} );
 						}
 						if ( els.play ) {
 							els.play.addEventListener( 'click', () => {
 								this.autoplay.start();
 								block.classList.add( 'wp-block-newspack-blocks-carousel__autoplay-playing' );
+								this.a11y.notify( __( 'Playing' ) );
+								// Move focus to the pause button.
+								els.pause.focus();
 							} );
 						}
 

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -6,7 +6,7 @@ import domReady from '@wordpress/dom-ready';
 /**
  * Internal dependencies
  */
-import { createSwiper } from './create-swiper';
+import createSwiper from './create-swiper';
 import './view.scss';
 
 if ( typeof window !== 'undefined' ) {

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -58,6 +58,9 @@ if ( typeof window !== 'undefined' ) {
 								block.classList.add( 'wp-block-newspack-blocks-carousel__autoplay-playing' );
 							} );
 						}
+
+						// set tabindex to -1 on all focusable elements that are not the current slide
+						this.wrapperEl.querySelectorAll( 'a' ).forEach( e => ( e.tabIndex = '-1' ) );
 					},
 				},
 			};

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import domReady from '@wordpress/dom-ready';
+import { speak } from '@wordpress/a11y';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -63,7 +64,7 @@ if ( typeof window !== 'undefined' ) {
 							els.pause.addEventListener( 'click', () => {
 								this.autoplay.stop();
 								block.classList.remove( 'wp-block-newspack-blocks-carousel__autoplay-playing' );
-								this.a11y.notify( __( 'Paused' ) );
+								speak( __( 'Paused', 'newspack-blocks' ), 'assertive' );
 								// Move focus to the play button.
 								els.play.focus();
 							} );
@@ -72,7 +73,7 @@ if ( typeof window !== 'undefined' ) {
 							els.play.addEventListener( 'click', () => {
 								this.autoplay.start();
 								block.classList.add( 'wp-block-newspack-blocks-carousel__autoplay-playing' );
-								this.a11y.notify( __( 'Playing' ) );
+								speak( __( 'Playing', 'newspack-blocks' ), 'assertive' );
 								// Move focus to the pause button.
 								els.pause.focus();
 							} );
@@ -93,13 +94,14 @@ if ( typeof window !== 'undefined' ) {
 						// If we're autoplaying, don't announce the slide change, as that would be supremely annoying.
 						if ( ! this.autoplay.running ) {
 							// Announce the contents of the slide.
-							this.a11y.notify(
+							speak(
 								`${ this.slides[ this.activeIndex ].innerHTML }, ${ sprintf(
 									/* translators: current slide number and the total number of slides */
 									__( 'Slide %s of %s', 'newspack-blocks' ),
 									this.realIndex + 1,
 									this.pagination.bullets.length
-								) }`
+								) }`,
+								'assertive'
 							);
 						}
 					},

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -75,19 +75,19 @@ if ( typeof window !== 'undefined' ) {
 							.forEach( e => ( e.tabIndex = '0' ) );
 					},
 					slideChange() {
-						// Get all the previous slides' <a> and set to tabIndex -1
+						// Get all the previous slides' <a> and set to tabIndex -1.
 						this.slides[ this.previousIndex ]
 							.querySelectorAll( 'a' )
 							.forEach( e => ( e.tabIndex = '-1' ) );
 
-						// Get the active slide's <a> and make them focusable again
+						// Get the active slide's <a> and make them focusable again.
 						this.slides[ this.activeIndex ]
 							.querySelectorAll( 'a' )
 							.forEach( e => ( e.tabIndex = '0' ) );
 
 						// If we're autoplaying, don't announce the slide change, as that would be supremely annoying.
 						if ( ! this.autoplay.running ) {
-							// Announce the contents of the slide
+							// Announce the contents of the slide.
 							this.a11y.notify( this.slides[ this.activeIndex ].innerHTML );
 						}
 					},

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -84,6 +84,12 @@ if ( typeof window !== 'undefined' ) {
 						this.slides[ this.activeIndex ]
 							.querySelectorAll( 'a' )
 							.forEach( e => ( e.tabIndex = '0' ) );
+
+						// If we're autoplaying, don't announce the slide change, as that would be supremely annoying.
+						if ( ! this.autoplay.running ) {
+							// Announce the contents of the slide
+							this.a11y.notify( this.slides[ this.activeIndex ].innerHTML );
+						}
 					},
 				},
 			};

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -17,6 +17,7 @@ if ( typeof window !== 'undefined' ) {
 		blocksArray.forEach( block => {
 			createSwiper(
 				{
+					block,
 					container: block.querySelector( '.swiper-container' ),
 					prev: block.querySelector( '.swiper-button-prev' ),
 					next: block.querySelector( '.swiper-button-next' ),

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -3,12 +3,12 @@
  */
 import domReady from '@wordpress/dom-ready';
 import { speak } from '@wordpress/a11y';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import createSwiper from './create-swiper';
+import { activateSlide, createSwiper, deactivateSlide } from './create-swiper';
 import './view.scss';
 
 if ( typeof window !== 'undefined' ) {
@@ -27,16 +27,6 @@ if ( typeof window !== 'undefined' ) {
 			};
 			const autoplay = parseInt( block.dataset.autoplay ) ? true : false;
 			const delay = parseInt( block.dataset.autoplay_delay ) * 1000;
-
-			const activateSlide = slide => {
-				slide.ariaHidden = 'false';
-				slide.querySelectorAll( 'a' ).forEach( e => ( e.tabIndex = '0' ) );
-			};
-
-			const deactivateSlide = slide => {
-				slide.ariaHidden = 'true';
-				slide.querySelectorAll( 'a' ).forEach( e => ( e.tabIndex = '-1' ) );
-			};
 
 			const swiperConfig = {
 				autoplay: autoplay
@@ -85,25 +75,6 @@ if ( typeof window !== 'undefined' ) {
 
 						// Set-up our active slide.
 						activateSlide( this.slides[ this.activeIndex ] );
-					},
-					slideChange() {
-						deactivateSlide( this.slides[ this.previousIndex ] );
-
-						activateSlide( this.slides[ this.activeIndex ] );
-
-						// If we're autoplaying, don't announce the slide change, as that would be supremely annoying.
-						if ( ! this.autoplay.running ) {
-							// Announce the contents of the slide.
-							speak(
-								`${ this.slides[ this.activeIndex ].innerHTML }, ${ sprintf(
-									/* translators: current slide number and the total number of slides */
-									__( 'Slide %s of %s', 'newspack-blocks' ),
-									this.realIndex + 1,
-									this.pagination.bullets.length
-								) }`,
-								'assertive'
-							);
-						}
 					},
 				},
 			};

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -136,20 +136,13 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 							<?php
 							endif;
 
-						if ( $attributes['showDate'] ) {
-							$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
-							if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
-								$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
-							}
-							$time_string = sprintf(
-								$time_string,
-								esc_attr( get_the_date( DATE_W3C ) ),
-								esc_html( get_the_date() ),
-								esc_attr( get_the_modified_date( DATE_W3C ) ),
-								esc_html( get_the_modified_date() )
-							);
-							echo $time_string; // phpcs:ignore
-						}
+							if ( $attributes['showDate'] ) :
+								printf(
+									'<time class="entry-date published" datetime="%1$s">%2$s</time>',
+									esc_attr( get_the_date( DATE_W3C ) ),
+									esc_html( get_the_date() )
+								);
+							endif;
 						?>
 					</div><!-- .entry-meta -->
 				</div><!-- .entry-wrapper -->

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -187,7 +187,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 			implode( '', $buttons )
 		);
 		$navigation  = sprintf(
-			'<button class="swiper-button swiper-button-prev" aria-label="%s"></button><button class="swiper-button swiper-button-next" aria-labvel="%s"></button>',
+			'<button class="swiper-button swiper-button-prev" aria-label="%s"></button><button class="swiper-button swiper-button-next" aria-label="%s"></button>',
 			esc_attr__( 'Previous Slide', 'newspack-blocks' ),
 			esc_attr__( 'Next Slide', 'newspack-blocks' )
 		);

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -210,8 +210,8 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 		esc_attr( $classes ),
 		absint( $newspack_blocks_carousel_id ),
 		esc_attr( implode( ' ', $data_attributes ) ),
-		$carousel,
 		$autoplay_ui,
+		$carousel,
 		$selector
 	);
 }

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -160,7 +160,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 			absint( $x + 1 )
 		);
 		$buttons[] = sprintf(
-			'<button option="%d" class="swiper-pagination-bullet" tabindex="0" role="button" aria-label="%s" %s></button>',
+			'<button option="%d" class="swiper-pagination-bullet" aria-label="%s" %s></button>',
 			absint( $x ),
 			esc_attr( $aria_label ),
 			0 === $x ? 'selected' : ''
@@ -187,7 +187,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 			implode( '', $buttons )
 		);
 		$navigation  = sprintf(
-			'<a class="swiper-button swiper-button-prev" role="button" aria-label="%s"></a><a class="swiper-button swiper-button-next" role="button" aria-labvel="%s"></a>',
+			'<button class="swiper-button swiper-button-prev" aria-label="%s"></button><button class="swiper-button swiper-button-next" aria-labvel="%s"></button>',
 			esc_attr__( 'Previous Slide', 'newspack-blocks' ),
 			esc_attr__( 'Next Slide', 'newspack-blocks' )
 		);
@@ -225,7 +225,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
  */
 function newspack_blocks_carousel_block_autoplay_ui( $block_ordinal = 0 ) {
 	return sprintf(
-		'<a aria-label="%s" class="swiper-button swiper-button-pause" role="button"></a><a aria-label="%s" class="swiper-button swiper-button-play" role="button"></a>',
+		'<button aria-label="%s" class="swiper-button swiper-button-pause"></button><button aria-label="%s" class="swiper-button swiper-button-play"></button>',
 		esc_attr__( 'Pause Slideshow', 'newspack-blocks' ),
 		esc_attr__( 'Play Slideshow', 'newspack-blocks' )
 	);
@@ -248,13 +248,13 @@ function newspack_blocks_carousel_block_autoplay_ui_amp( $block_ordinal = 0 ) {
 		absint( $block_ordinal )
 	);
 	$autoplay_pause  = sprintf(
-		'<a aria-label="%s" class="amp-carousel-button-pause amp-carousel-button" role="button" on="tap:%s.toggleAutoplay(toggleOn=false),%s.toggleClass(class=wp-block-newspack-blocks-carousel__autoplay-playing,force=false)"></a>',
+		'<button aria-label="%s" class="amp-carousel-button-pause amp-carousel-button" on="tap:%s.toggleAutoplay(toggleOn=false),%s.toggleClass(class=wp-block-newspack-blocks-carousel__autoplay-playing,force=false)"></button>',
 		esc_attr__( 'Pause Slideshow', 'newspack-blocks' ),
 		esc_attr( $amp_carousel_id ),
 		esc_attr( $block_id )
 	);
 	$autoplay_play   = sprintf(
-		'<a aria-label="%s" class="amp-carousel-button-play amp-carousel-button" role="button" on="tap:%s.toggleAutoplay(toggleOn=true),%s.toggleClass(class=wp-block-newspack-blocks-carousel__autoplay-playing,force=true)"></a>',
+		'<button aria-label="%s" class="amp-carousel-button-play amp-carousel-button" on="tap:%s.toggleAutoplay(toggleOn=true),%s.toggleClass(class=wp-block-newspack-blocks-carousel__autoplay-playing,force=true)"></button>',
 		esc_attr__( 'Play Slideshow', 'newspack-blocks' ),
 		esc_attr( $amp_carousel_id ),
 		esc_attr( $block_id )

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -181,7 +181,7 @@
 		right: 1.5em;
 		top: 1.5em;
 		transform: none;
-		z-index: 1;
+		z-index: 9;
 	}
 	.amp-carousel-button-play,
 	.swiper-button-play {

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -120,6 +120,10 @@
 			outline: 0;
 			width: 24px;
 		}
+
+		span {
+			@include visuallyHidden;
+		}
 	}
 	.swiper-button,
 	.amp-carousel-button {

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -248,4 +248,16 @@
 	.swiper-button-pause {
 		display: none;
 	}
+
+	// Make sure Jetpack Content Options don't affect the block.
+	.posted-on,
+	.cat-links,
+	.tags-links,
+	.byline,
+	.author-avatar {
+		clip: auto;
+		height: auto;
+		position: relative;
+		width: auto;
+	}
 }

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -357,6 +357,18 @@
 			display: block;
 		}
 	}
+
+	// Make sure Jetpack Content Options don't affect the block.
+	.posted-on,
+	.cat-links,
+	.tags-links,
+	.byline,
+	.author-avatar {
+		clip: auto;
+		height: auto;
+		position: relative;
+		width: auto;
+	}
 }
 
 /*

--- a/src/shared/sass/_mixins.scss
+++ b/src/shared/sass/_mixins.scss
@@ -23,3 +23,12 @@
 		}
 	}
 }
+
+@mixin visuallyHidden {
+	position: absolute !important;
+	height: 1px;
+	width: 1px;
+	overflow: hidden;
+	clip: rect( 1px, 1px, 1px, 1px );
+	white-space: nowrap; /* added line */
+}


### PR DESCRIPTION
Improves Articles Carousel accessibility through keyboard focus management and screen reader interactions.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* [x] Add the `@wordpress/a11y` package to use `speak()`
* [x] Add the `@wordpress/escape-html` package to escape slide change announcement
* [x] Uses `<button>` elements instead of `<a role="button">` elements
* [x] Removes inactive slide links from the focus order, so you can't tab to a new slide (must use the arrow or pagination bullets)
* [x] Announce new slide content and "slide _ of _" (if not autoplaying) 
* [x] Sets inactive slides to `aria-hidden`
* [x] Announce Paused/Playing state after button press
* [x] Fix focus loss when pressing Pause / Play button
* [x] Moves Pause/Play buttons to _before_ the slider so it can be stopped sooner by assistive technologies like screen readers (AT)
* [x] Remove "This is the last slide" announcement (and all other not-so-helpful Swiper 
 announcements) that prevents the slide content from being announced.
Closes https://github.com/Automattic/newspack-blocks/issues/436
* [x] Unifies `createSwiper` implementation across frontend and editor (Thanks @WunderBart!)

**Editor with VoiceOver on Safari**
![ezgif com-optimize](https://user-images.githubusercontent.com/967608/81612755-f30e3100-93a2-11ea-8cde-6ca78f0ca5f6.gif)

**Frontend with VoiceOver on Safari**
![ezgif com-optimize (1)](https://user-images.githubusercontent.com/967608/81613006-5304d780-93a3-11ea-81c8-21fc591e8339.gif)


### How to test the changes in this Pull Request:

1. Add an Articles Carousel to a post
2. Tab through the slider
3. It should not switch slides when tabbing
4. All Arrows and Navigation dots should be able to be used with the keyboard
5. Check that the current slide's title and author can be tabbed to
6. Pause/Play buttons should work and not lose focus when activating the button with a keyboard
7. Test the above on Editor side as well (you can move focus into the Editor Carousel by clicking initially into the carousel, then tabbing around)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
