### PR TITLE
feat: experimental title-only specific posts lookup endpoint

### DIFF
--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -61,7 +61,8 @@ class Newspack_Blocks {
 				'newspack-blocks-editor',
 				'newspack_blocks_data',
 				[
-					'patterns' => self::get_patterns_for_post_type( get_post_type() ),
+					'patterns'      => self::get_patterns_for_post_type( get_post_type() ),
+					'_experimental' => self::use_experimental(),
 				]
 			);
 
@@ -499,6 +500,15 @@ class Newspack_Blocks {
 			];
 		}
 		return $clean;
+	}
+
+	/**
+	 * Whether to use experimental features.
+	 *
+	 * @return bool Experimental status.
+	 */
+	public static function use_experimental() {
+		return defined( 'NEWSPACK_BLOCKS_EXPERIMENTAL' ) && NEWSPACK_BLOCKS_EXPERIMENTAL;
 	}
 }
 Newspack_Blocks::init();

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -23,8 +23,12 @@ class QueryControls extends Component {
 	};
 
 	fetchPostSuggestions = search => {
+		const basePath =
+			window && window.newspack_blocks_data && window.newspack_blocks_data._experimental
+				? '/newspack-blocks/v1/specific-posts'
+				: '/wp/v2/search';
 		return apiFetch( {
-			path: addQueryArgs( '/wp/v2/search', {
+			path: addQueryArgs( basePath, {
 				search,
 				per_page: 20,
 				_fields: 'id,title',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We've received feedback from Bangor Daily News that specific posts lookups in the Homepage Posts block can take 45-60 seconds, making homepage management a painfully slow operation. This seems to be because we're using the `/wp/v2/search` endpoint which does a full-text search. The site in question is very large (over 400k posts), so this operation runs slow. This branch introduces a new endpoint that queries `post_title` only, which should be orders of magnitude faster. Although I suspect most use of the specific posts field does use the title, this change is a feature removal, so for the moment it's behind a new `wp-config` flag (`NEWSPACK_BLOCKS_EXPERIMENTAL`). If this fix works well and we determine the full text search isn't essential, we can remove the flag and apply it universally.

### How to test the changes in this Pull Request:

1. Add `define( 'NEWSPACK_BLOCKS_EXPERIMENTAL', true );` to `wp-config.php`.
2. Checkout and build this branch.
3. Add a Homepage Posts block to a page.
4. Toggle "Specific Posts" on, try searching for various posts, verify the results are as expected.
5. Optionally, set `NEWSPACK_BLOCKS_EXPERIMENTAL` to `false` and compare request times. On a small instance the difference may be unnoticeable, but on a larger instance (e.g. the Newspack McMansion) it may be clear.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
