### PR TITLE
Homepage Posts: add paragraph markup to excerpt, content placeholders

### DIFF
--- a/src/blocks/homepage-articles/utils.js
+++ b/src/blocks/homepage-articles/utils.js
@@ -121,11 +121,11 @@ const PREVIEW_IMAGE_BASE = window.newspack_blocks_data.assets_path;
 const generatePreviewPost = () => ( {
 	author: 1,
 	content: {
-		rendered: __( 'The post content.', 'newspack' ),
+		rendered: '<p>' + __( 'The post content.', 'newspack' ) + '</p>',
 	},
 	date_gmt: new Date().toISOString(),
 	excerpt: {
-		rendered: __( 'The post excerpt.', 'newspack' ),
+		rendered: '<p>' + __( 'The post excerpt.', 'newspack' ) + '</p>',
 	},
 	featured_media: uniqueId(),
 	id: uniqueId(),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In WordPress 5.8, the Homepage Posts block placeholders are used pretty prominently on the Widget screen, and actually apply the different styles used by the block settings.

Currently, the excerpt and content placeholders don't pick up the font scale setting, because they're not wrapped in a paragraph tag like the actual excerpt and content markup is. 

This PR adds a paragraph tag to each.  

Closes #783 

### How to test the changes in this Pull Request:

1. Start with a test site running WordPress 5.8; navigate to WP Admin > Appearance > Widgets and add the Homepage Posts block.
2. Try increasing and decreasing the font scale on the right; note the excerpt font size doesn't change in the preview, but everything else (headline, post meta) does.
3. Apply the PR and run `npm run build`
4. Confirm that the excerpt now picks up the font scale with the other elements. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
