### PR TITLE
refactor: simplify donate block styles

### DIFF
--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -158,7 +158,10 @@ class Edit extends Component {
 				<form>
 					<div className="wp-block-newspack-blocks-donate__options">
 						{ Object.keys( frequencies ).map( frequencySlug => (
-							<div className="wp-block-newspack-blocks-donate__frequency" key={ frequencySlug }>
+							<div
+								className="wp-block-newspack-blocks-donate__frequency frequency"
+								key={ frequencySlug }
+							>
 								<input
 									type="radio"
 									onClick={ () => this.setState( { selectedFrequency: frequencySlug } ) }
@@ -168,7 +171,7 @@ class Edit extends Component {
 								/>
 								<label
 									htmlFor={ 'newspack-donate-' + frequencySlug + '-' + uid }
-									className="donation-frequency-label"
+									className="donation-frequency-label freq-label"
 								>
 									{ frequencies[ frequencySlug ] }
 								</label>
@@ -179,7 +182,7 @@ class Edit extends Component {
 									>
 										{ __( 'Donation amount', 'newspack-blocks' ) }
 									</label>
-									<div className="wp-block-newspack-blocks-donate__money-input">
+									<div className="wp-block-newspack-blocks-donate__money-input money-input">
 										<span className="currency">{ currencySymbol }</span>
 										<input
 											type="number"
@@ -231,9 +234,12 @@ class Edit extends Component {
 			<div className={ classNames( className, 'tiered wpbnbd' ) }>
 				<form>
 					<div className="wp-block-newspack-blocks-donate__options">
-						<div className="wp-block-newspack-blocks-donate__frequencies">
+						<div className="wp-block-newspack-blocks-donate__frequencies frequencies">
 							{ Object.keys( frequencies ).map( frequencySlug => (
-								<div className="wp-block-newspack-blocks-donate__frequency" key={ frequencySlug }>
+								<div
+									className="wp-block-newspack-blocks-donate__frequency frequency"
+									key={ frequencySlug }
+								>
 									<input
 										type="radio"
 										onClick={ () => this.setState( { selectedFrequency: frequencySlug } ) }
@@ -243,12 +249,12 @@ class Edit extends Component {
 									/>
 									<label
 										htmlFor={ 'newspack-donate-' + frequencySlug + '-' + uid }
-										className="donation-frequency-label"
+										className="donation-frequency-label freq-label"
 									>
 										{ frequencies[ frequencySlug ] }
 									</label>
 
-									<div className="wp-block-newspack-blocks-donate__tiers">
+									<div className="wp-block-newspack-blocks-donate__tiers tiers">
 										{ suggestedAmounts.map( ( suggestedAmount, index ) => (
 											<div className="wp-block-newspack-blocks-donate__tier" key={ index }>
 												<input
@@ -258,7 +264,7 @@ class Edit extends Component {
 													checked={ index === activeTier }
 												/>
 												<label
-													className="tier-select-label"
+													className="tier-select-label tier-label"
 													htmlFor={ 'newspack-tier-' + frequencySlug + '-' + uid + '-' + index }
 												>
 													{ this.formatCurrency(
@@ -279,18 +285,18 @@ class Edit extends Component {
 												checked={ 'other' === activeTier }
 											/>
 											<label
-												className="tier-select-label"
+												className="tier-select-label tier-label"
 												htmlFor={ 'newspack-tier-' + frequencySlug + '-' + uid + '-other' }
 											>
 												{ __( 'Other', 'newspack-blocks' ) }
 											</label>
 											<label
-												className="other-donate-label"
+												className="other-donate-label odl"
 												htmlFor={ 'newspack-tier-' + frequencySlug + '-' + uid + '-other-input' }
 											>
 												{ __( 'Donation amount', 'newspack-blocks' ) }
 											</label>
-											<div className="wp-block-newspack-blocks-donate__money-input">
+											<div className="wp-block-newspack-blocks-donate__money-input money-input">
 												<span className="currency">{ currencySymbol }</span>
 												<input
 													type="number"
@@ -305,7 +311,7 @@ class Edit extends Component {
 							) ) }
 						</div>
 					</div>
-					<p className="wp-block-newspack-blocks-donate__thanks">
+					<p className="wp-block-newspack-blocks-donate__thanks thanks">
 						{ __( 'Your contribution is appreciated.', 'newspack-blocks' ) }
 					</p>
 					<button type="submit" onClick={ evt => evt.preventDefault() }>

--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -197,7 +197,7 @@ class Edit extends Component {
 							</div>
 						) ) }
 					</div>
-					<p className="wp-block-newspack-blocks-donate__thanks">
+					<p className="wp-block-newspack-blocks-donate__thanks thanks">
 						{ __( 'Your contribution is appreciated.', 'newspack-blocks' ) }
 					</p>
 					<button type="submit" onClick={ evt => evt.preventDefault() }>

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -100,7 +100,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 						</div>
 					<?php endforeach; ?>
 				</div>
-				<p class='wp-block-newspack-blocks-donate__thanks'>
+				<p class='wp-block-newspack-blocks-donate__thanks thanks'>
 					<?php echo esc_html__( 'Your contribution is appreciated.', 'newspack-blocks' ); ?>
 				</p>
 				<button type='submit'>

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -64,7 +64,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 							$formatted_amount = number_format( $amount, floatval( $amount ) - intval( $amount ) ? 2 : 0 );
 						?>
 
-						<div class='wp-block-newspack-blocks-donate__frequency'>
+						<div class='wp-block-newspack-blocks-donate__frequency frequency'>
 							<input
 								type='radio'
 								value='<?php echo esc_attr( $frequency_slug ); ?>'
@@ -74,7 +74,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 							/>
 							<label
 								for='newspack-donate-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>'
-								class='donation-frequency-label'
+								class='donation-frequency-label freq-label'
 							>
 								<?php echo esc_html( $frequency_name ); ?>
 							</label>
@@ -85,7 +85,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 								>
 									<?php echo esc_html__( 'Donation amount', 'newspack-blocks' ); ?>
 								</label>
-								<div class='wp-block-newspack-blocks-donate__money-input'>
+								<div class='wp-block-newspack-blocks-donate__money-input money-input'>
 									<span class='currency'>
 										<?php echo esc_html( $settings['currencySymbol'] ); ?>
 									</span>
@@ -120,10 +120,10 @@ function newspack_blocks_render_block_donate( $attributes ) {
 			<form>
 				<input type='hidden' name='newspack_donate' value='1' />
 				<div class='wp-block-newspack-blocks-donate__options'>
-					<div class='wp-block-newspack-blocks-donate__frequencies'>
+					<div class='wp-block-newspack-blocks-donate__frequencies frequencies'>
 						<?php foreach ( $frequencies as $frequency_slug => $frequency_name ) : ?>
 
-							<div class='wp-block-newspack-blocks-donate__frequency'>
+							<div class='wp-block-newspack-blocks-donate__frequency frequency'>
 								<input
 									type='radio'
 									value='<?php echo esc_attr( $frequency_slug ); ?>'
@@ -133,12 +133,12 @@ function newspack_blocks_render_block_donate( $attributes ) {
 								/>
 								<label
 									for='newspack-donate-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>'
-									class='donation-frequency-label'
+									class='donation-frequency-label freq-label'
 								>
 									<?php echo esc_html( $frequency_name ); ?>
 								</label>
 
-								<div class='wp-block-newspack-blocks-donate__tiers'>
+								<div class='wp-block-newspack-blocks-donate__tiers tiers'>
 									<?php foreach ( $suggested_amounts as $index => $suggested_amount ) : ?>
 										<div class='wp-block-newspack-blocks-donate__tier'>
 											<?php
@@ -153,7 +153,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 												<?php checked( 1, $index ); ?>
 											/>
 											<label
-												class='tier-select-label'
+												class='tier-select-label tier-label'
 												for='newspack-tier-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-<?php echo (int) $index; ?>'
 											>
 												<?php echo esc_html( $formatted_amount ); ?>
@@ -171,18 +171,18 @@ function newspack_blocks_render_block_donate( $attributes ) {
 											id='newspack-tier-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-other'
 										/>
 										<label
-											class='tier-select-label'
+											class='tier-select-label tier-label'
 											for='newspack-tier-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-other'
 										>
 											<?php echo esc_html__( 'Other', 'newspack-blocks' ); ?>
 										</label>
 										<label
-											class='other-donate-label'
+											class='other-donate-label odl'
 											for='newspack-tier-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-other-input'
 										>
 											<?php echo esc_html__( 'Donation amount', 'newspack-blocks' ); ?>
 										</label>
-										<div class='wp-block-newspack-blocks-donate__money-input'>
+										<div class='wp-block-newspack-blocks-donate__money-input money-input'>
 											<span class='currency'>
 												<?php echo esc_html( $settings['currencySymbol'] ); ?>
 											</span>
@@ -200,7 +200,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 						<?php endforeach; ?>
 					</div>
 				</div>
-				<p class='wp-block-newspack-blocks-donate__thanks'>
+				<p class='wp-block-newspack-blocks-donate__thanks thanks'>
 					<?php echo esc_html__( 'Your contribution is appreciated.', 'newspack-blocks' ); ?>
 				</p>
 				<button type='submit'>

--- a/src/blocks/donate/view.scss
+++ b/src/blocks/donate/view.scss
@@ -13,14 +13,14 @@
 		display: none;
 	}
 
-	.donation-frequency-label,
-	.tier-select-label {
+	.freq-label,
+	.tier-label {
 		display: block;
 		font-weight: bold;
 		cursor: pointer;
 	}
 
-	.donation-frequency-label {
+	.freq-label {
 		background: $color__background-body;
 		color: $color__text-light;
 		line-height: $font__line-height-body;
@@ -43,7 +43,7 @@
 		}
 	}
 
-	button[type='submit'] {
+	button {
 		margin: 0 0.76rem 0.76rem;
 
 		@include media( tablet ) {
@@ -51,7 +51,7 @@
 		}
 	}
 
-	.wp-block-newspack-blocks-donate__thanks {
+	.thanks {
 		color: $color__text-light;
 		font-size: $font__size-sm;
 		margin: 0.38rem 0.76rem 0.76rem;
@@ -64,7 +64,7 @@
 }
 
 .wpbnbd.tiered {
-	.wp-block-newspack-blocks-donate__tiers {
+	.tiers {
 		margin: 0.38rem;
 		display: none;
 		flex-wrap: wrap;
@@ -74,7 +74,7 @@
 			margin: 1.12rem 1.12rem 0.38rem;
 		}
 
-		.tier-select-label {
+		.tier-label {
 			border: 1px solid $color__border;
 			border-radius: 5px;
 			margin: 0.38rem;
@@ -86,14 +86,15 @@
 		}
 
 		input[type='radio']:checked {
-			+ .tier-select-label {
+			+ .tier-label {
 				background-color: $color__primary;
 				border-color: transparent;
 				color: $color__background-body;
 			}
 		}
 
-		.other-donate-label {
+		// other-donate-label
+		.odl {
 			font-weight: bold;
 			left: 0.38rem;
 			position: absolute;
@@ -101,13 +102,14 @@
 		}
 
 		input.other-input {
-			~ .wp-block-newspack-blocks-donate__money-input,
-			~ .other-donate-label {
+			~ .money-input,
+			// other-donate-label
+			~ .odl {
 				display: none;
 			}
 
-			&:checked ~ .wp-block-newspack-blocks-donate__money-input,
-			&:checked ~ .other-donate-label {
+			&:checked ~ .money-input,
+			&:checked ~ .other-label {
 				display: block;
 			}
 
@@ -117,7 +119,7 @@
 		}
 	}
 
-	.wp-block-newspack-blocks-donate__money-input {
+	.money-input {
 		bottom: 0.38rem;
 		left: 0.38rem;
 		position: absolute;
@@ -134,7 +136,7 @@
 		padding-top: calc( 0.76rem + 1.28em + 1px );
 	}
 
-	.donation-frequency-label {
+	.freq-label {
 		font-size: $font__size-sm;
 	}
 
@@ -157,7 +159,7 @@
 	}
 }
 
-.wp-block-newspack-blocks-donate__money-input {
+.wpbnbd .money-input {
 	position: relative;
 	max-width: 200px;
 	background-color: $color__background-input;
@@ -191,7 +193,7 @@
 	}
 }
 
-.wp-block-newspack-blocks-donate__frequencies {
+.wpbnbd .frequencies {
 	font-size: $font__size-sm;
 	padding-top: 7.65em;
 	padding-top: calc( 3 * ( 0.76rem + 1.6em + 1px ) );
@@ -203,8 +205,8 @@
 	}
 }
 
-.wp-block-newspack-blocks-donate__frequency {
-	.donation-frequency-label {
+.wpbnbd .frequency {
+	.freq-label {
 		align-items: center;
 		border: 0 solid $color__border;
 		border-width: 0 0 1px;
@@ -215,12 +217,14 @@
 		width: 100%;
 
 		&::before {
-			background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24' viewBox='0 0 24 24' width='24'%3E%3Cpath d='M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z' fill='%23767676' /%3E%3C/svg%3E" );
+			border: 2px solid currentColor;
+			border-radius: 100%;
 			content: '';
 			display: block;
-			height: 24px;
+			height: 20px;
+			padding: 3px;
 			margin-right: 0.25rem;
-			width: 24px;
+			width: 20px;
 		}
 
 		@include media( tablet ) {
@@ -234,11 +238,12 @@
 	}
 
 	input[type='radio']:checked {
-		+ .donation-frequency-label {
+		+ .freq-label {
 			color: inherit;
 
 			&::before {
-				background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24' viewBox='0 0 24 24' width='24'%3E%3Cpath d='M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zm0-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z' fill='%23111'/%3E%3C/svg%3E" );
+				background: $color__text-main;
+				background-clip: content-box;
 			}
 
 			@include media( tablet ) {
@@ -250,12 +255,12 @@
 			}
 		}
 
-		~ .wp-block-newspack-blocks-donate__tiers {
+		~ .tiers {
 			display: flex;
 		}
 	}
 
-	&:nth-of-type( 2 ) .donation-frequency-label {
+	&:nth-of-type( 2 ) .freq-label {
 		top: calc( 0.76rem + 1.6em + 1px );
 
 		@include media( tablet ) {
@@ -266,7 +271,7 @@
 		}
 	}
 
-	&:nth-of-type( 3 ) .donation-frequency-label {
+	&:nth-of-type( 3 ) .freq-label {
 		top: calc( 2 * ( 0.76rem + 1.6em + 1px ) );
 
 		@include media( tablet ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR doesn't change anything visually about the Donate Block, but it reduces the CSS by a bit over 2kb for the tiered version when using AMP tree shaking:

Standard - before: 6,632b
Tree shaken - before: 6,025b

Standard - after: 4,678b (-1,954b)
Tree shaken - after: 3,998b (-2,027b -- or about 2.7% of the available total)

This block is often used on the homepage, and the homepage typically has the most CSS, so this seemed like a quick win!

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Apply custom colours and fonts on the site (just to verify that they are applied).
3. Set up the Donate Block on a page, with tiers.
4. Test in the editor and on the front end at both desktop and mobile sizes; confirm that it looks correct, and selecting different tabs/options still works:

![image](https://user-images.githubusercontent.com/177561/88231084-70b6ae80-cc28-11ea-9b87-8448e662f94a.png)

![image](https://user-images.githubusercontent.com/177561/88231112-7ad8ad00-cc28-11ea-9c63-7f3e4892d0ad.png)

5. Switch the donate block to the untiered version.
6. Repeat step 4 and test on the front-end and in the editor, on desktop and mobile.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
