### PR TITLE
fix: make sure colors aren't overridden in non-NP themes

### DIFF
--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -4,6 +4,7 @@
 .wp-block-newspack-blocks-carousel {
 	position: relative;
 	margin-top: 0;
+
 	article {
 		max-width: 100%;
 		padding: 0;
@@ -11,9 +12,8 @@
 		margin-bottom: 0;
 		word-break: break-word;
 		overflow-wrap: break-word;
-
 		a {
-			color: inherit;
+			color: #fff;
 
 			&:active,
 			&:focus,
@@ -59,12 +59,12 @@
 			right: 0;
 		}
 		.entry-meta {
-			color: inherit;
+			color: #fff;
 			margin-bottom: 0;
 			font-size: 0.8em;
 
 			a {
-				color: inherit;
+				color: #fff;
 				font-weight: bold;
 				text-decoration: none;
 
@@ -211,7 +211,7 @@
 	.entry-title {
 		margin: 0 0 0.25em;
 		a {
-			color: inherit;
+			color: #fff;
 			text-decoration: none;
 		}
 	}
@@ -227,7 +227,7 @@
 		}
 	}
 	.cat-links {
-		color: inherit;
+		color: #fff;
 		font-size: 0.6em;
 		font-weight: bold;
 		margin: 0 0 0.5em;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Post Carousel block's font colours are largely set to `inherit`; in a couple WP.com themes, the carousel is inheriting from the theme's more specific styles, rather than the block, making the colours too dark. This PR switches the block to use `#fff` to fix. It's possible it won't fix all themes, but we can adjust further as individual cases crop up!

Note: this needs a WP.com sandbox to test.

Closes #548

### How to test the changes in this Pull Request:

1. On your WP.com sandbox, switch to a theme where this issue happens, like Stratford or Independent Publisher 2. 
2. Add a Post Carousel block to a page and publish.
3. Note the issue on the front-end:

![image](https://user-images.githubusercontent.com/177561/88324057-fd6c7580-ccd7-11ea-9471-6916aba622c5.png)

4. Apply the PR and run `npm run build`
5. Sync your local dev site with your WP.com sandbox using the process for the FSE plugin in Calypso (just ping me if you need steps!)
6. Refresh your test post; the text should now be white:

![image](https://user-images.githubusercontent.com/177561/88323942-d44be500-ccd7-11ea-8d3b-a0fc9b9f170c.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
