### PR TITLE
fix: load more button functionality

### DIFF
--- a/amp/homepage-articles/view.js
+++ b/amp/homepage-articles/view.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 let isFetching = false;
 let isEndOfData = false;
 buildLoadMoreHandler( document.querySelector( '.wp-block-newspack-blocks-homepage-articles' ) );
@@ -7,7 +8,7 @@ function buildLoadMoreHandler( blockWrapperEl ) {
 		return;
 	}
 	const postsContainerEl = blockWrapperEl.querySelector( '[data-posts]' );
-	btnEl.addEventListener( 'click', function( e ) {
+	btnEl.addEventListener( 'click', function() {
 		if ( isFetching || isEndOfData ) {
 			return false;
 		}
@@ -15,9 +16,9 @@ function buildLoadMoreHandler( blockWrapperEl ) {
 		blockWrapperEl.classList.remove( 'is-error' );
 		blockWrapperEl.classList.add( 'is-loading' );
 		AMP.getState( 'newspackHomepagePosts.exclude_ids' ).then( function( exclude_ids ) {
-			const requestURL = new URL( btnEl.getAttribute( 'data-next' ) );
-			requestURL.searchParams.set( 'exclude_ids', JSON.parse( exclude_ids ).join( ',' ) );
-			apiFetchWithRetry( { url: requestURL.toString(), onSuccess, onError }, 3 );
+			const requestURL =
+				btnEl.getAttribute( 'data-next' ) + '&exclude_ids=' + JSON.parse( exclude_ids ).join( ',' );
+			apiFetchWithRetry( { url: requestURL, onSuccess, onError }, 3 );
 		} );
 		function onSuccess( data ) {
 			AMP.getState( 'newspackHomepagePosts.exclude_ids' ).then( function( exclude_ids ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug in the Homepage Posts block's "load more" functionality. Previously, if passing the `exclude_ids` args, we still decided whether to hide the "load more" button by comparing the query's `max_num_pages` property to the page number. But `max_num_pages` will no longer reflect the total number of found posts if using `post__not_in`, so the condition was met prematurely and the "load more" button would be hidden too early.

This fix takes into account whether `exclude_ids` is being passed, and if it is, it just checks whether `max_num_pages` is more than `1` (which would indicate that there are more posts to load after this current batch) and shows the "load more" button if it is. If `exclude_ids` is not passed, we use WP's standard `paged` query param, which will result in an accurate `max_num_pages` count.

Also includes a small refactor of the AMP JS to avoid the use of [`URL`, which is not supported by any version of IE](https://developer.mozilla.org/en-US/docs/Web/API/URL#browser_compatibility).

h/t @soatok for identifying the cause of the bug.

Closes #404 and replaces #628.

### How to test the changes in this Pull Request:

In short, #404 should not be replicable on this branch.

1. Check out this branch and run `npm run build`.
2. With AMP enabled, create a page with at least two Homepage Posts blocks.
  - **Block A** should be set to display all posts in a category that contains several posts, with "Show Load more posts Button" ON and "Number of Items" set to a low number that will force the block to paginate. e.g. If the Entertainment category has 30 posts, set Block A to show all Entertainment posts but with "Number of items" set to 3.
  - **Block B** should be set to display some posts that would also be displayed by Block A. Turn ON "Choose specific posts" and pick several posts from the Entertainment category.
3. View the page's front-end. Click "load more" on Block A and verify that:
  - Any posts shown by Block B are never shown in Block A.
  - The "load more" button continues to be shown and load additional Entertainment posts without repeating the ones already shown.
  - The "load more" button disappears as soon as all Entertainment posts are shown on the page (in either block).
4. Delete Block B, update, and refresh the page's front-end.
5. Verify that Block A's "load more" functionality loads all Entertainment posts 3 at a time until all 30 posts are shown.
6. Disable AMP on the page, restore Block B, and repeat steps 2-5.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
