### PR TITLE
Homepage Posts: Add article class for post types

### DIFF
--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -451,7 +451,7 @@ class Newspack_Blocks {
 	}
 
 	/**
-	 * Prepare a list of classes based on assigned tags, categories and post formats.
+	 * Prepare a list of classes based on assigned tags, categories, post formats and types.
 	 *
 	 * @param string $post_id Post ID.
 	 * @return string CSS classes.
@@ -476,6 +476,11 @@ class Newspack_Blocks {
 		$post_format = get_post_format( $post_id );
 		if ( false !== $post_format ) {
 			$classes[] = 'format-' . $post_format;
+		}
+
+		$post_type = get_post_type( $post_id );
+		if ( false !== $post_type ) {
+			$classes[] = 'type-' . $post_type;
 		}
 
 		return implode( ' ', $classes );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a CSS class with the format `.type-XXXX`, for the current post's post type.

Closes #658.

### How to test the changes in this Pull Request:

1. Add a homepage post block to a page; enable both posts and pages for the block, and make sure you have at least one of each in the current query, and publish.
2. Apply the PR.
3. Inspect the articles on the front end and in the editor; confirm that the posts have the CSS class `type-post` on the `<article>` tag, and the pages have the CSS class `type-page` on the `<article>` tag.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
