### PR TITLE
refactor: replace query global manipulation with hooks

### DIFF
--- a/src/blocks/homepage-articles/templates/articles-loop.php
+++ b/src/blocks/homepage-articles/templates/articles-loop.php
@@ -10,17 +10,12 @@
 
 call_user_func(
 	function( $data ) {
-		global $wp_query;
-		$main_query = $wp_query;
-		wp_reset_postdata();
-
 		$attributes    = $data['attributes'];
 		$article_query = $data['article_query'];
 
-		$wp_query = $article_query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-
 		global $newspack_blocks_post_id;
 		$post_counter = 0;
+		do_action( 'newspack_blocks_homepage_posts_before_render' );
 		while ( $article_query->have_posts() ) {
 			$article_query->the_post();
 			if ( ! Newspack_Blocks::is_experimental_mode() && ! $attributes['specificMode'] && ( isset( $newspack_blocks_post_id[ get_the_ID() ] ) || $post_counter >= $attributes['postsToShow'] ) ) {
@@ -30,7 +25,7 @@ call_user_func(
 			$post_counter++;
 			echo Newspack_Blocks::template_inc( __DIR__ . '/article.php', array( 'attributes' => $attributes ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
-		$wp_query = $main_query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		do_action( 'newspack_blocks_homepage_posts_after_render' );
 		wp_reset_postdata();
 	},
 	$data // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is a better approach to dealing with the issue in which Newspack Campaigns injected campaigns content into excerpts in the Homepage Posts block. The original solution tinkered with the `$wp_query` global which had unexpected negative side effects, and is generally a risky practice. The new approach fires a custom action before and after the block renders. These hooks allow Newspack Campaigns to remove and re-add the `the_content` filter, ensuring that Campaign content isn't injected into the block.

h/t @adamsilverstein for the approach.

Closes https://github.com/Automattic/newspack-blocks/issues/525

### How to test the changes in this Pull Request:

1. Switch Newspack Campaigns to `master`.
2. Create a Campaign, Sitewide Default, Placement: Center, Trigger: Timer, Frequency: Test Mode. Fill it with recognizable content (e.g. one of the Subscribe block patterns). Publish.
3. Create a Page, add Homepage Posts block, switch on `Show Excerpt`.
4. Publish and view the post. Observe the Campaign content is injected into the excerpts in the Homepage Posts block.
5. Switch Newspack Campaigns to `add/homepage-posts-hooks`.
6. Refresh the post. Observe the excerpts display normally.
7. Verify the Campaign is displayed as it should be in other posts, and on the homepage.    

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
