### PR TITLE
Don't render homepage posts blocks in feeds

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -13,6 +13,11 @@
  * @return string Returns the post content with latest posts added.
  */
 function newspack_blocks_render_block_homepage_articles( $attributes ) {
+	// Don't output the block inside RSS feeds.
+	if ( is_feed() ) {
+		return;
+	}
+
 	// This will let the FSE plugin know we need CSS/JS now.
 	do_action( 'newspack_blocks_render_homepage_articles' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Sometimes it makes sense to include a homepage posts block in a post, for example to show a more targeted related post element. This can cause issues with RSS feeds through as the markup for a homepage posts block can confuse parsers and services that ingest feeds for syndication purposes.

The re-circulation benefits of the block being in a post aren't going to carry through to a feed and the styling will not be present so it's best to remove them from the feed entirely, as this change does.

### How to test the changes in this Pull Request:

1. Add a new post with a homepage posts block in the content
2. View the main RSS feed and observe the block markup is added
3. Apply the patch
4. Reload the RSS feed and observe the markup is gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
