### PR TITLE
feat: support Newspack Listings hide entry meta options

### DIFF
--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -370,6 +370,12 @@ class Newspack_Blocks_API {
 				'post_link'                       => Newspack_Blocks::get_post_link( $post->ID ),
 			];
 
+			// Support Newspack Listings hide author/publish date options.
+			if ( class_exists( 'Newspack_Listings\Newspack_Listings_Core' ) ) {
+				$add_ons['newspack_listings_hide_author']       = apply_filters( 'newspack_listings_hide_author', false );
+				$add_ons['newspack_listings_hide_publish_date'] = apply_filters( 'newspack_listings_hide_publish_date', false );
+			}
+
 			$posts[] = array_merge( $data, $add_ons );
 		}
 

--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -372,8 +372,8 @@ class Newspack_Blocks_API {
 
 			// Support Newspack Listings hide author/publish date options.
 			if ( class_exists( 'Newspack_Listings\Newspack_Listings_Core' ) ) {
-				$add_ons['newspack_listings_hide_author']       = apply_filters( 'newspack_listings_hide_author', false );
-				$add_ons['newspack_listings_hide_publish_date'] = apply_filters( 'newspack_listings_hide_publish_date', false );
+				$add_ons['newspack_listings_hide_author']       = apply_filters( 'newspack_listings_hide_author', false ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+				$add_ons['newspack_listings_hide_publish_date'] = apply_filters( 'newspack_listings_hide_publish_date', false ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 			}
 
 			$posts[] = array_merge( $data, $add_ons );

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -59,6 +59,12 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 			$has_featured_image = has_post_thumbnail();
 			$post_type          = get_post_type();
 			$post_link          = Newspack_Blocks::get_post_link( $post_id );
+
+			// Support Newspack Listings hide author/publish date options.
+			$hide_author       = apply_filters( 'newspack_listings_hide_author', false );
+			$hide_publish_date = apply_filters( 'newspack_listings_hide_publish_date', false );
+			$show_author       = $attributes['showAuthor'] && ! $hide_author;
+			$show_date         = $attributes['showDate'] && ! $hide_publish_date;
 			?>
 
 			<article data-post-id="<?php echo esc_attr( $post_id ); ?>" class="<?php echo esc_attr( implode( ' ', $article_classes ) . ' ' . $post_type ); ?>">
@@ -85,7 +91,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 					<?php endif; ?>
 				</figure>
 
-				<?php if ( ! empty( $sponsors ) || $attributes['showCategory'] || $attributes['showTitle'] || $attributes['showAuthor'] || $attributes['showDate'] ) : ?>
+				<?php if ( ! empty( $sponsors ) || $attributes['showCategory'] || $attributes['showTitle'] || $show_author || $show_date ) : ?>
 					<div class="entry-wrapper">
 						<?php if ( ! empty( $sponsors ) ) : ?>
 						<span class="cat-links sponsor-label">
@@ -171,7 +177,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 								</span>
 								<?php
 							else :
-								if ( $attributes['showAuthor'] ) :
+								if ( $show_author ) :
 									if ( $attributes['showAvatar'] ) :
 										echo wp_kses(
 											newspack_blocks_format_avatars( $authors ),
@@ -199,7 +205,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 									<?php
 								endif;
 							endif;
-							if ( $attributes['showDate'] ) :
+							if ( $show_date ) :
 								printf(
 									'<time class="entry-date published" datetime="%1$s">%2$s</time>',
 									esc_attr( get_the_date( DATE_W3C ) ),

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -61,8 +61,8 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 			$post_link          = Newspack_Blocks::get_post_link( $post_id );
 
 			// Support Newspack Listings hide author/publish date options.
-			$hide_author       = apply_filters( 'newspack_listings_hide_author', false );
-			$hide_publish_date = apply_filters( 'newspack_listings_hide_publish_date', false );
+			$hide_author       = apply_filters( 'newspack_listings_hide_author', false ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+			$hide_publish_date = apply_filters( 'newspack_listings_hide_publish_date', false ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 			$show_author       = $attributes['showAuthor'] && ! $hide_author;
 			$show_date         = $attributes['showDate'] && ! $hide_publish_date;
 			?>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -210,13 +210,15 @@ class Edit extends Component {
 						{ post.newspack_post_sponsors && formatSponsorLogos( post.newspack_post_sponsors ) }
 						{ post.newspack_post_sponsors && formatSponsorByline( post.newspack_post_sponsors ) }
 						{ showAuthor &&
+							! post.newspack_listings_hide_author &&
 							showAvatar &&
 							! post.newspack_post_sponsors &&
 							formatAvatars( post.newspack_author_info ) }
 						{ showAuthor &&
+							! post.newspack_listings_hide_author &&
 							! post.newspack_post_sponsors &&
 							formatByline( post.newspack_author_info ) }
-						{ showDate && (
+						{ showDate && ! post.newspack_listings_hide_publish_date && (
 							<time className="entry-date published" key="pub-date">
 								{ dateI18n( dateFormat, post.date_gmt ) }
 							</time>

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -55,6 +55,12 @@ call_user_func(
 				$category = $categories_list[0];
 			}
 		}
+
+		// Support Newspack Listings hide author/publish date options.
+		$hide_author       = apply_filters( 'newspack_listings_hide_author', false );
+		$hide_publish_date = apply_filters( 'newspack_listings_hide_publish_date', false );
+		$show_author       = $attributes['showAuthor'] && ! $hide_author;
+		$show_date         = $attributes['showDate'] && ! $hide_publish_date;
 		?>
 
 	<article data-post-id="<?php the_id(); ?>"
@@ -133,7 +139,7 @@ call_user_func(
 				</a>
 				<?php
 			endif;
-			if ( $attributes['showAuthor'] || $attributes['showDate'] || ! empty( $sponsors ) ) :
+			if ( $show_author || $show_date || ! empty( $sponsors ) ) :
 				?>
 				<div class="entry-meta">
 					<?php if ( ! empty( $sponsors ) ) : ?>
@@ -174,7 +180,7 @@ call_user_func(
 					</span>
 						<?php
 					else :
-						if ( $attributes['showAuthor'] ) :
+						if ( $show_author ) :
 							if ( $attributes['showAvatar'] ) :
 								echo wp_kses(
 									newspack_blocks_format_avatars( $authors ),
@@ -202,7 +208,7 @@ call_user_func(
 							<?php
 						endif;
 					endif;
-					if ( $attributes['showDate'] ) :
+					if ( $show_date ) :
 						$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
 						if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) :
 							$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -57,8 +57,8 @@ call_user_func(
 		}
 
 		// Support Newspack Listings hide author/publish date options.
-		$hide_author       = apply_filters( 'newspack_listings_hide_author', false );
-		$hide_publish_date = apply_filters( 'newspack_listings_hide_publish_date', false );
+		$hide_author       = apply_filters( 'newspack_listings_hide_author', false ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		$hide_publish_date = apply_filters( 'newspack_listings_hide_publish_date', false ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$show_author       = $attributes['showAuthor'] && ! $hide_author;
 		$show_date         = $attributes['showDate'] && ! $hide_publish_date;
 		?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Hides the author names and published/modified dates for listings if the corresponding options in Newspack Listings are enabled.

### How to test the changes in this Pull Request:

See testing instructions in https://github.com/Automattic/newspack-listings/pull/57.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
