### PR TITLE
Resolve PHPCS issues in newspack-blocks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,20 @@ jobs:
     steps:
       - checkout_code
       - run:
-          name: Run Linter
+          name: Run JS linter
           command: npm run lint
+
+  php-lint:
+    docker:
+      - image: cimg/php:7.4
+    steps:
+      - checkout_code
+      - run:
+          name: Composer install
+          command: composer install
+      - run:
+          name: PHP lint
+          command: composer lint
 
   release:
     docker:
@@ -62,6 +74,9 @@ workflows:
     jobs:
       - build
       - lint:
+          requires:
+            - build
+      - php-lint:
           requires:
             - build
       - release:

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -48,4 +48,7 @@
 			<property name="blank_line_check" value="true"/>
 		</properties>
 	</rule>
+
+	<!-- Exclude compiled asset files -->
+	<exclude-pattern>*.asset.php</exclude-pattern>
 </ruleset>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Newspack Blocks
+
 This plugin is meant to serve as a container for most Newspack Gutenberg blocks. There may be certain blocks that relate to specific functionality in other plugins, in which case they would live with the primary functionality, but besides this exception most will live in this one.
 
 ## Setup
@@ -19,13 +20,12 @@ To work on Block development and have Webpack watch your files for changes run: 
 
 is performed on changed files before commiting. In other words, is run during `pre-commit` git hook, but only on staged files. The hook is configured in `composer.json`.
 
-|  | PHP | JS | SCSS |
-| :- | :- | :- | :- |
-| tool | [PHPCS](https://github.com/squizlabs/PHP_CodeSniffer) | [eslint](https://eslint.org/) | [stylelint](https://stylelint.io/) |
-| config | `.phpcs.xml.dist` | `.eslintrc.js` | `.stylelintrc` |
-| run manually | `./vendor/bin/phpcs <file>` | `npm run lint:js` | `npm run lint:scss` |
-| autofix ✨ | `./vendor/bin/phpcbf <file>` | `npm run lint:js -- --fix` | `npm run lint:scss -- --fix` |
-
+|              | PHP                                                   | JS                            | SCSS                               |
+| :----------- | :---------------------------------------------------- | :---------------------------- | :--------------------------------- |
+| tool         | [PHPCS](https://github.com/squizlabs/PHP_CodeSniffer) | [eslint](https://eslint.org/) | [stylelint](https://stylelint.io/) |
+| config       | `.phpcs.xml.dist`                                     | `.eslintrc.js`                | `.stylelintrc`                     |
+| run manually | `composer lint`                                       | `npm run lint:js`             | `npm run lint:scss`                |
+| autofix ✨   | `./vendor/bin/phpcbf <file>`                          | `npm run lint:js -- --fix`    | `npm run lint:scss -- --fix`       |
 
 ### Building new Blocks
 

--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -276,7 +276,7 @@ class Newspack_Blocks_API {
 		// Use Yoast primary category if set.
 		if ( class_exists( 'WPSEO_Primary_Term' ) ) {
 			$primary_term = new WPSEO_Primary_Term( 'category', $object['id'] );
-			$category_id = $primary_term->get_primary_term();
+			$category_id  = $primary_term->get_primary_term();
 			if ( $category_id ) {
 				$category = get_term( $category_id );
 			}
@@ -323,6 +323,7 @@ class Newspack_Blocks_API {
 			)
 		);
 		if ( ! empty( $sponsors ) ) {
+			$sponsor_info = [];
 			foreach ( $sponsors as $sponsor ) {
 				$sponsor_info_item = [
 					'flag'          => $sponsor['sponsor_flag'],
@@ -395,10 +396,10 @@ class Newspack_Blocks_API {
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ 'Newspack_Blocks_API', 'specific_posts_endpoint' ],
 				'args'                => [
-					'search'   => [
+					'search'    => [
 						'sanitize_callback' => 'sanitize_text_field',
 					],
-					'per_page' => [
+					'per_page'  => [
 						'sanitize_callback' => 'absint',
 					],
 					'post_type' => [

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -146,7 +146,7 @@ class Newspack_Blocks {
 	 * @param string $type The block's type.
 	 */
 	public static function enqueue_view_assets( $type ) {
-		$style_path= apply_filters(
+		$style_path = apply_filters(
 			'newspack_blocks_enqueue_view_assets',
 			NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css',
 			$type,

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -146,7 +146,7 @@ class Newspack_Blocks {
 	 * @param string $type The block's type.
 	 */
 	public static function enqueue_view_assets( $type ) {
-		$style_path = apply_filters(
+		$style_path= apply_filters(
 			'newspack_blocks_enqueue_view_assets',
 			NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css',
 			$type,

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -521,7 +521,19 @@ class Newspack_Blocks {
 	/**
 	 * Function to check if plugin is enabled, and if there are sponsors.
 	 *
-	 * @param string $id Post ID.
+	 * @see https://github.com/Automattic/newspack-sponsors/blob/8ebf72ec4fe744bca405a1f6fe8cd5bce3a29e6a/includes/newspack-sponsors-theme-helpers.php#L35
+	 *
+	 * @param int|null    $id    ID of the post or archive term to get sponsors for.
+	 *                           If not provided, we will try to guess based on context.
+	 * @param string|null $scope Scope of the sponsors to get. Can be 'native' or
+	 *                           'underwritten'. If provided, only sponsors with the
+	 *                           matching scope will be returned. If not, all sponsors
+	 *                           will be returned regardless of scope.
+	 * @param string|null $type  Type of the $id given: 'post' or 'archive'. If not
+	 *                           provided, we will try to guess based on context.
+	 * @param array       $logo_options Optional array of logo options. Valid options:
+	 *                                  maxwidth: max width of the logo image, in pixels.
+	 *                                  maxheight: max height of the logo image, in pixels.
 	 * @return array Array of sponsors.
 	 */
 	public static function get_all_sponsors( $id = null, $scope = 'native', $type = 'post', $logo_options = array(

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     ],
     "post-update-cmd": [
       "vendor/bin/cghooks update"
-    ]
+    ],
+    "lint": "phpcs ./"
   },
   "extra": {
     "hooks": {

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -26,7 +26,7 @@ require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'src/blocks/homepage-articles/class-w
 /**
  * Registers Articles block routes.
  */
-function newspack_articles_block_register_rest_routes() {
+function newspack_articles_block_register_rest_routes() { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
 	$articles_controller = new WP_REST_Newspack_Articles_Controller();
 	$articles_controller->register_routes();
 }

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -118,7 +118,6 @@ function newspack_blocks_render_block_donate( $attributes ) {
 			</form>
 		</div>
 		<?php
-
 	else :
 
 		?>
@@ -196,7 +195,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 												type='number'
 												name='donation_value_<?php echo esc_attr( $frequency_slug ); ?>_other'
 												value='<?php echo esc_attr( $amount ); ?>'
-												id='newspack-tier-<?php echo esc_attr( $frequency_slug . '-' . $uid  ); ?>-other-input'
+												id='newspack-tier-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-other-input'
 											/>
 										</div>
 									</div>

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -255,7 +255,7 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 		);
 		$xpath = new DOMXPath( $dom );
 		foreach ( iterator_to_array( $xpath->query( '//noscript | //comment()' ) ) as $node ) {
-			$node->parentNode->removeChild( $node ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
+			$node->parentNode->removeChild( $node ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		}
 		return AMP_DOM_Utils::get_content_from_dom( $dom );
 	}

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -5,10 +5,12 @@
  * @package WordPress
  */
 
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
 /**
  * Class WP_REST_Newspack_Articles_Controller.
  */
 class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
+// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
 
 	/**
 	 * Attribute schema.

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -99,7 +99,7 @@ call_user_func(
 				if ( has_post_format( 'aside' ) ) :
 					the_title( '<h3 class="entry-title">', '</h3>' );
 				else :
-				the_title( '<h3 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h3>' );
+					the_title( '<h3 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h3>' );
 				endif;
 			endif;
 			?>
@@ -164,7 +164,7 @@ call_user_func(
 						}
 						?>
 					</span>
-					<?php
+						<?php
 					else :
 						if ( $attributes['showAuthor'] ) :
 							if ( $attributes['showAvatar'] ) :

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -123,7 +123,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 					</h2>
 				<?php endif; ?>
 				<?php
-				echo Newspack_Blocks::template_inc(
+				echo Newspack_Blocks::template_inc( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					__DIR__ . '/templates/articles-list.php',
 					[
 						'articles_rest_url' => $articles_rest_url,
@@ -147,10 +147,10 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				?>
 				</button>
 				<p class="loading">
-					<?php _e( 'Loading...', 'newspack-blocks' ); ?>
+					<?php esc_html_e( 'Loading...', 'newspack-blocks' ); ?>
 				</p>
 				<p class="error">
-					<?php _e( 'Something went wrong. Please refresh the page and/or try again.', 'newspack-blocks' ); ?>
+					<?php esc_html_e( 'Something went wrong. Please refresh the page and/or try again.', 'newspack-blocks' ); ?>
 				</p>
 
 			<?php endif; ?>

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -123,7 +123,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 					</h2>
 				<?php endif; ?>
 				<?php
-				echo Newspack_Blocks::template_inc(
+				echo Newspack_Blocks::template_inc( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					__DIR__ . '/templates/articles-list.php',
 					[
 						'articles_rest_url' => $articles_rest_url,

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -123,7 +123,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 					</h2>
 				<?php endif; ?>
 				<?php
-				echo Newspack_Blocks::template_inc( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo Newspack_Blocks::template_inc(
 					__DIR__ . '/templates/articles-list.php',
 					[
 						'articles_rest_url' => $articles_rest_url,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,27 +5,27 @@
  * @package Newspack_Blocks
  */
 
-$_tests_dir = getenv( 'WP_TESTS_DIR' );
+$newspack_blocks_tests_dir = getenv( 'WP_TESTS_DIR' );
 
-if ( ! $_tests_dir ) {
-	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+if ( ! $newspack_blocks_tests_dir ) {
+	$newspack_blocks_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 }
 
-if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
-	echo "Could not find $_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // WPCS: XSS ok.
+if ( ! file_exists( $newspack_blocks_tests_dir . '/includes/functions.php' ) ) {
+	echo "Could not find $newspack_blocks_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	exit( 1 );
 }
 
 // Give access to tests_add_filter() function.
-require_once $_tests_dir . '/includes/functions.php';
+require_once $newspack_blocks_tests_dir . '/includes/functions.php';
 
 /**
  * Manually load the plugin being tested.
  */
-function _manually_load_plugin() {
+function newspack_blocks_manually_load_plugin() {
 	require dirname( dirname( __FILE__ ) ) . '/newspack-blocks.php';
 }
-tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+tests_add_filter( 'muplugins_loaded', 'newspack_blocks_manually_load_plugin' );
 
 // Start up the WP testing environment.
-require $_tests_dir . '/includes/bootstrap.php';
+require $newspack_blocks_tests_dir . '/includes/bootstrap.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR resolves all phpcs issues reported by `./vendor/bin/phpcs ./`, along with one extra which was reported when running the lint check on WordPress.com.

Why: we currently sync newspack blocks to WordPress.com via the editing toolkit plugin (ETK). There is a lint check in wpcom as part of the commit process. Up to now, we have that check disabled for the editing toolkit plugin, but I would like to enable it. To do so, all code in the plugin has to pass the test! I handled the ETK changes in https://github.com/Automattic/wp-calypso/pull/49692, and would also like to have newspack blocks pass that lint check.

Turns out that the local phpcs config caught even more lint things than the wpcom lint check did. As a result, I'd expect future code in this repo to be linted by about the same standard. There was only one rule wpcom complained about regarding an undefined variable, which I've fixed, but I think it was valid PHP syntax. (This is the only rule wpcom complained about which the local newspack lint did _not_ complain about.)

I fixed most things with `phpcbf`, and added the remaining fixes manually.

At any rate, the repo should now pass lint checks both locally and when syncing to wpcom.

### How to test the changes in this Pull Request:
1. Run `./vendor/bin/phpcs ./` with this branch checked out.
2. No errors or warnings should be reported.
3. Everything should still work :D
4. Automated tests should pass

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
