### PR TITLE
fix(homepage posts): fix inconsistent column sizing when border enabled

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -626,8 +626,6 @@ amp-script .wpnbha {
 		padding-bottom: 1em;
 
 		&:last-of-type {
-			margin-bottom: 0;
-
 			&:not( :first-of-type ) {
 				border-bottom: 0;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #825.

### How to test the changes in this Pull Request:

1. Open a new page.
2. Add Homepage Post Block.
3. Set Styles > Borders.
4. Set to Grid View.
5. Show media behind.
6. Observe the column height is the same for all columns.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
