### PR TITLE
fix(wp-5.8): do not initialize swiper instances if component is hidden

### DIFF
--- a/src/blocks/carousel/create-swiper.js
+++ b/src/blocks/carousel/create-swiper.js
@@ -64,6 +64,13 @@ function deactivateSlide( slide ) {
  * @return {Object} Swiper instance
  */
 export default function createSwiper( els, config = {} ) {
+	const isVisible = 0 < els.container.offsetWidth && 0 < els.container.offsetHeight;
+
+	// Don't initialize if the swiper is hidden on initial mount.
+	if ( ! isVisible ) {
+		return false;
+	}
+
 	const swiper = new Swiper( els.container, {
 		/**
 		 * Remove the messages, as we're announcing the slide content and number.

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -56,6 +56,10 @@ class Edit extends Component {
 		this.btnPrevRef = createRef();
 		this.carouselRef = createRef();
 		this.paginationRef = createRef();
+
+		this.state = {
+			swiperInitialized: false,
+		};
 	}
 
 	componentDidMount() {
@@ -64,6 +68,19 @@ class Edit extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
+		const isVisible =
+			0 < this.carouselRef.current.offsetWidth && 0 < this.carouselRef.current.offsetHeight;
+
+		// Bail early if the component is hidden.
+		if ( ! isVisible ) {
+			return false;
+		}
+
+		// If the swiper hasn't been initialized yet, initialize it.
+		if ( ! this.state.swiperInitialized ) {
+			return this.initializeSwiper( 0 );
+		}
+
 		if ( shouldReflow( prevProps, this.props ) ) {
 			this.props.triggerReflow();
 		}
@@ -93,11 +110,12 @@ class Edit extends Component {
 
 	initializeSwiper( initialSlide ) {
 		const { latestPosts } = this.props;
+		const { swiperInitialized } = this.state;
 
-		if ( latestPosts && latestPosts.length ) {
+		if ( ! swiperInitialized && latestPosts && latestPosts.length ) {
 			const { aspectRatio, autoplay, delay, slidesPerView } = this.props.attributes;
 
-			this.swiperInstance = createSwiper(
+			const swiperInstance = createSwiper(
 				{
 					block: this.carouselRef.current, // Editor uses the same wrapper for block and swiper container.
 					container: this.carouselRef.current,
@@ -115,6 +133,12 @@ class Edit extends Component {
 					slidesPerView: slidesPerView <= latestPosts.length ? slidesPerView : latestPosts.length,
 				}
 			);
+
+			// Swiper won't be initialized unless the component is visible in the viewport.
+			if ( swiperInstance ) {
+				this.swiperInstance = swiperInstance;
+				this.setState( { swiperInitialized: true } );
+			}
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

On the WP 5.8 Widgets page, widget areas after the first one are collapsed on initial page load, meaning the blocks within them are hidden. This causes issues with initializing SwiperJS instances inside Post Carousel blocks if those blocks are hidden when the component is first mounted.

This PR updates the editor component for the Post Carousel and waits until the component is visible before initializing its Swiper instance.

### How to test the changes in this Pull Request:

1. On `master`, go to **Appearance > Widgets**. In a widget area whose panel is collapsed on page load, add a Post Carousel block and save.
2. Refresh the page. Observe that the widget area panel is collapsed on page load. Expand it and observe that the Post Carousel block renders with an inert carousel; if you try to interact with it, you should see a JS console error like this:

```
Uncaught TypeError: currentSlide is undefined
    slideChange webpack:///./src/blocks/carousel/create-swiper.js?:144
    [...]
editor.js:144:30
```

3. Check out this branch, rebuild assets, refresh the page. Confirm that after expanding the widget area panel, the Post Carousel block renders a functioning carousel.
4. Confirm that the carousel renders as expected on the front-end, and that the block still works as expected when placed in a regular post or page or in a widget area in the Widgets section of the Customizer.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
