### PR TITLE
chore: add phpcs unused variable rule

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -48,6 +48,7 @@
 			<property name="blank_line_check" value="true"/>
 		</properties>
 	</rule>
+	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable"/>
 
 	<!-- Exclude compiled asset files -->
 	<exclude-pattern>*.asset.php</exclude-pattern>

--- a/class-newspack-blocks-api.php
+++ b/class-newspack-blocks-api.php
@@ -378,7 +378,7 @@ class Newspack_Blocks_API {
 			[
 				'methods'             => 'GET',
 				'callback'            => [ 'Newspack_Blocks_API', 'video_playlist_endpoint' ],
-				'permission_callback' => function( $request ) {
+				'permission_callback' => function() {
 					return current_user_can( 'edit_posts' );
 				},
 			]

--- a/class-newspack-blocks.php
+++ b/class-newspack-blocks.php
@@ -401,7 +401,7 @@ class Newspack_Blocks {
 	 * @param array  $data          Data to be passed into the template to be included.
 	 * @return string
 	 */
-	public static function template_inc( $template, $data = array() ) {
+	public static function template_inc( $template, $data = array() ) { //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		if ( ! strpos( $template, '.php' ) ) {
 			$template = $template . '.php';
 		}
@@ -676,7 +676,7 @@ class Newspack_Blocks {
 		if ( $attributes['showExcerpt'] ) {
 			self::$newspack_blocks_excerpt_length_closure = add_filter(
 				'excerpt_length',
-				function( $length ) use ( $attributes ) {
+				function() use ( $attributes ) {
 					if ( $attributes['excerptLength'] ) {
 						return $attributes['excerptLength'];
 					}
@@ -704,10 +704,8 @@ class Newspack_Blocks {
 
 	/**
 	 * Return a excerpt more replacement when using the 'Read More' link.
-	 *
-	 * @param string $more Default excerpt_more value.
 	 */
-	public static function more_excerpt( $more ) {
+	public static function more_excerpt() {
 		return '…';
 	}
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "brainmaestro/composer-git-hooks": "^2.6",
     "wp-coding-standards/wpcs": "*",
     "dealerdirect/phpcodesniffer-composer-installer": "*",
-    "phpcompatibility/phpcompatibility-wp": "*"
+    "phpcompatibility/phpcompatibility-wp": "*",
+    "sirbrillig/phpcs-variable-analysis": "^2.10"
   },
   "license": "GPL-3.0-or-later",
   "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3ed49d0dc2811a10284e5105544f668e",
+    "content-hash": "1fd83fe983f16020929b226d20ce6482",
     "packages": [],
     "packages-dev": [
         {
@@ -523,6 +523,54 @@
                 "psr"
             ],
             "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "v2.10.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "0775e0c683badad52c03b11c2cd86a9fdecb937a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/0775e0c683badad52c03b11c2cd86a9fdecb937a",
+                "reference": "0775e0c683badad52c03b11c2cd86a9fdecb937a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "limedeck/phpunit-detailed-printer": "^3.1 || ^4.0 || ^5.0",
+                "phpstan/phpstan": "^0.11.8",
+                "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
+                "sirbrillig/phpcs-import-detection": "^1.1"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "VariableAnalysis\\": "VariableAnalysis/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Graham",
+                    "email": "php-codesniffer-variableanalysis@illusori.co.uk"
+                },
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "A PHPCS sniff to detect problems with variables.",
+            "time": "2021-01-08T16:31:05+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -285,11 +285,9 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 /**
  * Generate autoplay play/pause UI for non-AMP requests.
  *
- * @param int $block_ordinal The ordinal number of the block, used in unique ID.
- *
  * @return string Autoplay UI markup.
  */
-function newspack_blocks_carousel_block_autoplay_ui( $block_ordinal = 0 ) {
+function newspack_blocks_carousel_block_autoplay_ui() {
 	return sprintf(
 		'<button aria-label="%s" class="swiper-button swiper-button-pause"></button><button aria-label="%s" class="swiper-button swiper-button-play"></button>',
 		esc_attr__( 'Pause Slideshow', 'newspack-blocks' ),

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -113,7 +113,7 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 						'default' => array(),
 					],
 				],
-				'permission_callback' => function( $request ) {
+				'permission_callback' => function() {
 					return current_user_can( 'edit_posts' );
 				},
 			]
@@ -141,7 +141,7 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 						'default' => array(),
 					],
 				],
-				'permission_callback' => function( $request ) {
+				'permission_callback' => function() {
 					return current_user_can( 'edit_posts' );
 				},
 			]


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add a PHPCS rule that ETK tracks to keep the two projects in sync. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
