### PR TITLE
Donate - recurring payments

### DIFF
--- a/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
+++ b/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
@@ -95,17 +95,27 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function charge( $request ) {
-		$response         = [
+		$response = [
 			'error'  => null,
 			'status' => null,
 		];
+		// Experimental NRH integration metadata.
 		$payment_metadata = [
-			'Source' => 'Newspack',
+			'schema_version'     => '1.0',
+			'source'             => 'newspack',
+			'referer'            => wp_get_referer(),
+			'agreed_to_pay_fees' => false,
 		];
-		$client_metadata  = [
+		if ( class_exists( 'Newspack\NRH' ) && method_exists( 'Newspack\NRH', 'get_nrh_config' ) ) {
+			$nrh_config = \Newspack\NRH::get_nrh_config();
+			if ( isset( $nrh_config['nrh_salesforce_campaign_id'] ) ) {
+				$payment_metadata['sf_campaign_id'] = $nrh_config['nrh_salesforce_campaign_id'];
+			}
+		}
+		$client_metadata = [
 			'clientId' => $request->get_param( 'clientId' ),
 		];
-		$amount_raw       = $request->get_param( 'amount' );
+		$amount_raw      = $request->get_param( 'amount' );
 
 		try {
 			$stripe = \Newspack\Stripe_Connection::get_stripe_client();

--- a/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
+++ b/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
@@ -100,7 +100,9 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 			'status' => null,
 		];
 		$payment_metadata = [
-			'Source'   => 'Newspack',
+			'Source' => 'Newspack',
+		];
+		$client_metadata  = [
 			'clientId' => $request->get_param( 'clientId' ),
 		];
 		$amount_raw       = $request->get_param( 'amount' );
@@ -121,13 +123,17 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 						'email'       => $email_address,
 						'description' => __( 'Newspack Donor', 'newspack-blocks' ),
 						'source'      => $token_data['id'],
+						'metadata'    => $client_metadata,
 					]
 				);
 			}
 			if ( $customer['default_source'] !== $token_data['card']['id'] ) {
 				$stripe->customers->update(
 					$customer['id'],
-					[ 'source' => $token_data['id'] ]
+					[
+						'source'   => $token_data['id'],
+						'metadata' => $client_metadata,
+					]
 				);
 			}
 

--- a/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
+++ b/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
@@ -48,7 +48,9 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 							],
 						],
 						'amount'    => [
-							'sanitize_callback' => 'absint',
+							'sanitize_callback' => function ( $amount ) {
+								return (float) abs( $amount );
+							},
 							'required'          => true,
 						],
 						'frequency' => [

--- a/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
+++ b/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
@@ -35,7 +35,7 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 			[
 				[
 					'methods'             => WP_REST_Server::EDITABLE,
-					'callback'            => [ $this, 'charge' ],
+					'callback'            => [ $this, 'process_donation' ],
 					'args'                => [
 						'tokenData' => [
 							'type'       => 'object',
@@ -72,33 +72,12 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Process the amount. Some currencies are zero-decimal, but for others,
-	 * the amount should be multiplied by 100 (100 USD is 100*100 currency units, aka cents).
-	 * https://stripe.com/docs/currencies#zero-decimal
-	 *
-	 * @param number $amount Amount to process.
-	 * @param strin  $currency Currency code.
-	 * @return number Amount.
-	 */
-	private static function get_amount( $amount, $currency ) {
-		$zero_decimal_currencies = [ 'BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF' ];
-		if ( in_array( $currency, $zero_decimal_currencies, true ) ) {
-			return $amount;
-		}
-		return $amount * 100;
-	}
-
-	/**
-	 * Charge a credit card.
+	 * Handle a donation.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response
 	 */
-	public function charge( $request ) {
-		$response = [
-			'error'  => null,
-			'status' => null,
-		];
+	public function process_donation( $request ) {
 		// Experimental NRH integration metadata.
 		$payment_metadata = [
 			'schema_version'     => '1.0',
@@ -112,93 +91,25 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 				$payment_metadata['sf_campaign_id'] = $nrh_config['nrh_salesforce_campaign_id'];
 			}
 		}
-		$client_metadata = [
-			'clientId' => $request->get_param( 'clientId' ),
-		];
-		$amount_raw      = $request->get_param( 'amount' );
 
-		try {
-			$stripe = \Newspack\Stripe_Connection::get_stripe_client();
-
-			$frequency     = $request->get_param( 'frequency' );
-			$token_data    = $request->get_param( 'tokenData' );
-			$email_address = $request->get_param( 'email' );
-
-			// Find or create the customer by email.
-			$found_customers = $stripe->customers->all( [ 'email' => $email_address ] )['data'];
-			$customer        = count( $found_customers ) ? $found_customers[0] : null;
-			if ( null === $customer ) {
-				$customer = $stripe->customers->create(
-					[
-						'email'       => $email_address,
-						'description' => __( 'Newspack Donor', 'newspack-blocks' ),
-						'source'      => $token_data['id'],
-						'metadata'    => $client_metadata,
-					]
-				);
-			}
-			if ( $customer['default_source'] !== $token_data['card']['id'] ) {
-				$stripe->customers->update(
-					$customer['id'],
-					[
-						'source'   => $token_data['id'],
-						'metadata' => $client_metadata,
-					]
-				);
-			}
-
-			if ( 'once' === $frequency ) {
-				// Create a Payment Intent on Stripe.
-				$payment_data              = self::get_payment_data();
-				$intent                    = $stripe->paymentIntents->create( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					[
-						'amount'               => self::get_amount( $amount_raw, $payment_data['currency'] ),
-						'currency'             => $payment_data['currency'],
-						'receipt_email'        => $email_address,
-						'customer'             => $customer['id'],
-						'metadata'             => $payment_metadata,
-						'description'          => __( 'Newspack One-Time Donation', 'newspack-blocks' ),
-						'payment_method_types' => [ 'card' ],
-					]
-				);
-				$response['client_secret'] = $intent['client_secret'];
-			} else {
-				// Create a Subscription on Stripe.
-				$prices = \Newspack\Stripe_Connection::get_donation_prices();
-				$price  = $prices[ $frequency ];
-				$amount = self::get_amount( $amount_raw, $price['currency'] );
-
-				$subscription = $stripe->subscriptions->create( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					[
-						'customer'         => $customer['id'],
-						'items'            => [
-							[
-								'price'    => $price['id'],
-								'quantity' => $amount,
-							],
-						],
-						'payment_behavior' => 'allow_incomplete',
-						'metadata'         => $payment_metadata,
-						'expand'           => [ 'latest_invoice.payment_intent' ],
-					]
-				);
-
-				if ( 'incomplete' === $subscription->status ) {
-					// The card may require additional authentication.
-					$response['client_secret'] = $subscription->latest_invoice->payment_intent->client_secret;
-				} elseif ( 'active' === $subscription->status ) {
-					$response['status'] = 'success';
-				}
-			}
-		} catch ( \Exception $e ) {
-			$response['error'] = $e->getMessage();
-		}
+		$response = \Newspack\Stripe_Connection::handle_donation(
+			[
+				'frequency'        => $request->get_param( 'frequency' ),
+				'token_data'       => $request->get_param( 'tokenData' ),
+				'email_address'    => $request->get_param( 'email' ),
+				'amount'           => $request->get_param( 'amount' ),
+				'client_metadata'  => [
+					'clientId' => $request->get_param( 'clientId' ),
+				],
+				'payment_metadata' => $payment_metadata,
+			]
+		);
 
 		return rest_ensure_response( $response );
 	}
 
 	/**
-	 * Retrieve Stripe data saved in WC Stripe Gateway.
+	 * Retrieve Stripe data.
 	 */
 	public static function get_payment_data() {
 		if ( ! Newspack_Blocks::can_use_streamlined_donate_block() ) {

--- a/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
+++ b/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
@@ -78,11 +78,11 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function process_donation( $request ) {
-		// Experimental NRH integration metadata.
 		$payment_metadata = [
+			'referer'            => wp_get_referer(),
+			// Experimental NRH integration metadata.
 			'schema_version'     => '1.0',
 			'source'             => 'newspack',
-			'referer'            => wp_get_referer(),
 			'agreed_to_pay_fees' => false,
 		];
 		if ( class_exists( 'Newspack\NRH' ) && method_exists( 'Newspack\NRH', 'get_nrh_config' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1. Removes donations handling code, it makes more sense to centralise that in the Newspack Plugin, where Stripe handler lives
2. Adds front-end handling of recurring donation response

### How to test the changes in this Pull Request:

1. Switch to `feat/stripe-recurrence` branch of `newspack-plugin`
2. Ensure that "News Revenue Hub" is the donations platform and Stripe keys are provided (in Reader Revenue wizard), and that `NEWSPACK_AMP_PLUS_ENABLED` env variable is set to true
3. Insert a Donation block somewhere, in the editor sidebar check the "Streamlined" option
4. Visit the front-end and test one-time and recurring donations using the streamlined block (with the CC input)
5. Use `4242424242424242` CC to test basic payment
6. Use `4000002760003184` CC to test a card with additional 3D secure verification
7. Use `4000000000000002` CC to test a declined payment
8. Verify the payments in Stripe. Recurring payments should have created Subscriptions, while one-time payments, well, one-time charges

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->