### PR TITLE
fix(homepage-posts): exclude posts already on the page from query

### DIFF
--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -361,9 +361,15 @@ class Newspack_Blocks {
 			$args['post__in'] = $specific_posts;
 			$args['orderby']  = 'post__in';
 		} else {
-			$args['posts_per_page'] = $posts_to_show + count( $newspack_blocks_post_id );
+			$args['posts_per_page'] = $posts_to_show;
 			if ( count( $newspack_blocks_all_specific_posts_ids ) ) {
 				$args['post__not_in'] = $newspack_blocks_all_specific_posts_ids;
+			}
+			if ( count( $newspack_blocks_post_id ) ) {
+				$args['post__not_in'] = array_merge(
+					$args['post__not_in'] ?? [],
+					array_keys( $newspack_blocks_post_id )
+				);
 			}
 			if ( $authors && count( $authors ) ) {
 				$args['author__in'] = $authors;

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -362,10 +362,13 @@ class Newspack_Blocks {
 			$args['orderby']  = 'post__in';
 		} else {
 			$args['posts_per_page'] = $posts_to_show;
+			if ( ! self::is_experimental_mode() ) {
+				$args['posts_per_page'] += count( $newspack_blocks_post_id );
+			}
 			if ( count( $newspack_blocks_all_specific_posts_ids ) ) {
 				$args['post__not_in'] = $newspack_blocks_all_specific_posts_ids;
 			}
-			if ( count( $newspack_blocks_post_id ) ) {
+			if ( self::is_experimental_mode() && count( $newspack_blocks_post_id ) ) {
 				$args['post__not_in'] = array_merge(
 					$args['post__not_in'] ?? [],
 					array_keys( $newspack_blocks_post_id )
@@ -500,6 +503,15 @@ class Newspack_Blocks {
 			];
 		}
 		return $clean;
+	}
+
+	/**
+	 * Is experimental mode flag set in wp-config.php
+	 *
+	 * @return boolean Experimental mode flag.
+	 */
+	public static function is_experimental_mode() {
+		return defined( 'NEWSPACK_BLOCKS_EXPERIMENTAL_MODE' ) && NEWSPACK_BLOCKS_EXPERIMENTAL_MODE;
 	}
 }
 Newspack_Blocks::init();

--- a/src/blocks/homepage-articles/templates/articles-loop.php
+++ b/src/blocks/homepage-articles/templates/articles-loop.php
@@ -23,7 +23,7 @@ call_user_func(
 		$post_counter = 0;
 		while ( $article_query->have_posts() ) {
 			$article_query->the_post();
-			if ( ! $attributes['specificMode'] && ( isset( $newspack_blocks_post_id[ get_the_ID() ] ) || $post_counter >= $attributes['postsToShow'] ) ) {
+			if ( ! Newspack_Blocks::is_experimental_mode() && ! $attributes['specificMode'] && ( isset( $newspack_blocks_post_id[ get_the_ID() ] ) || $post_counter >= $attributes['postsToShow'] ) ) {
 				continue;
 			}
 			$newspack_blocks_post_id[ get_the_ID() ] = true;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The "Load more posts" button isn't always appearing on the front end of the site, even when the site is public and there are definitely more posts to load.

**Without this PR**
<img width="400" alt="Screenshot 2020-06-08 at 5 40 58 PM" src="https://user-images.githubusercontent.com/1500769/83996038-3b733b80-a9af-11ea-9e31-91f037ccfae1.png">

I think this is to do with the code that prevents a post from appearing twice on the same page. From what I can tell the block [keeps a track of which posts have already been rendered on the page](https://github.com/Automattic/newspack-blocks/blob/31181a5536aef03779cf789d2dcd4d9de05b4371/src/blocks/homepage-articles/templates/articles-loop.php#L22) so that it doesn't render them again. I think the idea is to [over-fetch posts](https://github.com/Automattic/newspack-blocks/blob/31181a5536aef03779cf789d2dcd4d9de05b4371/class-newspack-blocks.php#L364)  when rendering the following blocks to make up for the fact that some of the posts [will be filtered out](https://github.com/Automattic/newspack-blocks/blob/31181a5536aef03779cf789d2dcd4d9de05b4371/src/blocks/homepage-articles/templates/articles-loop.php#L20).

The problem is that because size of the response page is larger than we actually render, it messes with the logic for deciding whether there are more pages of response to load. Which means the more posts button gets hidden.

This PR changes the approach so that rather than over-fetching posts, it excludes posts that have already rendered from the query.

A downside of this approach could be that the exclusion list grows in an unbounded way because the author can add many blocks which show many posts each. So the query size is unbounded. On the other hand by over-fetching we are growing the size of the query response body in an unbounded way and then throwing away the results. So I can't imagine query performance would be worse than before.

**With this PR**
![Jun-08-2020 17-38-44](https://user-images.githubusercontent.com/1500769/83996154-83925e00-a9af-11ea-9ff7-087763dc911d.gif)

Closes #510

### How to test the changes in this Pull Request:

Addition: The change in query approach is contingent on a `wp-config.php` constant, to allow easy switching between old/new approaches to assess performance. To test this branch, add this to `wp-config.php`:

`define( 'NEWSPACK_BLOCKS_EXPERIMENTAL_MODE', 1 );`

1. Create 2 categories, e.g. 'odd' and 'even'
2. Create 6 posts, assign 3 to each of the new categories
3. Create a new page
4. Add a homepage posts block, configure to show 2 blocks, filter by the 'odd' category, and show the more posts button
5. Add another home posts block, configure to show 2 blocks, filter by the 'even' category, and show the more posts button
6. Preview the page
7. The more posts button should appear on both blocks, and when clicked should display the extra
