### PR TITLE
Add centered style to author profile block

### DIFF
--- a/src/blocks/author-profile/edit.js
+++ b/src/blocks/author-profile/edit.js
@@ -254,7 +254,7 @@ export default ( { attributes, setAttributes } ) => {
 			</InspectorControls>
 			{ author && (
 				<BlockControls>
-					{ showAvatar && (
+					{ showAvatar && 'is-style-center' !== attributes.className && (
 						<Toolbar
 							controls={ [
 								{
@@ -286,18 +286,24 @@ export default ( { attributes, setAttributes } ) => {
 					/>
 				</BlockControls>
 			) }
-			<div className={ classnames( 'newspack-author-profile', 'avatar-' + avatarAlignment ) }>
+			<div
+				className={ classnames(
+					'wp-block-newspack-blocks-author-profile',
+					'avatar-' + avatarAlignment,
+					attributes.className
+				) }
+			>
 				{ ! isLoading && ! error && author && (
-					<div className="newspack-author-profile__author-card">
+					<>
 						{ showAvatar && author.avatar && (
-							<div className="newspack-author-profile__avatar">
+							<div className="wp-block-newspack-blocks-author-profile__avatar">
 								<figure
 									style={ { borderRadius: avatarBorderRadius, width: `${ avatarSize }px` } }
 									dangerouslySetInnerHTML={ { __html: author.avatar } }
 								/>
 							</div>
 						) }
-						<div className="newspack-author-profile__bio">
+						<div className="wp-block-newspack-blocks-author-profile__bio">
 							<h3>
 								<MaybeLink>{ author.name }</MaybeLink>
 							</h3>
@@ -306,13 +312,13 @@ export default ( { attributes, setAttributes } ) => {
 									{ author.bio }{' '}
 									{ showArchiveLink && (
 										<a href="#" className="no-op">
-											More by { author.name }
+											{ __( 'More by', 'newspack-blocks' ) + ' ' + author.name }
 										</a>
 									) }
 								</p>
 							) }
 							{ ( showEmail || showSocial ) && (
-								<ul className="newspack-author-profile__social-links">
+								<ul className="wp-block-newspack-blocks-author-profile__social-links">
 									{ Object.keys( socialLinks ).map( service => (
 										<li key={ service }>
 											<a href="#" className="no-op">
@@ -330,7 +336,7 @@ export default ( { attributes, setAttributes } ) => {
 								</ul>
 							) }
 						</div>
-					</div>
+					</>
 				) }
 				{ ! author && (
 					<Placeholder

--- a/src/blocks/author-profile/editor.scss
+++ b/src/blocks/author-profile/editor.scss
@@ -1,28 +1,40 @@
 @import './shared';
 
 .editor-styles-wrapper {
-	.newspack-author-profile {
+	.wp-block-newspack-blocks-author-profile {
 		.components-notice {
 			margin: 0 0 2rem 0;
 			width: 100%;
 		}
 
-		&__bio h3 {
-			.components-button,
-			.components-external-link {
-				font-size: 13px;
-				font-weight: normal;
+		a.no-op {
+			pointer-events: none;
+		}
+
+		&__bio {
+			@include media( mobile ) {
+				flex: 4;
+
+				h3 {
+					margin-top: 0;
+				}
 			}
 		}
 
-		a.no-op {
-			pointer-events: none;
+		&__social-links {
+			list-style: none;
+			margin: -8px;
+			padding: 0;
+
+			li {
+				margin: 8px;
+			}
 		}
 	}
 
 	.wp-block-group {
 		&.has-text-color {
-			.newspack-author-profile a {
+			.wp-block-newspack-blocks-author-profile a {
 				color: inherit;
 			}
 		}

--- a/src/blocks/author-profile/index.js
+++ b/src/blocks/author-profile/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { Icon, people } from '@wordpress/icons';
 
 /**
@@ -30,6 +30,10 @@ export const settings = {
 	},
 	keywords: [ __( 'author', 'newspack-blocks' ), __( 'profile', 'newspack-blocks' ) ],
 	description: __( 'Display an author profile card.', 'newspack-blocks' ),
+	styles: [
+		{ name: 'default', label: _x( 'Default', 'block style', 'newspack-blocks' ), isDefault: true },
+		{ name: 'center', label: _x( 'Centered', 'block style', 'newspack-blocks' ) },
+	],
 	attributes,
 	category,
 	supports: {

--- a/src/blocks/author-profile/shared.scss
+++ b/src/blocks/author-profile/shared.scss
@@ -1,44 +1,42 @@
 @import '../../shared/sass/variables';
 @import '../../shared/sass/mixins';
 
-.newspack-author-profile {
-	&__author-card {
+.wp-block-newspack-blocks-author-profile {
+	@include media( mobile ) {
+		display: flex;
+	}
+
+	&__avatar {
 		@include media( mobile ) {
-			display: flex;
+			flex: 0 1 auto;
+			margin-right: 1.5em;
 		}
 
-		.newspack-author-profile__avatar {
-			@include media( mobile ) {
-				flex: 0 1 auto;
-				margin-right: 1.5em;
-			}
-
-			figure {
-				margin: 0;
-				overflow: hidden;
-			}
-
-			.avatar {
-				border-radius: 0;
-				display: block;
-				height: auto;
-				max-width: none;
-				width: 100%;
-			}
+		figure {
+			margin: 0;
+			overflow: hidden;
 		}
 
-		.newspack-author-profile__bio {
-			@include media( mobile ) {
-				flex: 4;
+		.avatar {
+			border-radius: 0;
+			display: block;
+			height: auto;
+			max-width: none;
+			width: 100%;
+		}
+	}
 
-				h3 {
-					margin-top: 0;
-				}
+	&__bio {
+		@include media( mobile ) {
+			flex: 4;
+
+			h3 {
+				margin-top: 0;
 			}
 		}
 	}
 
-	ul.newspack-author-profile__social-links {
+	&__social-links {
 		display: flex;
 		flex-wrap: wrap;
 		list-style: none;
@@ -63,14 +61,35 @@
 		display: none;
 	}
 
-	// Avatar Right Aligned
+	// Avatar: Right
 	&.avatar-right {
 		@include media( mobile ) {
-			.newspack-author-profile__avatar {
+			.wp-block-newspack-blocks-author-profile__avatar {
 				margin-left: 1.5em;
 				margin-right: 0;
 				order: 2;
 			}
+		}
+	}
+
+	// Style: Center
+	&.is-style-center {
+		display: block;
+
+		.wp-block-newspack-blocks-author-profile__avatar {
+			margin: 0 0 1.5em;
+
+			figure {
+				margin: 0 auto;
+			}
+		}
+
+		.wp-block-newspack-blocks-author-profile__bio {
+			text-align: center;
+		}
+
+		.wp-block-newspack-blocks-author-profile__social-links {
+			justify-content: center;
 		}
 	}
 }

--- a/src/blocks/author-profile/view.php
+++ b/src/blocks/author-profile/view.php
@@ -107,18 +107,29 @@ function newspack_blocks_render_block_author_profile( $attributes ) {
 		$social_links['email'] = $author['email'];
 	}
 
+	// Classes
+	$classes = Newspack_Blocks::block_classes( 'author-profile' );
+
+	if ( $attributes['avatarAlignment'] ) {
+		$classes .= ' avatar-' . $attributes['avatarAlignment'];
+	}
+
+	if ( isset( $attributes['className'] ) ) {
+		$classes .= ' ' . $attributes['className'];
+	}
+
 	ob_start();
 
 	?>
-	<div class="newspack-author-profile newspack-author-profile__author-card avatar-<?php echo esc_attr( $attributes['avatarAlignment'] ); ?>">
+	<div class="<?php echo esc_attr( $classes ); ?>">
 		<?php if ( $attributes['showAvatar'] && $author['avatar'] ) : ?>
-			<div class="newspack-author-profile__avatar">
+			<div class="wp-block-newspack-blocks-author-profile__avatar">
 				<figure style="border-radius: <?php echo esc_attr( $attributes['avatarBorderRadius'] ); ?>; width: <?php echo esc_attr( $attributes['avatarSize'] ); ?>px;">
 					<?php echo wp_kses_post( $author['avatar'] ); ?>
 				</figure>
 			</div>
 		<?php endif; ?>
-		<div class="newspack-author-profile__bio">
+		<div class="wp-block-newspack-blocks-author-profile__bio">
 			<h3>
 				<?php if ( $show_archive_link ) : ?>
 				<a href="<?php echo esc_url( $author['url'] ); ?>">
@@ -147,7 +158,7 @@ function newspack_blocks_render_block_author_profile( $attributes ) {
 			<?php endif; ?>
 
 			<?php if ( $attributes['showEmail'] || $attributes['showSocial'] ) : ?>
-				<ul class="newspack-author-profile__social-links">
+				<ul class="wp-block-newspack-blocks-author-profile__social-links">
 					<?php foreach ( $social_links as $service => $social_data ) : ?>
 						<li>
 							<a href="<?php echo esc_url( $social_data['url'] ); ?>">

--- a/src/blocks/author-profile/view.php
+++ b/src/blocks/author-profile/view.php
@@ -107,7 +107,7 @@ function newspack_blocks_render_block_author_profile( $attributes ) {
 		$social_links['email'] = $author['email'];
 	}
 
-	// Classes
+	// Add classes to the block.
 	$classes = Newspack_Blocks::block_classes( 'author-profile' );
 
 	if ( $attributes['avatarAlignment'] ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a new style to the block: Center.
It's slightly different from the avatar alignment option because the entire content is being centered and not just the avatar like with the alignment option.
When this new style is active, the avatar alignment option is being removed.
Also, I renamed and reorganised some of the various classnames.

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Test both styles (Default, Center)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
