### PR TITLE
Feat: add support for the aside post format

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -101,6 +101,21 @@ class Newspack_Blocks_API {
 				],
 			]
 		);
+
+		/* Post format */
+		register_rest_field(
+			'post',
+			'newspack_post_format',
+			[
+				'get_callback' => [ 'Newspack_Blocks_API', 'newspack_blocks_post_format' ],
+				'schema'       => [
+					'context' => [
+						'edit',
+					],
+					'type'    => 'string',
+				],
+			]
+		);
 	}
 
 	/**
@@ -313,6 +328,17 @@ class Newspack_Blocks_API {
 		} else {
 			return false;
 		}
+	}
+
+	/**
+	 * Pass post format to editor.
+	 *
+	 * @param array $object The object info.
+	 * @return string post format.
+	 */
+	public static function newspack_blocks_post_format( $object ) {
+		$post_format = get_post_format( $object['id'] );
+		return $post_format;
 	}
 
 	/**

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -446,7 +446,7 @@ class Newspack_Blocks {
 	}
 
 	/**
-	 * Prepare a list of classes based on assigned tags and categories.
+	 * Prepare a list of classes based on assigned tags, categories and post formats.
 	 *
 	 * @param string $post_id Post ID.
 	 * @return string CSS classes.
@@ -466,6 +466,11 @@ class Newspack_Blocks {
 			foreach ( $categories as $cat ) {
 				$classes[] = 'category-' . $cat->slug;
 			}
+		}
+
+		$post_format = get_post_format( $post_id );
+		if ( false !== $post_format ) {
+			$classes[] = 'format-' . $post_format;
 		}
 
 		return implode( ' ', $classes );

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -178,11 +178,11 @@ class Edit extends Component {
 					) }
 					{ RichText.isEmpty( sectionHeader ) ? (
 						<h2 className="entry-title" key="title">
-							<a href="#">{ postTitle }</a>
+							{ post.newspack_post_format === 'aside' ? postTitle : <a href="#">{ postTitle }</a> }
 						</h2>
 					) : (
 						<h3 className="entry-title" key="title">
-							<a href="#">{ postTitle }</a>
+							{ post.newspack_post_format === 'aside' ? postTitle : <a href="#">{ postTitle }</a> }
 						</h3>
 					) }
 					{ IS_SUBTITLE_SUPPORTED_IN_THEME && showSubtitle && (
@@ -195,7 +195,9 @@ class Edit extends Component {
 					) }
 					{ showExcerpt && (
 						<RawHTML key="excerpt" className="excerpt-contain">
-							{ post.excerpt.rendered }
+							{ post.newspack_post_format === 'aside'
+								? post.content.rendered
+								: post.excerpt.rendered }
 						</RawHTML>
 					) }
 					<div className="entry-meta">

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -85,9 +85,19 @@ call_user_func(
 			endif;
 
 			if ( '' === $attributes['sectionHeader'] ) :
-				the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
+				// Don't link the title if using the post format aside.
+				if ( has_post_format( 'aside' ) ) :
+					the_title( '<h2 class="entry-title">', '</h2>' );
+				else :
+					the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
+				endif;
 			else :
+				// Don't link the title if using the post format aside.
+				if ( has_post_format( 'aside' ) ) :
+					the_title( '<h3 class="entry-title">', '</h3>' );
+				else :
 				the_title( '<h3 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h3>' );
+				endif;
 			endif;
 			?>
 			<?php
@@ -99,7 +109,11 @@ call_user_func(
 			<?php endif; ?>
 			<?php
 			if ( $attributes['showExcerpt'] ) :
-				the_excerpt();
+				if ( has_post_format( 'aside' ) ) :
+					the_content();
+				else :
+					the_excerpt();
+				endif;
 			endif;
 			if ( $attributes['showAuthor'] || $attributes['showDate'] || Newspack_Blocks::get_all_sponsors( get_the_id() ) ) :
 				?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds support for post formats to the Homepage Posts block, and some different treatment to the Aside post format (not adding a link to the title, and displaying `the_content` rather than `the_excerpt`.

This PR needs to be tested with https://github.com/Automattic/newspack-theme/pull/1074; additional information and testing steps are in that issue.

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
