### PR TITLE
Add permission_callback to all REST endpoints for wp 5.5

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -271,6 +271,9 @@ class Newspack_Blocks_API {
 			[
 				'methods'  => 'GET',
 				'callback' => [ 'Newspack_Blocks_API', 'video_playlist_endpoint' ],
+				'permission_callback' => function( $request ) {
+					return current_user_can( 'edit_posts' );
+				},
 			]
 		);
 	}
@@ -296,6 +299,9 @@ class Newspack_Blocks_API {
 						'sanitize_callback' => 'absint',
 					],
 				],
+				'permission_callback' => function( $request ) {
+					return current_user_can( 'edit_posts' );
+				},
 			]
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes an issue I noticed while beta testing WP 5.5. Starting in WP 5.5, REST endpoints without a permissions callback will throw an error in order to prevent people inadvertently making their endpoints public. There were a couple (safe) endpoints in Newspack Blocks with this issue, so I've added permissions callbacks. In theory, the endpoints would be fine as public endpoints, but there isn't really a reason to expose them outside the post editor.

### How to test the changes in this Pull Request:

1. Before applying this patch, install the latest WP 5.5 release candidate and add `define( 'NEWSPACK_BLOCKS_EXPERIMENTAL', true );` somewhere.
2. Observe notices shown at the top of every admin screen:
<img width="1079" alt="Screen Shot 2020-08-10 at 11 52 51 AM" src="https://user-images.githubusercontent.com/7317227/89819911-fed3d580-db00-11ea-99c1-800e881431f9.png">

3. Apply this patch. Observe notice disappears. Try the specific post search with the Homepage Posts block and try inserting a YouTube Playlist block, and they should continue working normally.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
