### PR TITLE
feat: optimize sponsor queries

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -340,9 +340,9 @@ class Newspack_Blocks_API {
 				$sponsor_info[] = $sponsor_info_item;
 			}
 			return $sponsor_info;
-		} else {
-			return false;
 		}
+
+		return false;
 	}
 
 	/**

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -514,39 +514,49 @@ class Newspack_Blocks {
 	 * @param string $id Post ID.
 	 * @return array Array of sponsors.
 	 */
-	public static function get_all_sponsors( $id = null, $scope = 'native', $type = 'post', $logo_options = array() ) {
+	public static function get_all_sponsors( $id = null, $scope = 'native', $type = 'post', $logo_options = array(
+		'maxwidth'  => 80,
+		'maxheight' => 40,
+	) ) {
 		if ( function_exists( '\Newspack_Sponsors\get_sponsors_for_post' ) ) {
-			$sponsors = \Newspack_Sponsors\get_all_sponsors( $id, $scope, $type, $logo_options ); // phpcs:ignore PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
-			if ( $sponsors ) {
-				return $sponsors;
-			} else {
-				return false;
-			}
+			return \Newspack_Sponsors\get_all_sponsors( $id, $scope, $type, $logo_options ); // phpcs:ignore PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
 		}
+
+		return false;
 	}
 
 	/**
 	 * Function to return sponsor 'flag' from first sponsor.
 	 *
+	 * @param array  $sponsors Array of sponsors.
 	 * @param string $id Post ID.
-	 * @return string Sponsor flag label.
+	 * @return string|boolean Sponsor flag label, or false if none found.
 	 */
-	public static function get_sponsor_label( $id ) {
-		$sponsors = self::get_all_sponsors( $id );
+	public static function get_sponsor_label( $sponsors = null, $id = null ) {
+		if ( null === $sponsors && ! empty( $id ) ) {
+			$sponsors = self::get_all_sponsors( $id );
+		}
+
 		if ( ! empty( $sponsors ) ) {
 			$sponsor_flag = $sponsors[0]['sponsor_flag'];
 			return $sponsor_flag;
 		}
+
+		return false;
 	}
 
 	/**
 	 * Outputs the sponsor byline markup for the theme.
 	 *
+	 * @param array  $sponsors Array of sponsors.
 	 * @param string $id Post ID.
-	 * @return array Array of Sponsor byline information.
+	 * @return array|boolean Array of Sponsor byline information, or false if none found.
 	 */
-	public static function get_sponsor_byline( $id ) {
-		$sponsors = self::get_all_sponsors( $id );
+	public static function get_sponsor_byline( $sponsors = null, $id = null ) {
+		if ( null === $sponsors & ! empty( $id ) ) {
+			$sponsors = self::get_all_sponsors( $id );
+		}
+
 		if ( ! empty( $sponsors ) ) {
 			$sponsor_count = count( $sponsors );
 			$i             = 1;
@@ -573,23 +583,30 @@ class Newspack_Blocks {
 			}
 			return $sponsor_list;
 		}
+
+		return false;
 	}
 
 	/**
 	 * Outputs set of sponsor logos with links.
 	 *
+	 * @param array  $sponsors Array of sponsors.
 	 * @param string $id Post ID.
+	 * @return array Array of sponsor logo images, or false if none found.
 	 */
-	public static function get_sponsor_logos( $id ) {
-		$sponsors = self::get_all_sponsors(
-			$id,
-			'native',
-			'post',
-			array(
-				'maxwidth'  => 80,
-				'maxheight' => 40,
-			)
-		);
+	public static function get_sponsor_logos( $sponsors = null, $id = null ) {
+		if ( null === $sponsors && ! empty( $id ) ) {
+			$sponsors = self::get_all_sponsors(
+				$id,
+				'native',
+				'post',
+				array(
+					'maxwidth'  => 80,
+					'maxheight' => 40,
+				)
+			);
+		}
+
 		if ( ! empty( $sponsors ) ) {
 			$sponsor_logos = [];
 			foreach ( $sponsors as $sponsor ) {
@@ -605,6 +622,8 @@ class Newspack_Blocks {
 
 			return $sponsor_logos;
 		}
+
+		return false;
 	}
 
 	/**

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -68,6 +68,10 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 			if ( ! has_post_thumbnail() ) {
 				continue;
 			}
+
+			// Get sponsors for this post.
+			$sponsors = Newspack_Blocks::get_all_sponsors( get_the_id() );
+
 			$counter++;
 			?>
 
@@ -87,10 +91,10 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 				</figure>
 				<div class="entry-wrapper">
 
-				<?php if ( Newspack_Blocks::get_all_sponsors( get_the_id() ) ) : ?>
+				<?php if ( ! empty( $sponsors ) ) : ?>
 					<span class="cat-links sponsor-label">
 						<span class="flag">
-							<?php echo esc_html( Newspack_Blocks::get_sponsor_label( get_the_id() ) ); ?>
+							<?php echo esc_html( Newspack_Blocks::get_sponsor_label( $sponsors ) ); ?>
 						</span>
 					</span>
 					<?php
@@ -131,8 +135,8 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 
 					<div class="entry-meta">
 						<?php
-						if ( Newspack_Blocks::get_all_sponsors( get_the_id() ) ) :
-							$logos = Newspack_Blocks::get_sponsor_logos( get_the_id() );
+						if ( ! empty( $sponsors ) ) :
+							$logos = Newspack_Blocks::get_sponsor_logos( $sponsors );
 							if ( ! empty( $logos ) ) :
 								?>
 							<span class="sponsor-logos">
@@ -152,7 +156,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 
 							<span class="byline sponsor-byline">
 								<?php
-								$bylines = Newspack_Blocks::get_sponsor_byline( get_the_id() );
+								$bylines = Newspack_Blocks::get_sponsor_byline( $sponsors );
 								echo esc_html( $bylines[0]['byline'] ) . ' ';
 								foreach ( $bylines as $byline ) {
 									echo '<span class="author">';

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -13,6 +13,9 @@ call_user_func(
 		$classes    = array();
 		$styles     = '';
 
+		// Get sponsors for this post.
+		$sponsors = Newspack_Blocks::get_all_sponsors( get_the_id() );
+
 		// Add classes based on the post's assigned categories and tags.
 		$classes[] = Newspack_Blocks::get_term_classes( get_the_ID() );
 
@@ -69,10 +72,10 @@ call_user_func(
 		<?php endif; ?>
 
 		<div class="entry-wrapper">
-			<?php if ( Newspack_Blocks::get_all_sponsors( get_the_id() ) ) : ?>
+			<?php if ( ! empty( $sponsors ) ) : ?>
 				<span class="cat-links sponsor-label">
 					<span class="flag">
-						<?php echo esc_html( Newspack_Blocks::get_sponsor_label( get_the_id() ) ); ?>
+						<?php echo esc_html( Newspack_Blocks::get_sponsor_label( $sponsors ) ); ?>
 					</span>
 				</span>
 			<?php elseif ( $attributes['showCategory'] && $category ) : ?>
@@ -115,12 +118,12 @@ call_user_func(
 					the_excerpt();
 				endif;
 			endif;
-			if ( $attributes['showAuthor'] || $attributes['showDate'] || Newspack_Blocks::get_all_sponsors( get_the_id() ) ) :
+			if ( $attributes['showAuthor'] || $attributes['showDate'] || ! empty( $sponsors ) ) :
 				?>
 				<div class="entry-meta">
-					<?php if ( Newspack_Blocks::get_all_sponsors( get_the_id() ) ) : ?>
+					<?php if ( ! empty( $sponsors ) ) : ?>
 						<?php
-						$logos = Newspack_Blocks::get_sponsor_logos( get_the_id() );
+						$logos = Newspack_Blocks::get_sponsor_logos( $sponsors );
 						if ( ! empty( $logos ) ) :
 							?>
 						<span class="sponsor-logos">
@@ -139,7 +142,7 @@ call_user_func(
 					<?php endif; ?>
 					<span class="byline sponsor-byline">
 						<?php
-						$bylines = Newspack_Blocks::get_sponsor_byline( get_the_id() );
+						$bylines = Newspack_Blocks::get_sponsor_byline( $sponsors );
 						echo esc_html( $bylines[0]['byline'] ) . ' ';
 						foreach ( $bylines as $byline ) {
 							echo '<span class="author">';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Like https://github.com/Automattic/newspack-theme/pull/1144, this attempts to minimize the number of queries executed by the sponsors plugin to at most once per post item in the Homepage Posts block.

Closes #614.

### How to test the changes in this Pull Request:

Front-end behavior shouldn't be any different. Testing instructions for sponsors are [here](https://github.com/Automattic/newspack-blocks/pull/563).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
