### PR TITLE
Homepage Posts Block: decode entities in categories when shown

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -153,7 +153,7 @@ class Edit extends Component {
 				<div className="entry-wrapper">
 					{ showCategory && post.newspack_category_info.length && (
 						<div className="cat-links">
-							<a href="#">{ post.newspack_category_info }</a>
+							<a href="#">{ decodeEntities( post.newspack_category_info ) }</a>
 						</div>
 					) }
 					{ RichText.isEmpty( sectionHeader ) ? (


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When you have a category with an ampersand, it appears encoded in the editor (`&amp;` rather than `&`). This PR wraps the category output in `decodeEntities()` to fix.

### How to test the changes in this Pull Request:

1. Add a category with an ampersand, and apply it to a post; publish.
2. Add the Homepage Posts block to a page, and make sure your new post is displaying in it.
3. Note the ampersand in the editor:

![image](https://user-images.githubusercontent.com/177561/81753595-fb30a400-9468-11ea-8b25-280bf64bad41.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the ampersand is now displaying as expected:

![image](https://user-images.githubusercontent.com/177561/81753683-2d420600-9469-11ea-8417-ae8b1b9efd09.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
