### PR TITLE
Add/donate block manual mode without woocommerce

### DIFF
--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -99,6 +99,7 @@ class Edit extends Component {
 	};
 
 	getSettings() {
+		const { setAttributes } = this.props;
 		const path = '/newspack/v1/wizard/newspack-donations-wizard/donation';
 
 		this.setState( { isLoading: true }, () => {
@@ -110,6 +111,7 @@ class Edit extends Component {
 						currencySymbol,
 						tiered,
 						created,
+						force_manual: forceManual,
 					} = settings;
 					this.setState( {
 						suggestedAmounts,
@@ -117,6 +119,7 @@ class Edit extends Component {
 						currencySymbol,
 						tiered,
 						created,
+						forceManual,
 						isLoading: false,
 						customDonationAmounts: {
 							once: tiered ? 12 * suggestedAmounts[ 1 ] : 12 * suggestedAmountUntiered,
@@ -125,6 +128,9 @@ class Edit extends Component {
 						},
 						activeTier: 1,
 					} );
+					if ( forceManual ) {
+						setAttributes( { manual: true } );
+					}
 				} )
 				.catch( error => {
 					this.setState( {
@@ -458,36 +464,39 @@ class Edit extends Component {
 
 	render() {
 		const { setAttributes } = this.props;
+		const { forceManual } = this.state;
 		const { manual, campaign } = this.blockData();
 		return (
 			<Fragment>
 				{ this.renderPlaceholder() }
 				{ this.renderForm() }
 				<InspectorControls>
-					<PanelBody title={ __( 'Donate Block', 'newspack-blocks' ) }>
-						<ToggleControl
-							key="manual"
-							checked={ manual }
-							onChange={ this.manualChanged }
-							label={ __( 'Configure manually', 'newspack-blocks' ) }
-						/>
-						{ ! manual && (
-							<Fragment>
-								<p>
-									{ __(
-										'The Donate Block allows you to collect donations from readers. The fields are automatically defined based on your donation settings.',
-										'newspack-blocks'
-									) }
-								</p>
+					{ ! forceManual && (
+						<PanelBody title={ __( 'Donate Block', 'newspack-blocks' ) }>
+							<ToggleControl
+								key="manual"
+								checked={ manual }
+								onChange={ this.manualChanged }
+								label={ __( 'Configure manually', 'newspack-blocks' ) }
+							/>
+							{ ! manual && (
+								<Fragment>
+									<p>
+										{ __(
+											'The Donate Block allows you to collect donations from readers. The fields are automatically defined based on your donation settings.',
+											'newspack-blocks'
+										) }
+									</p>
 
-								<ExternalLink href="/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/donations">
-									{ __( 'Edit donation settings.', 'newspack-blocks' ) }
-								</ExternalLink>
-							</Fragment>
-						) }
-					</PanelBody>
+									<ExternalLink href="/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/donations">
+										{ __( 'Edit donation settings.', 'newspack-blocks' ) }
+									</ExternalLink>
+								</Fragment>
+							) }
+						</PanelBody>
+					) }
 					{ manual && (
-						<PanelBody title={ __( 'Manual Settings', 'newspack-blocks' ) }>
+						<PanelBody title={ ! forceManual && __( 'Manual Settings', 'newspack-blocks' ) }>
 							{ this.renderManualControls() }
 						</PanelBody>
 					) }

--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -99,7 +99,7 @@ class Edit extends Component {
 	};
 
 	getSettings() {
-		const { setAttributes } = this.props;
+		const { attributes, setAttributes } = this.props;
 		const path = '/newspack/v1/wizard/newspack-donations-wizard/donation';
 
 		this.setState( { isLoading: true }, () => {
@@ -130,6 +130,12 @@ class Edit extends Component {
 					} );
 					if ( forceManual ) {
 						setAttributes( { manual: true } );
+						if (
+							attributes.suggestedAmounts.every( amount => amount === 0 ) &&
+							0 === attributes.suggestedAmountUntiered
+						) {
+							setAttributes( { suggestedAmounts, suggestedAmountUntiered } );
+						}
 					}
 				} )
 				.catch( error => {

--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -486,32 +486,30 @@ class Edit extends Component {
 				{ this.renderPlaceholder() }
 				{ this.renderForm() }
 				<InspectorControls>
-					<PanelBody>
-						{ ! forceManual && (
-							<Fragment>
-								<ToggleControl
-									key="manual"
-									checked={ manual }
-									onChange={ this.manualChanged }
-									label={ __( 'Configure manually', 'newspack-blocks' ) }
-								/>
-								{ ! manual && (
-									<Fragment>
-										<p>
-											{ __(
-												'The Donate Block allows you to collect donations from readers. The fields are automatically defined based on your donation settings.',
-												'newspack-blocks'
-											) }
-										</p>
+					{ ! forceManual && (
+						<PanelBody>
+							<ToggleControl
+								key="manual"
+								checked={ manual }
+								onChange={ this.manualChanged }
+								label={ __( 'Configure manually', 'newspack-blocks' ) }
+							/>
+							{ ! manual && (
+								<Fragment>
+									<p>
+										{ __(
+											'The Donate Block allows you to collect donations from readers. The fields are automatically defined based on your donation settings.',
+											'newspack-blocks'
+										) }
+									</p>
 
-										<ExternalLink href="/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/donations">
-											{ __( 'Edit donation settings.', 'newspack-blocks' ) }
-										</ExternalLink>
-									</Fragment>
-								) }
-							</Fragment>
-						) }
-					</PanelBody>
+									<ExternalLink href="/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/donations">
+										{ __( 'Edit donation settings.', 'newspack-blocks' ) }
+									</ExternalLink>
+								</Fragment>
+							) }
+						</PanelBody>
+					) }
 					{ manual && (
 						<PanelBody title={ ! forceManual && __( 'Manual Settings', 'newspack-blocks' ) }>
 							{ this.renderManualControls() }

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -240,7 +240,7 @@ function newspack_blocks_register_donate() {
 				'suggestedAmounts'        => [
 					'type'    => 'array',
 					'items'   => [
-						'type' => 'float',
+						'type' => 'number',
 					],
 					'default' => [ 0, 0, 0 ],
 				],

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -24,6 +24,12 @@ function newspack_blocks_render_block_donate( $attributes ) {
 		return '';
 	}
 
+	$manual = isset( $attributes['manual'] ) ? $attributes['manual'] : false;
+
+	if ( 'nrh' === $settings['platform'] && ! $manual ) {
+		return '';
+	}
+
 	/* If block is in "manual" mode, override certain state properties with values stored in attributes */
 	if ( $attributes['manual'] ?? false ) {
 		$settings = array_merge( $settings, $attributes );

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -240,7 +240,7 @@ function newspack_blocks_register_donate() {
 				'suggestedAmounts'        => [
 					'type'    => 'array',
 					'items'   => [
-						'type' => 'integer',
+						'type' => 'float',
 					],
 					'default' => [ 0, 0, 0 ],
 				],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Testing instructions in https://github.com/Automattic/newspack-plugin/pull/726

Closes https://github.com/Automattic/newspack-blocks/issues/623, https://github.com/Automattic/newspack-blocks/issues/518

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
