### PR TITLE
Feat/cpt picker

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -443,6 +443,13 @@ class Newspack_Blocks_API {
 						),
 						'default' => array(),
 					],
+					'post_type'    => [
+						'type'    => 'array',
+						'items'   => array(
+							'type' => 'string',
+						),
+						'default' => array(),
+					],
 				],
 				'permission_callback' => function( $request ) {
 					return current_user_can( 'edit_posts' );
@@ -467,6 +474,13 @@ class Newspack_Blocks_API {
 					],
 					'per_page' => [
 						'sanitize_callback' => 'absint',
+					],
+					'post_type' => [
+						'type'    => 'array',
+						'items'   => array(
+							'type' => 'string',
+						),
+						'default' => array(),
 					],
 				],
 				'permission_callback' => function( $request ) {
@@ -522,6 +536,10 @@ class Newspack_Blocks_API {
 		}
 		if ( $params['exclude'] && count( $params['exclude'] ) ) {
 			$args['post__not_in'] = $params['exclude'];
+		}
+
+		if ( $params['post_type'] && count( $params['post_type'] ) ) {
+			$args['post_type'] = $params['post_type'];
 		}
 
 		$query        = new WP_Query();
@@ -589,11 +607,16 @@ class Newspack_Blocks_API {
 		add_filter( 'posts_where', [ 'Newspack_Blocks_API', 'add_post_title_wildcard_search' ], 10, 2 );
 
 		$args = [
-			'post_type'             => 'post',
 			'post_status'           => 'publish',
 			'title_wildcard_search' => esc_sql( $params['search'] ),
 			'posts_per_page'        => $params['per_page'],
 		];
+
+		if ( $params['post_type'] && count( $params['post_type'] ) ) {
+			$args['post_type'] = $params['post_type'];
+		} else {
+			$args['post_type'] = 'post';
+		}
 
 		$query = new WP_Query( $args );
 		remove_filter( 'posts_where', [ 'Newspack_Blocks_API', 'add_post_title_wildcard_search' ], 10, 2 );

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -345,6 +345,7 @@ class Newspack_Blocks {
 			);
 		}
 
+		$post_type      = isset( $attributes['postType'] ) ? $attributes['postType'] : [ 'post' ];
 		$authors        = isset( $attributes['authors'] ) ? $attributes['authors'] : array();
 		$categories     = isset( $attributes['categories'] ) ? $attributes['categories'] : array();
 		$tags           = isset( $attributes['tags'] ) ? $attributes['tags'] : array();
@@ -353,6 +354,7 @@ class Newspack_Blocks {
 		$posts_to_show  = intval( $attributes['postsToShow'] );
 		$specific_mode  = intval( $attributes['specificMode'] );
 		$args           = array(
+			'post_type'           => $post_type,
 			'post_status'         => 'publish',
 			'suppress_filters'    => false,
 			'ignore_sticky_posts' => true,

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -61,8 +61,7 @@ class Newspack_Blocks {
 				'newspack-blocks-editor',
 				'newspack_blocks_data',
 				[
-					'patterns'      => self::get_patterns_for_post_type( get_post_type() ),
-					'_experimental' => self::use_experimental(),
+					'patterns' => self::get_patterns_for_post_type( get_post_type() ),
 				]
 			);
 
@@ -625,15 +624,6 @@ class Newspack_Blocks {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Whether to use experimental features.
-	 *
-	 * @return bool Experimental status.
-	 */
-	public static function use_experimental() {
-		return defined( 'NEWSPACK_BLOCKS_EXPERIMENTAL' ) && NEWSPACK_BLOCKS_EXPERIMENTAL;
 	}
 
 	/**

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -15,6 +15,8 @@ class Newspack_Blocks {
 	 */
 	public static function init() {
 		add_action( 'after_setup_theme', [ __CLASS__, 'add_image_sizes' ] );
+		add_post_type_support( 'post', 'newspack_blocks' );
+		add_post_type_support( 'page', 'newspack_blocks' );
 	}
 
 	/**

--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -130,6 +130,11 @@
     "showSubtitle": {
       "type": "boolean",
       "default": false
+    },
+    "postType": {
+      "type": "array",
+      "default": [ "post" ],
+      "items": { "type": "string" }
     }
   }
 }

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -754,13 +754,14 @@ export default compose( [
 		const isEditorBlock = editorBlocksIds.indexOf( clientId ) >= 0;
 
 		const { getPosts, getError, isUIDisabled } = select( STORE_NAMESPACE );
-
 		const props = {
 			isEditorBlock,
 			isUIDisabled: isUIDisabled(),
 			error: getError( { clientId } ),
 			topBlocksClientIdsInOrder: getBlocks().map( block => block.clientId ),
-			availablePostTypes: getPostTypes( { per_page: -1 } )?.filter( ( { viewable } ) => viewable ),
+			availablePostTypes: getPostTypes( { per_page: -1 } )?.filter(
+				( { supports: { newspack_blocks: newspackBlocks } } ) => newspackBlocks
+			),
 		};
 
 		if ( isEditorBlock ) {

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -39,6 +39,7 @@ import {
 import {
 	Button,
 	ButtonGroup,
+	CheckboxControl,
 	PanelBody,
 	PanelRow,
 	RangeControl,
@@ -250,7 +251,7 @@ class Edit extends Component {
 	};
 
 	renderInspectorControls = () => {
-		const { attributes, setAttributes, textColor, setTextColor } = this.props;
+		const { attributes, availablePostTypes, setAttributes, textColor, setTextColor } = this.props;
 
 		const {
 			authors,
@@ -258,6 +259,7 @@ class Edit extends Component {
 			postsToShow,
 			categories,
 			columns,
+			postType,
 			showImage,
 			showCaption,
 			imageScale,
@@ -336,6 +338,7 @@ class Edit extends Component {
 						onTagExclusionsChange={ _tagExclusions =>
 							setAttributes( { tagExclusions: _tagExclusions } )
 						}
+						postType={ postType }
 					/>
 					{ postLayout === 'grid' && (
 						<RangeControl
@@ -522,6 +525,28 @@ class Edit extends Component {
 							/>
 						</PanelRow>
 					) }
+				</PanelBody>
+				<PanelBody title={ __( 'Post Types', 'newspack-blocks' ) }>
+					{ availablePostTypes &&
+						availablePostTypes.map( ( { name, slug } ) => (
+							<PanelRow key={ slug }>
+								<CheckboxControl
+									label={ name }
+									checked={ postType.indexOf( slug ) > -1 }
+									onChange={ value => {
+										const cleanPostType = [ ...new Set( postType ) ];
+										if ( value && cleanPostType.indexOf( slug ) === -1 ) {
+											cleanPostType.push( slug );
+										} else if ( ! value && cleanPostType.indexOf( slug ) > -1 ) {
+											cleanPostType.splice( cleanPostType.indexOf( slug ), 1 );
+										}
+										setAttributes( {
+											postType: cleanPostType,
+										} );
+									} }
+								/>
+							</PanelRow>
+						) ) }
 				</PanelBody>
 			</Fragment>
 		);
@@ -722,6 +747,7 @@ class Edit extends Component {
 export default compose( [
 	withColors( { textColor: 'color' } ),
 	withSelect( ( select, { clientId, attributes } ) => {
+		const { getPostTypes } = select( 'core' );
 		const { getEditorBlocks, getBlocks } = select( 'core/editor' );
 		const editorBlocksIds = getEditorBlocksIds( getEditorBlocks() );
 		// The block might be rendered in the block styles preview, not in the editor.
@@ -734,6 +760,7 @@ export default compose( [
 			isUIDisabled: isUIDisabled(),
 			error: getError( { clientId } ),
 			topBlocksClientIdsInOrder: getBlocks().map( block => block.clientId ),
+			availablePostTypes: getPostTypes( { per_page: -1 } )?.filter( ( { viewable } ) => viewable ),
 		};
 
 		if ( isEditorBlock ) {

--- a/src/blocks/homepage-articles/store.js
+++ b/src/blocks/homepage-articles/store.js
@@ -94,7 +94,7 @@ function* getPosts( block ) {
 	const cacheKey = createCacheKey( block.postsQuery );
 	let posts = POSTS_QUERIES_CACHE[ cacheKey ];
 	if ( posts === undefined ) {
-		const path = addQueryArgs( '/wp/v2/posts', {
+		const path = addQueryArgs( '/newspack-blocks/v1/posts', {
 			...block.postsQuery,
 			// `context=edit` is needed, so that custom REST fields are returned.
 			context: 'edit',

--- a/src/blocks/homepage-articles/utils.js
+++ b/src/blocks/homepage-articles/utils.js
@@ -25,6 +25,7 @@ const POST_QUERY_ATTRIBUTES = [
 	'specificPosts',
 	'specificMode',
 	'tagExclusions',
+	'postType',
 ];
 
 /**
@@ -54,6 +55,7 @@ export const queryCriteriaFromAttributes = attributes => {
 		postsToShow,
 		authors,
 		categories,
+		postType,
 		tags,
 		specificPosts,
 		specificMode,
@@ -68,6 +70,7 @@ export const queryCriteriaFromAttributes = attributes => {
 					include: cleanPosts,
 					orderby: 'include',
 					per_page: specificPosts.length,
+					post_type: postType,
 			  }
 			: {
 					per_page: postsToShow,
@@ -75,6 +78,7 @@ export const queryCriteriaFromAttributes = attributes => {
 					author: authors,
 					tags,
 					tags_exclude: tagExclusions,
+					post_type: postType,
 			  },
 		value => ! isUndefined( value )
 	);

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -23,10 +23,7 @@ class QueryControls extends Component {
 	};
 
 	fetchPostSuggestions = search => {
-		const basePath =
-			window && window.newspack_blocks_data && window.newspack_blocks_data._experimental
-				? '/newspack-blocks/v1/specific-posts'
-				: '/wp/v2/search';
+		const basePath = '/newspack-blocks/v1/specific-posts';
 		return apiFetch( {
 			path: addQueryArgs( basePath, {
 				search,

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -23,6 +23,7 @@ class QueryControls extends Component {
 	};
 
 	fetchPostSuggestions = search => {
+		const { postType } = this.props;
 		const basePath = '/newspack-blocks/v1/specific-posts';
 		return apiFetch( {
 			path: addQueryArgs( basePath, {
@@ -30,6 +31,7 @@ class QueryControls extends Component {
 				per_page: 20,
 				_fields: 'id,title',
 				type: 'post',
+				post_type: postType,
 			} ),
 		} ).then( function( posts ) {
 			const result = posts.map( post => ( {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds custom post type support to the Homepage Posts block. At the bottom of the block sidebar there's a new `Post Types` panel with checkboxes for Posts and Pages. Other CPTs can opt in by adding this line: `add_post_type_support( 'cpt_name', 'newspack_blocks' );`

Closes https://github.com/Automattic/newspack-blocks/issues/522

### How to test the changes in this Pull Request:

1. Add a series of Homepage Posts blocks to a page. Open the block sidebar and in the Post Types panel choose different combinations of the two available options. 
2. Confirm the posts shown accurately reflect the selections in both the editor and front end.
3. Verify all other block settings work for pages just as they do for posts.
4. Verify deduplication logic works correctly.
5. Verify "Load More" functionality still works properly.
6. Try creating  a few blocks on `master` and verify they continue to work after branch switching to this one.
7. Bonus: try adding support for another CPT.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
