### PR TITLE
Blog Posts block: Remove load more button in specific mode

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -100,7 +100,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	 */
 	$is_blog_private = (int) get_option( 'blog_public' ) === -1;
 
-	$has_more_button = ! $is_blog_private && $has_more_pages && (bool) $attributes['moreButton'];
+	$has_more_button = ! $is_blog_private && $has_more_pages && (bool) $attributes['moreButton'] && ! ( (bool) $attributes['specificMode'] );
 
 	if ( $has_more_button ) {
 		$classes .= ' has-more-button';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Load more button shouldn't be available when specific posts are selected to be shown. Right now the load more button shows up and duplicates the already shown blog posts.

Since the load more button doesn't make sense in this context, we remove it by checking for the specific mode.

### How to test the changes in this Pull Request:

1. Change global settings for how many posts to show (Settings -> Reading -> Blog pages show at most) to 1
2. Create a page
3. Add Blog Posts block
4. Enable load more button
5. Specify 2 posts (note: load more button setting disappears but is still in effect)
6. Publish
7. Open your published page and you will see 1 post and no load more button (in `master` you would see 1 post and a load more button which loads the same post again)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### More context

Partial fix for https://github.com/Automattic/wp-calypso/issues/47086