### PR TITLE
fix: remove autoload dependency from donation class

### DIFF
--- a/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
+++ b/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
@@ -5,8 +5,6 @@
  * @package WordPress
  */
 
-require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'vendor/autoload.php';
-
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a PHP dependency bug in the CI release builds. Seems like this dependency isn't needed because the Stripe PHP library was moved to `newspack-plugin` instead, which does load Composer dependencies on release build jobs.

### How to test the changes in this Pull Request:

1. Install the built `newspack-blocks.zip` asset from [the latest alpha release](https://github.com/Automattic/newspack-blocks/releases/tag/v1.30.0-alpha.2) on a fresh site. Attempt to activate and observe a PHP dependency error that prevents activation:

```
Warning: require_once(/srv/htdocs/wp-content/plugins/newspack-blocks-v1.30.0-alpha.2/vendor/autoload.php): failed to open stream: No such file or directory in /srv/htdocs/wp-content/plugins/newspack-blocks-v1.30.0-alpha.2/src/blocks/donate/class-wp-rest-newspack-donate-controller.php on line 8
Fatal error: require_once(): Failed opening required '/srv/htdocs/wp-content/plugins/newspack-blocks-v1.30.0-alpha.2/vendor/autoload.php' (include_path='.:') in /srv/htdocs/wp-content/plugins/newspack-blocks-v1.30.0-alpha.2/src/blocks/donate/class-wp-rest-newspack-donate-controller.php on line 8
```

2. Check out this branch, delete the `vendor` folder in the root repository directory (`composer install` isn't run as part of the release jobs for this repo).
3. Run `npm run release:archive` to build the release without the `vendor` folder. Install the built .zip file onto your test site.
4. Verify that the plugin activates without error and that all blocks (Author Profile, Post Carousel, Donate, Homepage Posts, Video Playlist) work as expected on the editor and front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
