### PR TITLE
Homepage Posts: Add image shape classes to the front end

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -508,7 +508,7 @@ class Edit extends Component {
 			[ `image-align${ mediaPosition }` ]: showImage,
 			[ `is-${ imageScale }` ]: imageScale !== '1' && showImage,
 			'mobile-stack': mobileStack,
-			[ `image-shape${ imageShape }` ]: imageShape !== 'landscape',
+			[ `is-${ imageShape }` ]: showImage,
 			'has-text-color': textColor.color !== '',
 			'show-caption': showCaption,
 			'show-category': showCategory,

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -35,6 +35,9 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	if ( $attributes['showImage'] && isset( $attributes['imageScale'] ) ) {
 		$classes .= ' is-' . $attributes['imageScale'];
 	}
+	if ( $attributes['showImage'] ) {
+		$classes .= ' is-' . $attributes['imageShape'];
+	}
 	if ( $attributes['showImage'] && $attributes['mobileStack'] ) {
 		$classes .= ' mobile-stack';
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure the 'image shape' classes are actually being output on the front-end of the block (right now they only work in the editor). It also simplifies the classes a bit, from image-shape[shapename] to just is-[shapename], to shorten them, and make them match other class formats.

These classes can be used to change the image aspect ratio a bit with CSS only -- so if someone wanted their landscape images to be 16:9 rather than 4:3 on the front end, they could use CSS like the example in #472 to adjust them.

Closes #472.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Add four homepage posts blocks to the editor; one with the default image shape, one with portrait, once with square and one with no crop.
3. Inspect each and confirm that a class for each shape is output on the main block element, with the `wpnbha` class.
4. Publish your page. 
5. Confirm that those classes are also showing up on the homepage.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
