### PR TITLE
feat: exclude current post in homepage posts block

### DIFF
--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -367,7 +367,8 @@ class Newspack_Blocks {
 			}
 			$args['post__not_in'] = array_merge(
 				$args['post__not_in'] ?? [],
-				array_keys( $newspack_blocks_post_id )
+				array_keys( $newspack_blocks_post_id ),
+				get_the_ID() ? [ get_the_ID() ] : []
 			);
 			if ( $authors && count( $authors ) ) {
 				$args['author__in'] = $authors;

--- a/src/blocks/homepage-articles/store.js
+++ b/src/blocks/homepage-articles/store.js
@@ -117,6 +117,7 @@ const createFetchPostsSaga = blockName => {
 		yield delay( 300 );
 
 		const { getBlocks } = select( 'core/block-editor' );
+		const { getCurrentPostId } = select( 'core/editor' );
 
 		yield put( { type: 'DISABLE_UI' } );
 
@@ -130,7 +131,7 @@ const createFetchPostsSaga = blockName => {
 			return acc;
 		}, [] );
 
-		let exclude = specificPostsId;
+		let exclude = [ ...specificPostsId, getCurrentPostId() ];
 		while ( blockQueries.length ) {
 			const nextBlock = blockQueries.shift();
 			nextBlock.postsQuery.exclude = exclude;

--- a/src/blocks/homepage-articles/view.js
+++ b/src/blocks/homepage-articles/view.js
@@ -108,6 +108,12 @@ function getRenderedPostsIds() {
 	);
 	const postIds = Array.from( postEls ).map( el => el.getAttribute( 'data-post-id' ) );
 
+	postIds.push(
+		document
+			.querySelector( '.wp-block-newspack-blocks-homepage-articles > div[data-current-post-id]' )
+			.getAttribute( 'data-current-post-id' )
+	);
+
 	return [ ...new Set( postIds ) ]; // Make values unique with Set
 }
 

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -111,7 +111,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 			class="<?php echo esc_attr( $classes ); ?>"
 			style="<?php echo esc_attr( $styles ); ?>"
 			>
-			<div data-posts>
+			<div data-posts data-current-post-id="<?php the_ID(); ?>">
 				<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
 					<h2 class="article-section-title">
 						<span><?php echo wp_kses_post( $attributes['sectionHeader'] ); ?></span>
@@ -261,7 +261,7 @@ function newspack_blocks_inject_amp_state() {
 	if ( ! $newspack_blocks_post_id || ! count( $newspack_blocks_post_id ) ) {
 		return;
 	}
-	$post_ids = implode( ', ', array_keys( $newspack_blocks_post_id ) );
+	$post_ids = implode( ', ', array_merge( array_keys( $newspack_blocks_post_id ), [ get_the_ID() ] ) );
 	ob_start();
 	?>
 	<amp-state id='newspackHomepagePosts'>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Exclude the current post ID in Homepage Posts block. This change allows placement of the block in content without the obvious mistake of displaying the current post. 

Note: There are some unrelated issues that will occur when the Homepage Posts block is used in a Campaign. These will be addressed in a future PR.

Closes https://github.com/Automattic/newspack-blocks/issues/359

### How to test the changes in this Pull Request:

1. On `master`, create a new Post, add Homepage Posts block. Publish the post then refresh the editor page. Observe the current page is displayed in the block.
2. View the published post. Observe the current page is shown in the block in frontend as well.
3. Switch to this branch. Observe the current page is no longer visible in editor or frontend.
4. Verify "Show More Button" works properly  and doesn't show the current page. Check this in AMP and non-AMP.
5. Verify complex homepage layouts continue to work normally. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
