### PR TITLE
fix: override WooCommerce Memberships excerpt length in block

### DIFF
--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -657,6 +657,16 @@ class Newspack_Blocks {
 	public static $newspack_blocks_excerpt_length_closure = null;
 
 	/**
+	 * Function to override WooCommerce Membership's Excerpt Length filter.
+	 *
+	 * @return string Current post's original excerpt.
+	 */
+	public static function remove_wc_memberships_excerpt_limit() {
+		$excerpt = get_the_excerpt( get_the_id() );
+		return $excerpt;
+	}
+
+	/**
 	 * Filter for excerpt length.
 	 *
 	 * @param array $attributes The block's attributes.
@@ -674,6 +684,7 @@ class Newspack_Blocks {
 				},
 				999
 			);
+			add_filter( 'wc_memberships_trimmed_restricted_excerpt', [ 'Newspack_Blocks', 'remove_wc_memberships_excerpt_limit' ], 999 );
 		}
 	}
 
@@ -687,6 +698,7 @@ class Newspack_Blocks {
 				self::$newspack_blocks_excerpt_length_closure,
 				999
 			);
+			remove_filter( 'wc_memberships_trimmed_restricted_excerpt', [ 'Newspack_Blocks', 'remove_wc_memberships_excerpt_limit' ] );
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

WooCommerce Memberships v1.21 introduced an option to change the preview excerpt length of protected posts (the option appears under WP Admin > WooCommerce > Settings > Memberships). This control also affects the Homepage Posts block, overriding the per-block setting, even when left at the default 55 value.

This PR adds a filter to retrieve the post's original excerpt, rather than the truncated excerpt generated by the WC plugin.

### How to test the changes in this Pull Request:

1. Make sure your test site is running at least v. 1.21 of the WooCommerce Memberships plugin.
2. Using WooCommerce Memberships, set it up so a category requires you to be a member to view; apply the category to a mix of recent posts.
3. Add a Homepage Posts block that has a mix of regular and member only posts; change the excerpt length to a lower number, like 15-20.
4. View on the front-end; note that your member only post excerpts are longer:

![image](https://user-images.githubusercontent.com/177561/107077885-572f1b80-67a2-11eb-9ab8-86a7c627161b.png)

5. Apply the PR.
6. Confirm that your shorter excerpt length is now applied all posts:

![image](https://user-images.githubusercontent.com/177561/107078073-aa08d300-67a2-11eb-8466-786fdbcc7ade.png)

7. Click on a members only post; confirm that the longer excerpt is still applied there.
8. Try changing the excerpt length under WP Admin > WooCommerce > Settings > Memberships, and make sure it doesn't affect the block, only single posts.
9. Try giving one of the members only posts a custom excerpt that's longer; make sure it's shown in full, and not affected by either excerpt restriction. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
