### PR TITLE
feat: control to select default tab in donate block

### DIFF
--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -60,8 +60,8 @@ class Edit extends Component {
 	/* If block is in "manual" mode, override certain state properties with values stored in attributes */
 	blockData() {
 		const { attributes } = this.props;
-		const { manual, campaign } = attributes;
-		const data = { ...this.state, ...attributes };
+		const { defaultFrequency, manual, campaign } = attributes;
+		const data = { ...this.state, ...( manual ? attributes : { defaultFrequency } ) };
 		if ( manual ) {
 			data.customDonationAmounts = {
 				once: data.tiered ? 12 * data.suggestedAmounts[ 1 ] : 12 * data.suggestedAmountUntiered,

--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -15,6 +15,7 @@ import {
 	ExternalLink,
 	Placeholder,
 	Spinner,
+	SelectControl,
 	TextControl,
 	ToggleControl,
 } from '@wordpress/components';
@@ -32,7 +33,6 @@ class Edit extends Component {
 
 			isLoading: false,
 			activeTier: 1,
-			selectedFrequency: 'month',
 			customDonationAmounts: {
 				once: 0,
 				month: 0,
@@ -46,6 +46,15 @@ class Edit extends Component {
 	}
 	componentDidMount() {
 		this.getSettings();
+	}
+
+	componentDidUpdate( prevProps ) {
+		const { selectedFrequency } = this.state;
+		const { attributes } = this.props;
+		const { attributes: prevAttributes } = prevProps;
+		if ( ! selectedFrequency || attributes.defaultFrequency !== prevAttributes.defaultFrequency ) {
+			this.setState( { selectedFrequency: attributes.defaultFrequency } );
+		}
 	}
 
 	/* If block is in "manual" mode, override certain state properties with values stored in attributes */
@@ -458,7 +467,7 @@ class Edit extends Component {
 
 	render() {
 		const { setAttributes } = this.props;
-		const { manual, campaign } = this.blockData();
+		const { manual, campaign, defaultFrequency } = this.blockData();
 		return (
 			<Fragment>
 				{ this.renderPlaceholder() }
@@ -470,6 +479,29 @@ class Edit extends Component {
 							checked={ manual }
 							onChange={ this.manualChanged }
 							label={ __( 'Configure manually', 'newspack-blocks' ) }
+						/>
+						<SelectControl
+							label={ __( 'Default Tab', 'newspack' ) }
+							value={ defaultFrequency }
+							options={ [
+								{
+									label: __( 'One-time', 'newspack' ),
+									value: 'once',
+								},
+								{
+									label: __( 'Monthly', 'newspack' ),
+									value: 'month',
+								},
+								{
+									label: __( 'Annually', 'newspack' ),
+									value: 'year',
+								},
+							] }
+							onChange={ _defaultFrequency => {
+								setAttributes( {
+									defaultFrequency: _defaultFrequency,
+								} );
+							} }
 						/>
 						{ ! manual && (
 							<Fragment>

--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -61,7 +61,7 @@ class Edit extends Component {
 	blockData() {
 		const { attributes } = this.props;
 		const { manual, campaign } = attributes;
-		const data = { ...this.state, ...( manual ? attributes : {} ) };
+		const data = { ...this.state, ...attributes };
 		if ( manual ) {
 			data.customDonationAmounts = {
 				once: data.tiered ? 12 * data.suggestedAmounts[ 1 ] : 12 * data.suggestedAmountUntiered,

--- a/src/blocks/donate/index.js
+++ b/src/blocks/donate/index.js
@@ -65,6 +65,10 @@ export const settings = {
 			type: 'string',
 			default: __( 'Donate now!', 'newspack-blocks' ),
 		},
+		defaultFrequency: {
+			type: 'string',
+			default: 'month',
+		},
 	},
 	supports: {
 		html: false,

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -35,7 +35,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 		'year'  => __( 'Annually', 'newspack-blocks' ),
 	];
 
-	$selected_frequency = 'month';
+	$selected_frequency = $attributes['defaultFrequency'] ?? 'month';
 	$suggested_amounts  = $settings['suggestedAmounts'];
 
 	$campaign = $attributes['campaign'] ?? false;
@@ -251,6 +251,10 @@ function newspack_blocks_register_donate() {
 				'buttonText'              => [
 					'type'    => 'string',
 					'default' => __( 'Donate now!', 'newspack-blocks' ),
+				],
+				'defaultFrequency'        => [
+					'type'    => 'string',
+					'default' => 'month',
 				],
 			),
 			'render_callback' => 'newspack_blocks_render_block_donate',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a control to specify the initially selected tab in the Donate block. 

<img width="1399" alt="Screen Shot 2020-12-06 at 11 04 20 AM" src="https://user-images.githubusercontent.com/1477002/101285389-e7f17700-37b2-11eb-9d3e-a119c3a008df.png">

Closes: https://github.com/Automattic/newspack-blocks/issues/303

### How to test the changes in this Pull Request:

1. Add Donate block to a page or post. Verify `Monthly` is the selected tab, as it has been all along.
2. In the block sidebar, change `Default Tab`. Verify the tab changes.
3. Publish the post/page, in the frontend verify the correct tab is initially selected.
4. Verify this flow works properly with `Configure manually` selected or unselected.
5. To verify this won't break existing blocks, switch to `master`, create Donate blocks, then switch to this branch and verify there is no disruption.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
