### PR TITLE
Homepage Posts, Post Carousel Blocks: Add sponsored labels

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -86,6 +86,21 @@ class Newspack_Blocks_API {
 				],
 			]
 		);
+
+		/* Sponsors */
+		register_rest_field(
+			'post',
+			'newspack_post_sponsors',
+			[
+				'get_callback' => [ 'Newspack_Blocks_API', 'newspack_blocks_sponsor_info' ],
+				'schema'       => [
+					'context' => [
+						'edit',
+					],
+					'type'    => 'array',
+				],
+			]
+		);
 	}
 
 	/**
@@ -259,6 +274,34 @@ class Newspack_Blocks_API {
 	 */
 	public static function newspack_blocks_get_cat_tag_classes( $object ) {
 		return Newspack_Blocks::get_term_classes( $object['id'] );
+	}
+
+	/**
+	 * Get all sponsor information for the rest field.
+	 *
+	 * @param array $object The object info.
+	 * @return array sponsor information.
+	 */
+	public static function newspack_blocks_sponsor_info( $object ) {
+		if ( Newspack_Blocks::get_post_sponsors( $object['id'] ) ) {
+			$sponsors = Newspack_Blocks::get_post_sponsors( $object['id'] );
+			foreach ( $sponsors as $sponsor ) {
+				$sponsor_logo   = Newspack_Blocks::get_sponsor_logo_sized( $sponsor['sponsor_id'] );
+				$sponsor_info[] = array(
+					'flag'          => Newspack_Blocks::get_sponsor_label( $sponsor['sponsor_id'] ),
+					'display_name'  => $sponsor['sponsor_name'],
+					'sponsor_url'   => $sponsor['sponsor_url'],
+					'byline_prefix' => $sponsor['sponsor_byline'],
+					'id'            => $sponsor['sponsor_id'],
+					'src'           => $sponsor_logo['src'],
+					'img_width'     => $sponsor_logo['img_width'],
+					'img_height'    => $sponsor_logo['img_height'],
+				);
+			}
+			return $sponsor_info;
+		} else {
+			return false;
+		}
 	}
 
 	/**

--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -289,10 +289,11 @@ class Newspack_Blocks_API {
 				$sponsor_logo   = Newspack_Blocks::get_sponsor_logo_sized( $sponsor['sponsor_id'] );
 				$sponsor_info[] = array(
 					'flag'          => Newspack_Blocks::get_sponsor_label( $sponsor['sponsor_id'] ),
-					'display_name'  => $sponsor['sponsor_name'],
+					'sponsor_name'  => $sponsor['sponsor_name'],
 					'sponsor_url'   => $sponsor['sponsor_url'],
 					'byline_prefix' => $sponsor['sponsor_byline'],
 					'id'            => $sponsor['sponsor_id'],
+					'scope'         => $sponsor['sponsor_scope'],
 					'src'           => $sponsor_logo['src'],
 					'img_width'     => $sponsor_logo['img_width'],
 					'img_height'    => $sponsor_logo['img_height'],

--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -288,7 +288,7 @@ class Newspack_Blocks_API {
 			foreach ( $sponsors as $sponsor ) {
 				$sponsor_logo   = Newspack_Blocks::get_sponsor_logo_sized( $sponsor['sponsor_id'] );
 				$sponsor_info[] = array(
-					'flag'          => Newspack_Blocks::get_sponsor_label( $sponsor['sponsor_id'] ),
+					'flag'          => $sponsor['sponsor_flag'],
 					'sponsor_name'  => $sponsor['sponsor_name'],
 					'sponsor_url'   => $sponsor['sponsor_url'],
 					'byline_prefix' => $sponsor['sponsor_byline'],

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -517,6 +517,10 @@ class Newspack_Blocks {
 			$sponsors   = array();
 			$duplicates = array();
 			foreach ( $sponsors_all as $sponsor ) {
+				// For the blocks, only add visual elements to 'native' sponsored content.
+				if ( 'native' !== $sponsor['sponsor_scope'] ) {
+					continue;
+				}
 				if ( ! in_array( $sponsor['sponsor_id'], $duplicates, true ) ) {
 					$duplicates[] = $sponsor['sponsor_id'];
 					$sponsors[]   = $sponsor;

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -30,7 +30,12 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import QueryControls from '../../components/query-controls';
 import createSwiper from './create-swiper';
-import { formatAvatars, formatByline } from '../../shared/js/utils';
+import {
+	formatAvatars,
+	formatByline,
+	formatSponsorLogos,
+	formatSponsorByline,
+} from '../../shared/js/utils';
 
 class Edit extends Component {
 	constructor( props ) {
@@ -153,19 +158,35 @@ class Edit extends Component {
 													) }
 												</figure>
 												<div className="entry-wrapper">
-													{ showCategory && post.newspack_category_info.length && (
-														<div className="cat-links">
-															<a href="#">{ decodeEntities( post.newspack_category_info ) }</a>
-														</div>
+													{ post.newspack_post_sponsors && (
+														<span className="cat-links sponsor-label">
+															<span className="flag">
+																{ post.newspack_post_sponsors[ 0 ].flag }
+															</span>
+														</span>
 													) }
+													{ showCategory &&
+														post.newspack_category_info.length &&
+														! post.newspack_post_sponsors && (
+															<div className="cat-links">
+																<a href="#">{ decodeEntities( post.newspack_category_info ) }</a>
+															</div>
+														) }
 													<h3 className="entry-title">
 														<a href="#">{ decodeEntities( post.title.rendered.trim() ) }</a>
 													</h3>
 													<div className="entry-meta">
+														{ post.newspack_post_sponsors &&
+															formatSponsorLogos( post.newspack_post_sponsors ) }
+														{ post.newspack_post_sponsors &&
+															formatSponsorByline( post.newspack_post_sponsors ) }
 														{ showAuthor &&
 															showAvatar &&
+															! post.newspack_post_sponsors &&
 															formatAvatars( post.newspack_author_info ) }
-														{ showAuthor && formatByline( post.newspack_author_info ) }
+														{ showAuthor &&
+															! post.newspack_post_sponsors &&
+															formatByline( post.newspack_author_info ) }
 														{ showDate && (
 															<time className="entry-date published" key="pub-date">
 																{ dateI18n( dateFormat, post.date_gmt ) }

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -87,33 +87,41 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 				</figure>
 				<div class="entry-wrapper">
 
+				<?php if ( Newspack_Blocks::get_post_sponsors( get_the_id() ) ) : ?>
+					<span class="cat-links sponsor-label">
+						<span class="flag">
+							<?php echo esc_html( Newspack_Blocks::get_sponsor_label( get_the_id() ) ); ?>
+						</span>
+					</span>
 					<?php
-					$category = false;
+					else :
+						$category = false;
 
-					// Use Yoast primary category if set.
-					if ( class_exists( 'WPSEO_Primary_Term' ) ) {
-						$primary_term = new WPSEO_Primary_Term( 'category', get_the_ID() );
-						$category_id  = $primary_term->get_primary_term();
-						if ( $category_id ) {
-							$category = get_term( $category_id );
+						// Use Yoast primary category if set.
+						if ( class_exists( 'WPSEO_Primary_Term' ) ) {
+							$primary_term = new WPSEO_Primary_Term( 'category', get_the_ID() );
+							$category_id  = $primary_term->get_primary_term();
+							if ( $category_id ) {
+								$category = get_term( $category_id );
+							}
 						}
-					}
 
-					if ( ! $category ) {
-						$categories_list = get_the_category();
-						if ( ! empty( $categories_list ) ) {
-							$category = $categories_list[0];
+						if ( ! $category ) {
+							$categories_list = get_the_category();
+							if ( ! empty( $categories_list ) ) {
+								$category = $categories_list[0];
+							}
 						}
-					}
 
-					if ( $attributes['showCategory'] && $category ) :
-						?>
-						<div class="cat-links">
-							<a href="<?php echo esc_url( get_category_link( $category->term_id ) ); ?>">
-								<?php echo esc_html( $category->name ); ?>
-							</a>
-						</div>
-						<?php
+						if ( $attributes['showCategory'] && $category ) :
+							?>
+							<div class="cat-links">
+								<a href="<?php echo esc_url( get_category_link( $category->term_id ) ); ?>">
+									<?php echo esc_html( $category->name ); ?>
+								</a>
+							</div>
+							<?php
+						endif;
 					endif;
 					?>
 
@@ -122,31 +130,56 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 					?>
 
 					<div class="entry-meta">
-						<?php if ( $attributes['showAuthor'] ) : ?>
-							<?php
-							if ( $attributes['showAvatar'] ) {
-								echo get_avatar( get_the_author_meta( 'ID' ) );
-							}
-							?>
-							<span class="byline">
+						<?php if ( Newspack_Blocks::get_post_sponsors( get_the_id() ) ) : ?>
+							<span class="sponsor-logos">
 								<?php
-								printf(
-									/* translators: %s: post author. */
-									esc_html_x( 'by %s', 'post author', 'newspack-blocks' ),
-									'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
-								);
+								$logos = Newspack_Blocks::get_sponsor_logos( get_the_id() );
+								foreach ( $logos as $logo ) {
+									if ( '' !== $logo['url'] ) {
+										echo '<a href="' . esc_url( $logo['url'] ) . '" target="_blank">';
+									}
+									echo '<img src="' . esc_url( $logo['src'] ) . '" width="' . esc_attr( $logo['width'] ) . '" height="' . esc_attr( $logo['height'] ) . '">';
+									if ( '' !== $logo['url'] ) {
+										echo '</a>';
+									}
+								}
 								?>
-							</span><!-- .author-name -->
+							</span>
+							<span class="byline sponsor-byline">
+								<?php
+								$bylines = Newspack_Blocks::get_sponsor_byline( get_the_id() );
+								echo esc_html( $bylines[0]['byline'] ) . ' ';
+								foreach ( $bylines as $byline ) {
+									echo '<span class="author"><a target="_blank" href="' . esc_url( $byline['url'] ) . '">' . esc_html( $byline['name'] ) . '</a></span>' . esc_html( $byline['sep'] );
+								}
+								?>
+							</span>
 							<?php
+						else :
+							if ( $attributes['showAuthor'] ) :
+								if ( $attributes['showAvatar'] ) {
+									echo get_avatar( get_the_author_meta( 'ID' ) );
+								}
+								?>
+								<span class="byline">
+									<?php
+									printf(
+										/* translators: %s: post author. */
+										esc_html_x( 'by %s', 'post author', 'newspack-blocks' ),
+										'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
+									);
+									?>
+								</span><!-- .author-name -->
+								<?php
 							endif;
-
-							if ( $attributes['showDate'] ) :
-								printf(
-									'<time class="entry-date published" datetime="%1$s">%2$s</time>',
-									esc_attr( get_the_date( DATE_W3C ) ),
-									esc_html( get_the_date() )
-								);
-							endif;
+						endif;
+						if ( $attributes['showDate'] ) :
+							printf(
+								'<time class="entry-date published" datetime="%1$s">%2$s</time>',
+								esc_attr( get_the_date( DATE_W3C ) ),
+								esc_html( get_the_date() )
+							);
+						endif;
 						?>
 					</div><!-- .entry-meta -->
 				</div><!-- .entry-wrapper -->

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -11,7 +11,12 @@ import {
 	shouldReflow,
 	queryCriteriaFromAttributes,
 } from './utils';
-import { formatAvatars, formatByline } from '../../shared/js/utils';
+import {
+	formatAvatars,
+	formatByline,
+	formatSponsorLogos,
+	formatSponsorByline,
+} from '../../shared/js/utils';
 
 /**
  * External dependencies
@@ -135,6 +140,7 @@ class Edit extends Component {
 
 		const postTitle = this.titleForPost( post );
 		const dateFormat = __experimentalGetSettings().formats.date;
+
 		return (
 			<article className={ postClasses } key={ post.id } style={ styles }>
 				{ showImage && post.newspack_featured_image_src && (
@@ -160,7 +166,12 @@ class Edit extends Component {
 				) }
 
 				<div className="entry-wrapper">
-					{ showCategory && post.newspack_category_info.length && (
+					{ post.newspack_post_sponsors && (
+						<span className="cat-links sponsor-label">
+							<span className="flag">{ post.newspack_post_sponsors[ 0 ].flag }</span>
+						</span>
+					) }
+					{ showCategory && post.newspack_category_info.length && ! post.newspack_post_sponsors && (
 						<div className="cat-links">
 							<a href="#">{ decodeEntities( post.newspack_category_info ) }</a>
 						</div>
@@ -188,8 +199,15 @@ class Edit extends Component {
 						</RawHTML>
 					) }
 					<div className="entry-meta">
-						{ showAuthor && showAvatar && formatAvatars( post.newspack_author_info ) }
-						{ showAuthor && formatByline( post.newspack_author_info ) }
+						{ post.newspack_post_sponsors && formatSponsorLogos( post.newspack_post_sponsors ) }
+						{ post.newspack_post_sponsors && formatSponsorByline( post.newspack_post_sponsors ) }
+						{ showAuthor &&
+							showAvatar &&
+							! post.newspack_post_sponsors &&
+							formatAvatars( post.newspack_author_info ) }
+						{ showAuthor &&
+							! post.newspack_post_sponsors &&
+							formatByline( post.newspack_author_info ) }
 						{ showDate && (
 							<time className="entry-date published" key="pub-date">
 								{ dateI18n( dateFormat, post.date_gmt ) }

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -69,7 +69,13 @@ call_user_func(
 		<?php endif; ?>
 
 		<div class="entry-wrapper">
-			<?php if ( $attributes['showCategory'] && $category ) : ?>
+			<?php if ( Newspack_Blocks::get_post_sponsors( get_the_id() ) ) : ?>
+				<span class="cat-links sponsor-label">
+					<span class="flag">
+						<?php echo esc_html( Newspack_Blocks::get_sponsor_label( get_the_id() ) ); ?>
+					</span>
+				</span>
+			<?php elseif ( $attributes['showCategory'] && $category ) : ?>
 				<div class="cat-links">
 					<a href="<?php echo esc_url( get_category_link( $category->term_id ) ); ?>">
 						<?php echo esc_html( $category->name ); ?>
@@ -95,57 +101,83 @@ call_user_func(
 			if ( $attributes['showExcerpt'] ) :
 				the_excerpt();
 			endif;
-			if ( $attributes['showAuthor'] || $attributes['showDate'] ) :
+			if ( $attributes['showAuthor'] || $attributes['showDate'] || Newspack_Blocks::get_post_sponsors( get_the_id() ) ) :
 				?>
 				<div class="entry-meta">
+					<?php if ( Newspack_Blocks::get_post_sponsors( get_the_id() ) ) : ?>
+						<span class="sponsor-logos">
+							<?php
+							$logos = Newspack_Blocks::get_sponsor_logos( get_the_id() );
+							foreach ( $logos as $logo ) {
+								if ( '' !== $logo['url'] ) {
+									echo '<a href="' . esc_url( $logo['url'] ) . '" target="_blank">';
+								}
+								echo '<img src="' . esc_url( $logo['src'] ) . '" width="' . esc_attr( $logo['width'] ) . '" height="' . esc_attr( $logo['height'] ) . '">';
+								if ( '' !== $logo['url'] ) {
+									echo '</a>';
+								}
+							}
+							?>
+						</span>
+						<span class="byline sponsor-byline">
+							<?php
+							$bylines = Newspack_Blocks::get_sponsor_byline( get_the_id() );
+							echo esc_html( $bylines[0]['byline'] ) . ' ';
+							foreach ( $bylines as $byline ) {
+								echo '<span class="author"><a target="_blank" href="' . esc_url( $byline['url'] ) . '">' . esc_html( $byline['name'] ) . '</a></span>' . esc_html( $byline['sep'] );
+							}
+							?>
+						</span>
 					<?php
-					if ( $attributes['showAuthor'] ) :
-						if ( $attributes['showAvatar'] ) :
-							echo wp_kses(
-								newspack_blocks_format_avatars( $authors ),
-								array(
-									'img'      => array(
-										'class'  => true,
-										'src'    => true,
-										'alt'    => true,
-										'width'  => true,
-										'height' => true,
-										'data-*' => true,
-										'srcset' => true,
-									),
-									'noscript' => array(),
-									'a'        => array(
-										'href' => true,
-									),
-								)
+					else :
+						if ( $attributes['showAuthor'] ) :
+							if ( $attributes['showAvatar'] ) :
+								echo wp_kses(
+									newspack_blocks_format_avatars( $authors ),
+									array(
+										'img'      => array(
+											'class'  => true,
+											'src'    => true,
+											'alt'    => true,
+											'width'  => true,
+											'height' => true,
+											'data-*' => true,
+											'srcset' => true,
+										),
+										'noscript' => array(),
+										'a'        => array(
+											'href' => true,
+										),
+									)
+								);
+							endif;
+							?>
+							<span class="byline">
+								<?php echo wp_kses_post( newspack_blocks_format_byline( $authors ) ); ?>
+							</span><!-- .author-name -->
+							<?php
+						endif;
+						if ( $attributes['showDate'] ) :
+							$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
+							if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) :
+								$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
+							endif;
+							printf(
+								wp_kses(
+									$time_string,
+									array(
+										'time' => array(
+											'class'    => true,
+											'datetime' => true,
+										),
+									)
+								),
+								esc_attr( get_the_date( DATE_W3C ) ),
+								esc_html( get_the_date() ),
+								esc_attr( get_the_modified_date( DATE_W3C ) ),
+								esc_html( get_the_modified_date() )
 							);
 						endif;
-						?>
-						<span class="byline">
-							<?php echo wp_kses_post( newspack_blocks_format_byline( $authors ) ); ?>
-						</span><!-- .author-name -->
-						<?php
-					endif;
-					if ( $attributes['showDate'] ) :
-						$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
-						if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) :
-							$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
-						endif;
-						printf(
-							wp_kses(
-								$time_string,
-								array(
-									'time' => array(
-										'class'    => true,
-										'datetime' => true,
-									),
-								)
-							),
-							esc_attr( get_the_date( DATE_W3C ) ),
-							esc_html( get_the_date() ),
-							esc_attr( get_the_modified_date( DATE_W3C ) ),
-							esc_html( get_the_modified_date() )
-						);
 					endif;
 					?>
 				</div><!-- .entry-meta -->

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -157,27 +157,27 @@ call_user_func(
 							</span><!-- .author-name -->
 							<?php
 						endif;
-						if ( $attributes['showDate'] ) :
-							$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
-							if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) :
-								$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
-							endif;
-							printf(
-								wp_kses(
-									$time_string,
-									array(
-										'time' => array(
-											'class'    => true,
-											'datetime' => true,
-										),
-									)
-								),
-								esc_attr( get_the_date( DATE_W3C ) ),
-								esc_html( get_the_date() ),
-								esc_attr( get_the_modified_date( DATE_W3C ) ),
-								esc_html( get_the_modified_date() )
-							);
+					endif;
+					if ( $attributes['showDate'] ) :
+						$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
+						if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) :
+							$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
 						endif;
+						printf(
+							wp_kses(
+								$time_string,
+								array(
+									'time' => array(
+										'class'    => true,
+										'datetime' => true,
+									),
+								)
+							),
+							esc_attr( get_the_date( DATE_W3C ) ),
+							esc_html( get_the_date() ),
+							esc_attr( get_the_modified_date( DATE_W3C ) ),
+							esc_html( get_the_modified_date() )
+						);
 					endif;
 					?>
 				</div><!-- .entry-meta -->

--- a/src/shared/js/utils.js
+++ b/src/shared/js/utils.js
@@ -32,3 +32,36 @@ export const formatByline = authorInfo => (
 		}, [] ) }
 	</span>
 );
+
+export const formatSponsorLogos = sponsorInfo => (
+	<span className="sponsor-logos">
+		{ sponsorInfo.map( sponsor => (
+			<a href={ sponsor.sponsor_url } key={ sponsor.id }>
+				<img
+					src={ sponsor.src }
+					width={ sponsor.img_width }
+					height={ sponsor.img_height }
+					alt={ sponsor.display_name }
+				/>
+			</a>
+		) ) }
+	</span>
+);
+
+export const formatSponsorByline = sponsorInfo => (
+	<span className="byline sponsor-byline">
+		{ sponsorInfo[ 0 ].byline_prefix }{' '}
+		{ sponsorInfo.reduce( ( accumulator, sponsor, index ) => {
+			return [
+				...accumulator,
+				<span className="author" key={ sponsor.id }>
+					<a href={ sponsor.author_link }>{ sponsor.display_name }</a>
+				</span>,
+				index < sponsorInfo.length - 2 && ', ',
+				sponsorInfo.length > 1 &&
+					index === sponsorInfo.length - 2 &&
+					_x( ' and ', 'post author', 'newspack-blocks' ),
+			];
+		}, [] ) }
+	</span>
+);

--- a/src/shared/js/utils.js
+++ b/src/shared/js/utils.js
@@ -41,7 +41,7 @@ export const formatSponsorLogos = sponsorInfo => (
 					src={ sponsor.src }
 					width={ sponsor.img_width }
 					height={ sponsor.img_height }
-					alt={ sponsor.display_name }
+					alt={ sponsor.sponsor_name }
 				/>
 			</a>
 		) ) }
@@ -55,7 +55,7 @@ export const formatSponsorByline = sponsorInfo => (
 			return [
 				...accumulator,
 				<span className="author" key={ sponsor.id }>
-					<a href={ sponsor.author_link }>{ sponsor.display_name }</a>
+					<a href={ sponsor.author_link }>{ sponsor.sponsor_name }</a>
 				</span>,
 				index < sponsorInfo.length - 2 && ', ',
 				sponsorInfo.length > 1 &&


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds some visuals elements when a post is marked as native sponsored content using the Newspack Sponsors plugin (the underwritten posts only show visual elements on single posts).

It needs to be tested in partnership with https://github.com/Automattic/newspack-theme/pull/1008 to apply the correct styles.

Closes #563

### How to test the changes in this Pull Request:

1. Install and activate the Newspack Sponsors plugin (ping myself or Derrick if unsure where to find it).
2. Switch your site to use AMP transitional so you can test both the AMP and non-AMP versions, just to make sure there's no weirdness with the scaled down logos.
3. Add at least four sponsors; make sure to include the following combinations; make sure to use at least one horizontal and one vertically-oriented logo:

* Set scope to native content, attached to a category
* Set scope to native content, attached to a specific story
* Set scope to underwritten content, attached to a category
* Set scope to underwritten content, attached to a specific story.
* Make sure at least one story will end up with more than one sponsor.

4. Set up at least one Homepage Posts block and at least one Post Carousel block on the homepage. Make sure both will show at least one post that's native content, one that's underwritten content, and one that has no sponsor assigned at all. Turn on the categories and all author settings.
5. View on the front-end and in the editor; confirm that your sponsored content is displaying the 'Sponsored' flag, logos and byline, using the custom values set on your testing site, and the underwritten/non-sponsored content doesn't show anything:

![image](https://user-images.githubusercontent.com/177561/89470731-4fc68100-d731-11ea-8a82-098356ba6db8.png)

![image](https://user-images.githubusercontent.com/177561/89471003-ec891e80-d731-11ea-960c-d1011072c2b1.png)

6. Navigate to the editor, and turn off the categories and authors for all the blocks; confirm that the author and category are removed for posts with underwritten content or no sponsors, but not the posts with native content:

![image](https://user-images.githubusercontent.com/177561/89473060-c7e37580-d736-11ea-92ec-724b32800ae1.png)

7. If you haven't already, change the sponsored content strings (under Sponsors > Settings), and the Sponsored Content flag colour (under Customizer > Sponsor Settings); confirm the blocks are picking up both on the front-end and in the editor:

![image](https://user-images.githubusercontent.com/177561/89473412-a46cfa80-d737-11ea-98ed-cfba6a760f49.png)

8. Cycle through the different themes and confirm that things look OK:

**Newspack Joseph:**

![image](https://user-images.githubusercontent.com/177561/89473938-12fe8800-d739-11ea-9eef-536161763ee7.png)

**Newspack Katharine:**

![image](https://user-images.githubusercontent.com/177561/89473994-3aedeb80-d739-11ea-8930-b6cc5b80743c.png)

**Newspack Nelson:**

![image](https://user-images.githubusercontent.com/177561/89474247-f0b93a00-d739-11ea-9ac2-5ace4b3501a6.png)

**Newspack Sacha:**

![image](https://user-images.githubusercontent.com/177561/89474300-16deda00-d73a-11ea-8f9a-d891741e07d1.png)

**Newspack Scott:**

![image](https://user-images.githubusercontent.com/177561/89474434-7806ad80-d73a-11ea-99ca-e057e5a661d8.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
