### PR TITLE
Fix donations wizard link

### DIFF
--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -324,7 +324,7 @@ class Edit extends Component {
 					label={ __( 'Error', 'newspack-blocks' ) }
 					instructions={ error }
 				>
-					<ExternalLink href="/wp-admin/admin.php?page=newspack-donations-wizard#/">
+					<ExternalLink href="/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/donations">
 						{ __( 'Go to donation settings to troubleshoot.', 'newspack-blocks' ) }
 					</ExternalLink>
 				</Placeholder>
@@ -340,7 +340,7 @@ class Edit extends Component {
 						'newspack-blocks'
 					) }
 				>
-					<ExternalLink href="/wp-admin/admin.php?page=newspack-donations-wizard#/">
+					<ExternalLink href="/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/donations">
 						{ __( 'Set up donation settings.', 'newspack-blocks' ) }
 					</ExternalLink>
 				</Placeholder>
@@ -461,7 +461,7 @@ class Edit extends Component {
 									) }
 								</p>
 
-								<ExternalLink href="/wp-admin/admin.php?page=newspack-donations-wizard#/">
+								<ExternalLink href="/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/donations">
 									{ __( 'Edit donation settings.', 'newspack-blocks' ) }
 								</ExternalLink>
 							</Fragment>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This just brings donations wizard links in Donate block editing code up to date. 

### How to test the changes in this Pull Request:

1. On master branch
1. Insert a Donate block, in the sidebar, click the "Edit donation settings" link
2. Observe the link leading to an error page
1. Switch to this branch and rebuild 
1. Click the link again, observe it leads to the Reader Revenue wizard, Donations section

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
