### PR TITLE
Homepage Posts: Add option to change excerpt length

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -360,7 +360,7 @@ class Newspack_Blocks_API {
 	 * Pass whether there is a custom excerpt to the editor.
 	 *
 	 * @param array $object The object info.
-	 * @return string post format.
+	 * @return boolean custom excerpt status.
 	 */
 	public static function newspack_blocks_has_custom_excerpt( $object ) {
 		$post_has_custom_excerpt = has_excerpt( $object['id'] );

--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -116,6 +116,21 @@ class Newspack_Blocks_API {
 				],
 			]
 		);
+
+		/* Has custom excerpt */
+		register_rest_field(
+			'post',
+			'newspack_has_custom_excerpt',
+			[
+				'get_callback' => [ 'Newspack_Blocks_API', 'newspack_blocks_has_custom_excerpt' ],
+				'schema'       => [
+					'context' => [
+						'edit',
+					],
+					'type'    => 'boolean',
+				],
+			]
+		);
 	}
 
 	/**
@@ -339,6 +354,17 @@ class Newspack_Blocks_API {
 	public static function newspack_blocks_post_format( $object ) {
 		$post_format = get_post_format( $object['id'] );
 		return $post_format;
+	}
+
+	/**
+	 * Pass whether there is a custom excerpt to the editor.
+	 *
+	 * @param array $object The object info.
+	 * @return string post format.
+	 */
+	public static function newspack_blocks_has_custom_excerpt( $object ) {
+		$post_has_custom_excerpt = has_excerpt( $object['id'] );
+		return $post_has_custom_excerpt;
 	}
 
 	/**

--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -10,6 +10,10 @@
       "type": "boolean",
       "default": true
     },
+    "excerptLength": {
+      "type": "number",
+      "default": 55
+    },
     "showDate": {
       "type": "boolean",
       "default": true

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -141,6 +141,22 @@ class Edit extends Component {
 		const postTitle = this.titleForPost( post );
 		const dateFormat = __experimentalGetSettings().formats.date;
 
+		const getTrimmedExcerpt = ( currentPost, { excerptLength } ) => {
+			const regex = /(<([^>]+)>)/gi;
+			const excerpt = currentPost.excerpt.rendered;
+			const content = currentPost.content.rendered;
+			const newExcerpt = content.replace( regex, '' );
+
+			const needsEllipsis = excerptLength < newExcerpt.trim().split( ' ' ).length;
+			const postExcerpt = needsEllipsis
+				? `${ newExcerpt.split( ' ', excerptLength ).join( ' ' ) } […]`
+				: newExcerpt;
+
+			return currentPost.newspack_has_custom_excerpt
+				? excerpt
+				: '<p>' + postExcerpt.trim() + '</p>';
+		};
+
 		return (
 			<article className={ postClasses } key={ post.id } style={ styles }>
 				{ showImage && post.newspack_featured_image_src && (
@@ -197,7 +213,7 @@ class Edit extends Component {
 						<RawHTML key="excerpt" className="excerpt-contain">
 							{ post.newspack_post_format === 'aside'
 								? post.content.rendered
-								: post.excerpt.rendered }
+								: getTrimmedExcerpt( post, attributes ) }
 						</RawHTML>
 					) }
 					<div className="entry-meta">
@@ -249,6 +265,7 @@ class Edit extends Component {
 			minHeight,
 			moreButton,
 			showExcerpt,
+			excerptLength,
 			showSubtitle,
 			typeScale,
 			showDate,
@@ -442,6 +459,15 @@ class Edit extends Component {
 							onChange={ () => setAttributes( { showExcerpt: ! showExcerpt } ) }
 						/>
 					</PanelRow>
+					{ showExcerpt && (
+						<RangeControl
+							label={ __( 'Max number of words in excerpt', 'newspack-blocks' ) }
+							value={ excerptLength }
+							onChange={ value => setAttributes( { excerptLength: value } ) }
+							min={ 10 }
+							max={ 100 }
+						/>
+					) }
 					<RangeControl
 						className="type-scale-slider"
 						label={ __( 'Type Scale', 'newspack-blocks' ) }

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -110,9 +110,16 @@ call_user_func(
 			<?php
 			if ( $attributes['showExcerpt'] ) :
 				if ( has_post_format( 'aside' ) ) :
+					// If is an aside, show the full content.
 					the_content();
-				else :
+				elseif ( has_excerpt( get_the_ID() ) ) :
+					// If the post has a custom excerpt, use it.
 					the_excerpt();
+				else :
+					// Otherwise, craft a custom excerpt length from the content.
+					$excerpt_length = $attributes['excerptLength'];
+					$post_content   = get_the_content();
+					echo '<p>' . esc_html( wp_trim_words( wp_strip_all_tags( $post_content ), $excerpt_length, ' [&hellip;] ' ) ) . '</p>';
 				endif;
 			endif;
 			if ( $attributes['showAuthor'] || $attributes['showDate'] || Newspack_Blocks::get_all_sponsors( get_the_id() ) ) :

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -110,16 +110,9 @@ call_user_func(
 			<?php
 			if ( $attributes['showExcerpt'] ) :
 				if ( has_post_format( 'aside' ) ) :
-					// If is an aside, show the full content.
 					the_content();
-				elseif ( has_excerpt( get_the_ID() ) ) :
-					// If the post has a custom excerpt, use it.
-					the_excerpt();
 				else :
-					// Otherwise, craft a custom excerpt length from the content.
-					$excerpt_length = $attributes['excerptLength'];
-					$post_content   = get_the_content();
-					echo '<p>' . esc_html( wp_trim_words( wp_strip_all_tags( $post_content ), $excerpt_length, ' [&hellip;] ' ) ) . '</p>';
+					the_excerpt();
 				endif;
 			endif;
 			if ( $attributes['showAuthor'] || $attributes['showDate'] || Newspack_Blocks::get_all_sponsors( get_the_id() ) ) :

--- a/src/blocks/homepage-articles/templates/articles-loop.php
+++ b/src/blocks/homepage-articles/templates/articles-loop.php
@@ -13,13 +13,23 @@ call_user_func(
 		$attributes    = $data['attributes'];
 		$article_query = $data['article_query'];
 
-		// Get and set custom excerpt length.
-		global $newspack_blocks_excerpt_length;
-		$newspack_blocks_excerpt_length = $attributes['excerptLength'];
-
 		global $newspack_blocks_post_id;
 		$post_counter = 0;
 		do_action( 'newspack_blocks_homepage_posts_before_render' );
+
+		// Create a callable closure that can be added and removed.
+		$newspack_blocks_excerpt_length = function( $length ) use ( $attributes ) {
+			if ( $attributes['excerptLength'] ) {
+				return $attributes['excerptLength'];
+			}
+
+			return 55;
+		};
+
+		// If showing excerpt, filter the length using the block attribute.
+		if ( $attributes['showExcerpt'] ) {
+			add_filter( 'excerpt_length', $newspack_blocks_excerpt_length, 999 );
+		}
 
 		while ( $article_query->have_posts() ) {
 			$article_query->the_post();
@@ -27,9 +37,11 @@ call_user_func(
 			$post_counter++;
 			echo Newspack_Blocks::template_inc( __DIR__ . '/article.php', array( 'attributes' => $attributes ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
-		// Reset custom excerpt length.
-		$newspack_blocks_excerpt_length = 0;
 
+		// Remove the excerpt_length filter so it doesn't affect excerpts outside this block instance.
+		if ( $attributes['showExcerpt'] ) {
+			remove_filter( 'excerpt_length', $newspack_blocks_excerpt_length, 999 );
+		}
 		do_action( 'newspack_blocks_homepage_posts_after_render' );
 		wp_reset_postdata();
 	},

--- a/src/blocks/homepage-articles/templates/articles-loop.php
+++ b/src/blocks/homepage-articles/templates/articles-loop.php
@@ -13,15 +13,23 @@ call_user_func(
 		$attributes    = $data['attributes'];
 		$article_query = $data['article_query'];
 
+		// Get and set custom excerpt length.
+		global $newspack_blocks_excerpt_length;
+		$newspack_blocks_excerpt_length = $attributes['excerptLength'];
+
 		global $newspack_blocks_post_id;
 		$post_counter = 0;
 		do_action( 'newspack_blocks_homepage_posts_before_render' );
+
 		while ( $article_query->have_posts() ) {
 			$article_query->the_post();
 			$newspack_blocks_post_id[ get_the_ID() ] = true;
 			$post_counter++;
 			echo Newspack_Blocks::template_inc( __DIR__ . '/article.php', array( 'attributes' => $attributes ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
+		// Reset custom excerpt length.
+		$newspack_blocks_excerpt_length = 0;
+
 		do_action( 'newspack_blocks_homepage_posts_after_render' );
 		wp_reset_postdata();
 	},

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -255,7 +255,6 @@ function newspack_blocks_format_byline( $author_info ) {
 	return implode( '', $elements );
 }
 
-
 /**
  * Inject amp-state containing all post IDs visible on page load.
  */
@@ -282,3 +281,16 @@ function newspack_blocks_inject_amp_state() {
 }
 
 add_action( 'wp_footer', 'newspack_blocks_inject_amp_state' );
+
+/**
+ * Add global variable to control excerpt length.
+ */
+function newspack_blocks_excerpt_length() {
+	global $newspack_blocks_excerpt_length;
+	if ( $newspack_blocks_excerpt_length ) {
+		return $newspack_blocks_excerpt_length;
+	} else {
+		return 55;
+	}
+}
+add_filter( 'excerpt_length', 'newspack_blocks_excerpt_length', 999 );

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -281,16 +281,3 @@ function newspack_blocks_inject_amp_state() {
 }
 
 add_action( 'wp_footer', 'newspack_blocks_inject_amp_state' );
-
-/**
- * Add global variable to control excerpt length.
- */
-function newspack_blocks_excerpt_length() {
-	global $newspack_blocks_excerpt_length;
-	if ( $newspack_blocks_excerpt_length ) {
-		return $newspack_blocks_excerpt_length;
-	} else {
-		return 55;
-	}
-}
-add_filter( 'excerpt_length', 'newspack_blocks_excerpt_length', 999 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is a rework of #605 with the same testing steps.

It replaces the front-end approach to truncating the excerpts with a filter, so they will still be normal excerpts that pick up other filters. 

The one remaining issue is that the_excerpt is no longer filtered in the editor, so theme's 'Continue Reading' and social links will no longer show up there. I think this is an acceptable loss, between the 'Continue Reading' styles not usually being included in the editor styles, and the social links not displaying correctly anyway.

If it comes up as an issue, we can always rework it there, too!

### How to test the changes in this Pull Request:

1. See #605.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
