### PR TITLE
Handle no posts without crashing

### DIFF
--- a/src/blocks/carousel/create-swiper.js
+++ b/src/blocks/carousel/create-swiper.js
@@ -98,17 +98,18 @@ export default function createSwiper( els, config = {} ) {
 		touchStartPreventDefault: false,
 		on: {
 			init() {
-				forEachNode( this.wrapperEl.querySelectorAll( '.swiper-slide' ), slide =>
+				forEachNode( swiper.wrapperEl.querySelectorAll( '.swiper-slide' ), ( slide ) =>
 					deactivateSlide( slide )
 				);
 
-				activateSlide( this.slides[ this.activeIndex ] ); // Set-up our active slide.
+				const maybeActiveSlide = swiper.slides[ swiper.activeIndex ];
+				maybeActiveSlide && activateSlide( maybeActiveSlide ); // Set-up our active slide.
 			},
 
 			slideChange() {
-				const currentSlide = this.slides[ this.activeIndex ];
+				const currentSlide = swiper.slides[ swiper.activeIndex ];
 
-				deactivateSlide( this.slides[ this.previousIndex ] );
+				deactivateSlide( swiper.slides[ swiper.previousIndex ] );
 
 				activateSlide( currentSlide );
 
@@ -116,7 +117,7 @@ export default function createSwiper( els, config = {} ) {
 				 * If we're autoplaying, don't announce the slide change, as that would
 				 * be supremely annoying.
 				 */
-				if ( ! this.autoplay.running ) {
+				if ( ! swiper.autoplay.running ) {
 					// Announce the contents of the slide.
 					const currentImage = currentSlide.querySelector( 'img' );
 					const alt = currentImage ? currentImage.alt : false;
@@ -124,8 +125,8 @@ export default function createSwiper( els, config = {} ) {
 					const slideInfo = sprintf(
 						/* translators: current slide number and the total number of slides */
 						__( 'Slide %s of %s', 'newspack-blocks' ),
-						this.realIndex + 1,
-						this.pagination.bullets.length
+						swiper.realIndex + 1,
+						swiper.pagination.bullets.length
 					);
 
 					speak(

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -190,7 +190,7 @@ class Edit extends Component {
 								ref={ this.paginationRef }
 							/>
 						</Fragment>
-					) }
+					) || (<div className="swiper-wrapper"></div> ) }
 				</div>
 				<InspectorControls>
 					<PanelBody title={ __( 'Display Settings' ) } initialOpen={ true }>

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -14,11 +14,13 @@ if ( typeof window !== 'undefined' ) {
 		const blocksArray = Array.from(
 			document.querySelectorAll( '.wp-block-newspack-blocks-carousel' )
 		);
-		blocksArray.forEach( block => {
+		blocksArray.forEach( ( block ) => {
 			createSwiper(
 				{
 					block,
-					container: block.querySelector( '.swiper-container' ),
+					container: block.classList.contains('swiper-container')
+					  ? block
+					  : block.querySelector( '.swiper-container' ),
 					prev: block.querySelector( '.swiper-button-prev' ),
 					next: block.querySelector( '.swiper-button-next' ),
 					pagination: block.querySelector( '.swiper-pagination-bullets' ),


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I was testing the Carousel on an atomic site and ran in a series of weird errors - a missing element that swiper expects to exist, a bunch of `this` referring to the class instead of the instance, and a couple of unsafe dereferences when there are no slides.

This still feels like it might be me doing something wrong, but I wanted to get these changes up to see if someone could explain why I'm seeing them, so a PR isn't quite right, but it's pretty close.

I'm seeing this on an ephemeral site where I'm uploading the synced-coblocks plugin manually, and in chrome.

Closes # .

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
