### PR TITLE
Fix duplicate category names

### DIFF
--- a/src/components/autocomplete-tokenfield.js
+++ b/src/components/autocomplete-tokenfield.js
@@ -119,6 +119,10 @@ class AutocompleteTokenField extends Component {
 					const currentSuggestions = [];
 
 					suggestions.forEach( suggestion => {
+						const duplicatedSuggestionIndex = currentSuggestions.indexOf( suggestion.label );
+						if ( duplicatedSuggestionIndex >= 0 ) {
+							suggestion.label = `${ suggestion.label } (${ suggestion.value })`;
+						}
 						currentSuggestions.push( suggestion.label );
 						validValues[ suggestion.value ] = suggestion.label;
 					} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #669.

### How to test the changes in this Pull Request:

1. Observe #669 is not reproducible
2. Create four categories named "Foo", assign different parrent to two of them
3. Insert a Homepage Posts block and use the category filter in the sidebar, insert "Foo"
4. Observe that the four are present in the suggestions: the ones with the parents have `Foo – <parent>` as label, while the duplicated parent-less one has `Foo (<id>)` as label

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
