### PR TITLE
feat: allow different post types in carousel; plus new block options

### DIFF
--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -366,6 +366,7 @@ class Newspack_Blocks_API {
 				'newspack_has_custom_excerpt'     => self::newspack_blocks_has_custom_excerpt( $data ),
 				'newspack_post_format'            => self::newspack_blocks_post_format( $data ),
 				'newspack_post_sponsors'          => self::newspack_blocks_sponsor_info( $data ),
+				'post_type'                       => $post->post_type,
 			];
 
 			$posts[] = array_merge( $data, $add_ons );

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -42,6 +42,10 @@ export const settings = {
 		className: {
 			type: 'string',
 		},
+		imageFit: {
+			type: 'string',
+			default: 'cover',
+		},
 		autoplay: {
 			type: 'boolean',
 			default: false,
@@ -78,6 +82,26 @@ export const settings = {
 		showCategory: {
 			type: 'boolean',
 			default: false,
+		},
+		showTitle: {
+			type: 'boolean',
+			default: true,
+		},
+		postType: {
+			type: 'array',
+			default: [ 'post' ],
+			items: {
+				type: 'string',
+			},
+		},
+		specificMode: {
+			type: 'boolean',
+			default: false,
+		},
+		specificPosts: {
+			type: 'array',
+			default: [],
+			items: { type: 'integer' },
 		},
 	},
 	supports: {

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -87,7 +87,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 								<?php echo esc_html( Newspack_Blocks::get_sponsor_label( $sponsors ) ); ?>
 							</span>
 						</span>
-						<?php
+							<?php
 						else :
 							$category = false;
 

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -46,25 +46,29 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 	if ( $article_query->have_posts() ) :
 		while ( $article_query->have_posts() ) :
 			$article_query->the_post();
-			$authors                                 = Newspack_Blocks::prepare_authors();
-			$newspack_blocks_post_id[ get_the_ID() ] = true;
+			$post_id                             = get_the_ID();
+			$authors                             = Newspack_Blocks::prepare_authors();
+			$newspack_blocks_post_id[ $post_id ] = true;
 
 			// Get sponsors for this post.
-			$sponsors = Newspack_Blocks::get_all_sponsors( get_the_id() );
+			$sponsors = Newspack_Blocks::get_all_sponsors( $post_id );
 
 			$counter++;
 			$has_featured_image = has_post_thumbnail();
+			$post_type          = get_post_type();
+			$external_url       = get_post_meta( $post_id, 'newspack_sponsor_url', true );
+			$link               = ! empty( $external_url ) ? $external_url : get_permalink();
 			?>
 
-			<article data-post-id="<?php the_id(); ?>" class="<?php echo esc_attr( implode( ' ', $article_classes ) ); ?>">
+			<article data-post-id="<?php echo esc_attr( $post_id ); ?>" class="<?php echo esc_attr( implode( ' ', $article_classes ) . ' ' . $post_type ); ?>">
 				<figure class="post-thumbnail">
-					<a href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
+					<a href="<?php echo esc_url( $link ); ?>" rel="bookmark">
 						<?php if ( $has_featured_image ) : ?>
 							<?php
 								the_post_thumbnail(
 									'large',
 									array(
-										'object-fit' => 'cover',
+										'object-fit' => $attributes['imageFit'],
 										'layout'     => 'fill',
 									)
 								);
@@ -74,128 +78,133 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 						<?php endif; ?>
 					</a>
 				</figure>
-				<div class="entry-wrapper">
 
-				<?php if ( ! empty( $sponsors ) ) : ?>
-					<span class="cat-links sponsor-label">
-						<span class="flag">
-							<?php echo esc_html( Newspack_Blocks::get_sponsor_label( $sponsors ) ); ?>
+				<?php if ( ! empty( $sponsors ) || $attributes['showCategory'] || $attributes['showTitle'] || $attributes['showAuthor'] || $attributes['showDate'] ) : ?>
+					<div class="entry-wrapper">
+
+					<?php if ( ! empty( $sponsors ) ) : ?>
+						<span class="cat-links sponsor-label">
+							<span class="flag">
+								<?php echo esc_html( Newspack_Blocks::get_sponsor_label( $sponsors ) ); ?>
+							</span>
 						</span>
-					</span>
-					<?php
-					else :
-						$category = false;
-
-						// Use Yoast primary category if set.
-						if ( class_exists( 'WPSEO_Primary_Term' ) ) {
-							$primary_term = new WPSEO_Primary_Term( 'category', get_the_ID() );
-							$category_id  = $primary_term->get_primary_term();
-							if ( $category_id ) {
-								$category = get_term( $category_id );
-							}
-						}
-
-						if ( ! $category ) {
-							$categories_list = get_the_category();
-							if ( ! empty( $categories_list ) ) {
-								$category = $categories_list[0];
-							}
-						}
-
-						if ( $attributes['showCategory'] && $category ) :
-							?>
-							<div class="cat-links">
-								<a href="<?php echo esc_url( get_category_link( $category->term_id ) ); ?>">
-									<?php echo esc_html( $category->name ); ?>
-								</a>
-							</div>
-							<?php
-						endif;
-					endif;
-					?>
-
-					<?php
-						the_title( '<h3 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h3>' );
-					?>
-
-					<div class="entry-meta">
 						<?php
-						if ( ! empty( $sponsors ) ) :
-							$logos = Newspack_Blocks::get_sponsor_logos( $sponsors );
-							if ( ! empty( $logos ) ) :
-								?>
-							<span class="sponsor-logos">
-								<?php
-								foreach ( $logos as $logo ) {
-									if ( '' !== $logo['url'] ) {
-										echo '<a href="' . esc_url( $logo['url'] ) . '" target="_blank">';
-									}
-									echo '<img src="' . esc_url( $logo['src'] ) . '" width="' . esc_attr( $logo['width'] ) . '" height="' . esc_attr( $logo['height'] ) . '">';
-									if ( '' !== $logo['url'] ) {
-										echo '</a>';
-									}
-								}
-								?>
-							</span>
-							<?php endif; ?>
-
-							<span class="byline sponsor-byline">
-								<?php
-								$bylines = Newspack_Blocks::get_sponsor_byline( $sponsors );
-								echo esc_html( $bylines[0]['byline'] ) . ' ';
-								foreach ( $bylines as $byline ) {
-									echo '<span class="author">';
-									if ( '' !== $byline['url'] ) {
-										echo '<a target="_blank" href="' . esc_url( $byline['url'] ) . '">';
-									}
-									echo esc_html( $byline['name'] );
-									if ( '' !== $byline['url'] ) {
-										'</a>';
-									}
-									echo '</span>' . esc_html( $byline['sep'] );
-								}
-								?>
-							</span>
-							<?php
 						else :
-							if ( $attributes['showAuthor'] ) :
-								if ( $attributes['showAvatar'] ) :
-									echo wp_kses(
-										newspack_blocks_format_avatars( $authors ),
-										array(
-											'img'      => array(
-												'class'  => true,
-												'src'    => true,
-												'alt'    => true,
-												'width'  => true,
-												'height' => true,
-												'data-*' => true,
-												'srcset' => true,
-											),
-											'noscript' => array(),
-											'a'        => array(
-												'href' => true,
-											),
-										)
-									);
-								endif;
+							$category = false;
+
+							// Use Yoast primary category if set.
+							if ( class_exists( 'WPSEO_Primary_Term' ) ) {
+								$primary_term = new WPSEO_Primary_Term( 'category', $post_id );
+								$category_id  = $primary_term->get_primary_term();
+								if ( $category_id ) {
+									$category = get_term( $category_id );
+								}
+							}
+
+							if ( ! $category ) {
+								$categories_list = get_the_category();
+								if ( ! empty( $categories_list ) ) {
+									$category = $categories_list[0];
+								}
+							}
+
+							if ( $attributes['showCategory'] && $category ) :
 								?>
-								<span class="byline">
-									<?php echo wp_kses_post( newspack_blocks_format_byline( $authors ) ); ?>
-								</span><!-- .author-name -->
+								<div class="cat-links">
+									<a href="<?php echo esc_url( get_category_link( $category->term_id ) ); ?>">
+										<?php echo esc_html( $category->name ); ?>
+									</a>
+								</div>
 								<?php
 							endif;
 						endif;
-						if ( $attributes['showDate'] ) :
-							printf(
-								'<time class="entry-date published" datetime="%1$s">%2$s</time>',
-								esc_attr( get_the_date( DATE_W3C ) ),
-								esc_html( get_the_date() )
-							);
-						endif;
 						?>
-					</div><!-- .entry-meta -->
-				</div><!-- .entry-wrapper -->
+
+						<?php
+						if ( $attributes['showTitle'] ) {
+							the_title( '<h3 class="entry-title"><a href="' . esc_url( $link ) . '" rel="bookmark">', '</a></h3>' );
+						}
+						?>
+
+						<div class="entry-meta">
+							<?php
+							if ( ! empty( $sponsors ) ) :
+								$logos = Newspack_Blocks::get_sponsor_logos( $sponsors );
+								if ( ! empty( $logos ) ) :
+									?>
+								<span class="sponsor-logos">
+									<?php
+									foreach ( $logos as $logo ) {
+										if ( '' !== $logo['url'] ) {
+											echo '<a href="' . esc_url( $logo['url'] ) . '" target="_blank">';
+										}
+										echo '<img src="' . esc_url( $logo['src'] ) . '" width="' . esc_attr( $logo['width'] ) . '" height="' . esc_attr( $logo['height'] ) . '">';
+										if ( '' !== $logo['url'] ) {
+											echo '</a>';
+										}
+									}
+									?>
+								</span>
+								<?php endif; ?>
+
+								<span class="byline sponsor-byline">
+									<?php
+									$bylines = Newspack_Blocks::get_sponsor_byline( $sponsors );
+									echo esc_html( $bylines[0]['byline'] ) . ' ';
+									foreach ( $bylines as $byline ) {
+										echo '<span class="author">';
+										if ( '' !== $byline['url'] ) {
+											echo '<a target="_blank" href="' . esc_url( $byline['url'] ) . '">';
+										}
+										echo esc_html( $byline['name'] );
+										if ( '' !== $byline['url'] ) {
+											'</a>';
+										}
+										echo '</span>' . esc_html( $byline['sep'] );
+									}
+									?>
+								</span>
+								<?php
+							else :
+								if ( $attributes['showAuthor'] ) :
+									if ( $attributes['showAvatar'] ) :
+										echo wp_kses(
+											newspack_blocks_format_avatars( $authors ),
+											array(
+												'img'      => array(
+													'class'  => true,
+													'src'    => true,
+													'alt'    => true,
+													'width'  => true,
+													'height' => true,
+													'data-*' => true,
+													'srcset' => true,
+												),
+												'noscript' => array(),
+												'a'        => array(
+													'href' => true,
+												),
+											)
+										);
+									endif;
+									?>
+									<span class="byline">
+										<?php echo wp_kses_post( newspack_blocks_format_byline( $authors ) ); ?>
+									</span><!-- .author-name -->
+									<?php
+								endif;
+							endif;
+							if ( $attributes['showDate'] ) :
+								printf(
+									'<time class="entry-date published" datetime="%1$s">%2$s</time>',
+									esc_attr( get_the_date( DATE_W3C ) ),
+									esc_html( get_the_date() )
+								);
+							endif;
+							?>
+						</div><!-- .entry-meta -->
+					</div><!-- .entry-wrapper -->
+				<?php endif; ?>
 			</article>
 			<?php
 		endwhile;
@@ -249,7 +258,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 		$autoplay_ui = $autoplay ? newspack_blocks_carousel_block_autoplay_ui( $newspack_blocks_carousel_id ) : '';
 	}
 	$data_attributes = [
-		'data-current-post-id=' . get_the_ID(),
+		'data-current-post-id=' . $post_id,
 	];
 
 	if ( $autoplay && ! $is_amp ) {

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -172,10 +172,10 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 											newspack_blocks_format_avatars( $authors ),
 											array(
 												'img'      => array(
-													'class'  => true,
-													'src'    => true,
-													'alt'    => true,
-													'width'  => true,
+													'class' => true,
+													'src' => true,
+													'alt' => true,
+													'width' => true,
 													'height' => true,
 													'data-*' => true,
 													'srcset' => true,

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -81,8 +81,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 
 				<?php if ( ! empty( $sponsors ) || $attributes['showCategory'] || $attributes['showTitle'] || $attributes['showAuthor'] || $attributes['showDate'] ) : ?>
 					<div class="entry-wrapper">
-
-					<?php if ( ! empty( $sponsors ) ) : ?>
+						<?php if ( ! empty( $sponsors ) ) : ?>
 						<span class="cat-links sponsor-label">
 							<span class="flag">
 								<?php echo esc_html( Newspack_Blocks::get_sponsor_label( $sponsors ) ); ?>
@@ -383,6 +382,10 @@ function newspack_blocks_register_carousel() {
 						'default' => false,
 					),
 					'showDate'     => array(
+						'type'    => 'boolean',
+						'default' => true,
+					),
+					'showTitle'    => array(
 						'type'    => 'boolean',
 						'default' => true,
 					),

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -204,6 +204,10 @@
 
 		.post-thumbnail img {
 			object-fit: cover;
+
+			&.image-fit-contain {
+				object-fit: contain;
+			}
 		}
 	}
 

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -12,17 +12,22 @@ call_user_func(
 		$authors    = Newspack_Blocks::prepare_authors();
 		$classes    = array();
 		$styles     = '';
+		$post_id    = get_the_ID();
 
 		// Get sponsors for this post.
-		$sponsors = Newspack_Blocks::get_all_sponsors( get_the_id() );
+		$sponsors = Newspack_Blocks::get_all_sponsors( $post_id );
 
 		// Add classes based on the post's assigned categories and tags.
-		$classes[] = Newspack_Blocks::get_term_classes( get_the_ID() );
+		$classes[] = Newspack_Blocks::get_term_classes( $post_id );
 
 		// Add class if post has a featured image.
 		if ( has_post_thumbnail() ) {
 			$classes[] = 'post-has-image';
 		}
+
+		// If the post is a sponsor, it won't have a working permalink, but it will have an external URL.
+		$external_url = get_post_meta( $post_id, 'newspack_sponsor_url', true );
+		$link         = ! empty( $external_url ) ? $external_url : get_permalink();
 
 		if ( 'behind' === $attributes['mediaPosition'] && $attributes['showImage'] && has_post_thumbnail() ) {
 			$styles = 'min-height: ' . $attributes['minHeight'] . 'vh; padding-top: ' . ( $attributes['minHeight'] / 5 ) . 'vh;';
@@ -39,7 +44,7 @@ call_user_func(
 		$category = false;
 		// Use Yoast primary category if set.
 		if ( class_exists( 'WPSEO_Primary_Term' ) ) {
-			$primary_term = new WPSEO_Primary_Term( 'category', get_the_ID() );
+			$primary_term = new WPSEO_Primary_Term( 'category', $post_id );
 			$category_id  = $primary_term->get_primary_term();
 			if ( $category_id ) {
 				$category = get_term( $category_id );
@@ -61,7 +66,7 @@ call_user_func(
 		>
 		<?php if ( has_post_thumbnail() && $attributes['showImage'] && $attributes['imageShape'] ) : ?>
 			<figure class="post-thumbnail">
-				<a href="<?php the_permalink(); ?>" rel="bookmark">
+				<a href="<?php echo esc_url( $link ); ?>" rel="bookmark">
 					<?php the_post_thumbnail( $image_size, $thumbnail_args ); ?>
 				</a>
 
@@ -92,14 +97,14 @@ call_user_func(
 				if ( has_post_format( 'aside' ) ) :
 					the_title( '<h2 class="entry-title">', '</h2>' );
 				else :
-					the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
+					the_title( '<h2 class="entry-title"><a href="' . esc_url( $link ) . '" rel="bookmark">', '</a></h2>' );
 				endif;
 			else :
 				// Don't link the title if using the post format aside.
 				if ( has_post_format( 'aside' ) ) :
 					the_title( '<h3 class="entry-title">', '</h3>' );
 				else :
-					the_title( '<h3 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h3>' );
+					the_title( '<h3 class="entry-title"><a href="' . esc_url( $link ) . '" rel="bookmark">', '</a></h3>' );
 				endif;
 			endif;
 			?>
@@ -107,7 +112,7 @@ call_user_func(
 			if ( $attributes['showSubtitle'] ) :
 				?>
 				<div class="newspack-post-subtitle newspack-post-subtitle--in-homepage-block">
-					<?php echo esc_html( get_post_meta( get_the_ID(), 'newspack_post_subtitle', true ) ); ?>
+					<?php echo esc_html( get_post_meta( $post_id, 'newspack_post_subtitle', true ) ); ?>
 				</div>
 			<?php endif; ?>
 			<?php
@@ -120,7 +125,7 @@ call_user_func(
 			endif;
 			if ( ! has_post_format( 'aside' ) && ( $attributes['showReadMore'] ) ) :
 				?>
-				<a class="more-link" href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
+				<a class="more-link" href="<?php echo esc_url( $link ); ?>" rel="bookmark">
 					<?php echo esc_html( $attributes['readMoreLabel'] ); ?>
 				</a>
 				<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Makes a few changes:

* Allows any post types with `newspack_blocks` support to be selected and added to a Posts Carousel, much like with the Homepage Posts block.
* Enables Specific Posts mode for the carousel, just like with Homepage Posts.
* On the front-end, if a post has an external sponsor URL meta value defined, the slide will link to this, otherwise it will link to the post's permalink. This is to accommodate sponsors, who don't have working permalinks but should have an external sponsor URL set. If it turns out that some sponsors don't have that metavalue set, we can add a block attribute to choose whether to link the slides at all.
* Adds some new block options:
  - `imageFit` – Lets you specify whether the image is cropped to fill the slider or downsized to fit within it. The latter is useful for showing sponsor logos that you don't want to be visually cropped.
  - `showTitle` – Lets you show or hide the title. Now, if you toggle off all options under "Article Meta Settings", the meta container at the bottom of each slide with the translucent black background is not rendered at all, which should be useful if you want to show sponsor logos with no other information.

You must have this change active in the Newspack Sponsors plugin if you want to test with the sponsor CPT: https://github.com/Automattic/newspack-sponsors/pull/52

Closes #745.

### How to test the changes in this Pull Request:

1. Check out this branch, run `npm run build` to build files.
2. On a post or page, add a Post Carousel block.

#### Post Types options

1. In the editor, select the Post Carousel block and confirm that there's a new "Post Types" sidebar panel. Expand it.
2. Confirm that there are several post type options that can be toggled on here, with "Posts" being the only one selected by default. Note that the options you see here depend on which other Newspack plugins you have active on your site:
  - If you have Newspack Newsletters active, you'll see an option "Newsletters"
  - If you have Listings active, you'll see options for "Generic Listings", "Events", "Marketplace Listings", and "Places"
  - If you have Sponsors active, you'll see an option for "Sponsors" (must have https://github.com/Automattic/newspack-sponsors/pull/52 active for that plugin)
  - At the very least, you'll see options for "Posts" and "Pages".
3. Toggle on and off each option and confirm that when the option is on, its corresponding post types a.) are shown in the preview and on the front-end query results, and b.) can be searched for if the block is in "Specific Posts" mode (see below for testing on that).
4. Note that other post types can be added here as options by adding support for `newspack_blocks` to the post type, e.g. `add_post_type_support( 'cpt_name', 'newspack_blocks' );`

#### Specific Posts mode

1. In the editor, select the Post Carousel block and expand the "Display Settings" sidebar panel. Confirm that there's now a "Choose Specific Posts" toggle here:

<img width="276" alt="Screen Shot 2021-04-29 at 4 58 38 PM" src="https://user-images.githubusercontent.com/2230142/116628363-2f1c0800-a90c-11eb-9590-fc216e4ba593.png">

2. Toggle it on and enter post titles to search for them. Select one or more posts and confirm that it works as expected, and that the carousel in the preview and on the front-end shows only the posts selected if in specific posts mode.

#### Image Fit option

1. In the editor, select the Post Carousel block and expand the "Slideshow Settings" sidebar panel. Confirm that there's now an "Image Fit Style" setting with two options, with "Cover" being the default (which means that existing carousels won't change their behavior):

<img width="273" alt="Screen Shot 2021-04-29 at 5 02 09 PM" src="https://user-images.githubusercontent.com/2230142/116628576-a487d880-a90c-11eb-901b-b64fd32b9e60.png">

2. Set the option to "Contain" and confirm that the carousel now renders its images centered and uncropped, instead of cropping them to fill the space. Confirm in both the editor and on the front-end.

#### Show Title option

1. In the editor, select the Post Carousel block and expand the "Article Meta Settings" sidebar panel. Confirm that there's a new "Show Title" setting which is enabled by default.

<img width="273" alt="Screen Shot 2021-04-29 at 5 04 19 PM" src="https://user-images.githubusercontent.com/2230142/116628714-f597cc80-a90c-11eb-8ef0-0d89d893fcb6.png">

2. Toggle the setting off and confirm that the carousel renders without showing post titles in both the editor and front-end.
3. Toggle off all settings under "Article Meta Settings" and confirm that the carousel now renders without any entry-meta info, or its translucent black background, in both editor and front-end:

<img width="808" alt="Screen Shot 2021-04-29 at 5 05 41 PM" src="https://user-images.githubusercontent.com/2230142/116628834-342d8700-a90d-11eb-84b9-75c7522d4add.png">

#### Sponsor links

Sponsor CPTs don't have working permalinks and are not viewable as public posts by themselves. They do, however, have a "Sponsor URL" meta field, so if this exists sponsor CPTs will link to that instead of the permalink in Post Carousel and Homepage Posts blocks.

**Note:** It's possible to create a sponsor without defining an external URL? In this situation, the blocks will fall back to the permalink, which will be broken. :\ If this turns out to be a problem I would say we should add a block attribute to not link any slides in the slideshow.

1. Create and publish several sponsor posts using Newspack Sponsors. Make sure to add Sponsor URLs to them.
2. Create a Post Carousel and Homepage Posts block.
3. In each, under Post Types, enable the Sponsors post type. Publish/update the post.
4. On the front-end, confirm that the sponsor slides link to the Sponsor URLs, not the permalinks.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
