### PR TITLE
feat/nrh donations handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react": "^16.12.0",
         "redux": "^4.0.5",
         "redux-saga": "^1.1.3",
+        "regenerator-runtime": "^0.13.7",
         "swiper": "4.5.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react": "^16.12.0",
     "redux": "^4.0.5",
     "redux-saga": "^1.1.3",
+    "regenerator-runtime": "^0.13.7",
     "swiper": "4.5.1"
   },
   "scripts": {

--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -118,7 +118,6 @@ class Edit extends Component {
 	};
 
 	getSettings() {
-		const { attributes, setAttributes } = this.props;
 		const path = '/newspack/v1/wizard/newspack-donations-wizard/donation';
 
 		this.setState( { isLoading: true }, () => {
@@ -130,7 +129,6 @@ class Edit extends Component {
 						currencySymbol,
 						tiered,
 						created,
-						force_manual: forceManual,
 					} = settings;
 					this.setState( {
 						suggestedAmounts,
@@ -138,7 +136,6 @@ class Edit extends Component {
 						currencySymbol,
 						tiered,
 						created,
-						forceManual,
 						isLoading: false,
 						customDonationAmounts: {
 							once: tiered ? 12 * suggestedAmounts[ 1 ] : 12 * suggestedAmountUntiered,
@@ -147,15 +144,6 @@ class Edit extends Component {
 						},
 						activeTier: 1,
 					} );
-					if ( forceManual ) {
-						setAttributes( { manual: true } );
-						if (
-							attributes.suggestedAmounts.every( amount => amount === 0 ) &&
-							0 === attributes.suggestedAmountUntiered
-						) {
-							setAttributes( { suggestedAmounts, suggestedAmountUntiered } );
-						}
-					}
 				} )
 				.catch( error => {
 					this.setState( {
@@ -496,39 +484,36 @@ class Edit extends Component {
 
 	render() {
 		const { setAttributes } = this.props;
-		const { forceManual } = this.state;
 		const { manual, campaign, defaultFrequency } = this.blockData();
 		return (
 			<Fragment>
 				{ this.renderPlaceholder() }
 				{ this.renderForm() }
 				<InspectorControls>
-					{ ! forceManual && (
-						<PanelBody>
-							<ToggleControl
-								key="manual"
-								checked={ manual }
-								onChange={ this.manualChanged }
-								label={ __( 'Configure manually', 'newspack-blocks' ) }
-							/>
-							{ ! manual && (
-								<Fragment>
-									<p>
-										{ __(
-											'The Donate Block allows you to collect donations from readers. The fields are automatically defined based on your donation settings.',
-											'newspack-blocks'
-										) }
-									</p>
+					<PanelBody>
+						<ToggleControl
+							key="manual"
+							checked={ manual }
+							onChange={ this.manualChanged }
+							label={ __( 'Configure manually', 'newspack-blocks' ) }
+						/>
+						{ ! manual && (
+							<Fragment>
+								<p>
+									{ __(
+										'The Donate Block allows you to collect donations from readers. The fields are automatically defined based on your donation settings.',
+										'newspack-blocks'
+									) }
+								</p>
 
-									<ExternalLink href="/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/donations">
-										{ __( 'Edit donation settings.', 'newspack-blocks' ) }
-									</ExternalLink>
-								</Fragment>
-							) }
-						</PanelBody>
-					) }
+								<ExternalLink href="/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/donations">
+									{ __( 'Edit donation settings.', 'newspack-blocks' ) }
+								</ExternalLink>
+							</Fragment>
+						) }
+					</PanelBody>
 					{ manual && (
-						<PanelBody title={ ! forceManual && __( 'Manual Settings', 'newspack-blocks' ) }>
+						<PanelBody title={ __( 'Manual Settings', 'newspack-blocks' ) }>
 							{ this.renderManualControls() }
 						</PanelBody>
 					) }

--- a/src/blocks/donate/streamlined.js
+++ b/src/blocks/donate/streamlined.js
@@ -62,6 +62,9 @@ const renderMessages = ( messages, el, type = 'error' ) => {
 		if ( formValues.amount === 'other' ) {
 			formValues.amount = formValues[ `${ valueKey }_other` ];
 		}
+		if ( ! formValues.amount ) {
+			formValues.amount = formValues[ `${ valueKey }_untiered` ];
+		}
 
 		const validationErrors = Object.values( validateFormData( formValues ) );
 		if ( validationErrors.length > 0 ) {
@@ -90,6 +93,9 @@ const renderMessages = ( messages, el, type = 'error' ) => {
 			} ),
 		} );
 		const chargeResultData = await chargeResult.json();
+		if ( chargeResultData.data?.status !== 200 && chargeResultData.message ) {
+			renderMessages( [ chargeResultData.message ], messagesEl );
+		}
 		if ( chargeResultData.error ) {
 			renderMessages( [ chargeResultData.error ], messagesEl );
 		}

--- a/src/blocks/donate/streamlined.js
+++ b/src/blocks/donate/streamlined.js
@@ -7,6 +7,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * External dependencies
  */
 import { loadStripe } from '@stripe/stripe-js';
+import 'regenerator-runtime'; // Required in WP >=5.8.
 
 /**
  * Internal dependencies

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -101,12 +101,6 @@ function newspack_blocks_render_block_donate( $attributes ) {
 		return '';
 	}
 
-	$manual = isset( $attributes['manual'] ) ? $attributes['manual'] : false;
-
-	if ( 'nrh' === $settings['platform'] && ! $manual ) {
-		return '';
-	}
-
 	/* If block is in "manual" mode, override certain state properties with values stored in attributes */
 	if ( $attributes['manual'] ?? false ) {
 		$settings = array_merge( $settings, $attributes );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes forcing the Donate block to manual mode (done by the Newspack Plugin when the donation platform is NRH).

### How to test the changes in this Pull Request:

1. Set Newspack Plugin to branch `fix/donations-nrh-tweaks` (https://github.com/Automattic/newspack-plugin/pull/1046)
2. Set the platform in Reader Revenue wizard to News Revenue Hub and fill in NRH Organization ID and NRH Salesforce Campaign ID (use `montanafreepress` as the former for a valid ID)
3. Insert a donate block on a page, observe that it can be - optionally - configured manually
4. Test different configuration of the block (tiered/untiered, different suggested amounts)
5. Observe that with each configuration, after clicking submitting the donation form on the frontend, you're redirected to NRH checkout with the correct donation amount

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->