### PR TITLE
fix: load more posts button breaks styling in AMP pages

### DIFF
--- a/amp/homepage-articles/view.js
+++ b/amp/homepage-articles/view.js
@@ -1,6 +1,29 @@
 let isFetching = false;
 let isEndOfData = false;
 buildLoadMoreHandler( document.querySelector( '.wp-block-newspack-blocks-homepage-articles' ) );
+function addClass( el, classToAdd ) {
+	const classes = el.className.split( ' ' );
+	let hasClass = false;
+	classes.forEach( function( c ) {
+		if ( c.trim() === classToAdd.trim() ) {
+			hasClass = true;
+		}
+	} );
+	if ( ! hasClass ) {
+		classes.push( classToAdd );
+	}
+	el.className = classes.join( ' ' );
+}
+function removeClass( el, classToRemove ) {
+	const classes = el.className.split( ' ' );
+	const newClasses = [];
+	classes.forEach( function( c ) {
+		if ( c.trim() !== classToRemove.trim() ) {
+			newClasses.push( c );
+		}
+	} );
+	el.className = newClasses.join( ' ' );
+}
 function buildLoadMoreHandler( blockWrapperEl ) {
 	const btnEl = blockWrapperEl.querySelector( '[data-next]' );
 	if ( ! btnEl ) {
@@ -12,8 +35,8 @@ function buildLoadMoreHandler( blockWrapperEl ) {
 			return false;
 		}
 		isFetching = true;
-		blockWrapperEl.classList.remove( 'is-error' );
-		blockWrapperEl.classList.add( 'is-loading' );
+		removeClass( blockWrapperEl, 'is-error' );
+		addClass( blockWrapperEl, 'is-loading' );
 		AMP.getState( 'newspackHomepagePosts.exclude_ids' ).then( function( exclude_ids ) {
 			const requestURL = new URL( btnEl.getAttribute( 'data-next' ) );
 			requestURL.searchParams.set( 'exclude_ids', JSON.parse( exclude_ids ).join( ',' ) );
@@ -36,16 +59,16 @@ function buildLoadMoreHandler( blockWrapperEl ) {
 				}
 				if ( ! data.items.length || ! data.next ) {
 					isEndOfData = true;
-					blockWrapperEl.classList.remove( 'has-more-button' );
+					removeClass( blockWrapperEl, 'has-more-button' );
 				}
 				isFetching = false;
-				blockWrapperEl.classList.remove( 'is-loading' );
+				removeClass( blockWrapperEl, 'is-loading' );
 			}
 		}
 		function onError() {
 			isFetching = false;
-			blockWrapperEl.classList.remove( 'is-loading' );
-			blockWrapperEl.classList.add( 'is-error' );
+			removeClass( blockWrapperEl, 'is-loading' );
+			addClass( blockWrapperEl, 'is-error' );
 		}
 	} );
 }

--- a/amp/homepage-articles/view.js
+++ b/amp/homepage-articles/view.js
@@ -2,7 +2,7 @@ let isFetching = false;
 let isEndOfData = false;
 buildLoadMoreHandler( document.querySelector( '.wp-block-newspack-blocks-homepage-articles' ) );
 function addClass( el, classToAdd ) {
-	const classes = el.className.split( ' ' );
+	const classes = classesArray( el );
 	let hasClass = false;
 	classes.forEach( function( c ) {
 		if ( c.trim() === classToAdd.trim() ) {
@@ -11,18 +11,23 @@ function addClass( el, classToAdd ) {
 	} );
 	if ( ! hasClass ) {
 		classes.push( classToAdd );
+		el.className = classes.join( ' ' );
 	}
-	el.className = classes.join( ' ' );
 }
 function removeClass( el, classToRemove ) {
-	const classes = el.className.split( ' ' );
+	const classes = classesArray( el );
 	const newClasses = [];
 	classes.forEach( function( c ) {
 		if ( c.trim() !== classToRemove.trim() ) {
 			newClasses.push( c );
 		}
 	} );
-	el.className = newClasses.join( ' ' );
+	if ( newClasses.length !== classes.length ) {
+		el.className = newClasses.join( ' ' );
+	}
+}
+function classesArray( el ) {
+	return el.className.trim().split( /\s+/ );
 }
 function buildLoadMoreHandler( blockWrapperEl ) {
 	const btnEl = blockWrapperEl.querySelector( '[data-next]' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes an issue where, in an AMP page, clicking the `Load More Posts` button in Homepage Posts block strips the block element of classes and breaks styling of the block. This regression appears to be due to a change in the AMP codebase, although details aren't clear yet. 

`classList` operations in `amp-script` are returning an object, which effectively blanks out all the classes on an element. This PR resolves by converting the `className` attribute to an array and manually adding or removing classes as needed.

Closes https://github.com/Automattic/newspack-blocks/issues/534

### How to test the changes in this Pull Request:

1. On `master`, create a page with a single Homepage Posts block, switch on Load More Posts button.
2. View in AMP page, click Load More Posts, observe all styling of the block is lost.
3. Apply this branch, re-test, observe the styling remains intact.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
