### PR TITLE
Add permission callbacks (required in WP 5.5.)

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -271,6 +271,7 @@ class Newspack_Blocks_API {
 			[
 				'methods'  => 'GET',
 				'callback' => [ 'Newspack_Blocks_API', 'video_playlist_endpoint' ],
+				'permission_callback' => [ __CLASS__, 'api_permission_callback' ],
 			]
 		);
 	}
@@ -288,6 +289,7 @@ class Newspack_Blocks_API {
 			[
 				'methods'  => \WP_REST_Server::READABLE,
 				'callback' => [ 'Newspack_Blocks_API', 'specific_posts_endpoint' ],
+				'permission_callback' => [ __CLASS__, 'api_permission_callback' ],
 				'args'     => [
 					'search'   => [
 						'sanitize_callback' => 'sanitize_text_field',
@@ -298,6 +300,22 @@ class Newspack_Blocks_API {
 				],
 			]
 		);
+	}
+
+	/**
+	 * Check capabilities when getting plugin info.
+	 *
+	 * @param WP_REST_Request $request API request object.
+	 * @return bool|WP_Error
+	 */
+	public function api_permission_callback( $request ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'newspack_rest_forbidden',
+				esc_html__( 'You cannot view this resource.', 'newspack-blocks' )
+			);
+		}
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds `permission_callback` to `register_rest_route` calls, as it's a required argument in WP 5.5

### How to test the changes in this Pull Request:

1. Use the video playlist block, verify video preview in the editor is refreshing as before
2. Use the homepage poss block, verify specific posts lookup in the editor is working as before

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
