### PR TITLE
Assorted bugfixes

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -294,17 +294,20 @@ class Newspack_Blocks_API {
 		);
 		if ( ! empty( $sponsors ) ) {
 			foreach ( $sponsors as $sponsor ) {
-				$sponsor_info[] = array(
+				$sponsor_info_item = [
 					'flag'          => $sponsor['sponsor_flag'],
 					'sponsor_name'  => $sponsor['sponsor_name'],
 					'sponsor_url'   => $sponsor['sponsor_url'],
 					'byline_prefix' => $sponsor['sponsor_byline'],
 					'id'            => $sponsor['sponsor_id'],
 					'scope'         => $sponsor['sponsor_scope'],
-					'src'           => $sponsor['sponsor_logo']['src'],
-					'img_width'     => $sponsor['sponsor_logo']['img_width'],
-					'img_height'    => $sponsor['sponsor_logo']['img_height'],
-				);
+				];
+				if ( ! empty( $sponsor['sponsor_logo'] ) ) {
+					$sponsor_info_item['src']        = $sponsor['sponsor_logo']['src'];
+					$sponsor_info_item['img_width']  = $sponsor['sponsor_logo']['img_width'];
+					$sponsor_info_item['img_height'] = $sponsor['sponsor_logo']['img_height'];
+				}
+				$sponsor_info[] = $sponsor_info_item;
 			}
 			return $sponsor_info;
 		} else {

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -328,16 +328,23 @@ class Edit extends Component {
 							required
 						/>
 					) }
-					{ ! specificMode && ! isBlogPrivate() && (
+					{ ! specificMode && isBlogPrivate() ? (
 						/*
-						 * Hide the "More" button option on private sites.
+						 * Hide the "Load more posts" button option on private sites.
 						 *
 						 * Client-side fetching from a private WP.com blog requires authentication,
 						 * which is not provided in the current implementation.
 						 * See https://github.com/Automattic/newspack-blocks/issues/306.
 						 */
+						<i>
+							{ __(
+								'This blog is private, therefore the "Load more posts" feature is not active.',
+								'newspack-blocks'
+							) }
+						</i>
+					) : (
 						<ToggleControl
-							label={ __( 'Show "More" Button', 'newspack-blocks' ) }
+							label={ __( 'Show "Load more posts" Button', 'newspack-blocks' ) }
 							checked={ moreButton }
 							onChange={ () => setAttributes( { moreButton: ! moreButton } ) }
 						/>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #507.

### How to test the changes in this Pull Request:

1. Open a private WPCOM site (or simulate it by setting `window.wpcomGutenberg = {blogPublic: '-1'}`)
2. In the editor, Homepage Posts Block settings, Display Settings panel observe a notice in place of the "Show "Load more posts" toggle
3. Open a public site's editor, observe the toggle working as before
4. Create a block with post/s sponsored by a sponsor which does not have an image, observe no warnings are logged during rendering

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
