### PR TITLE
Fix/sponsor logo accessibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ node_modules/
 *.tar.gz
 *.zip
 
+.idea/
+
 /vendor/
 dist/
 release/

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -694,6 +694,7 @@ class Newspack_Blocks {
 					$sponsor_logos[] = array(
 						'url'    => $sponsor['sponsor_url'],
 						'src'    => esc_url( $sponsor['sponsor_logo']['src'] ),
+						'alt'    => esc_attr( $sponsor['sponsor_name'] ),
 						'width'  => esc_attr( $sponsor['sponsor_logo']['img_width'] ),
 						'height' => esc_attr( $sponsor['sponsor_logo']['img_height'] ),
 					);

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -149,7 +149,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 										if ( '' !== $logo['url'] ) {
 											echo '<a href="' . esc_url( $logo['url'] ) . '" target="_blank">';
 										}
-										echo '<img src="' . esc_url( $logo['src'] ) . '" width="' . esc_attr( $logo['width'] ) . '" height="' . esc_attr( $logo['height'] ) . '">';
+										echo '<img src="' . esc_url( $logo['src'] ) . '" alt="' . esc_attr( $logo['alt'] ) . '" width="' . esc_attr( $logo['width'] ) . '" height="' . esc_attr( $logo['height'] ) . '">';
 										if ( '' !== $logo['url'] ) {
 											echo '</a>';
 										}

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -153,7 +153,7 @@ call_user_func(
 								if ( '' !== $logo['url'] ) {
 									echo '<a href="' . esc_url( $logo['url'] ) . '" target="_blank">';
 								}
-								echo '<img src="' . esc_url( $logo['src'] ) . '" width="' . esc_attr( $logo['width'] ) . '" height="' . esc_attr( $logo['height'] ) . '">';
+								echo '<img src="' . esc_url( $logo['src'] ) . '" alt="' . esc_attr( $logo['alt'] ) . '" width="' . esc_attr( $logo['width'] ) . '" height="' . esc_attr( $logo['height'] ) . '">';
 								if ( '' !== $logo['url'] ) {
 									echo '</a>';
 								}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #678 by adding the sponsor name as alternative text for their logo in the homepage posts block. 
Did the same for the sponsor logo in the carousel block.

### How to test the changes in this Pull Request:

1. Make sure the [newspack-sponsors plugin](https://github.com/Automattic/newspack-sponsors) is installed, add a sponsor with a logo from the sponsors' menu.
2. Create a new post and set the newly created sponsor as a sponsor.
3. Create a new page and add the homepage posts or the carousel block.
4. Preview the page, and inspect the sponsor logo.
5. Observe there is no `alt` tag.
6. Pull the branch with the fix, and reload the preview page.
7. Observe the sponsor logo image tag with the `alt` attribute.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
