### PR TITLE
New filter to get and apply a custom set of posts for newspack blocks

### DIFF
--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -357,6 +357,21 @@ class Newspack_Blocks {
 			'suppress_filters'    => false,
 			'ignore_sticky_posts' => true,
 		);
+
+		$custom_post_set = apply_filters( 'newspack_set_posts', array() );
+		// Remove post IDs that are part of the excluion array.
+		$custom_post_set = array_diff( $custom_post_set, $newspack_blocks_all_specific_posts_ids );
+		if ( ! empty( $custom_post_set ) ) {
+			// There are still posts in the custom list that have not been shown, so force specific mode.
+			$specific_mode = true;
+
+			// Pop off a number of posts equal to $posts_to_show, set them as the specific_posts array.
+			$specific_posts = array_slice( $custom_post_set, 0, $posts_to_show );
+
+			// Add those posts to the global exclusion list.
+			$newspack_blocks_all_specific_posts_ids = array_merge( $specific_posts, $newspack_blocks_all_specific_posts_ids );
+		}
+
 		if ( $specific_mode && $specific_posts ) {
 			$args['post__in'] = $specific_posts;
 			$args['orderby']  = 'post__in';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add a filter to allow posts in newspack blocks to be set dynamically (from an ACF repeater, for instance).

### How to test the changes in this Pull Request:

1. Create a filter that passes through post IDs for display.
2. The posts will display in newspack blocks were appropriate.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
