### PR TITLE
fix: php warnings, phpcs warnings in donate block

### DIFF
--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -40,7 +40,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 
 	$campaign = $attributes['campaign'] ?? false;
 
-	$uid = rand(); // Unique identifier to prevent labels colliding with other instances of Donate block.
+	$uid = wp_rand( 10000, 99999 ); // Unique identifier to prevent labels colliding with other instances of Donate block.
 
 	$button_text = $attributes['buttonText'];
 
@@ -212,7 +212,6 @@ function newspack_blocks_render_block_donate( $attributes ) {
 			</form>
 		</div>
 		<?php
-
 	endif;
 
 	return apply_filters( 'newspack_blocks_donate_block_html', ob_get_clean() );
@@ -234,6 +233,9 @@ function newspack_blocks_register_donate() {
 				],
 				'suggestedAmounts'        => [
 					'type'    => 'array',
+					'items'   => [
+						'type' => 'integer',
+					],
 					'default' => [ 0, 0, 0 ],
 				],
 				'suggestedAmountUntiered' => [
@@ -244,7 +246,7 @@ function newspack_blocks_register_donate() {
 					'default' => true,
 				],
 				'campaign'                => [
-					'type'    => 'string',
+					'type' => 'string',
 				],
 				'buttonText'              => [
 					'type'    => 'string',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Resolves a few PHP and PHPCS warnings in the Donate block. There should be no change to the block's functionality. 

### How to test the changes in this Pull Request:

1. On `master`, add Donate block to post, toggle to "configure manually." Publish and view the post.
2. In PHP error log, observe many notices like this: `PHP Notice:  Undefined index: items in /srv/www/wordpress-simple/public_html/wp-includes/rest-api.php on line 1251`
3. Switch to this branch and refresh the page. 
4. Observe the notices are gone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
