### PR TITLE
fix: select specific posts with white space at the end of the title

### DIFF
--- a/src/components/autocomplete-tokenfield.js
+++ b/src/components/autocomplete-tokenfield.js
@@ -119,12 +119,13 @@ class AutocompleteTokenField extends Component {
 					const currentSuggestions = [];
 
 					suggestions.forEach( suggestion => {
-						const duplicatedSuggestionIndex = currentSuggestions.indexOf( suggestion.label );
+						const trimmedSuggestionLabel = suggestion.label.trim();
+						const duplicatedSuggestionIndex = currentSuggestions.indexOf( trimmedSuggestionLabel );
 						if ( duplicatedSuggestionIndex >= 0 ) {
-							suggestion.label = `${ suggestion.label } (${ suggestion.value })`;
+							suggestion.label = `${ trimmedSuggestionLabel } (${ suggestion.value })`;
 						}
-						currentSuggestions.push( suggestion.label );
-						validValues[ suggestion.value ] = suggestion.label;
+						currentSuggestions.push( trimmedSuggestionLabel );
+						validValues[ suggestion.value ] = trimmedSuggestionLabel;
 					} );
 
 					this.setState( { suggestions: currentSuggestions, validValues, loading: false } );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #777.

### How to test the changes in this Pull Request:

1. Create a new post and grab the post ID.
2. In MySQL run update wp_posts set post_title = "This post has a space at the end of the title " where ID = 1234; (Use the ID from step 1). Then run wp cache flush to flush the post cache so the changes apply quickly.
3. On a different post/page, create a homepage posts block and use the specific select option.
4. Check the `Choose Specific Posts` display setting and search for "space". Select the newly added post from the suggested posts.
5. Observe the post gets added to the posts list.
6. If you check the `code view`,  we don't have a `null` anymore but the proper post ID:
`<!-- wp:newspack-blocks/homepage-articles {"specificPosts":["112","144","97"],"specificMode":true} /-->`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
