### PR TITLE
Fix: moving check for sponsors to prevent notices

### DIFF
--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -513,6 +513,10 @@ class Newspack_Blocks {
 			// Get all assigned sponsors.
 			$sponsors_all = \Newspack_Sponsors\get_sponsors_for_post( $post_id );
 
+			if ( empty( $sponsors_all ) ) {
+				return false;
+			}
+
 			// Loop through sponsors and remove duplicates.
 			$sponsors   = array();
 			$duplicates = array();
@@ -526,11 +530,11 @@ class Newspack_Blocks {
 					$sponsors[]   = $sponsor;
 				}
 			}
+
+			if ( $sponsors ) {
+				return $sponsors;
+			}
 		}
-		if ( $sponsors ) {
-			return $sponsors;
-		}
-		return false;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Similar to https://github.com/Automattic/newspack-theme/pull/1032, this PR moves the check for sponsors so it doesn't throw an error when the Newspack Sponsors plugin is not installed.

### How to test the changes in this Pull Request:

1. Start with a test site with the Newspack Sponsors plugin disabled, and set up some Homepage Posts and Post Carousel Blocks. Make sure `wp_debug` is enabled.
2. View on front-end; note each block throws an error, `Notice: Undefined variable: sponsors in /srv/www/newspack-build/public_html/wp-content/plugins/newspack-blocks/class-newspack-blocks.php on line 530`.
3. Apply the PR and confirm the errors go away.
4. Activate the Newspack Sponsors plugin, and make the sponsor flair (flag, logos and byline) still show up for Homepage Posts and Post Carousel blocks with native sponsors, on the front-end and in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
