### PR TITLE
Fix for columns width not adjusting on some themes

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -5,6 +5,7 @@
 	margin-bottom: 1em;
 
 	article {
+		min-width: 0; // fixes column width on certain themes
 		margin-bottom: 1.5em;
 		word-break: break-word;
 		overflow-wrap: break-word;


### PR DESCRIPTION
Closes #587 

### Changes proposed in this Pull Request:
For some reason, on themes that display blog posts in full width such as Radcliffe 2 and Intergalactic the `flex-basis` is not being applied.

Setting a `min-width` fixes the issue and does not affect the `flex-basis` of each column amount.

### Before
[![Screenshot](https://d.pr/i/yNi4Sq+)](https://d.pr/i/yNi4Sq)

### After
[![Screenshot](https://d.pr/i/bRm96W+)](https://d.pr/i/bRm96W)

### Test Site
https://premelini.wordpress.com/testing-posts/

### How to test the changes in this Pull Request:

1. Activate Radcliffe 2 theme
2. Add Blog Posts block and set to display in at least 2 columns
3. View the blocks functioning properly. You should be able to adjust the columns and see the width change appropriately based on the preset `flex-basis`
4. Optionally, switch to the Intergalactic theme and observe the fix persists.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?