### PR TITLE
fix: sanitize post id arrays in includes and excludes

### DIFF
--- a/src/blocks/homepage-articles/store.js
+++ b/src/blocks/homepage-articles/store.js
@@ -17,7 +17,7 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import metadata from './block.json';
-import { getBlockQueries } from './utils';
+import { getBlockQueries, sanitizePostList } from './utils';
 
 const { name } = metadata;
 export const STORE_NAMESPACE = `newspack-blocks/${ name }`;
@@ -131,7 +131,7 @@ const createFetchPostsSaga = blockName => {
 			return acc;
 		}, [] );
 
-		let exclude = [ ...specificPostsId, getCurrentPostId() ];
+		let exclude = sanitizePostList( [ ...specificPostsId, getCurrentPostId() ] );
 		while ( blockQueries.length ) {
 			const nextBlock = blockQueries.shift();
 			nextBlock.postsQuery.exclude = exclude;

--- a/src/blocks/homepage-articles/utils.js
+++ b/src/blocks/homepage-articles/utils.js
@@ -60,12 +60,12 @@ export const queryCriteriaFromAttributes = attributes => {
 		tagExclusions,
 	} = pick( attributes, POST_QUERY_ATTRIBUTES );
 
-	const isSpecificPostModeActive = specificMode && specificPosts && specificPosts.length;
-
+	const cleanPosts = sanitizePostList( specificPosts );
+	const isSpecificPostModeActive = specificMode && cleanPosts && cleanPosts.length;
 	const criteria = pickBy(
 		isSpecificPostModeActive
 			? {
-					include: specificPosts,
+					include: cleanPosts,
 					orderby: 'include',
 					per_page: specificPosts.length,
 			  }
@@ -81,6 +81,9 @@ export const queryCriteriaFromAttributes = attributes => {
 	criteria.suppress_password_protected_posts = true;
 	return criteria;
 };
+
+export const sanitizePostList = postList =>
+	postList.map( id => parseInt( id ) ).filter( id => id > 0 );
 
 export const getBlockQueries = ( blocks, blockName ) =>
 	blocks.flatMap( block => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Addresses a condition where `null` is included in post arrays in `include` or `exclude` parameters, leading to `Invalid parameter(s):` errors and block failure in the editor.

Closes https://github.com/Automattic/newspack-blocks/issues/650

### How to test the changes in this Pull Request:

1. While still on `master` branch, grab raw markup from the affected page (https://sahanjournal.com/) and paste into a post or page in test environment.
2. Observe multiple `Invalid parameter(s):` errors.
3. Switch to this branch, observe the errors are gone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
