### PR TITLE
chore: categories exclude in rest params

### DIFF
--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -57,62 +57,69 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ 'Newspack_Blocks_API', 'posts_endpoint' ],
 				'args'                => [
-					'author'         => [
+					'author'             => [
 						'type'    => 'array',
 						'items'   => array(
 							'type' => 'integer',
 						),
 						'default' => array(),
 					],
-					'categories'     => [
+					'categories'         => [
 						'type'    => 'array',
 						'items'   => array(
 							'type' => 'integer',
 						),
 						'default' => array(),
 					],
-					'excerpt_length' => [
+					'categories_exclude' => [
+						'type'    => 'array',
+						'items'   => array(
+							'type' => 'integer',
+						),
+						'default' => array(),
+					],
+					'excerpt_length'     => [
 						'type'    => 'integer',
 						'default' => 55,
 					],
-					'exclude'        => [
+					'exclude'            => [
 						'type'    => 'array',
 						'items'   => array(
 							'type' => 'integer',
 						),
 						'default' => array(),
 					],
-					'include'        => [
+					'include'            => [
 						'type'    => 'array',
 						'items'   => array(
 							'type' => 'integer',
 						),
 						'default' => array(),
 					],
-					'orderby'        => [
+					'orderby'            => [
 						'sanitize_callback' => 'sanitize_text_field',
 					],
-					'per_page'       => [
+					'per_page'           => [
 						'sanitize_callback' => 'absint',
 					],
-					'show_excerpt'   => [
+					'show_excerpt'       => [
 						'type' => 'boolean',
 					],
-					'tags'           => [
+					'tags'               => [
 						'type'    => 'array',
 						'items'   => array(
 							'type' => 'integer',
 						),
 						'default' => array(),
 					],
-					'tags_exclude'   => [
+					'tags_exclude'       => [
 						'type'    => 'array',
 						'items'   => array(
 							'type' => 'integer',
 						),
 						'default' => array(),
 					],
-					'post_type'      => [
+					'post_type'          => [
 						'type'    => 'array',
 						'items'   => array(
 							'type' => 'string',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Prevents a PHP notice.

### How to test the changes in this Pull Request:

1. On `master`, open the editor and insert a Homepage Posts block
2. Observe a PHP notice logged: `Undefined index: categories_exclude…`
3. Switch to this branch, observe notice not displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->