### PR TITLE
Add alignment options to post carousel block

### DIFF
--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -76,7 +76,7 @@ export const settings = {
 	},
 	supports: {
 		html: false,
-		align: false,
+		align: [ 'center', 'wide', 'full' ],
 	},
 	edit,
 	save: () => null, // to use view.php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Adds wide and full alignment options to the Post Carousel block

Closes: #488

### How to test the changes in this Pull Request:

1. Check out this PR locally and run built blocks in a local WP install
2. Insert a Post Carousel block and check that there are now Centre, Wide, Full alignment options in the tool bar
3. Check that each of the alignment options displays correctly in editor and front end

![cpalign1](https://user-images.githubusercontent.com/3629020/94484047-4c82d980-0238-11eb-85de-3cf253ec8e65.gif)

![cpalign2](https://user-images.githubusercontent.com/3629020/94484370-cd41d580-0238-11eb-9db6-909dda734ae2.gif)

### Other information:
* [x] Have you successfully ran tests with your changes locally?

