### PR TITLE
fix: allow swiper to reinitialize carousel on attribute changes

### DIFF
--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -110,9 +110,8 @@ class Edit extends Component {
 
 	initializeSwiper( initialSlide ) {
 		const { latestPosts } = this.props;
-		const { swiperInitialized } = this.state;
 
-		if ( ! swiperInitialized && latestPosts && latestPosts.length ) {
+		if ( latestPosts && latestPosts.length ) {
 			const { aspectRatio, autoplay, delay, slidesPerView } = this.props.attributes;
 
 			const swiperInstance = createSwiper(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Allow SwiperJS to reinitialize carousels when block attributes are updated that affect the carousel's visual rendering. Fixes a regression introduced in #804.

### How to test the changes in this Pull Request:

1. On `master`, add a Post Carousel block to post or page content. Observe that the carousel functions in the editor preview as expected.
2. Alter some of the visual attributes in the block sidebar under Slideshow Settings and Article Meta Settings. Observe that after updating one of those attributes, the carousel ceases to be interactive unless you update the post and refresh.
3. Check out this branch, rebuild, refresh, confirm that this is no longer the case.
4. Confirm that the block still works as expected in the **Appearance > Widgets** and **Customizer > Widgets** admin pages.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
