### PR TITLE
fix: php notices in gutenberg 8.6.0

### DIFF
--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -330,6 +330,7 @@ function newspack_blocks_register_carousel() {
 					),
 				),
 				'render_callback' => 'newspack_blocks_render_block_carousel',
+				'supports'        => [],
 			),
 			'carousel'
 		)

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -254,6 +254,7 @@ function newspack_blocks_register_donate() {
 				],
 			),
 			'render_callback' => 'newspack_blocks_render_block_donate',
+			'supports'        => [],
 		)
 	);
 }

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -178,6 +178,7 @@ function newspack_blocks_register_homepage_articles() {
 			array(
 				'attributes'      => $block['attributes'],
 				'render_callback' => 'newspack_blocks_render_block_homepage_articles',
+				'supports'        => [],
 			),
 			$block['name']
 		)

--- a/src/blocks/video-playlist/view.php
+++ b/src/blocks/video-playlist/view.php
@@ -43,6 +43,7 @@ function newspack_blocks_register_video_playlist() {
 				),
 			),
 			'render_callback' => 'newspack_blocks_render_block_video_playlist',
+			'supports'        => [],
 		)
 	);
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When running Gutenberg 8.6.0 server-rendered blocks that don't have a `supports` parameter defined in `register_block_type` will throw PHP Notices:

```
Notice: Undefined property: WP_Block_Type::$supports in /srv/users/userf199047f/apps/userf199047f/public/wp-content/plugins/gutenberg/lib/blocks.php on line 241
```

This branch adds an empty `supports` parameter for all four blocks, temporarily silencing the notices.

### How to test the changes in this Pull Request:

1. Install Gutenberg 8.6.0.
2. On `master` branch, add each of the blocks to a post (Homepage Articles, Donate, Video Playlist, Carousel). Publish and view. Observe a PHP Notice for each block.
3. Switch to this branch, observe the Notices are gone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
