### PR TITLE
fix(api): fallback to standard if post_format is false

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -353,7 +353,7 @@ class Newspack_Blocks_API {
 	 */
 	public static function newspack_blocks_post_format( $object ) {
 		$post_format = get_post_format( $object['id'] );
-		return $post_format;
+		return $post_format ? $post_format : 'standard';
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Make sure `newspack_post_format` REST API field fallbacks to `standard` value if the post format is `false`. This change is for consistency. Right now we are returning `false` which doesn't comply with the schema we use. We specified `string` as the field type. So returning a boolean doesn't make sense.

It also fixes an issue with updating posts via REST API. If you are reusing the post object returned by the GET WP REST API for a PUT request, then you are going to get an error: `newspack_post_format is not of type string`. Since we received `false` as a value for `newspack_post_format` which isn't a string so it doesn't comply with our schema.

### How to test the changes in this Pull Request:

1. `GET /wp/v2/posts/`
2. Make sure body contains `newspack_post_format` and it isn't `false`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
