### PR TITLE
fix: include author profile block in release packages

### DIFF
--- a/block-list.json
+++ b/block-list.json
@@ -1,3 +1,3 @@
 {
-  "production": [ "carousel", "donate", "homepage-articles", "video-playlist" ]
+  "production": [ "author-profile", "carousel", "donate", "homepage-articles", "video-playlist" ]
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Includes the new `author-profile` block in the manifest of blocks to be included in webpack production builds. This is necessary for CI-built release assets.

### How to test the changes in this Pull Request:

Not really testable without merging this into an alpha release. Testing with https://github.com/Automattic/newspack-blocks/pull/771 and https://github.com/Automattic/newspack-blocks/releases/tag/v1.28.0-alpha.2.

1. Download and install [v1.28.0-alpha.2](https://github.com/Automattic/newspack-blocks/releases/tag/v1.28.0-alpha.2) to a test site.
2. Verify that the Author Profile block can be inserted and used in a post.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
