### PR TITLE
Post Carousel: Tweak image width styles to not affect avatars

### DIFF
--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -213,7 +213,7 @@
 		position: relative;
 
 		.entry-wrapper,
-		img {
+		.post-thumbnail img {
 			left: 8px;
 			width: calc( 100% - 16px );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes some image sizing styles in the Post Carousel block more specific, so they're only picked up by the post thumbnail, and not the avatar.

I noticed the styles are fine when the block is out of the box, but when I try to scale down the avatar for the new widget spaces in WordPress 5.8, the avatar placement gets a bit weird (it's not perfectly square; it can overlap the byline). 

### How to test the changes in this Pull Request:

1. Add the Post Carousel block to a post or page; make sure you have posts with both one author, and more than one.
2. View the carousel on the front end with AMP enabled; note its appearance.
3. Apply the PR and run `npm run build`.
3. Confirm that the carousel's appearance hasn't changed (outside of the avatar moving minutely to the left -- part of the styles I'm trying to stop being applied are the `left: 8px` positioning). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
