### PR TITLE
refactor: get specific posts REST endpoint from localized value

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -385,38 +385,6 @@ class Newspack_Blocks_API {
 	}
 
 	/**
-	 * Register specific posts endpoint.
-	 */
-	public static function register_post_lookup_endpoint() {
-		register_rest_route(
-			'newspack-blocks/v1',
-			'/specific-posts',
-			[
-				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => [ 'Newspack_Blocks_API', 'specific_posts_endpoint' ],
-				'args'                => [
-					'search'   => [
-						'sanitize_callback' => 'sanitize_text_field',
-					],
-					'per_page' => [
-						'sanitize_callback' => 'absint',
-					],
-					'post_type' => [
-						'type'    => 'array',
-						'items'   => array(
-							'type' => 'string',
-						),
-						'default' => array(),
-					],
-				],
-				'permission_callback' => function( $request ) {
-					return current_user_can( 'edit_posts' );
-				},
-			]
-		);
-	}
-
-	/**
 	 * Process requests to the video-playlist endpoint.
 	 *
 	 * @param WP_REST_Request $request Request object.
@@ -607,5 +575,4 @@ class Newspack_Blocks_API {
 
 add_action( 'rest_api_init', array( 'Newspack_Blocks_API', 'register_rest_fields' ) );
 add_action( 'rest_api_init', array( 'Newspack_Blocks_API', 'register_video_playlist_endpoint' ) );
-add_action( 'rest_api_init', array( 'Newspack_Blocks_API', 'register_post_lookup_endpoint' ) );
 add_filter( 'rest_post_query', array( 'Newspack_Blocks_API', 'post_meta_request_params' ), 10, 2 );

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -63,8 +63,9 @@ class Newspack_Blocks {
 				'newspack-blocks-editor',
 				'newspack_blocks_data',
 				[
-					'patterns'       => self::get_patterns_for_post_type( get_post_type() ),
-					'posts_rest_url' => rest_url( 'newspack-blocks/v1/newspack-blocks-posts' ),
+					'patterns'                => self::get_patterns_for_post_type( get_post_type() ),
+					'posts_rest_url'          => rest_url( 'newspack-blocks/v1/newspack-blocks-posts' ),
+					'specific_posts_rest_url' => rest_url( 'newspack-blocks/v1/newspack-blocks-specific-posts' ),
 				]
 			);
 

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -33,6 +33,7 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 	 * @access public
 	 */
 	public function register_routes() {
+		// Endpoint to get articles on the front-end.
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base,
@@ -45,6 +46,8 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 				],
 			]
 		);
+
+		// Endpoint to get articles in the editor, in regular/query mode.
 		register_rest_route(
 			$this->namespace,
 			'/newspack-blocks-posts',
@@ -101,6 +104,34 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 						'default' => array(),
 					],
 					'post_type'    => [
+						'type'    => 'array',
+						'items'   => array(
+							'type' => 'string',
+						),
+						'default' => array(),
+					],
+				],
+				'permission_callback' => function( $request ) {
+					return current_user_can( 'edit_posts' );
+				},
+			]
+		);
+
+		// Endpoint to get articles in the editor, in specific posts mode.
+		register_rest_route(
+			'newspack-blocks/v1',
+			'/newspack-blocks-specific-posts',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ 'Newspack_Blocks_API', 'specific_posts_endpoint' ],
+				'args'                => [
+					'search'    => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'per_page'  => [
+						'sanitize_callback' => 'absint',
+					],
+					'post_type' => [
 						'type'    => 'array',
 						'items'   => array(
 							'type' => 'string',

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -119,7 +119,7 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 
 		// Endpoint to get articles in the editor, in specific posts mode.
 		register_rest_route(
-			'newspack-blocks/v1',
+			$this->namespace,
 			'/newspack-blocks-specific-posts',
 			[
 				'methods'             => \WP_REST_Server::READABLE,

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -377,11 +377,13 @@ class Edit extends Component {
 							) }
 						</i>
 					) : (
-						<ToggleControl
-							label={ __( 'Show "Load more posts" Button', 'newspack-blocks' ) }
-							checked={ moreButton }
-							onChange={ () => setAttributes( { moreButton: ! moreButton } ) }
-						/>
+						! specificMode && (
+							<ToggleControl
+								label={ __( 'Show "Load more posts" Button', 'newspack-blocks' ) }
+								checked={ moreButton }
+								onChange={ () => setAttributes( { moreButton: ! moreButton } ) }
+							/>
+						)
 					) }
 				</PanelBody>
 				<PanelBody title={ __( 'Featured Image Settings', 'newspack-blocks' ) }>

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -27,9 +27,9 @@ class QueryControls extends Component {
 
 	fetchPostSuggestions = search => {
 		const { postType } = this.props;
-		const basePath = '/newspack-blocks/v1/specific-posts';
+		const restUrl = window.newspack_blocks_data.specific_posts_rest_url;
 		return apiFetch( {
-			path: addQueryArgs( basePath, {
+			url: addQueryArgs( restUrl, {
 				search,
 				per_page: 20,
 				_fields: 'id,title',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The same fix as #677, but for `specific-posts`.

Refactors the `newspack-blocks/v1/specific-posts` custom endpoint so that it is a.) retrieved from a localized value, so that it gets run through the `rest_url` filter, and b.) moved to the Homepage Posts REST controller, so that the downstream application knows to pick it up.

Also fixes #685.

### How to test the changes in this Pull Request:

#### Endpoint test

This is a pure refactor and shouldn't affect behavior in a non-WP.com environment. To test, create a block in Specific Posts mode and ensure that the posts load as expected in both the editor and on the front-end.


#### "Load More" test

1. Create a new Homepage Posts block and enable "specific posts" mode.
2. Confirm that the `Show "Load more posts" Button` is hidden when specific posts mode is on, and shown when it's off.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
