### PR TITLE
fix: don't use main wp_query when rendering homepage posts

### DIFF
--- a/src/blocks/homepage-articles/templates/articles-loop.php
+++ b/src/blocks/homepage-articles/templates/articles-loop.php
@@ -30,8 +30,8 @@ call_user_func(
 			$post_counter++;
 			echo Newspack_Blocks::template_inc( __DIR__ . '/article.php', array( 'attributes' => $attributes ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
-
 		$wp_query = $main_query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		wp_reset_postdata();
 	},
 	$data // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 );

--- a/src/blocks/homepage-articles/templates/articles-loop.php
+++ b/src/blocks/homepage-articles/templates/articles-loop.php
@@ -10,8 +10,15 @@
 
 call_user_func(
 	function( $data ) {
+		global $wp_query;
+		$main_query = $wp_query;
+		wp_reset_postdata();
+
 		$attributes    = $data['attributes'];
 		$article_query = $data['article_query'];
+
+		$wp_query = $article_query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
 		global $newspack_blocks_post_id;
 		$post_counter = 0;
 		while ( $article_query->have_posts() ) {
@@ -23,7 +30,8 @@ call_user_func(
 			$post_counter++;
 			echo Newspack_Blocks::template_inc( __DIR__ . '/article.php', array( 'attributes' => $attributes ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
-		wp_reset_postdata();
+
+		$wp_query = $main_query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	},
 	$data // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Full description and testing instructions: https://github.com/Automattic/newspack-popups/pull/136

To distinguish the `WP_Query` in Homepage Posts from the main loop, this branch holds the `wp_query` global in a temporary variable, then restores it after the block is rendered.

h/t @claudiulodro for the fix!

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-popups/pull/136

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
