### PR TITLE
Homepage Posts: add max width to avatar placeholder

### DIFF
--- a/src/blocks/homepage-articles/utils.js
+++ b/src/blocks/homepage-articles/utils.js
@@ -139,7 +139,7 @@ const generatePreviewPost = () => ( {
 	newspack_author_info: [
 		{
 			display_name: __( 'Author Name', 'newspack' ),
-			avatar: `<div style="background: #36f;width: 40px;height: 40px;display: block;overflow: hidden;border-radius: 50%;"></div>`,
+			avatar: `<div style="background: #36f;width: 40px;height: 40px;display: block;overflow: hidden;border-radius: 50%; max-width: 100%; max-height: 100%;"></div>`,
 			id: 1,
 			author_link: '/',
 		},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In WordPress 5.8, the Homepage Posts block placeholders are used pretty prominently on the Widget screen, and actually apply the different styles used by the block settings.

When the font scale is adjusted, the avatars in the block scale down for the smaller font sizes, so they fit in with the byline size better. But the placeholder avatar has a fixed 40px x 40px size, so it stays the same size. 

This PR adds a max width and height, so the avatar preview behaves more like the front-end. 

Closes #782

### How to test the changes in this Pull Request:

1. Start with a test site running the WordPress 5.8 RC (you can use the [beta testing plugin for this](https://wordpress.org/plugins/wordpress-beta-tester/)); navigate to WP Admin > Appearance > Widgets and add the Homepage Posts block.
2. Try decreasing the font scale on the right; note the avatar stays the same size, and the byline can start running over top of it:

![image](https://user-images.githubusercontent.com/177561/124182358-9751ac00-da6b-11eb-8431-a4c3e565f9b1.png)

3. Apply the PR and run `npm run build`.
4. Try decreasing the font size again; confirm that the avatar now scales down with the rest of the fonts:
![image](https://user-images.githubusercontent.com/177561/124182049-34601500-da6b-11eb-85f0-5177166817a7.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
