### PR TITLE
Try/main query alternate

### DIFF
--- a/src/blocks/homepage-articles/templates/articles-loop.php
+++ b/src/blocks/homepage-articles/templates/articles-loop.php
@@ -10,6 +10,7 @@
 
 call_user_func(
 	function( $data ) {
+		// By temporarily overriding $wp_the_query, is_main_query() will return false, which is the expected behavior.
 		global $wp_query, $wp_the_query;
 		$temp_query = null;
 		if ( $wp_query === $wp_the_query ) {

--- a/src/blocks/homepage-articles/templates/articles-loop.php
+++ b/src/blocks/homepage-articles/templates/articles-loop.php
@@ -10,14 +10,15 @@
 
 call_user_func(
 	function( $data ) {
-		global $wp_query;
-		$main_query = $wp_query;
-		wp_reset_postdata();
+		global $wp_query, $wp_the_query;
+		$temp_query = null;
+		if ( $wp_query === $wp_the_query ) {
+			$temp_query   = $wp_query;
+			$wp_the_query = null; //phpcs:ignore
+		}
 
 		$attributes    = $data['attributes'];
 		$article_query = $data['article_query'];
-
-		$wp_query = $article_query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		global $newspack_blocks_post_id;
 		$post_counter = 0;
@@ -30,7 +31,9 @@ call_user_func(
 			$post_counter++;
 			echo Newspack_Blocks::template_inc( __DIR__ . '/article.php', array( 'attributes' => $attributes ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
-		$wp_query = $main_query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		if ( $temp_query ) {
+			$wp_the_query = $temp_query; //phpcs:ignore
+		}
 		wp_reset_postdata();
 	},
 	$data // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

An alternate approach to https://github.com/Automattic/newspack-blocks/pull/512. Rather than tinkering with `$wp_query`, this approach nulls out `$wp_the_query` while the block's loop executes, then restore it. This will cause `is_main_loop()` to return false during the block's loop, which is the expected behavior. 

Test with https://github.com/Automattic/newspack-popups/pull/136 to verify https://github.com/Automattic/newspack-popups/issues/134 is still resolved.

This approach resolves https://github.com/Automattic/newspack-blocks/issues/525

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
