### PR TITLE
fix: height of post carousel blocks in editor preview

### DIFF
--- a/src/blocks/carousel/editor.scss
+++ b/src/blocks/carousel/editor.scss
@@ -2,6 +2,7 @@
 
 .wp-block-newspack-blocks-carousel {
 	.swiper-wrapper {
+		height: auto;
 		pointer-events: none;
 	}
 	.entry-title {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a visual bug I've noticed in WP v5.8 affecting Post Carousel blocks in the editor.

### How to test the changes in this Pull Request:

1. On a site running WP v5.8, insert a Post Carousel block into a post's content. Observe that it looks strangely tall:

<img width="912" alt="Screen Shot 2021-07-08 at 11 10 10 AM" src="https://user-images.githubusercontent.com/2230142/124963474-18b1bd00-dfdd-11eb-9abc-4480f28d0668.png">

2. Check out this branch, refresh, confirm that it now appears at the expected height:

<img width="976" alt="Screen Shot 2021-07-08 at 11 11 02 AM" src="https://user-images.githubusercontent.com/2230142/124963544-32530480-dfdd-11eb-8269-f615c48c9107.png">

3. View on the front-end and confirm that the carousel appears as expected there, too.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
