### PR TITLE
fix(class-newspack-blocks.php): assets meta file path for scripts

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -33,7 +33,7 @@ class Newspack_Blocks {
 		}
 
 		$path_info   = pathinfo( $local_path );
-		$asset_path  = $path_info['dirname'] . '../' . $path_info['filename'] . '.asset.php';
+		$asset_path  = $path_info['dirname'] . '/' . $path_info['filename'] . '.asset.php';
 		$script_data = file_exists( $asset_path )
 			? require $asset_path
 			: array(


### PR DESCRIPTION
Due to incorrect assets path, view and editor scripts were loading fallback dependencies. This
resulted in unnecessary scripts being added to the front end as well as wrong dependencies being
added for editor scripts.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #779.

### How to test the changes in this Pull Request:

Test 1:
1. Create a new page/post with Homepage Articles block.
2. Preview or view the page using devTools inspect mode.
3. Observe that there are no extraneous scripts added at bottom of the page.

Test 2: ( Using debug methods )
1. If you are using xdebug add a breakpoint at following line
https://github.com/Automattic/newspack-blocks/blob/d8dd2a98d89bbc3addc43b41a03ad263c3889fd5/includes/class-newspack-blocks.php#L44
2. Check that `$script_data['dependencies']` has the values defined in corresponding `dist/{script-path}.assets.php`
