### PR TITLE
Blog Posts block: Disabling paging in specific mode

### DIFF
--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -360,6 +360,7 @@ class Newspack_Blocks {
 			'has_password'        => false,
 		);
 		if ( $specific_mode && $specific_posts ) {
+			$args['nopaging'] = true;
 			$args['post__in'] = $specific_posts;
 			$args['orderby']  = 'post__in';
 		} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When specific posts are selected to be shown, `posts_per_page` is not specified for the `WP_Query` which results in using the default value. If specific posts are selected then we should show all the selected posts, rather than cutting off some of them.

### How to test the changes in this Pull Request:

1. Change global settings for how many posts to show (Settings -> Reading -> Blog pages show at most) to 1
2. Create a page
3. Add Blog Posts block
4. Specify 2 posts
5. Publish
6. Open your published page and make sure you see 2 posts (on `master` you should only see 1 post)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### More context

Partial fix for https://github.com/Automattic/wp-calypso/issues/47086