### PR TITLE
Article Carousel: decode entities in categories in editor

### DIFF
--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -128,7 +128,7 @@ class Edit extends Component {
 												<div className="entry-wrapper">
 													{ showCategory && post.newspack_category_info.length && (
 														<div className="cat-links">
-															<a href="#">{ post.newspack_category_info }</a>
+															<a href="#">{ decodeEntities( post.newspack_category_info ) }</a>
 														</div>
 													) }
 													<h3 className="entry-title">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Similar to #474, this PR adds `decodeEntities()` to the categories in the Article Carousel block, so when a category has an ampersand, it's not turned into `&amp;`.

### How to test the changes in this Pull Request:

1. Add a category with an ampersand, and apply it to a post; publish.
2. Add the Article Carousel block to a page, and make sure your new post is displaying in it.
3. Note the encoded ampersand in the editor:

![Screen Shot 2020-05-12 at 3 58 39 PM](https://user-images.githubusercontent.com/177561/81754689-a80c2080-946b-11ea-884a-450442922604.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the ampersand is now displaying as expected:

![Screen Shot 2020-05-12 at 4 08 51 PM](https://user-images.githubusercontent.com/177561/81754722-b6f2d300-946b-11ea-9a8a-6ae3da583918.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
