### PR TITLE
fix: respect excerpt length attribute in load more display

### DIFF
--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -635,5 +635,46 @@ class Newspack_Blocks {
 	public static function use_experimental() {
 		return defined( 'NEWSPACK_BLOCKS_EXPERIMENTAL' ) && NEWSPACK_BLOCKS_EXPERIMENTAL;
 	}
+
+	/**
+	 * Closure for excerpt filtering that can be added and removed.
+	 *
+	 * @var newspack_blocks_excerpt_length_closure
+	 */
+	public static $newspack_blocks_excerpt_length_closure = null;
+
+	/**
+	 * Filter for excerpt length.
+	 *
+	 * @param array $attributes The block's attributes.
+	 */
+	public static function filter_excerpt_length( $attributes ) {
+		// If showing excerpt, filter the length using the block attribute.
+		if ( $attributes['showExcerpt'] ) {
+			self::$newspack_blocks_excerpt_length_closure = add_filter(
+				'excerpt_length',
+				function( $length ) use ( $attributes ) {
+					if ( $attributes['excerptLength'] ) {
+						return $attributes['excerptLength'];
+					}
+					return 55;
+				},
+				999
+			);
+		}
+	}
+
+	/**
+	 * Remove excerpt length filter after Homepage Posts block loop.
+	 */
+	public static function remove_excerpt_length_filter() {
+		if ( self::$newspack_blocks_excerpt_length_closure ) {
+			remove_filter(
+				'excerpt_length',
+				self::$newspack_blocks_excerpt_length_closure,
+				999
+			);
+		}
+	}
 }
 Newspack_Blocks::init();

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -79,6 +79,8 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 		$ids      = [];
 		$next_url = '';
 
+		Newspack_Blocks::filter_excerpt_length( $attributes );
+
 		// The Loop.
 		while ( $article_query->have_posts() ) {
 			$article_query->the_post();
@@ -95,6 +97,8 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 			$items[]['html'] = $html;
 			$ids[]           = get_the_ID();
 		}
+
+		Newspack_Blocks::remove_excerpt_length_filter();
 
 		// Provide next URL if there are more pages.
 		if ( $next_page <= $article_query->max_num_pages ) {

--- a/src/blocks/homepage-articles/templates/articles-loop.php
+++ b/src/blocks/homepage-articles/templates/articles-loop.php
@@ -17,19 +17,7 @@ call_user_func(
 		$post_counter = 0;
 		do_action( 'newspack_blocks_homepage_posts_before_render' );
 
-		// Create a callable closure that can be added and removed.
-		$newspack_blocks_excerpt_length = function( $length ) use ( $attributes ) {
-			if ( $attributes['excerptLength'] ) {
-				return $attributes['excerptLength'];
-			}
-
-			return 55;
-		};
-
-		// If showing excerpt, filter the length using the block attribute.
-		if ( $attributes['showExcerpt'] ) {
-			add_filter( 'excerpt_length', $newspack_blocks_excerpt_length, 999 );
-		}
+		Newspack_Blocks::filter_excerpt_length( $attributes );
 
 		while ( $article_query->have_posts() ) {
 			$article_query->the_post();
@@ -38,10 +26,8 @@ call_user_func(
 			echo Newspack_Blocks::template_inc( __DIR__ . '/article.php', array( 'attributes' => $attributes ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
-		// Remove the excerpt_length filter so it doesn't affect excerpts outside this block instance.
-		if ( $attributes['showExcerpt'] ) {
-			remove_filter( 'excerpt_length', $newspack_blocks_excerpt_length, 999 );
-		}
+		Newspack_Blocks::remove_excerpt_length_filter();
+
 		do_action( 'newspack_blocks_homepage_posts_after_render' );
 		wp_reset_postdata();
 	},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In `Homepage Posts` block the `Max number of words in excerpt` is not respected for posts shown after page load by clicking the `Load More` button. This PR fixes this. 

Closes https://github.com/Automattic/newspack-blocks/issues/627

### How to test the changes in this Pull Request:

1. On `master` add Homepage Posts block to a page, toggle on `Show Excerpt` and set `Max number of words in excerpt` to 10, publish and view.
2. Observe the initial set of posts have 10 word excerpts. Click `Load more` button and observe the new posts have much longer excerpts.
3. Switch to this branch and repeat.
4. Observe the correct excerpt length for posts loaded asynchronously.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
