### PR TITLE
Homepage Posts block: add optional 'continue reading' link underneath excerpts

### DIFF
--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -676,5 +676,33 @@ class Newspack_Blocks {
 			);
 		}
 	}
+
+	/**
+	 * Return a excerpt more replacement when using the 'Read More' link.
+	 *
+	 * @param string $more Default excerpt_more value.
+	 */
+	public static function more_excerpt( $more ) {
+		return '…';
+	}
+
+	/**
+	 * Filter for excerpt ellipsis.
+	 *
+	 * @param array $attributes The block's attributes.
+	 */
+	public static function filter_excerpt_more( $attributes ) {
+		// If showing the 'Read More' link, modify the ellipsis.
+		if ( $attributes['showReadMore'] ) {
+			add_filter( 'excerpt_more', [ __CLASS__, 'more_excerpt' ], 999 );
+		}
+	}
+
+	/**
+	 * Remove excerpt ellipsis filter after Homepage Posts block loop.
+	 */
+	public static function remove_excerpt_more_filter() {
+		remove_filter( 'excerpt_more', [ __CLASS__, 'more_excerpt' ], 999 );
+	}
 }
 Newspack_Blocks::init();

--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -14,6 +14,14 @@
       "type": "number",
       "default": 55
     },
+    "showReadMore": {
+      "type": "boolean",
+      "default": false
+    },
+    "readMoreLabel": {
+      "type": "string",
+      "default": "Keep reading"
+    },
     "showDate": {
       "type": "boolean",
       "default": true

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -80,6 +80,7 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 		$next_url = '';
 
 		Newspack_Blocks::filter_excerpt_length( $attributes );
+		Newspack_Blocks::filter_excerpt_ellipses( $attributes );
 
 		// The Loop.
 		while ( $article_query->have_posts() ) {
@@ -99,6 +100,7 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 		}
 
 		Newspack_Blocks::remove_excerpt_length_filter();
+		Newspack_Blocks::remove_excerpt_ellipsis_filter();
 
 		// Provide next URL if there are more pages.
 		if ( $next_page <= $article_query->max_num_pages ) {

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -80,7 +80,7 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 		$next_url = '';
 
 		Newspack_Blocks::filter_excerpt_length( $attributes );
-		Newspack_Blocks::filter_excerpt_ellipses( $attributes );
+		Newspack_Blocks::filter_excerpt_more( $attributes );
 
 		// The Loop.
 		while ( $article_query->have_posts() ) {
@@ -100,7 +100,7 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 		}
 
 		Newspack_Blocks::remove_excerpt_length_filter();
-		Newspack_Blocks::remove_excerpt_ellipsis_filter();
+		Newspack_Blocks::remove_excerpt_more_filter();
 
 		// Provide next URL if there are more pages.
 		if ( $next_page <= $article_query->max_num_pages ) {

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -480,14 +480,14 @@ class Edit extends Component {
 					) }
 					{ showExcerpt && (
 						<ToggleControl
-							label={ __( 'Add a link after the excerpt', 'newspack-blocks' ) }
+							label={ __( 'Add a "Read More" link after the excerpt', 'newspack-blocks' ) }
 							checked={ showReadMore }
 							onChange={ () => setAttributes( { showReadMore: ! showReadMore } ) }
 						/>
 					) }
 					{ showReadMore && showExcerpt && (
 						<TextControl
-							label={ __( 'Read More link text', 'newspack-blocks' ) }
+							label={ __( '"Read More" link text', 'newspack-blocks' ) }
 							value={ readMoreLabel }
 							placeholder={ readMoreLabel }
 							onChange={ value => setAttributes( { readMoreLabel: value } ) }

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -222,7 +222,7 @@ class Edit extends Component {
 						</RawHTML>
 					) }
 					{ showReadMore && (
-						<a href="#" key="readmore" className="newspack-more-link">
+						<a href="#" key="readmore" className="more-link">
 							{ readMoreLabel }
 						</a>
 					) }

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -44,6 +44,7 @@ import {
 	RangeControl,
 	Toolbar,
 	ToggleControl,
+	TextControl,
 	Placeholder,
 	Spinner,
 	BaseControl,
@@ -109,6 +110,8 @@ class Edit extends Component {
 			minHeight,
 			showCaption,
 			showExcerpt,
+			showReadMore,
+			readMoreLabel,
 			showSubtitle,
 			showAuthor,
 			showAvatar,
@@ -216,6 +219,11 @@ class Edit extends Component {
 								: getTrimmedExcerpt( post, attributes ) }
 						</RawHTML>
 					) }
+					{ showExcerpt && showReadMore && (
+						<a href="#" className="newspack-more-link">
+							{ readMoreLabel }
+						</a>
+					) }
 					<div className="entry-meta">
 						{ post.newspack_post_sponsors && formatSponsorLogos( post.newspack_post_sponsors ) }
 						{ post.newspack_post_sponsors && formatSponsorByline( post.newspack_post_sponsors ) }
@@ -265,6 +273,8 @@ class Edit extends Component {
 			minHeight,
 			moreButton,
 			showExcerpt,
+			showReadMore,
+			readMoreLabel,
 			excerptLength,
 			showSubtitle,
 			typeScale,
@@ -466,6 +476,21 @@ class Edit extends Component {
 							onChange={ value => setAttributes( { excerptLength: value } ) }
 							min={ 10 }
 							max={ 100 }
+						/>
+					) }
+					{ showExcerpt && (
+						<ToggleControl
+							label={ __( 'Add a link after the excerpt', 'newspack-blocks' ) }
+							checked={ showReadMore }
+							onChange={ () => setAttributes( { showReadMore: ! showReadMore } ) }
+						/>
+					) }
+					{ showReadMore && showExcerpt && (
+						<TextControl
+							label={ __( 'Read More link text', 'newspack-blocks' ) }
+							value={ readMoreLabel }
+							placeholder={ readMoreLabel }
+							onChange={ value => setAttributes( { readMoreLabel: value } ) }
 						/>
 					) }
 					<RangeControl

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -150,9 +150,11 @@ class Edit extends Component {
 			const content = currentPost.content.rendered;
 			const newExcerpt = content.replace( regex, '' );
 
+			const excerptEllipsis = showReadMore ? '…' : ' […]';
+
 			const needsEllipsis = excerptLength < newExcerpt.trim().split( ' ' ).length;
 			const postExcerpt = needsEllipsis
-				? `${ newExcerpt.split( ' ', excerptLength ).join( ' ' ) } […]`
+				? `${ newExcerpt.split( ' ', excerptLength ).join( ' ' ) + excerptEllipsis } `
 				: newExcerpt;
 
 			return currentPost.newspack_has_custom_excerpt
@@ -219,8 +221,8 @@ class Edit extends Component {
 								: getTrimmedExcerpt( post, attributes ) }
 						</RawHTML>
 					) }
-					{ showExcerpt && showReadMore && (
-						<a href="#" className="newspack-more-link">
+					{ showReadMore && (
+						<a href="#" key="readmore" className="newspack-more-link">
 							{ readMoreLabel }
 						</a>
 					) }
@@ -478,14 +480,12 @@ class Edit extends Component {
 							max={ 100 }
 						/>
 					) }
-					{ showExcerpt && (
-						<ToggleControl
-							label={ __( 'Add a "Read More" link after the excerpt', 'newspack-blocks' ) }
-							checked={ showReadMore }
-							onChange={ () => setAttributes( { showReadMore: ! showReadMore } ) }
-						/>
-					) }
-					{ showReadMore && showExcerpt && (
+					<ToggleControl
+						label={ __( 'Add a "Read More" link', 'newspack-blocks' ) }
+						checked={ showReadMore }
+						onChange={ () => setAttributes( { showReadMore: ! showReadMore } ) }
+					/>
+					{ showReadMore && (
 						<TextControl
 							label={ __( '"Read More" link text', 'newspack-blocks' ) }
 							value={ readMoreLabel }

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -116,6 +116,14 @@ call_user_func(
 					the_content();
 				else :
 					the_excerpt();
+
+					if ( $attributes['showReadMore'] ) :
+						?>
+					<a class="newspack-more-link" href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
+						<?php echo esc_html( $attributes['readMoreLabel'] ); ?>
+					</a>
+						<?php
+					endif;
 				endif;
 			endif;
 			if ( $attributes['showAuthor'] || $attributes['showDate'] || ! empty( $sponsors ) ) :

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -116,15 +116,14 @@ call_user_func(
 					the_content();
 				else :
 					the_excerpt();
-
-					if ( $attributes['showReadMore'] ) :
-						?>
-					<a class="newspack-more-link" href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
-						<?php echo esc_html( $attributes['readMoreLabel'] ); ?>
-					</a>
-						<?php
-					endif;
 				endif;
+			endif;
+			if ( ! has_post_format( 'aside' ) && ( $attributes['showReadMore'] ) ) :
+				?>
+				<a class="newspack-more-link" href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
+					<?php echo esc_html( $attributes['readMoreLabel'] ); ?>
+				</a>
+				<?php
 			endif;
 			if ( $attributes['showAuthor'] || $attributes['showDate'] || ! empty( $sponsors ) ) :
 				?>

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -120,7 +120,7 @@ call_user_func(
 			endif;
 			if ( ! has_post_format( 'aside' ) && ( $attributes['showReadMore'] ) ) :
 				?>
-				<a class="newspack-more-link" href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
+				<a class="more-link" href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
 					<?php echo esc_html( $attributes['readMoreLabel'] ); ?>
 				</a>
 				<?php

--- a/src/blocks/homepage-articles/templates/articles-loop.php
+++ b/src/blocks/homepage-articles/templates/articles-loop.php
@@ -18,6 +18,7 @@ call_user_func(
 		do_action( 'newspack_blocks_homepage_posts_before_render' );
 
 		Newspack_Blocks::filter_excerpt_length( $attributes );
+		Newspack_Blocks::filter_excerpt_more( $attributes );
 
 		while ( $article_query->have_posts() ) {
 			$article_query->the_post();
@@ -27,6 +28,7 @@ call_user_func(
 		}
 
 		Newspack_Blocks::remove_excerpt_length_filter();
+		Newspack_Blocks::remove_excerpt_more_filter();
 
 		do_action( 'newspack_blocks_homepage_posts_after_render' );
 		wp_reset_postdata();

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -549,7 +549,8 @@ amp-script .wpnbha {
 			font-size: 1em;
 		}
 		.newspack-post-subtitle,
-		.entry-wrapper p {
+		.entry-wrapper p,
+		.entry-wrapper .more-link {
 			font-size: 0.8em;
 		}
 		.entry-meta {
@@ -575,6 +576,7 @@ amp-script .wpnbha {
 			font-size: 0.7em;
 		}
 		.entry-wrapper p,
+		.entry-wrapper .more-link,
 		.entry-meta {
 			font-size: 0.7em;
 		}
@@ -593,7 +595,8 @@ amp-script .wpnbha {
 
 	&.ts-1 article {
 		.entry-title,
-		.entry-wrapper p {
+		.entry-wrapper p,
+		.entry-wrapper .more-link {
 			font-size: 0.7em;
 		}
 		.newspack-post-subtitle {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an option to add a customize-able 'Read More' link for each story on a per-post basis.

Unfortunately, current behaviour in WP.com themes could complicate this. This is a comment from me from the [original enhancement request](https://github.com/Automattic/newspack-blocks/issues/495):

> There are a number of themes that replace the [...] at the end of automatically generated excerpts with something else by filtering excerpt_more ([example](https://github.com/Automattic/themes/blob/b6ae2c8a45c2317cef960b8c0ef94da55427ffa5/textbook/inc/template-tags.php#L181-L201)). The reason the link doesn't happen with Custom Excerpts is that the [...] is not there, since it's assumed that those would end with a full stop and not need an ellipsis.

To work around this, I added a filter that should override any `entry_more` customization in the theme, switching it to `...` when the 'Read More' link is turned on, then removing the filter so it falls back to whatever a theme might be doing for blocks that have it left off. 

Closes #495

Note: I've added the 'Don't Merge' tag so some theme styles can be added for this as well (there is a bit adding an arrow already, but it could use refining); in the meantime the block uses the comment class name `more-link` on the link, so it should pick up styles from most WordPress themes that it's already getting links from.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`
2. Add a homepage posts block to the editor; in the Post Control settings section, confirm there is an option to enable a 'Read More' link that is off by default. Toggle it on and confirm a field to change the read more text appears below it, with the default text "Keep reading":

![image](https://user-images.githubusercontent.com/177561/102427257-d5065000-3fc5-11eb-8ba4-b3e661d86b36.png)

3. Add 4 Homepage posts block to the editor with different configurations including:
* A block with the excerpt on and the read more link on; change the read more text.
* A block with the excerpt on, a custom excerpt length, and the read more link on.
* A block with no excerpt, and the read more link on; change the read more link text.
* A block with the excerpt on, and the read more link off. 
4. Confirm on the front end and in the editor, your settings are respected, including the different read more link text, and, when enabled, that the default `[...]` is replaced with `...`.
5. Note: on the front-end, you can see that the `.more-link` already has styles in the theme, adding an arrow; that will be updated:
![image](https://user-images.githubusercontent.com/177561/102431647-fbc58600-3fc7-11eb-8de0-539bae1d411f.png)

6. Download Varia from WordPress.com and enable it on your test site. 
7. View on the front end and confirm that Varia's custom `excerpt_more` filter ("Continue Reading") is being picked up on blocks that don't have the 'Read More' link set, but the ones with a 'Read More' link set should still be applying it. All of the links should be applying the arrow from Varia, since it also uses the `.more-link` CSS class. (Note: Varia's custom filter will not be applied in the editor, since the theme only applies it to the front-end; in that case, the blocks without the 'Read More' link enabled should still fall back to the default `[...]`):

![image](https://user-images.githubusercontent.com/177561/102428058-092e4080-3fc7-11eb-851f-cc781f4af880.png)

8. Enable the 'Load More Posts' option on the blocks, and confirm that the Read More options are being applied correctly to posts that are newly loaded, both with and without AMP enabled.
9. On the front-end, click on the Read More links to confirm they go to the correct posts. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
