### PR TITLE
Override the default :after content from swiper

### DIFF
--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -175,12 +175,12 @@
 	.swiper-button-prev {
 		margin-top: -24px;
 	}
-	.swiper-button-prev:after,
-	.swiper-container-rtl .swiper-button-next:after {
+	.swiper-button-prev::after,
+	.swiper-container-rtl .swiper-button-next::after {
 		content: none;
 	}
-	.swiper-button-next:after,
-	.swiper-container-rtl .swiper-button-prev:after {
+	.swiper-button-next::after,
+	.swiper-container-rtl .swiper-button-prev::after {
 		content: none;
 	}
 	.amp-carousel-button-next,

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -175,6 +175,14 @@
 	.swiper-button-prev {
 		margin-top: -24px;
 	}
+	.swiper-button-prev:after,
+	.swiper-container-rtl .swiper-button-next:after {
+		content: none;
+	}
+	.swiper-button-next:after,
+	.swiper-container-rtl .swiper-button-prev:after {
+		content: none;
+	}
 	.amp-carousel-button-next,
 	.swiper-button-next {
 		background-image: url( "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M5.88%204.12L13.76%2012l-7.88%207.88L8%2022l10-10L8%202z'%20fill='white'/%3E%3Cpath%20fill='none'%20d='M0 0h24v24H0z'/%3E%3C/svg%3E" );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #793

### How to test the changes in this Pull Request:

1. Run Newspack blocks with the latest Jetpack
2. Comment out the temporary Newspack fix from top of `projects/plugins/jetpack/modules/carousel/jetpack-carousel.css`
3. Turn on the Jetpack gallery carousel option
4. Add a Newpack Post Carousel block and a gallery block to a post, on editor and frontend notice additional next and previous buttons

Before:
<img width="532" alt="Screen Shot 2021-07-08 at 9 39 40 AM" src="https://user-images.githubusercontent.com/3629020/124833236-febead00-dfd1-11eb-8038-84a58010ed9e.png">

After:
<img width="529" alt="Screen Shot 2021-07-08 at 9 39 57 AM" src="https://user-images.githubusercontent.com/3629020/124833251-03836100-dfd2-11eb-94aa-6151319aa2e8.png">
