### PR TITLE
fix: disallow 0 as post to show value

### DIFF
--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -187,7 +187,9 @@ class Edit extends Component {
 							<QueryControls
 								enableSpecific={ false }
 								numberOfItems={ postsToShow }
-								onNumberOfItemsChange={ value => setAttributes( { postsToShow: value } ) }
+								onNumberOfItemsChange={ value =>
+									setAttributes( { postsToShow: value ? value : 1 } )
+								}
 								authors={ authors }
 								onAuthorsChange={ value => setAttributes( { authors: value } ) }
 								categories={ categories }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

It is possible to break the block's UI by clearing the `Number of Items` control, as described in https://github.com/Automattic/newspack-blocks/issues/477. This branch fixes the issue by ensuring the value is 1 or greater.

If this approach is successful, I'll make the same fix for Homepage Posts.

Closes https://github.com/Automattic/newspack-blocks/issues/477

### How to test the changes in this Pull Request:

1. On `master`, observe the scenario described in the issue.
2. Switch to this branch and attempt to repeat the scenario.
3. Verify it is impossible to set the field to a value less than 1.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
