### PR TITLE
Update sponsor code to use new function

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -283,10 +283,17 @@ class Newspack_Blocks_API {
 	 * @return array sponsor information.
 	 */
 	public static function newspack_blocks_sponsor_info( $object ) {
-		if ( Newspack_Blocks::get_post_sponsors( $object['id'] ) ) {
-			$sponsors = Newspack_Blocks::get_post_sponsors( $object['id'] );
+		$sponsors = Newspack_Blocks::get_all_sponsors(
+			$object['id'],
+			'native',
+			'post',
+			array(
+				'maxwidth'  => 80,
+				'maxheight' => 40,
+			)
+		);
+		if ( ! empty( $sponsors ) ) {
 			foreach ( $sponsors as $sponsor ) {
-				$sponsor_logo   = Newspack_Blocks::get_sponsor_logo_sized( $sponsor['sponsor_id'] );
 				$sponsor_info[] = array(
 					'flag'          => $sponsor['sponsor_flag'],
 					'sponsor_name'  => $sponsor['sponsor_name'],
@@ -294,9 +301,9 @@ class Newspack_Blocks_API {
 					'byline_prefix' => $sponsor['sponsor_byline'],
 					'id'            => $sponsor['sponsor_id'],
 					'scope'         => $sponsor['sponsor_scope'],
-					'src'           => $sponsor_logo['src'],
-					'img_width'     => $sponsor_logo['img_width'],
-					'img_height'    => $sponsor_logo['img_height'],
+					'src'           => $sponsor['sponsor_logo']['src'],
+					'img_width'     => $sponsor['sponsor_logo']['img_width'],
+					'img_height'    => $sponsor['sponsor_logo']['img_height'],
 				);
 			}
 			return $sponsor_info;

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -87,10 +87,10 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 				</figure>
 				<div class="entry-wrapper">
 
-				<?php if ( Newspack_Blocks::get_post_sponsors( get_the_id() ) ) : ?>
+				<?php if ( Newspack_Blocks::get_all_sponsors( get_the_id() ) ) : ?>
 					<span class="cat-links sponsor-label">
 						<span class="flag">
-							<?php echo esc_html( Newspack_Blocks::get_sponsor_label( get_the_id() ) ); ?>
+							<?php echo esc_html( Newspack_Blocks::get_all_sponsors( get_the_id() ) ); ?>
 						</span>
 					</span>
 					<?php
@@ -130,7 +130,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 					?>
 
 					<div class="entry-meta">
-						<?php if ( Newspack_Blocks::get_post_sponsors( get_the_id() ) ) : ?>
+						<?php if ( Newspack_Blocks::get_all_sponsors( get_the_id() ) ) : ?>
 							<span class="sponsor-logos">
 								<?php
 								$logos = Newspack_Blocks::get_sponsor_logos( get_the_id() );

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -90,7 +90,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 				<?php if ( Newspack_Blocks::get_all_sponsors( get_the_id() ) ) : ?>
 					<span class="cat-links sponsor-label">
 						<span class="flag">
-							<?php echo esc_html( Newspack_Blocks::get_all_sponsors( get_the_id() ) ); ?>
+							<?php echo esc_html( Newspack_Blocks::get_sponsor_label( get_the_id() ) ); ?>
 						</span>
 					</span>
 					<?php

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -69,7 +69,7 @@ call_user_func(
 		<?php endif; ?>
 
 		<div class="entry-wrapper">
-			<?php if ( Newspack_Blocks::get_post_sponsors( get_the_id() ) ) : ?>
+			<?php if ( Newspack_Blocks::get_all_sponsors( get_the_id() ) ) : ?>
 				<span class="cat-links sponsor-label">
 					<span class="flag">
 						<?php echo esc_html( Newspack_Blocks::get_sponsor_label( get_the_id() ) ); ?>
@@ -101,10 +101,10 @@ call_user_func(
 			if ( $attributes['showExcerpt'] ) :
 				the_excerpt();
 			endif;
-			if ( $attributes['showAuthor'] || $attributes['showDate'] || Newspack_Blocks::get_post_sponsors( get_the_id() ) ) :
+			if ( $attributes['showAuthor'] || $attributes['showDate'] || Newspack_Blocks::get_all_sponsors( get_the_id() ) ) :
 				?>
 				<div class="entry-meta">
-					<?php if ( Newspack_Blocks::get_post_sponsors( get_the_id() ) ) : ?>
+					<?php if ( Newspack_Blocks::get_all_sponsors( get_the_id() ) ) : ?>
 						<span class="sponsor-logos">
 							<?php
 							$logos = Newspack_Blocks::get_sponsor_logos( get_the_id() );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the sponsor code for blocks to use the new function in the sponsors plugin. Like the theme approach, it still creates a new function to avoid linting errors. 

### How to test the changes in this Pull Request:

1. Start with a test site sponsored content; ideally both native and underwritten content (even though the latter shouldn't show anything in the block).
2. Set up a Homepage Posts block and a Post Carousel block with setting so they both show sponsored and non-sponsored content.
3. View in the editor and on the front-end; confirm that sponsored content shows the sponsor flag, logos and byline, even when the author and category are set not to display:

![image](https://user-images.githubusercontent.com/177561/90702500-44e71280-e240-11ea-8c92-f9ec2e1168cb.png)

![image](https://user-images.githubusercontent.com/177561/90702600-7b249200-e240-11ea-82a9-cd0e72cbc33c.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
