### PR TITLE
refactor: remove experimental flag for frontend exclusion queries

### DIFF
--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -361,19 +361,14 @@ class Newspack_Blocks {
 			$args['post__in'] = $specific_posts;
 			$args['orderby']  = 'post__in';
 		} else {
-			$args['posts_per_page'] = $posts_to_show;
-			if ( ! self::is_experimental_mode() ) {
-				$args['posts_per_page'] += count( $newspack_blocks_post_id );
-			}
+			$args['posts_per_page'] = $posts_to_show + count( $newspack_blocks_post_id );
 			if ( count( $newspack_blocks_all_specific_posts_ids ) ) {
 				$args['post__not_in'] = $newspack_blocks_all_specific_posts_ids;
 			}
-			if ( self::is_experimental_mode() && count( $newspack_blocks_post_id ) ) {
-				$args['post__not_in'] = array_merge(
-					$args['post__not_in'] ?? [],
-					array_keys( $newspack_blocks_post_id )
-				);
-			}
+			$args['post__not_in'] = array_merge(
+				$args['post__not_in'] ?? [],
+				array_keys( $newspack_blocks_post_id )
+			);
 			if ( $authors && count( $authors ) ) {
 				$args['author__in'] = $authors;
 			}
@@ -503,15 +498,6 @@ class Newspack_Blocks {
 			];
 		}
 		return $clean;
-	}
-
-	/**
-	 * Is experimental mode flag set in wp-config.php
-	 *
-	 * @return boolean Experimental mode flag.
-	 */
-	public static function is_experimental_mode() {
-		return defined( 'NEWSPACK_BLOCKS_EXPERIMENTAL_MODE' ) && NEWSPACK_BLOCKS_EXPERIMENTAL_MODE;
 	}
 }
 Newspack_Blocks::init();

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -361,7 +361,7 @@ class Newspack_Blocks {
 			$args['post__in'] = $specific_posts;
 			$args['orderby']  = 'post__in';
 		} else {
-			$args['posts_per_page'] = $posts_to_show + count( $newspack_blocks_post_id );
+			$args['posts_per_page'] = $posts_to_show;
 			if ( count( $newspack_blocks_all_specific_posts_ids ) ) {
 				$args['post__not_in'] = $newspack_blocks_all_specific_posts_ids;
 			}

--- a/src/blocks/homepage-articles/templates/articles-loop.php
+++ b/src/blocks/homepage-articles/templates/articles-loop.php
@@ -23,9 +23,6 @@ call_user_func(
 		$post_counter = 0;
 		while ( $article_query->have_posts() ) {
 			$article_query->the_post();
-			if ( ! Newspack_Blocks::is_experimental_mode() && ! $attributes['specificMode'] && ( isset( $newspack_blocks_post_id[ get_the_ID() ] ) || $post_counter >= $attributes['postsToShow'] ) ) {
-				continue;
-			}
 			$newspack_blocks_post_id[ get_the_ID() ] = true;
 			$post_counter++;
 			echo Newspack_Blocks::template_inc( __DIR__ . '/article.php', array( 'attributes' => $attributes ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fully adopts the approach of https://github.com/Automattic/newspack-blocks/pull/515, using `post__not_in` queries rather than the original approach of "overshooting" and removing duplicates in PHP. This PR removes the experimental flag and applies the exclusion approach everywhere. 

Using the experimental flag some testing was done on production sites comparing the performance of the old and new approaches. Results were similar but the new approach looks a bit faster, and since it resolves the Load More issue it should be adopted.

cc: @p-jackson 

### How to test the changes in this Pull Request:

1. Create a complex homepage. Verify the results seen in the editor match the frontend, with no duplicate posts shown. 
2. Go through testing instructions in https://github.com/Automattic/newspack-blocks/pull/515 and verify the Load More buttons are functioning as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
