### PR TITLE
feat: editable donate button text

### DIFF
--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -18,6 +18,7 @@ import {
 	TextControl,
 	ToggleControl,
 } from '@wordpress/components';
+import { RichText } from '@wordpress/block-editor';
 
 class Edit extends Component {
 	constructor( props ) {
@@ -141,7 +142,8 @@ class Edit extends Component {
 	}
 
 	renderUntieredForm() {
-		const { className } = this.props;
+		const { attributes, className, setAttributes } = this.props;
+		const { buttonText } = attributes;
 		const { uid } = this.state;
 		const { currencySymbol, customDonationAmounts, selectedFrequency } = this.blockData();
 
@@ -196,7 +198,12 @@ class Edit extends Component {
 						{ __( 'Your contribution is appreciated.', 'newspack-blocks' ) }
 					</p>
 					<button type="submit" onClick={ evt => evt.preventDefault() }>
-						{ __( 'Donate now!', 'newspack-blocks' ) }
+						<RichText
+							onChange={ value => setAttributes( { buttonText: value } ) }
+							placeholder={ __( 'Button text…', 'newspack-blocks' ) }
+							value={ buttonText }
+							tagName="span"
+						/>
 					</button>
 				</form>
 			</div>
@@ -204,7 +211,8 @@ class Edit extends Component {
 	}
 
 	renderTieredForm() {
-		const { className } = this.props;
+		const { attributes, className, setAttributes } = this.props;
+		const { buttonText } = attributes;
 		const { uid } = this.state;
 		const {
 			activeTier,
@@ -301,7 +309,12 @@ class Edit extends Component {
 						{ __( 'Your contribution is appreciated.', 'newspack-blocks' ) }
 					</p>
 					<button type="submit" onClick={ evt => evt.preventDefault() }>
-						{ __( 'Donate now!', 'newspack-blocks' ) }
+						<RichText
+							onChange={ value => setAttributes( { buttonText: value } ) }
+							placeholder={ __( 'Button text…', 'newspack-blocks' ) }
+							value={ buttonText }
+							tagName="span"
+						/>
 					</button>
 				</form>
 			</div>

--- a/src/blocks/donate/index.js
+++ b/src/blocks/donate/index.js
@@ -58,6 +58,10 @@ export const settings = {
 		campaign: {
 			type: 'string',
 		},
+		buttonText: {
+			type: 'string',
+			default: __( 'Donate now!', 'newspack-blocks' ),
+		},
 	},
 	supports: {
 		html: false,

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -42,6 +42,8 @@ function newspack_blocks_render_block_donate( $attributes ) {
 
 	$uid = rand(); // Unique identifier to prevent labels colliding with other instances of Donate block.
 
+	$button_text = $attributes['buttonText'];
+
 	ob_start();
 
 	/**
@@ -102,7 +104,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 					<?php echo esc_html__( 'Your contribution is appreciated.', 'newspack-blocks' ); ?>
 				</p>
 				<button type='submit'>
-					<?php echo esc_html__( 'Donate now!', 'newspack-blocks' ); ?>
+					<?php echo wp_kses_post( $button_text ); ?>
 				</button>
 				<?php if ( $campaign ) : ?>
 					<input type='hidden' name='campaign' value='<?php echo esc_attr( $campaign ); ?>' />
@@ -202,7 +204,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 					<?php echo esc_html__( 'Your contribution is appreciated.', 'newspack-blocks' ); ?>
 				</p>
 				<button type='submit'>
-					<?php echo esc_html__( 'Donate now!', 'newspack-blocks' ); ?>
+					<?php echo wp_kses_post( $button_text ); ?>
 				</button>
 				<?php if ( $campaign ) : ?>
 					<input type='hidden' name='campaign' value='<?php echo esc_attr( $campaign ); ?>' />
@@ -243,7 +245,11 @@ function newspack_blocks_register_donate() {
 				],
 				'campaign'                => [
 					'type'    => 'string',
-				]
+				],
+				'buttonText'              => [
+					'type'    => 'string',
+					'default' => __( 'Donate now!', 'newspack-blocks' ),
+				],
 			),
 			'render_callback' => 'newspack_blocks_render_block_donate',
 		)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Makes the text of the Donate button editable. 

Closes https://github.com/Automattic/newspack-blocks/issues/361

### How to test the changes in this Pull Request:

1. Add Donate block to a post.
2. Edit the button text in place.
3. Publish, verify the text change is visible in frontend.
4. Try with manual settings and Newspack-set defaults, verify all works as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
