### PR TITLE
refactor: render custom excerpt length server-side

### DIFF
--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -438,6 +438,12 @@ class Newspack_Blocks_API {
 			$args['post_type'] = $params['post_type'];
 		}
 
+		$block_attributes = [
+			'showExcerpt'   => $params['show_excerpt'],
+			'excerptLength' => $params['excerpt_length'],
+		];
+		Newspack_Blocks::filter_excerpt_length( $block_attributes );
+
 		$query        = new WP_Query();
 		$query_result = $query->query( $args );
 		$posts        = [];
@@ -486,6 +492,9 @@ class Newspack_Blocks_API {
 
 			$posts[] = array_merge( $data, $add_ons );
 		}
+
+		Newspack_Blocks::remove_excerpt_length_filter();
+
 		return new \WP_REST_Response( $posts );
 	}
 

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -57,55 +57,62 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ 'Newspack_Blocks_API', 'posts_endpoint' ],
 				'args'                => [
-					'author'       => [
+					'author'         => [
 						'type'    => 'array',
 						'items'   => array(
 							'type' => 'integer',
 						),
 						'default' => array(),
 					],
-					'categories'   => [
+					'categories'     => [
 						'type'    => 'array',
 						'items'   => array(
 							'type' => 'integer',
 						),
 						'default' => array(),
 					],
-					'exclude'      => [
+					'excerpt_length' => [
+						'type'    => 'integer',
+						'default' => 55,
+					],
+					'exclude'        => [
 						'type'    => 'array',
 						'items'   => array(
 							'type' => 'integer',
 						),
 						'default' => array(),
 					],
-					'include'      => [
+					'include'        => [
 						'type'    => 'array',
 						'items'   => array(
 							'type' => 'integer',
 						),
 						'default' => array(),
 					],
-					'orderby'      => [
+					'orderby'        => [
 						'sanitize_callback' => 'sanitize_text_field',
 					],
-					'per_page'     => [
+					'per_page'       => [
 						'sanitize_callback' => 'absint',
 					],
-					'tags'         => [
+					'show_excerpt'   => [
+						'type' => 'boolean',
+					],
+					'tags'           => [
 						'type'    => 'array',
 						'items'   => array(
 							'type' => 'integer',
 						),
 						'default' => array(),
 					],
-					'tags_exclude' => [
+					'tags_exclude'   => [
 						'type'    => 'array',
 						'items'   => array(
 							'type' => 'integer',
 						),
 						'default' => array(),
 					],
-					'post_type'    => [
+					'post_type'      => [
 						'type'    => 'array',
 						'items'   => array(
 							'type' => 'string',

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -144,25 +144,6 @@ class Edit extends Component {
 
 		const postTitle = this.titleForPost( post );
 		const dateFormat = __experimentalGetSettings().formats.date;
-
-		const getTrimmedExcerpt = ( currentPost, { excerptLength } ) => {
-			const regex = /(<([^>]+)>)/gi;
-			const excerpt = currentPost.excerpt.rendered;
-			const content = currentPost.content.rendered;
-			const newExcerpt = content.replace( regex, '' );
-
-			const excerptEllipsis = showReadMore ? '…' : ' […]';
-
-			const needsEllipsis = excerptLength < newExcerpt.trim().split( ' ' ).length;
-			const postExcerpt = needsEllipsis
-				? `${ newExcerpt.split( ' ', excerptLength ).join( ' ' ) + excerptEllipsis } `
-				: newExcerpt;
-
-			return currentPost.newspack_has_custom_excerpt
-				? excerpt
-				: '<p>' + postExcerpt.trim() + '</p>';
-		};
-
 		return (
 			<article className={ postClasses } key={ post.id } style={ styles }>
 				{ showImage && post.newspack_featured_image_src && (
@@ -219,7 +200,7 @@ class Edit extends Component {
 						<RawHTML key="excerpt" className="excerpt-contain">
 							{ post.newspack_post_format === 'aside'
 								? post.content.rendered
-								: getTrimmedExcerpt( post, attributes ) }
+								: post.excerpt.rendered }
 						</RawHTML>
 					) }
 					{ showReadMore && (

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -5,12 +5,7 @@
  */
 import QueryControls from '../../components/query-controls';
 import { STORE_NAMESPACE } from './store';
-import {
-	getEditorBlocksIds,
-	isBlogPrivate,
-	shouldReflow,
-	queryCriteriaFromAttributes,
-} from './utils';
+import { getEditorBlocksIds, isBlogPrivate, shouldReflow, getCoreStorePosts } from './utils';
 import {
 	formatAvatars,
 	formatByline,
@@ -777,11 +772,7 @@ export default compose( [
 		} else {
 			// For block preview, display without deduplication. If there would be a way to match the outside-editor's
 			// block clientId to the clientId of the block that's being previewed, the correct posts could be shown here.
-			props.latestPosts = select( 'core' ).getEntityRecords(
-				'postType',
-				'post',
-				queryCriteriaFromAttributes( attributes )
-			);
+			props.latestPosts = getCoreStorePosts( attributes );
 		}
 
 		return props;

--- a/src/blocks/homepage-articles/store.js
+++ b/src/blocks/homepage-articles/store.js
@@ -90,7 +90,7 @@ const createCacheKey = JSON.stringify;
  *
  * @param {Object} block an object with a postsQuery and a clientId
  */
-function* getPosts( block ) {
+function* getPostsForBlock( block ) {
 	const cacheKey = createCacheKey( block.postsQuery );
 	const restUrl = window.newspack_blocks_data.posts_rest_url;
 	let posts = POSTS_QUERIES_CACHE[ cacheKey ];
@@ -138,7 +138,7 @@ const createFetchPostsSaga = blockName => {
 			nextBlock.postsQuery.exclude = exclude;
 			let fetchedPostIds = [];
 			try {
-				fetchedPostIds = yield call( getPosts, nextBlock );
+				fetchedPostIds = yield call( getPostsForBlock, nextBlock );
 			} catch ( e ) {
 				yield put( { type: 'UPDATE_BLOCK_ERROR', clientId: nextBlock.clientId, error: e.message } );
 			}

--- a/src/blocks/homepage-articles/utils.js
+++ b/src/blocks/homepage-articles/utils.js
@@ -21,7 +21,9 @@ const POST_QUERY_ATTRIBUTES = [
 	'postsToShow',
 	'authors',
 	'categories',
+	'excerptLength',
 	'tags',
+	'showExcerpt',
 	'specificPosts',
 	'specificMode',
 	'tagExclusions',
@@ -55,7 +57,9 @@ export const queryCriteriaFromAttributes = attributes => {
 		postsToShow,
 		authors,
 		categories,
+		excerptLength,
 		postType,
+		showExcerpt,
 		tags,
 		specificPosts,
 		specificMode,
@@ -82,6 +86,8 @@ export const queryCriteriaFromAttributes = attributes => {
 		value => ! isUndefined( value )
 	);
 	criteria.suppress_password_protected_posts = true;
+	criteria.excerpt_length = excerptLength;
+	criteria.show_excerpt = showExcerpt;
 	return criteria;
 };
 

--- a/src/blocks/homepage-articles/utils.js
+++ b/src/blocks/homepage-articles/utils.js
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { isEqual, isUndefined, pick, pickBy } from 'lodash';
+import { debounce, isEqual, isUndefined, pick, pickBy } from 'lodash';
+
+/**
+ * External dependencies
+ */
+import { select as globalSelect } from '@wordpress/data';
 
 /**
  * Based global WP.com blog_public option, checks whether current blog is
@@ -110,3 +115,13 @@ export const getEditorBlocksIds = blocks =>
 		homepageArticleBlocks.push( block.clientId );
 		return homepageArticleBlocks.concat( getEditorBlocksIds( block.innerBlocks ) );
 	} );
+
+export const getCoreStorePosts = debounce(
+	attributes =>
+		globalSelect( 'core' ).getEntityRecords(
+			'postType',
+			'post',
+			queryCriteriaFromAttributes( attributes )
+		),
+	500
+);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The custom excerpt length control introduced in https://github.com/Automattic/newspack-blocks/pull/607 had one drawback, which is that `the_excerpt is no longer filtered in the editor.` This has come up in https://github.com/Automattic/newspack-blocks/issues/700 as a problem for blocks with fallback content. The custom posts endpoint introduced in https://github.com/Automattic/newspack-blocks/pull/661 opens up a cleaner way to deal with this problem. In this PR, the block excerpt length and visibility attributes are passed to the endpoint and the endpoint uses excerpt filtering identical to the block's front-end rendering. This should also mean the truncated excerpt is _slightly_ more WYSIWYG since the editor and front-end are now using the exact same approach.

Closes https://github.com/Automattic/newspack-blocks/issues/700

### How to test the changes in this Pull Request:

1. Add a few Homepage Posts blocks to a post, toggle on `Show Excerpt` on some of them, and try a variety of `Max number of words in excerpt` settings.
2. Verify the results seen in the editor match the results seen in front end.
3. On `master`, replicate the issue described in https://github.com/Automattic/newspack-blocks/issues/700 using a block with fallback content (Podcast Player or Eventbrite Checkout). 
4. Switch to this branch, verify the issue is resolved.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
