### PR TITLE
fix: suppress password protected posts

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -468,8 +468,13 @@ class Newspack_Blocks_API {
 			// phpcs:enable WordPress.DB.SlowDBQuery
 		}
 
+		if ( $request->get_param( 'suppress_password_protected_posts' ) ) {
+			$args['has_password'] = false;
+		}
+
 		return $args;
 	}
+
 }
 
 add_action( 'rest_api_init', array( 'Newspack_Blocks_API', 'register_rest_fields' ) );

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -357,6 +357,7 @@ class Newspack_Blocks {
 			'post_status'         => 'publish',
 			'suppress_filters'    => false,
 			'ignore_sticky_posts' => true,
+			'has_password'        => false,
 		);
 		if ( $specific_mode && $specific_posts ) {
 			$args['post__in'] = $specific_posts;

--- a/src/blocks/homepage-articles/utils.js
+++ b/src/blocks/homepage-articles/utils.js
@@ -78,6 +78,7 @@ export const queryCriteriaFromAttributes = attributes => {
 			  },
 		value => ! isUndefined( value )
 	);
+	criteria.suppress_password_protected_posts = true;
 	return criteria;
 };
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Suppresses password-protected posts in the Homepage Posts and Posts Carousel blocks.

Closes https://github.com/Automattic/newspack-blocks/issues/608

### How to test the changes in this Pull Request:

1. On `master`, create and publish one or more password protected posts.
2. Add Homepage Posts and/or Posts Carousel blocks to a Page or Post, showing the most recent few posts.
3. Observe the password-protected posts are visible in the editor and front end.
4. Switch to this branch. Observe the password-protected posts are no longer visible.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
