### PR TITLE
refactor: rename articles carousel block->post carousel

### DIFF
--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -16,7 +16,7 @@ import './view.scss';
 import './editor.scss';
 
 export const name = 'carousel';
-export const title = __( 'Articles Carousel' );
+export const title = __( 'Post Carousel' );
 
 /* From https://material.io/tools/icons */
 export const icon = (
@@ -31,7 +31,7 @@ export const settings = {
 	icon,
 	category: 'newspack',
 	keywords: [ __( 'posts' ), __( 'slideshow' ), __( 'carousel' ) ],
-	description: __( 'A carousel of articles.' ),
+	description: __( 'A carousel of posts.' ),
 	attributes: {
 		className: {
 			type: 'string',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Rename "Articles Carousel" block to "Post Carousel". Discussion in `pbAPfg-no-p2#comment-1012`

### How to test the changes in this Pull Request:

1. Verify name change in the block picker.
2. Verify name and description change in the Post Carousel block's sidebar.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
