### PR TITLE
feat: show term classes for Post Carousel blocks

### DIFF
--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -263,7 +263,9 @@ class Edit extends Component {
 							<div className="swiper-wrapper">
 								{ latestPosts.map( post => (
 									<article
-										className={ `post-has-image swiper-slide ${ post.post_type }` }
+										className={ `post-has-image swiper-slide ${ post.post_type } ${
+											post.newspack_article_classes || ''
+										}` }
 										key={ post.id }
 									>
 										<figure className="post-thumbnail">

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -35,15 +35,9 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 	if ( false === $article_query->have_posts() ) {
 		return;
 	}
-	$counter         = 0;
-	$article_classes = [
-		'post-has-image',
-	];
-	if ( $is_amp ) {
-		$article_classes[] = 'amp-carousel-slide';
-	} else {
-		$article_classes[] = 'swiper-slide';
-	}
+
+	$counter = 0;
+
 	ob_start();
 	if ( $article_query->have_posts() ) :
 		while ( $article_query->have_posts() ) :
@@ -51,6 +45,18 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 			$post_id                             = get_the_ID();
 			$authors                             = Newspack_Blocks::prepare_authors();
 			$newspack_blocks_post_id[ $post_id ] = true;
+
+			$article_classes = [
+				'post-has-image',
+			];
+			if ( $is_amp ) {
+				$article_classes[] = 'amp-carousel-slide';
+			} else {
+				$article_classes[] = 'swiper-slide';
+			}
+
+			// Add classes based on the post's assigned categories and tags.
+			$article_classes[] = Newspack_Blocks::get_term_classes( $post_id );
 
 			// Get sponsors for this post.
 			$sponsors = Newspack_Blocks::get_all_sponsors( $post_id );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The Homepage Post block currently renders class names for the post type, categories, and tags for each item shown by the block. This PR applies the same classes for Post Carousel items, as well.

Related to but not dependent on https://github.com/Automattic/newspack-listings/pull/103.

### How to test the changes in this Pull Request:

1. On `master`, add a Homepage Posts and Post Carousel block to a page. Ensure that each is displaying posts with categories and tags.
2. In the editor and on the front-end, observe that the items shown by Homepage Posts have class names for post type, categories, and tags but that the Post Carousel items do not.
3. Check out this branch, rebuild and refresh. Now confirm that the items in both blocks show post type, category and tag class names.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
