### PR TITLE
fix: carousel block renders authors like homepage articles

### DIFF
--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -65,6 +65,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 	if ( $article_query->have_posts() ) :
 		while ( $article_query->have_posts() ) :
 			$article_query->the_post();
+			$authors = Newspack_Blocks::prepare_authors();
 			if ( ! has_post_thumbnail() ) {
 				continue;
 			}
@@ -174,18 +175,29 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 							<?php
 						else :
 							if ( $attributes['showAuthor'] ) :
-								if ( $attributes['showAvatar'] ) {
-									echo get_avatar( get_the_author_meta( 'ID' ) );
-								}
+								if ( $attributes['showAvatar'] ) :
+									echo wp_kses(
+										newspack_blocks_format_avatars( $authors ),
+										array(
+											'img'      => array(
+												'class'  => true,
+												'src'    => true,
+												'alt'    => true,
+												'width'  => true,
+												'height' => true,
+												'data-*' => true,
+												'srcset' => true,
+											),
+											'noscript' => array(),
+											'a'        => array(
+												'href' => true,
+											),
+										)
+									);
+								endif;
 								?>
 								<span class="byline">
-									<?php
-									printf(
-										/* translators: %s: post author. */
-										esc_html_x( 'by %s', 'post author', 'newspack-blocks' ),
-										'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
-									);
-									?>
+									<?php echo wp_kses_post( newspack_blocks_format_byline( $authors ) ); ?>
 								</span><!-- .author-name -->
 								<?php
 							endif;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This should cause the Carousel block to render authors exactly like Homepage Posts on the front end.

Closes https://github.com/Automattic/newspack-blocks/issues/456

### How to test the changes in this Pull Request:

1. Publish a series of posts with different author configurations, including a) more than one guest author, b) one guest author, c) one WordPress author, d) one guest author, one WordPress author, e) any of the above with avatars. 
2. Create two pages, one with a Posts Carousel block and one with a Homepage Posts block.
3. Compare the two in the editor, verify the author displays are identical (this should be true on `master`).
4. Compare the two on front end. On `master` the Posts Carousel block's author display is broken, on this branch it should be identical to Homepage Posts.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
