### PR TITLE
Enqueue styles and scripts at render time

### DIFF
--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -14,6 +14,10 @@
  */
 function newspack_blocks_render_block_carousel( $attributes ) {
 	static $newspack_blocks_carousel_id = 0;
+
+	wp_enqueue_style( 'carousel-block-view' );
+	wp_enqueue_script( 'carousel-block-view' );
+
 	$newspack_blocks_carousel_id++;
 	$autoplay      = isset( $attributes['autoplay'] ) ? $attributes['autoplay'] : false;
 	$delay         = isset( $attributes['delay'] ) ? absint( $attributes['delay'] ) : 3;

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -15,7 +15,7 @@
 function newspack_blocks_render_block_carousel( $attributes ) {
 	static $newspack_blocks_carousel_id = 0;
 
-	// This will let the FSE plugin know we need CSS/JS now
+	// This will let the FSE plugin know we need CSS/JS now.
 	do_action( 'newspack_blocks_render_post_carousel' );
 
 	$newspack_blocks_carousel_id++;

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -15,8 +15,8 @@
 function newspack_blocks_render_block_carousel( $attributes ) {
 	static $newspack_blocks_carousel_id = 0;
 
-	wp_enqueue_style( 'carousel-block-view' );
-	wp_enqueue_script( 'carousel-block-view' );
+	// This will let the FSE plugin know we need CSS/JS now
+	do_action( 'newspack_blocks_render_post_carousel' );
 
 	$newspack_blocks_carousel_id++;
 	$autoplay      = isset( $attributes['autoplay'] ) ? $attributes['autoplay'] : false;

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -13,7 +13,7 @@
  * @return string Returns the post content with latest posts added.
  */
 function newspack_blocks_render_block_homepage_articles( $attributes ) {
-	// This will let the FSE plugin know we need CSS/JS now
+	// This will let the FSE plugin know we need CSS/JS now.
 	do_action( 'newspack_blocks_render_homepage_articles' );
 
 	$article_query = new WP_Query( Newspack_Blocks::build_articles_query( $attributes ) );

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -14,7 +14,7 @@
  */
 function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	// This will let the FSE plugin know we need CSS/JS now
-	do_action( 'newspack_blocks_render_post_carousel' );
+	do_action( 'newspack_blocks_render_homepage_articles' );
 
 	$article_query = new WP_Query( Newspack_Blocks::build_articles_query( $attributes ) );
 

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -13,8 +13,8 @@
  * @return string Returns the post content with latest posts added.
  */
 function newspack_blocks_render_block_homepage_articles( $attributes ) {
-	wp_enqueue_style( 'blog-posts-block-view' );
-	wp_enqueue_script( 'blog-posts-block-view' );
+	// This will let the FSE plugin know we need CSS/JS now
+	do_action( 'newspack_blocks_render_post_carousel' );
 
 	$article_query = new WP_Query( Newspack_Blocks::build_articles_query( $attributes ) );
 

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -13,6 +13,9 @@
  * @return string Returns the post content with latest posts added.
  */
 function newspack_blocks_render_block_homepage_articles( $attributes ) {
+	wp_enqueue_style( 'blog-posts-block-view' );
+	wp_enqueue_script( 'blog-posts-block-view' );
+
 	$article_query = new WP_Query( Newspack_Blocks::build_articles_query( $attributes ) );
 
 	$classes = Newspack_Blocks::block_classes( 'homepage-articles', $attributes, [ 'wpnbha' ] );


### PR DESCRIPTION
Currently the carousel and homepage-arcticle blocks will load their
CSS and JS resources on every page view, as soon as the Full Site Editing
plugin is activated.  This change is part of a two part process to have
these two blocks only load these resources on page views where the blocks
are being used.

The second part of this change will to the Full Site Editing plugin in the
newspack_blocks_block_args() function.

### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
