### PR TITLE
fix: a PHP warning when editing newsletters

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -282,7 +282,7 @@ class Newspack_Blocks {
 				get_post_thumbnail_id( get_the_ID() ),
 				'newspack-article-block-' . $orientation . '-' . $key
 			);
-			if ( $dimensions[0] === $attachment[1] && $dimensions[1] === $attachment[2] ) {
+			if ( ! empty( $attachment ) && $dimensions[0] === $attachment[1] && $dimensions[1] === $attachment[2] ) {
 				return 'newspack-article-block-' . $orientation . '-' . $key;
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids a PHP warning thrown when editing a Newspack newsletter CPT. It's another question why the Blocks handler is running at all on a CPT that doesn't register any blocks from Newspack Blocks, but this should fix the warning wherever it might happen.

### How to test the changes in this Pull Request:

1. On `master`, create or edit a newsletter in the Newspack Newsletters plugin.
2. Observe a PHP notice in your debug.log like this:

```
[24-Mar-2021 16:05:09 UTC] PHP Notice:  Trying to access array offset on value of type bool in /newspack/app/public/wp-content/plugins/newspack-blocks/includes/class-newspack-blocks.php on line 285
```

3. Check out this branch, refresh the editor page. Confirm that the warning is no longer thrown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
