### PR TITLE
Homepage Posts: make bottom margins less specific for easier overrides on WP.com

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -36,10 +36,7 @@
 			flex-basis: 100%;
 
 			@include media( tablet ) {
-				&:last-child,
-				& {
-					margin-bottom: 1em;
-				}
+				margin-bottom: 1em;
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Some of the spacing styles on the Homepage Posts block are too specific when in grid view, overriding styles set in the Varia theme collection. The issue is only noticeable when using the "Featured Image Behind" image placement, and (I think due to the order the CSS is loaded in), can only be recreated on a WP.com sandbox.

Closes #482.

### How to test the changes in this Pull Request:

1. On a localhost site running the Newspack theme, add the homepage posts block; set it to grid view, and set the featured image behind style. If the last post in the block doesn't have a featured image, assign one. 
2. Duplicate that block, and set it to list view (for a later spacing comparison).

![image](https://user-images.githubusercontent.com/177561/82356432-696ced80-99b8-11ea-9ca2-f79c303f86b2.png)

3. Check the margin on the last article in the list-view of the block; confirm it's 0.
4. On a WordPress.com sandbox site running one of the Varia themes (like Hever), and do the same: add the blog posts block with the grid layout, and featured image behind; if the last post in the block doesn't have a featured image, assign one.
5. Duplicate that block, and set it to list view (for a later spacing comparison).

![image](https://user-images.githubusercontent.com/177561/82356470-7689dc80-99b8-11ea-90cd-400714b402b8.png)

6. Note in the second example, the last item in the grid is taller than the rest. This is due to some too-specific styles that should be removing the bottom margin from the last article when in list view; the styles to re-add it for grid view are overpowering the styles set in WP.com themes like 
Hever.
7. Check the bottom margin of the last article in the list view of the block; it should be picking up a bottom margin of 96px from the theme.
8. Apply the PR locally and run `npm run build`.
9. Confirm that the Newspack site displays the grid posts the without changes.
10. Inspect the list view of the posts; confirm that the last article in the block still does not have a bottom margin:

![image](https://user-images.githubusercontent.com/177561/82356717-d6808300-99b8-11ea-9efa-74c354590d58.png)

11. Copy the block's generated view.css to your WP.com sandbox to test those changes there. It should replace the blog-posts-block-view.css file under wp-content/plugins/full-site-editing-plugin/#####/newspack-blocks/dist. 
12. Refresh the sandbox.
13. Confirm that the grid view of the block now displays all the articles at the same height: 

![image](https://user-images.githubusercontent.com/177561/82356893-1b0c1e80-99b9-11ea-89fb-b3de1af01df5.png)

14. Confirm that the last article in the list-view of the block still picks up the correct spacing -- in this case, you can see in the CSS that the `:last-child` should be picking up a bottom margin of 96px from the theme: 

![image](https://user-images.githubusercontent.com/177561/82356976-3aa34700-99b9-11ea-8005-cdb9ee02fb26.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
