### PR TITLE
Fallback to author if coauthors fails

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -171,7 +171,7 @@ class Newspack_Blocks_API {
 	public static function newspack_blocks_get_author_info( $object ) {
 		$author_data = [];
 
-		if ( function_exists( 'coauthors_posts_links' ) ) :
+		if ( function_exists( 'coauthors_posts_links' ) && ! empty( get_coauthors() ) ) :
 			$authors = get_coauthors();
 
 			foreach ( $authors as $author ) {

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -417,7 +417,7 @@ class Newspack_Blocks {
 	 * @return array Array of WP_User objects.
 	 */
 	public static function prepare_authors() {
-		if ( function_exists( 'coauthors_posts_links' ) ) {
+		if ( function_exists( 'coauthors_posts_links' ) && ! empty( get_coauthors() ) ) {
 			$authors = get_coauthors();
 			foreach ( $authors as $author ) {
 				// Check if this is a guest author post type.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This is a companion PR to https://github.com/Automattic/newspack-theme/pull/974, but that PR isn't required for this one.

This PR fixes an issue I noticed on BDN. On some historic posts, `get_coauthors()` would return an empty array. I haven't figured out the exact cause why, but it's likely old metadata with the same key or something like that.

This PR adds a fall back to display the regular post author if `get_coauthors()` doesn't return anything.

### How to test the changes in this Pull Request:

1. Add the following somewhere: `add_filter( 'get_coauthors', '__return_empty_array' );`
2. Look at homepage block with author display enabled on the frontend and in the editor. Observe author is "By {nothing}":
<img width="329" alt="Screen Shot 2020-06-15 at 7 11 35 PM" src="https://user-images.githubusercontent.com/7317227/84724526-41cc5f00-af3d-11ea-98af-5aaa229a260c.png">
<img width="335" alt="Screen Shot 2020-06-15 at 7 12 32 PM" src="https://user-images.githubusercontent.com/7317227/84724535-46911300-af3d-11ea-93b3-e1f6f5e1d75c.png">

3. Apply this patch. Look again. Observe author is correct:
<img width="321" alt="Screen Shot 2020-06-15 at 7 11 48 PM" src="https://user-images.githubusercontent.com/7317227/84724539-498c0380-af3d-11ea-8bc8-14596ee06fb9.png">
<img width="364" alt="Screen Shot 2020-06-15 at 7 12 56 PM" src="https://user-images.githubusercontent.com/7317227/84724545-4db82100-af3d-11ea-88d0-1809ed85191d.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
