### PR TITLE
Added margin-bottom definition for grid layout

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -36,7 +36,7 @@
 		article {
 			flex-basis: 100%;
 
-			@include media( tablet ) {
+			@include media( mobile ) {
 				margin-bottom: 1em;
 			}
 		}
@@ -629,6 +629,13 @@ amp-script .wpnbha {
 
 			&:not( :first-of-type ) {
 				border-bottom: 0;
+			}
+		}
+	}
+	&.is-grid {
+		article {
+			@include media( mobile ) {
+				margin-bottom: 1em;
 			}
 		}
 	}


### PR DESCRIPTION
When the homepage articles block was configured to be in grid form, use
borders style (or regular style and the view width was smaller than tablet),
had featured image content and content text the last item
was taller than the rest (it had no bottom margin).

This change copies the behavior of NON-borders style by having a higher
specificity margin-bottom for the article and updates both to break on
MOBILE instead of TABLET.

Before:
![image](https://user-images.githubusercontent.com/146530/120501075-504e9900-c38f-11eb-8c4b-a76c72bd6c9c.png)


After:
![image](https://user-images.githubusercontent.com/146530/120500923-32813400-c38f-11eb-9c4a-d9642f5d0133.png)

Closes: [Themes Bug 1797](https://github.com/Automattic/themes/issues/1797


