### PR TITLE
Post Carousel: correct path to placeholder image

### DIFF
--- a/src/blocks/homepage-articles/utils.js
+++ b/src/blocks/homepage-articles/utils.js
@@ -147,11 +147,11 @@ const generatePreviewPost = () => ( {
 	newspack_category_info: __( 'Category', 'newspack' ),
 	newspack_featured_image_caption: __( 'Featured image caption', 'newspack' ),
 	newspack_featured_image_src: {
-		large: `${ PREVIEW_IMAGE_BASE }/newspack-1024x683.jpg`,
+		large: `${ PREVIEW_IMAGE_BASE }/newspack-1024x536.jpg`,
 		landscape: `${ PREVIEW_IMAGE_BASE }/newspack-800x600.jpg`,
 		portrait: `${ PREVIEW_IMAGE_BASE }/newspack-600x800.jpg`,
 		square: `${ PREVIEW_IMAGE_BASE }/newspack-800x800.jpg`,
-		uncropped: `${ PREVIEW_IMAGE_BASE }/newspack-1024x683.jpg`,
+		uncropped: `${ PREVIEW_IMAGE_BASE }/newspack-1024x536.jpg`,
 	},
 	newspack_has_custom_excerpt: false,
 	newspack_post_format: 'standard',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In the utils.js file, there are placeholder images listed; the 'large' and 'uncropped' images were both referencing a size (1024x683) that didn't actually exist in the assets directory. 

This image was being used by the Post Carousel block in the preview under Appearance > Widgets and in the Customizer. 

This seems to close #788 for me, but I'm not 100% sure if that's just because that issue was a bit intermittent. Would appreciate another set of eyes on that, to make sure it has actually stopped! 

### How to test the changes in this Pull Request:

1. Start on a test site running the latest WordPress 5.8 release candidate.
2. Navigate to WP Admin > Appearance > Widgets and add a Post Carousel widget.
3. Note that the space where the featured image would be is empty; if you open the console, you should also see a bunch of 404s for the 1024x683 image size. 
4. Try to recreate the issue in #788 (post carousel collapsing and bouncing back as you click or hover around).
5. Apply the PR and run `npm run build`.
6. Confirm that the featured image placeholders are now populated, and the 404s are gone. 
7. Confirm whether the issue in #788 is resolved. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
