### PR TITLE
Blog Posts Block: Force image to be the right size when used behind the block

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -249,10 +249,11 @@
 				top: 0;
 
 				img {
-					height: 100%;
-					object-fit: cover;
-					max-width: 1000%;
-					width: 100%;
+					height: 100% !important;
+					object-fit: cover !important;
+					margin: 0 !important;
+					max-width: 1000% !important;
+					width: 100% !important;
 				}
 
 				figcaption {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When using the "show media behind" option in the block, these rules need to be stronger than others that might be applied to images. Using `!important` in CSS is generally considered bad practice, but I believe in this case it is the right tool for the job, since we always want this CSS to apply regardless of the context the block is loaded in. 

This will solve issues like https://github.com/Automattic/themes/issues/3341.

### How to test the changes in this Pull Request:

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
