### PR TITLE
Always display query controls

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -267,7 +267,9 @@ class Edit extends Component {
 				<PanelBody title={ __( 'Display Settings', 'newspack-blocks' ) } initialOpen={ true }>
 					<QueryControls
 						numberOfItems={ postsToShow }
-						onNumberOfItemsChange={ _postsToShow => setAttributes( { postsToShow: _postsToShow } ) }
+						onNumberOfItemsChange={ _postsToShow =>
+							setAttributes( { postsToShow: _postsToShow || 1 } )
+						}
 						specificMode={ specificMode }
 						onSpecificModeChange={ _specificMode =>
 							setAttributes( { specificMode: _specificMode } )

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -265,34 +265,31 @@ class Edit extends Component {
 		return (
 			<Fragment>
 				<PanelBody title={ __( 'Display Settings', 'newspack-blocks' ) } initialOpen={ true }>
-					{ postsToShow && (
-						<QueryControls
-							numberOfItems={ postsToShow }
-							onNumberOfItemsChange={ _postsToShow =>
-								setAttributes( { postsToShow: _postsToShow } )
-							}
-							specificMode={ specificMode }
-							onSpecificModeChange={ _specificMode =>
-								setAttributes( { specificMode: _specificMode } )
-							}
-							specificPosts={ specificPosts }
-							onSpecificPostsChange={ _specificPosts =>
-								setAttributes( { specificPosts: _specificPosts } )
-							}
-							authors={ authors }
-							onAuthorsChange={ _authors => setAttributes( { authors: _authors } ) }
-							categories={ categories }
-							onCategoriesChange={ _categories => setAttributes( { categories: _categories } ) }
-							tags={ tags }
-							onTagsChange={ _tags => {
-								setAttributes( { tags: _tags } );
-							} }
-							tagExclusions={ tagExclusions }
-							onTagExclusionsChange={ _tagExclusions =>
-								setAttributes( { tagExclusions: _tagExclusions } )
-							}
-						/>
-					) }
+					<QueryControls
+						numberOfItems={ postsToShow }
+						onNumberOfItemsChange={ _postsToShow => setAttributes( { postsToShow: _postsToShow } ) }
+						specificMode={ specificMode }
+						onSpecificModeChange={ _specificMode =>
+							setAttributes( { specificMode: _specificMode } )
+						}
+						specificPosts={ specificPosts }
+						onSpecificPostsChange={ _specificPosts =>
+							setAttributes( { specificPosts: _specificPosts } )
+						}
+						authors={ authors }
+						onAuthorsChange={ _authors => setAttributes( { authors: _authors } ) }
+						categories={ categories }
+						onCategoriesChange={ _categories => setAttributes( { categories: _categories } ) }
+						tags={ tags }
+						onTagsChange={ _tags => {
+							setAttributes( { tags: _tags } );
+						} }
+						tagExclusions={ tagExclusions }
+						onTagExclusionsChange={ _tagExclusions =>
+							setAttributes( { tagExclusions: _tagExclusions } )
+						}
+					/>
+
 					{ postLayout === 'grid' && (
 						<RangeControl
 							label={ __( 'Columns', 'newspack-blocks' ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Resolves an unreported bug which causes part of "Display Settings" section to disappear.

### How to test the changes in this Pull Request:

1. On master,
2. Insert or edit a Homepage Posts block, set the "Number of items" in "Display Settings" section of sidebar settings manually to 0, or just clear the input next to slider
3. Observe the query controls disappearing, leaving only "Choose Specific Posts" control in the "Display Settings" section
3. Switch to this branch and rebuild
3. Redo step 2, observe that no part of settings UI disappears

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
