### PR TITLE
Fix: exclude specific posts from other blocks from query

### DIFF
--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -331,8 +331,7 @@ class Newspack_Blocks {
 				function ( $acc, $block ) use ( $block_name ) {
 					if (
 						$block_name === $block['blockName'] &&
-						isset( $block['attrs']['specificMode'] ) &&
-						isset( $block['attrs']['specificPosts'] ) &&
+						isset( $block['attrs']['specificMode'], $block['attrs']['specificPosts'] ) &&
 						count( $block['attrs']['specificPosts'] )
 					) {
 						return array_merge(

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -322,26 +322,29 @@ class Newspack_Blocks {
 		}
 
 		// Get all blocks and gather specificPosts ids of all Homepage Articles blocks.
-		$blocks                 = parse_blocks( get_the_content() );
-		$block_name             = apply_filters( 'newspack_blocks_block_name', 'newspack-blocks/homepage-articles' );
-		$all_specific_posts_ids = array_reduce(
-			$blocks,
-			function ( $acc, $block ) use ( $block_name ) {
-				if (
-					$block_name === $block['blockName'] &&
-					isset( $block['attrs']['specificMode'] ) &&
-					isset( $block['attrs']['specificPosts'] ) &&
-					count( $block['attrs']['specificPosts'] )
-				) {
-					return array_merge(
-						$block['attrs']['specificPosts'],
-						$acc
-					);
-				}
-				return $acc;
-			},
-			[]
-		);
+		global $newspack_blocks_all_specific_posts_ids;
+		if ( ! is_array( $newspack_blocks_all_specific_posts_ids ) ) {
+			$blocks                                 = parse_blocks( get_the_content() );
+			$block_name                             = apply_filters( 'newspack_blocks_block_name', 'newspack-blocks/homepage-articles' );
+			$newspack_blocks_all_specific_posts_ids = array_reduce(
+				$blocks,
+				function ( $acc, $block ) use ( $block_name ) {
+					if (
+						$block_name === $block['blockName'] &&
+						isset( $block['attrs']['specificMode'] ) &&
+						isset( $block['attrs']['specificPosts'] ) &&
+						count( $block['attrs']['specificPosts'] )
+					) {
+						return array_merge(
+							$block['attrs']['specificPosts'],
+							$acc
+						);
+					}
+					return $acc;
+				},
+				[]
+			);
+		}
 
 		$authors        = isset( $attributes['authors'] ) ? $attributes['authors'] : array();
 		$categories     = isset( $attributes['categories'] ) ? $attributes['categories'] : array();
@@ -360,8 +363,8 @@ class Newspack_Blocks {
 			$args['orderby']  = 'post__in';
 		} else {
 			$args['posts_per_page'] = $posts_to_show + count( $newspack_blocks_post_id );
-			if ( count( $all_specific_posts_ids ) ) {
-				$args['post__not_in'] = $all_specific_posts_ids;
+			if ( count( $newspack_blocks_all_specific_posts_ids ) ) {
+				$args['post__not_in'] = $newspack_blocks_all_specific_posts_ids;
 			}
 			if ( $authors && count( $authors ) ) {
 				$args['author__in'] = $authors;

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -320,6 +320,29 @@ class Newspack_Blocks {
 		if ( ! $newspack_blocks_post_id ) {
 			$newspack_blocks_post_id = array();
 		}
+
+		// Get all blocks and gather specificPosts ids of all Homepage Articles blocks.
+		$blocks                 = parse_blocks( get_the_content() );
+		$block_name             = apply_filters( 'newspack_blocks_block_name', 'newspack-blocks/homepage-articles' );
+		$all_specific_posts_ids = array_reduce(
+			$blocks,
+			function ( $acc, $block ) use ( $block_name ) {
+				if (
+					$block_name === $block['blockName'] &&
+					isset( $block['attrs']['specificMode'] ) &&
+					isset( $block['attrs']['specificPosts'] ) &&
+					count( $block['attrs']['specificPosts'] )
+				) {
+					return array_merge(
+						$block['attrs']['specificPosts'],
+						$acc
+					);
+				}
+				return $acc;
+			},
+			[]
+		);
+
 		$authors        = isset( $attributes['authors'] ) ? $attributes['authors'] : array();
 		$categories     = isset( $attributes['categories'] ) ? $attributes['categories'] : array();
 		$tags           = isset( $attributes['tags'] ) ? $attributes['tags'] : array();
@@ -337,6 +360,9 @@ class Newspack_Blocks {
 			$args['orderby']  = 'post__in';
 		} else {
 			$args['posts_per_page'] = $posts_to_show + count( $newspack_blocks_post_id );
+			if ( count( $all_specific_posts_ids ) ) {
+				$args['post__not_in'] = $all_specific_posts_ids;
+			}
 			if ( $authors && count( $authors ) ) {
 				$args['author__in'] = $authors;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Ideally, creation of `$all_specific_posts_ids` array should happen once per page request (currently it happens once per HP block), but I don't know how to do that – all suggestions welcome!

Closes #498

### How to test the changes in this Pull Request:

1. On master, reproduce #498
2. Switch to this branch, observe that #498 is not reproducible

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
