### PR TITLE
Carousel: Ensure that the swiper arrows don't overlap in RTL

### DIFF
--- a/src/blocks/carousel/editor.scss
+++ b/src/blocks/carousel/editor.scss
@@ -30,6 +30,7 @@
 			left: 1.5em;
 			margin-top: -24px; // buttons height / 2
 			transform: translateY( -50% );
+			right: auto;
 		}
 
 		&.amp-carousel-button-next {

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -166,6 +166,7 @@
 	.swiper-button-prev {
 		left: 1.5em;
 		display: none;
+		right: auto;
 
 		@include media( mobile ) {
 			display: block;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

Adds `right: auto` to `.swiper-button-prev` to ensure the previous arrow button does not overlap the next arrow.

In RTL locales such as Arabic or Hebrew, the previous arrow styles are being dictated by SwiperJS CSS (`right: 10px`). 

**What I expected:**

<img width="662" alt="Screen Shot 2021-07-14 at 7 57 11 pm" src="https://user-images.githubusercontent.com/6458278/125603686-6868c0c3-61aa-4910-9bb1-1482406bb5b0.png">

**What I see:**

<img width="667" alt="Screen Shot 2021-07-14 at 7 46 24 pm" src="https://user-images.githubusercontent.com/6458278/125603672-a297ec9d-a628-4edc-a238-5df1995fe7bd.png">


### How to test the changes in this Pull Request:

1. Insert a Post Carousel block
2. Switch your site and user language to Arabic/Hebrew
3. Ensure that the carousel arrows do not overlap in the editor or the frontend
4. Switch back to a LTR language and make sure these changes don't affect the arrows.

### Other information:

* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

