### PR TITLE
Homepage Posts: Add option to change excerpt length

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -360,7 +360,7 @@ class Newspack_Blocks_API {
 	 * Pass whether there is a custom excerpt to the editor.
 	 *
 	 * @param array $object The object info.
-	 * @return string post format.
+	 * @return boolean custom excerpt status.
 	 */
 	public static function newspack_blocks_has_custom_excerpt( $object ) {
 		$post_has_custom_excerpt = has_excerpt( $object['id'] );

--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -116,6 +116,21 @@ class Newspack_Blocks_API {
 				],
 			]
 		);
+
+		/* Has custom excerpt */
+		register_rest_field(
+			'post',
+			'newspack_has_custom_excerpt',
+			[
+				'get_callback' => [ 'Newspack_Blocks_API', 'newspack_blocks_has_custom_excerpt' ],
+				'schema'       => [
+					'context' => [
+						'edit',
+					],
+					'type'    => 'boolean',
+				],
+			]
+		);
 	}
 
 	/**
@@ -339,6 +354,17 @@ class Newspack_Blocks_API {
 	public static function newspack_blocks_post_format( $object ) {
 		$post_format = get_post_format( $object['id'] );
 		return $post_format;
+	}
+
+	/**
+	 * Pass whether there is a custom excerpt to the editor.
+	 *
+	 * @param array $object The object info.
+	 * @return string post format.
+	 */
+	public static function newspack_blocks_has_custom_excerpt( $object ) {
+		$post_has_custom_excerpt = has_excerpt( $object['id'] );
+		return $post_has_custom_excerpt;
 	}
 
 	/**

--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -10,6 +10,10 @@
       "type": "boolean",
       "default": true
     },
+    "excerptLength": {
+      "type": "number",
+      "default": 55
+    },
     "showDate": {
       "type": "boolean",
       "default": true

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -141,6 +141,22 @@ class Edit extends Component {
 		const postTitle = this.titleForPost( post );
 		const dateFormat = __experimentalGetSettings().formats.date;
 
+		const getTrimmedExcerpt = ( currentPost, { excerptLength } ) => {
+			const regex = /(<([^>]+)>)/gi;
+			const excerpt = currentPost.excerpt.rendered;
+			const content = currentPost.content.rendered;
+			const newExcerpt = content.replace( regex, '' );
+
+			const needsEllipsis = excerptLength < newExcerpt.trim().split( ' ' ).length;
+			const postExcerpt = needsEllipsis
+				? `${ newExcerpt.split( ' ', excerptLength ).join( ' ' ) } […]`
+				: newExcerpt;
+
+			return currentPost.newspack_has_custom_excerpt
+				? excerpt
+				: '<p>' + postExcerpt.trim() + '</p>';
+		};
+
 		return (
 			<article className={ postClasses } key={ post.id } style={ styles }>
 				{ showImage && post.newspack_featured_image_src && (
@@ -197,7 +213,7 @@ class Edit extends Component {
 						<RawHTML key="excerpt" className="excerpt-contain">
 							{ post.newspack_post_format === 'aside'
 								? post.content.rendered
-								: post.excerpt.rendered }
+								: getTrimmedExcerpt( post, attributes ) }
 						</RawHTML>
 					) }
 					<div className="entry-meta">
@@ -249,6 +265,7 @@ class Edit extends Component {
 			minHeight,
 			moreButton,
 			showExcerpt,
+			excerptLength,
 			showSubtitle,
 			typeScale,
 			showDate,
@@ -442,6 +459,15 @@ class Edit extends Component {
 							onChange={ () => setAttributes( { showExcerpt: ! showExcerpt } ) }
 						/>
 					</PanelRow>
+					{ showExcerpt && (
+						<RangeControl
+							label={ __( 'Max number of words in excerpt', 'newspack-blocks' ) }
+							value={ excerptLength }
+							onChange={ value => setAttributes( { excerptLength: value } ) }
+							min={ 10 }
+							max={ 100 }
+						/>
+					) }
 					<RangeControl
 						className="type-scale-slider"
 						label={ __( 'Type Scale', 'newspack-blocks' ) }

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -110,9 +110,16 @@ call_user_func(
 			<?php
 			if ( $attributes['showExcerpt'] ) :
 				if ( has_post_format( 'aside' ) ) :
+					// If is an aside, show the full content.
 					the_content();
-				else :
+				elseif ( has_excerpt( get_the_ID() ) ) :
+					// If the post has a custom excerpt, use it.
 					the_excerpt();
+				else :
+					// Otherwise, craft a custom excerpt length from the content.
+					$excerpt_length = $attributes['excerptLength'];
+					$post_content   = get_the_content();
+					echo '<p>' . esc_html( wp_trim_words( wp_strip_all_tags( $post_content ), $excerpt_length, ' [&hellip;] ' ) ) . '</p>';
 				endif;
 			endif;
 			if ( $attributes['showAuthor'] || $attributes['showDate'] || Newspack_Blocks::get_all_sponsors( get_the_id() ) ) :


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an option to the Homepage Posts block to control the excerpt length. It uses the WordPress default (55 words) as the default, and allows you to increase the length up to 100 words, or down to 10 words. 

It appears to work well on Newspack sites but could break some things that currently work on WP.com:

The 'excerpt' is no longer an excerpt, so it will no longer pick up filters for `the_excerpt`. This won't be an issue on Newspack sites, but on WP.com, some themes -- like Varia -- filter `the_excerpt` to replace the `[...]` with a "Continue Reading" link. 

Similarily, things like the share and like buttons can be made to appear with certain settings using themes other than the Newspack theme (since it removes it from the bottom of the content/excerpts).

If this approach otherwise makes sense, adding an option for a Continue Reading link in the block (https://github.com/Automattic/newspack-blocks/issues/495) could be a way to make it behave more consistently and as an alternative for sites that may like this behaviour. 

I'm not sure what we can do about the share buttons; they also don't work properly with some settings (like if you have them set for posts and not pages, the buttons will appear, but the icons will not -- https://github.com/Automattic/newspack-blocks/issues/420).

It's possible there's another approach that will maintain the excerpts (filtering the excerpt length on a per-block basis seemed like a bad idea, but maybe it's better than this?), or ways to work around the above (only making the option available when a theme opts in, similar to the Article Subtitle?). I'd be very interested to hear other's thoughts about that!

Closes #22.

### How to test the changes in this Pull Request:

1. Make sure you have a few recent posts with the following settings: a regular post; a very short (< 10 words) post, a post with a longer custom excerpt, and a post that has the post format set to aside.
2. Apply the PR and run `npm run build`.
3. Create/edit a page and add the Homepage Posts block. 
4. With the block selected, confirm that there is now a range slider in the right column, under the Post Control Settings, with a default value of 55:

![image](https://user-images.githubusercontent.com/177561/96794209-a481ab80-13b2-11eb-9a2b-4a6f96d4eb13.png)

5. Toggle off the Show Excerpt option and confirm that the range slider disappears, too.
6. Toggle Show Excerpt back on again.
7. Adjust the excerpt length up and down. Confirm that only the posts with the dynamically generated excerpt are affected, and that the excerpt length changes in the preview. **Note:** By default in WordPress, Custom Excerpts are displayed in full, and we've designed the Aside post format to display the full-content in the blocks, too. Because of this, I opted to only have this slider affect the dynamically generated excerpts, but am open to feedback on that!
8. Publish the post.
9. Confirm that your custom excerpt length is also reflected on the front end.
10. Try steps 7-9 with both longer, and shorter excerpts, to confirm it works as expected.

![image](https://user-images.githubusercontent.com/177561/96794465-1b1ea900-13b3-11eb-8ef1-0432b40101b2.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
