### PR TITLE
Articles Carousel: Fix Swiper init for additional blocks

### DIFF
--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -44,9 +44,12 @@ class Edit extends Component {
 		this.paginationRef = createRef();
 	}
 
+	componentDidMount() {
+		this.initializeSwiper( 0 );
+	}
+
 	componentDidUpdate( prevProps ) {
 		const { attributes, latestPosts } = this.props;
-		const { autoplay, delay } = attributes;
 
 		if (
 			prevProps.latestPosts !== latestPosts ||
@@ -64,24 +67,32 @@ class Edit extends Component {
 				this.swiperInstance.destroy( true, true );
 			}
 
-			if ( latestPosts && latestPosts.length > 0 ) {
-				this.swiperInstance = createSwiper(
-					{
-						block: this.carouselRef.current, // Editor uses the same wrapper for block and swiper container
-						container: this.carouselRef.current,
-						next: this.btnNextRef.current,
-						prev: this.btnPrevRef.current,
-						play: this.btnPlayRef.current,
-						pause: this.btnPauseRef.current,
-						pagination: this.paginationRef.current,
-					},
-					{
-						autoplay,
-						delay: delay * 1000,
-						initialSlide,
-					}
-				);
-			}
+			this.initializeSwiper( initialSlide );
+		}
+	}
+
+	initializeSwiper( initialSlide ) {
+		const { latestPosts } = this.props;
+
+		if ( latestPosts && latestPosts.length ) {
+			const { autoplay, delay } = this.props.attributes;
+
+			this.swiperInstance = createSwiper(
+				{
+					block: this.carouselRef.current, // Editor uses the same wrapper for block and swiper container.
+					container: this.carouselRef.current,
+					next: this.btnNextRef.current,
+					prev: this.btnPrevRef.current,
+					play: this.btnPlayRef.current,
+					pause: this.btnPauseRef.current,
+					pagination: this.paginationRef.current,
+				},
+				{
+					autoplay,
+					delay: delay * 1000,
+					initialSlide,
+				}
+			);
 		}
 	}
 


### PR DESCRIPTION
Solves issue described in https://github.com/Automattic/newspack-blocks/pull/469#pullrequestreview-411362555.

Swiper wasn't initializing for additional blocks because `componentDidUpdate` (where we initialize Swiper) is not called for them. The reason that only the first block is calling `componentDidUpdate` is that the `latestPosts` prop is empty on mount and changes once the request is done, triggering the update. That is not the case for additional blocks because the `latestPosts` data is already there. Initializing `Swiper` on `componentDidMount` (if posts are available) fixes the issue.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?