### PR TITLE
Homepage Posts: Make sure sponsored content styles survive tree shaking

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -68,7 +68,6 @@
 	}
 
 	/* Image styles */
-
 	.post-thumbnail {
 		margin: 0;
 		margin-bottom: 0.25em;
@@ -181,21 +180,6 @@
 		a {
 			color: inherit;
 			text-decoration: none;
-		}
-	}
-
-	/* Article meta */
-	.cat-links {
-		font-size: $font__size-xxs;
-		font-weight: bold;
-		margin: 0 0 0.5em;
-
-		a {
-			text-decoration: none;
-
-			&:hover {
-				text-decoration: underline;
-			}
 		}
 	}
 
@@ -367,6 +351,27 @@
 		width: auto;
 	}
 }
+
+/* stylelint-disable selector-type-no-unknown  */
+.wpnbha,
+amp-script .wpnbha {
+	/* Article meta */
+	.cat-links {
+		display: flex;
+		font-size: $font__size-xxs;
+		font-weight: bold;
+		margin: 0 0 0.5em;
+
+		a {
+			text-decoration: none;
+
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}
+/* stylelint-enable */
 
 /*
 	Some really rough font sizing.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When you pair sponsored content with the 'Load More' option in the Homepage Posts block, and the sponsored content is not in the first 'page' of posts, AMP will remove the styles because they're not needed on page load. 

This PR, with https://github.com/Automattic/newspack-theme/pull/1046, makes sure AMP doesn't remove these styles. They will need to be tested together.

### How to test the changes in this Pull Request:

1. Set up a test site with sponsored content, and with AMP enabled.
2. Add a Homepage posts block to the front page, set up to use the 'Load More' button. Make sure your sponsored content will appear in the block, but not on the first "page" of posts, so it doesn't display until you click "Load More" on the front-page.
3. View on the front end, and click 'Load More' until your sponsored content appears.
4. Note that the Sponsored flag is not styled:

5. Apply this PR and [the theme PR](https://github.com/Automattic/newspack-theme/pull/1046); run `npm run build` in each directory.
6. Refresh the page, and click 'Load More' until your sponsored content appears.
7. Note that it is now styled:

<img width="1229" alt="image" src="https://user-images.githubusercontent.com/177561/91496428-ef7ab900-e870-11ea-8d65-230cebbcc5d4.png">

8. Confirm that the non-AMP version still looks correct.
9. Try changing the header font and sponsored flag colour (under Customizer > Sponsored Content) and confirm both are applied:

<img width="1244" alt="image" src="https://user-images.githubusercontent.com/177561/91496859-bd1d8b80-e871-11ea-8193-6cc1c9e3e95f.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
