### PR TITLE
fix: in specific posts mode, post order should match input order

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -423,9 +423,6 @@ class Newspack_Blocks_API {
 						),
 						'default' => array(),
 					],
-					'orderby'      => [
-						'sanitize_callback' => 'sanitize_text_field',
-					],
 					'per_page'     => [
 						'sanitize_callback' => 'absint',
 					],
@@ -533,6 +530,8 @@ class Newspack_Blocks_API {
 		}
 		if ( $params['include'] && count( $params['include'] ) ) {
 			$args['post__in'] = $params['include'];
+			$args['orderby']  = 'post__in';
+			$args['order']    = 'ASC';
 		}
 		if ( $params['exclude'] && count( $params['exclude'] ) ) {
 			$args['post__not_in'] = $params['exclude'];

--- a/src/blocks/homepage-articles/utils.js
+++ b/src/blocks/homepage-articles/utils.js
@@ -68,7 +68,6 @@ export const queryCriteriaFromAttributes = attributes => {
 		isSpecificPostModeActive
 			? {
 					include: cleanPosts,
-					orderby: 'include',
 					per_page: specificPosts.length,
 					post_type: postType,
 			  }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug reported by a Newspack publisher:

> We had this come in from the editorial team and am curious if anything changed in how the post order is displayed for editors. For context, here is the editor's note " The order of stories displayed in the three-story row when editing the home page no longer reflects the list of post order in the editing window on the rail, or on the actual page. (fortunately, the order in the editing window matches the actual page, but until now changing the order on editing window also changed the preview display on the backend.)"

To summarize: since #661, when editing a block in Specific Posts mode, the posts in the editor preview are always shown in descending order of publish date (same as in query mode), which doesn't match the front-end display. Posts in the front-end are shown in the order they appear in the Specific Posts autocomplete field.

Note: I'm removing the `orderby` param from the `/posts` endpoint callback, since we're no longer using it anywhere at the moment, but we can always add it back if we find a need to pass that arg in from the JS.

### How to test the changes in this Pull Request:

1. On `master`, create a Homepage Posts block and enable Specific Posts mode. Add several posts, ensuring that you add them in an order that won't match their publish date. Observe that the posts in the editor preview appear in descending order of publish date.
2. Publish the page and view the front-end, and observe that the order of the posts in the front-end matches the order you entered in them into the autocomplete field.
3. Check out this branch and run `npm run build`.
4. Refresh the page editor and confirm that the editor preview now shows the posts in the same order as both the autocomplete field and the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
