### PR TITLE
refactor: use rest_url to get the /posts route, for Toolkit

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -390,7 +390,7 @@ class Newspack_Blocks_API {
 	public static function register_posts_endpoint() {
 		register_rest_route(
 			'newspack-blocks/v1',
-			'/homepage-article-posts',
+			'/newspack-blocks-posts',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ 'Newspack_Blocks_API', 'posts_endpoint' ],

--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -385,80 +385,6 @@ class Newspack_Blocks_API {
 	}
 
 	/**
-	 * Register custom posts endpoint.
-	 */
-	public static function register_posts_endpoint() {
-		register_rest_route(
-			'newspack-blocks/v1',
-			'/newspack-blocks-posts',
-			[
-				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => [ 'Newspack_Blocks_API', 'posts_endpoint' ],
-				'args'                => [
-					'author'       => [
-						'type'    => 'array',
-						'items'   => array(
-							'type' => 'integer',
-						),
-						'default' => array(),
-					],
-					'categories'   => [
-						'type'    => 'array',
-						'items'   => array(
-							'type' => 'integer',
-						),
-						'default' => array(),
-					],
-					'exclude'      => [
-						'type'    => 'array',
-						'items'   => array(
-							'type' => 'integer',
-						),
-						'default' => array(),
-					],
-					'include'      => [
-						'type'    => 'array',
-						'items'   => array(
-							'type' => 'integer',
-						),
-						'default' => array(),
-					],
-					'orderby'      => [
-						'sanitize_callback' => 'sanitize_text_field',
-					],
-					'per_page'     => [
-						'sanitize_callback' => 'absint',
-					],
-					'tags'         => [
-						'type'    => 'array',
-						'items'   => array(
-							'type' => 'integer',
-						),
-						'default' => array(),
-					],
-					'tags_exclude' => [
-						'type'    => 'array',
-						'items'   => array(
-							'type' => 'integer',
-						),
-						'default' => array(),
-					],
-					'post_type'    => [
-						'type'    => 'array',
-						'items'   => array(
-							'type' => 'string',
-						),
-						'default' => array(),
-					],
-				],
-				'permission_callback' => function( $request ) {
-					return current_user_can( 'edit_posts' );
-				},
-			]
-		);
-	}
-
-	/**
 	 * Register specific posts endpoint.
 	 */
 	public static function register_post_lookup_endpoint() {
@@ -680,5 +606,4 @@ class Newspack_Blocks_API {
 add_action( 'rest_api_init', array( 'Newspack_Blocks_API', 'register_rest_fields' ) );
 add_action( 'rest_api_init', array( 'Newspack_Blocks_API', 'register_video_playlist_endpoint' ) );
 add_action( 'rest_api_init', array( 'Newspack_Blocks_API', 'register_post_lookup_endpoint' ) );
-add_action( 'rest_api_init', array( 'Newspack_Blocks_API', 'register_posts_endpoint' ) );
 add_filter( 'rest_post_query', array( 'Newspack_Blocks_API', 'post_meta_request_params' ), 10, 2 );

--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -390,7 +390,7 @@ class Newspack_Blocks_API {
 	public static function register_posts_endpoint() {
 		register_rest_route(
 			'newspack-blocks/v1',
-			'/posts',
+			'/homepage-article-posts',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ 'Newspack_Blocks_API', 'posts_endpoint' ],

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -63,7 +63,8 @@ class Newspack_Blocks {
 				'newspack-blocks-editor',
 				'newspack_blocks_data',
 				[
-					'patterns' => self::get_patterns_for_post_type( get_post_type() ),
+					'patterns'       => self::get_patterns_for_post_type( get_post_type() ),
+					'posts_rest_url' => rest_url( 'newspack-blocks/v1/posts' ),
 				]
 			);
 

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -64,7 +64,7 @@ class Newspack_Blocks {
 				'newspack_blocks_data',
 				[
 					'patterns'       => self::get_patterns_for_post_type( get_post_type() ),
-					'posts_rest_url' => rest_url( 'newspack-blocks/v1/posts' ),
+					'posts_rest_url' => rest_url( 'newspack-blocks/v1/homepage-article-posts' ),
 				]
 			);
 

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -64,7 +64,7 @@ class Newspack_Blocks {
 				'newspack_blocks_data',
 				[
 					'patterns'       => self::get_patterns_for_post_type( get_post_type() ),
-					'posts_rest_url' => rest_url( 'newspack-blocks/v1/homepage-article-posts' ),
+					'posts_rest_url' => rest_url( 'newspack-blocks/v1/newspack-blocks-posts' ),
 				]
 			);
 

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -45,6 +45,74 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 				],
 			]
 		);
+		register_rest_route(
+			$this->namespace,
+			'/newspack-blocks-posts',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ 'Newspack_Blocks_API', 'posts_endpoint' ],
+				'args'                => [
+					'author'       => [
+						'type'    => 'array',
+						'items'   => array(
+							'type' => 'integer',
+						),
+						'default' => array(),
+					],
+					'categories'   => [
+						'type'    => 'array',
+						'items'   => array(
+							'type' => 'integer',
+						),
+						'default' => array(),
+					],
+					'exclude'      => [
+						'type'    => 'array',
+						'items'   => array(
+							'type' => 'integer',
+						),
+						'default' => array(),
+					],
+					'include'      => [
+						'type'    => 'array',
+						'items'   => array(
+							'type' => 'integer',
+						),
+						'default' => array(),
+					],
+					'orderby'      => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'per_page'     => [
+						'sanitize_callback' => 'absint',
+					],
+					'tags'         => [
+						'type'    => 'array',
+						'items'   => array(
+							'type' => 'integer',
+						),
+						'default' => array(),
+					],
+					'tags_exclude' => [
+						'type'    => 'array',
+						'items'   => array(
+							'type' => 'integer',
+						),
+						'default' => array(),
+					],
+					'post_type'    => [
+						'type'    => 'array',
+						'items'   => array(
+							'type' => 'string',
+						),
+						'default' => array(),
+					],
+				],
+				'permission_callback' => function( $request ) {
+					return current_user_can( 'edit_posts' );
+				},
+			]
+		);
 	}
 
 	/**

--- a/src/blocks/homepage-articles/store.js
+++ b/src/blocks/homepage-articles/store.js
@@ -92,14 +92,15 @@ const createCacheKey = JSON.stringify;
  */
 function* getPosts( block ) {
 	const cacheKey = createCacheKey( block.postsQuery );
+	const restUrl = window.newspack_blocks_data.posts_rest_url;
 	let posts = POSTS_QUERIES_CACHE[ cacheKey ];
 	if ( posts === undefined ) {
-		const path = addQueryArgs( '/newspack-blocks/v1/posts', {
+		const url = addQueryArgs( restUrl, {
 			...block.postsQuery,
 			// `context=edit` is needed, so that custom REST fields are returned.
 			context: 'edit',
 		} );
-		posts = yield call( apiFetch, { path } );
+		posts = yield call( apiFetch, { url } );
 		POSTS_QUERIES_CACHE[ cacheKey ] = posts;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

WP.com Toolkit (formerly Full Site Editing) performs some kind of server-side transformation of REST API endpoints. This refactor will ensure that the path used for the new `/posts` endpoint comes from the server with the required transformations, rather than being hard-coded in the JS.

This is a pure refactor and shouldn't cause any changes in behavior when the plugin is run on a non-WP.com site.

Related to #404 

### How to test the changes in this Pull Request:

1. Create or edit a page and add a Homepage Posts block. 
2. Verify that the block loads posts in the editor as expected, with no change in behavior.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
