### PR TITLE
fix: prevent errors when there is no sponsor logo, link

### DIFF
--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -587,7 +587,7 @@ class Newspack_Blocks {
 		if ( ! empty( $sponsors ) ) {
 			$sponsor_logos = [];
 			foreach ( $sponsors as $sponsor ) {
-				if ( '' !== $sponsor['sponsor_logo'] ) :
+				if ( ! empty( $sponsor['sponsor_logo'] ) ) :
 					$sponsor_logos[] = array(
 						'url'    => $sponsor['sponsor_url'],
 						'src'    => esc_url( $sponsor['sponsor_logo']['src'] ),

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -150,7 +150,15 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 								$bylines = Newspack_Blocks::get_sponsor_byline( get_the_id() );
 								echo esc_html( $bylines[0]['byline'] ) . ' ';
 								foreach ( $bylines as $byline ) {
-									echo '<span class="author"><a target="_blank" href="' . esc_url( $byline['url'] ) . '">' . esc_html( $byline['name'] ) . '</a></span>' . esc_html( $byline['sep'] );
+									echo '<span class="author">';
+									if ( '' !== $byline['url'] ) {
+										echo '<a target="_blank" href="' . esc_url( $byline['url'] ) . '">';
+									}
+									echo esc_html( $byline['name'] );
+									if ( '' !== $byline['url'] ) {
+										'</a>';
+									}
+									echo '</span>' . esc_html( $byline['sep'] );
 								}
 								?>
 							</span>

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -130,10 +130,13 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 					?>
 
 					<div class="entry-meta">
-						<?php if ( Newspack_Blocks::get_all_sponsors( get_the_id() ) ) : ?>
+						<?php
+						if ( Newspack_Blocks::get_all_sponsors( get_the_id() ) ) :
+							$logos = Newspack_Blocks::get_sponsor_logos( get_the_id() );
+							if ( ! empty( $logos ) ) :
+								?>
 							<span class="sponsor-logos">
 								<?php
-								$logos = Newspack_Blocks::get_sponsor_logos( get_the_id() );
 								foreach ( $logos as $logo ) {
 									if ( '' !== $logo['url'] ) {
 										echo '<a href="' . esc_url( $logo['url'] ) . '" target="_blank">';
@@ -145,6 +148,8 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 								}
 								?>
 							</span>
+							<?php endif; ?>
+
 							<span class="byline sponsor-byline">
 								<?php
 								$bylines = Newspack_Blocks::get_sponsor_byline( get_the_id() );

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -105,9 +105,12 @@ call_user_func(
 				?>
 				<div class="entry-meta">
 					<?php if ( Newspack_Blocks::get_all_sponsors( get_the_id() ) ) : ?>
+						<?php
+						$logos = Newspack_Blocks::get_sponsor_logos( get_the_id() );
+						if ( ! empty( $logos ) ) :
+							?>
 						<span class="sponsor-logos">
 							<?php
-							$logos = Newspack_Blocks::get_sponsor_logos( get_the_id() );
 							foreach ( $logos as $logo ) {
 								if ( '' !== $logo['url'] ) {
 									echo '<a href="' . esc_url( $logo['url'] ) . '" target="_blank">';
@@ -119,23 +122,24 @@ call_user_func(
 							}
 							?>
 						</span>
-						<span class="byline sponsor-byline">
-							<?php
-							$bylines = Newspack_Blocks::get_sponsor_byline( get_the_id() );
-							echo esc_html( $bylines[0]['byline'] ) . ' ';
-							foreach ( $bylines as $byline ) {
-								echo '<span class="author">';
-								if ( '' !== $byline['url'] ) {
-									echo '<a target="_blank" href="' . esc_url( $byline['url'] ) . '">';
-								}
-								echo esc_html( $byline['name'] );
-								if ( '' !== $byline['url'] ) {
-									'</a>';
-								}
-								echo '</span>' . esc_html( $byline['sep'] );
+					<?php endif; ?>
+					<span class="byline sponsor-byline">
+						<?php
+						$bylines = Newspack_Blocks::get_sponsor_byline( get_the_id() );
+						echo esc_html( $bylines[0]['byline'] ) . ' ';
+						foreach ( $bylines as $byline ) {
+							echo '<span class="author">';
+							if ( '' !== $byline['url'] ) {
+								echo '<a target="_blank" href="' . esc_url( $byline['url'] ) . '">';
 							}
-							?>
-						</span>
+							echo esc_html( $byline['name'] );
+							if ( '' !== $byline['url'] ) {
+								'</a>';
+							}
+							echo '</span>' . esc_html( $byline['sep'] );
+						}
+						?>
+					</span>
 					<?php
 					else :
 						if ( $attributes['showAuthor'] ) :

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -124,7 +124,15 @@ call_user_func(
 							$bylines = Newspack_Blocks::get_sponsor_byline( get_the_id() );
 							echo esc_html( $bylines[0]['byline'] ) . ' ';
 							foreach ( $bylines as $byline ) {
-								echo '<span class="author"><a target="_blank" href="' . esc_url( $byline['url'] ) . '">' . esc_html( $byline['name'] ) . '</a></span>' . esc_html( $byline['sep'] );
+								echo '<span class="author">';
+								if ( '' !== $byline['url'] ) {
+									echo '<a target="_blank" href="' . esc_url( $byline['url'] ) . '">';
+								}
+								echo esc_html( $byline['name'] );
+								if ( '' !== $byline['url'] ) {
+									'</a>';
+								}
+								echo '</span>' . esc_html( $byline['sep'] );
 							}
 							?>
 						</span>

--- a/src/shared/js/utils.js
+++ b/src/shared/js/utils.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { _x } from '@wordpress/i18n';
-import { RawHTML } from '@wordpress/element';
+import { RawHTML, Fragment } from '@wordpress/element';
 
 export const formatAvatars = authorInfo =>
 	authorInfo.map( author => (
@@ -36,14 +36,18 @@ export const formatByline = authorInfo => (
 export const formatSponsorLogos = sponsorInfo => (
 	<span className="sponsor-logos">
 		{ sponsorInfo.map( sponsor => (
-			<a href={ sponsor.sponsor_url } key={ sponsor.id }>
-				<img
-					src={ sponsor.src }
-					width={ sponsor.img_width }
-					height={ sponsor.img_height }
-					alt={ sponsor.sponsor_name }
-				/>
-			</a>
+			<Fragment key={ sponsor.id }>
+				{ sponsor.src && (
+					<a href={ sponsor.sponsor_url }>
+						<img
+							src={ sponsor.src }
+							width={ sponsor.img_width }
+							height={ sponsor.img_height }
+							alt={ sponsor.sponsor_name }
+						/>
+					</a>
+				) }
+			</Fragment>
 		) ) }
 	</span>
 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR helps make sure the block doesn't throw notices when a sponsor is missing a logo or a link.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Set up a couple native sponsors; one with everything and one missing a logo/link or both.
3. Set up a homepage posts block and a post carousel block that will display some of each.
4. Confirm the sponsors are linked only when links are available on the front end (links are not clickable in the editor), and that logos only display when available on the front-end and in the editor. 

Correct placement in post carousel:

<img width="1229" alt="image" src="https://user-images.githubusercontent.com/177561/91210678-6faeec00-e6c2-11ea-9c7f-3bc017caeeb5.png">

<img width="1227" alt="image" src="https://user-images.githubusercontent.com/177561/91210654-67ef4780-e6c2-11ea-9a08-977e25ff6346.png">

Correct placement in homepage posts: 

<img width="313" alt="image" src="https://user-images.githubusercontent.com/177561/91210736-85241600-e6c2-11ea-890d-303787c6955f.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
