### PR TITLE
feat(homepage-posts): handle category exclusion

### DIFF
--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -293,6 +293,9 @@ class Newspack_Blocks_API {
 		if ( $params['categories'] && count( $params['categories'] ) ) {
 			$args['category__in'] = $params['categories'];
 		}
+		if ( $params['categories_exclude'] && count( $params['categories_exclude'] ) ) {
+			$args['category__not_in'] = $params['categories_exclude'];
+		}
 		if ( $params['tags'] && count( $params['tags'] ) ) {
 			$args['tag__in'] = $params['tags'];
 		}

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -406,15 +406,16 @@ class Newspack_Blocks {
 			);
 		}
 
-		$post_type      = isset( $attributes['postType'] ) ? $attributes['postType'] : [ 'post' ];
-		$authors        = isset( $attributes['authors'] ) ? $attributes['authors'] : array();
-		$categories     = isset( $attributes['categories'] ) ? $attributes['categories'] : array();
-		$tags           = isset( $attributes['tags'] ) ? $attributes['tags'] : array();
-		$tag_exclusions = isset( $attributes['tagExclusions'] ) ? $attributes['tagExclusions'] : array();
-		$specific_posts = isset( $attributes['specificPosts'] ) ? $attributes['specificPosts'] : array();
-		$posts_to_show  = intval( $attributes['postsToShow'] );
-		$specific_mode  = isset( $attributes['specificMode'] ) ? intval( $attributes['specificMode'] ) : false;
-		$args           = array(
+		$post_type           = isset( $attributes['postType'] ) ? $attributes['postType'] : [ 'post' ];
+		$authors             = isset( $attributes['authors'] ) ? $attributes['authors'] : array();
+		$categories          = isset( $attributes['categories'] ) ? $attributes['categories'] : array();
+		$tags                = isset( $attributes['tags'] ) ? $attributes['tags'] : array();
+		$tag_exclusions      = isset( $attributes['tagExclusions'] ) ? $attributes['tagExclusions'] : array();
+		$category_exclusions = isset( $attributes['categoryExclusions'] ) ? $attributes['categoryExclusions'] : array();
+		$specific_posts      = isset( $attributes['specificPosts'] ) ? $attributes['specificPosts'] : array();
+		$posts_to_show       = intval( $attributes['postsToShow'] );
+		$specific_mode       = isset( $attributes['specificMode'] ) ? intval( $attributes['specificMode'] ) : false;
+		$args                = array(
 			'post_type'           => $post_type,
 			'post_status'         => 'publish',
 			'suppress_filters'    => false,
@@ -446,6 +447,9 @@ class Newspack_Blocks {
 			}
 			if ( $tag_exclusions && count( $tag_exclusions ) ) {
 				$args['tag__not_in'] = $tag_exclusions;
+			}
+			if ( $category_exclusions && count( $category_exclusions ) ) {
+				$args['category__not_in'] = $category_exclusions;
 			}
 		}
 		return $args;

--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -98,6 +98,11 @@
       "default": [],
       "items": { "type": "integer" }
     },
+    "categoryExclusions": {
+      "type": "array",
+      "default": [],
+      "items": { "type": "integer" }
+    },
     "specificPosts": {
       "type": "array",
       "default": [],

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -272,6 +272,7 @@ class Edit extends Component {
 			specificMode,
 			tags,
 			tagExclusions,
+			categoryExclusions,
 		} = attributes;
 
 		const imageSizeOptions = [
@@ -330,6 +331,10 @@ class Edit extends Component {
 						tagExclusions={ tagExclusions }
 						onTagExclusionsChange={ _tagExclusions =>
 							setAttributes( { tagExclusions: _tagExclusions } )
+						}
+						categoryExclusions={ categoryExclusions }
+						onCategoryExclusionsChange={ _categoryExclusions =>
+							setAttributes( { categoryExclusions: _categoryExclusions } )
 						}
 						postType={ postType }
 					/>

--- a/src/blocks/homepage-articles/utils.js
+++ b/src/blocks/homepage-articles/utils.js
@@ -34,6 +34,7 @@ const POST_QUERY_ATTRIBUTES = [
 	'specificPosts',
 	'specificMode',
 	'tagExclusions',
+	'categoryExclusions',
 	'postType',
 ];
 
@@ -71,6 +72,7 @@ export const queryCriteriaFromAttributes = attributes => {
 		specificPosts = [],
 		specificMode,
 		tagExclusions,
+		categoryExclusions,
 	} = pick( attributes, POST_QUERY_ATTRIBUTES );
 
 	const cleanPosts = sanitizePostList( specificPosts );
@@ -88,6 +90,7 @@ export const queryCriteriaFromAttributes = attributes => {
 					author: authors,
 					tags,
 					tags_exclude: tagExclusions,
+					categories_exclude: categoryExclusions,
 					post_type: postType,
 			  },
 		value => ! isUndefined( value )

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -178,6 +178,8 @@ class QueryControls extends Component {
 			onTagsChange,
 			tagExclusions,
 			onTagExclusionsChange,
+			categoryExclusions,
+			onCategoryExclusionsChange,
 			enableSpecific,
 		} = this.props;
 		const { showAdvancedFilters } = this.state;
@@ -256,6 +258,16 @@ class QueryControls extends Component {
 					fetchSuggestions={ this.fetchTagSuggestions }
 					fetchSavedInfo={ this.fetchSavedTags }
 					label={ __( 'Excluded Tags', 'newspack-blocks' ) }
+				/>
+			),
+			! specificMode && onCategoryExclusionsChange && showAdvancedFilters && (
+				<AutocompleteTokenField
+					key="category-exclusion"
+					tokens={ categoryExclusions || [] }
+					onChange={ onCategoryExclusionsChange }
+					fetchSuggestions={ this.fetchCategorySuggestions }
+					fetchSavedInfo={ this.fetchSavedCategories }
+					label={ __( 'Excluded Categories', 'newspack-blocks' ) }
 				/>
 			),
 		];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #600.

### How to test the changes in this Pull Request:

1. Insert Homepage Posts block
2. In the sidebar, "Display Settings" panel, click on "Show Advanced Filters" 
3. Fill in a category to exclude from the query and observe that posts from this category are not included in the block
4. Publish the content, observe that on the frontend too, the posts with the excluded category are not displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->