### PR TITLE
Fix: add missing Carousel block attribute

### DIFF
--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -389,7 +389,7 @@ function newspack_blocks_register_carousel() {
 						'type'    => 'boolean',
 						'default' => true,
 					),
-					'imageFit'    => array(
+					'imageFit'     => array(
 						'type'    => 'string',
 						'default' => 'cover',
 					),

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -389,6 +389,10 @@ function newspack_blocks_register_carousel() {
 						'type'    => 'boolean',
 						'default' => true,
 					),
+					'imageFit'    => array(
+						'type'    => 'string',
+						'default' => 'cover',
+					),
 				),
 				'render_callback' => 'newspack_blocks_render_block_carousel',
 				'supports'        => [],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#746 added a new attribute to the Carousel block, but it was not registered on the backend - this fixes that.

Ideally the block attributes should be defined in a single JSON file, so that's the next step.

### How to test the changes in this Pull Request:

1. On `master`, insert a Carousel block
2. Observe a PHP error logged about missing `'imageFit'` index
3. Switch to this branch, observe that all is well now

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->