### PR TITLE
feat(donate): handle newsletter opt-in

### DIFF
--- a/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
+++ b/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
@@ -37,7 +37,7 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => [ $this, 'process_donation' ],
 					'args'                => [
-						'tokenData' => [
+						'tokenData'         => [
 							'type'       => 'object',
 							'properties' => [
 								'id' => [
@@ -47,26 +47,29 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 								],
 							],
 						],
-						'amount'    => [
+						'amount'            => [
 							'sanitize_callback' => function ( $amount ) {
 								return (float) abs( $amount );
 							},
 							'required'          => true,
 						],
-						'frequency' => [
+						'frequency'         => [
 							'sanitize_callback' => 'sanitize_text_field',
 							'required'          => true,
 						],
-						'email'     => [
+						'email'             => [
 							'sanitize_callback' => 'sanitize_text_field',
 							'required'          => true,
 						],
-						'full_name' => [
+						'full_name'         => [
 							'sanitize_callback' => 'sanitize_text_field',
 							'required'          => true,
 						],
-						'clientId'  => [
+						'clientId'          => [
 							'sanitize_callback' => 'sanitize_text_field',
+						],
+						'newsletter_opt_in' => [
+							'sanitize_callback' => 'rest_sanitize_boolean',
 						],
 					],
 					'permission_callback' => '__return_true',
@@ -104,7 +107,8 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 				'full_name'        => $request->get_param( 'full_name' ),
 				'amount'           => $request->get_param( 'amount' ),
 				'client_metadata'  => [
-					'clientId' => $request->get_param( 'clientId' ),
+					'clientId'        => $request->get_param( 'clientId' ),
+					'newsletterOptIn' => $request->get_param( 'newsletter_opt_in' ),
 				],
 				'payment_metadata' => $payment_metadata,
 			]

--- a/src/blocks/donate/streamlined.js
+++ b/src/blocks/donate/streamlined.js
@@ -138,6 +138,7 @@ const getClientIDValue = () => getCookies()[ 'newspack-cid' ];
 				email: formValues.email,
 				full_name: formValues.full_name,
 				frequency: formValues.donation_frequency,
+				newsletter_opt_in: Boolean( formValues.newsletter_opt_in ),
 				clientId: formValues.cid,
 			} ),
 		} );

--- a/src/blocks/donate/streamlined.scss
+++ b/src/blocks/donate/streamlined.scss
@@ -8,15 +8,19 @@
 			border: 1px solid $color__border;
 			padding: 0.34rem 0.66rem;
 		}
-		input,
+		input[type='text'],
+		input[type='email'],
+		&__checkbox,
 		button {
 			font-size: 0.7em;
 		}
-		input,
+		input[type='text'],
+		input[type='email'],
 		&__messages {
 			width: 100%;
 		}
-		input {
+		input[type='text'],
+		input[type='email'] {
 			font-family: sans-serif;
 
 			@include media( tablet ) {
@@ -28,6 +32,12 @@
 		&__inputs {
 			&--hidden {
 				display: none;
+			}
+		}
+
+		&__checkbox {
+			input {
+				margin-right: 5px;
 			}
 		}
 

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -13,9 +13,11 @@
  * @return string
  */
 function newspack_blocks_render_block_donate_footer( $attributes ) {
-	$is_streamlined = Newspack_Blocks::is_rendering_streamlined_block();
+	$is_streamlined                      = Newspack_Blocks::is_rendering_streamlined_block();
+	$is_rendering_newsletter_list_opt_in = false;
 	if ( $is_streamlined ) {
-		$payment_data = WP_REST_Newspack_Donate_Controller::get_payment_data();
+		$payment_data                        = WP_REST_Newspack_Donate_Controller::get_payment_data();
+		$is_rendering_newsletter_list_opt_in = isset( $payment_data['newsletter_list_id'] ) && ! empty( $payment_data['newsletter_list_id'] );
 	}
 	$button_text = $attributes['buttonText'];
 	$campaign    = $attributes['campaign'] ?? false;
@@ -41,6 +43,13 @@ function newspack_blocks_render_block_donate_footer( $attributes ) {
 						<input required placeholder="<?php echo esc_html__( 'Email', 'newspack-blocks' ); ?>" type="email" name="email" value="">
 						<input required placeholder="<?php echo esc_html__( 'Full Name', 'newspack-blocks' ); ?>" type="text" name="full_name" value="">
 					</div>
+					<?php if ( $is_rendering_newsletter_list_opt_in ) : ?>
+						<div class="stripe-payment__row">
+							<label class="stripe-payment__checkbox">
+								<input type="checkbox" name="newsletter_opt_in" checked value="true"><?php echo esc_html__( 'Sign up for our newsletter', 'newspack-blocks' ); ?>
+							</label>
+						</div>
+					<?php endif; ?>
 					<div class="stripe-payment__messages">
 						<div class="type-error"></div>
 						<div class="type-success"></div>

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -16,8 +16,10 @@ function newspack_blocks_render_block_donate_footer( $attributes ) {
 	$is_streamlined                      = Newspack_Blocks::is_rendering_streamlined_block();
 	$is_rendering_newsletter_list_opt_in = false;
 	if ( $is_streamlined ) {
-		$payment_data                        = WP_REST_Newspack_Donate_Controller::get_payment_data();
-		$is_rendering_newsletter_list_opt_in = isset( $payment_data['newsletter_list_id'] ) && ! empty( $payment_data['newsletter_list_id'] );
+		$payment_data = WP_REST_Newspack_Donate_Controller::get_payment_data();
+		if ( class_exists( 'Newspack_Newsletters' ) ) {
+			$is_rendering_newsletter_list_opt_in = isset( $payment_data['newsletter_list_id'] ) && ! empty( $payment_data['newsletter_list_id'] );
+		}
 	}
 	$button_text = $attributes['buttonText'];
 	$campaign    = $attributes['campaign'] ?? false;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a newsletter opt-in checkbox in the donation form of the Donate block.

### How to test the changes in this Pull Request:

1. Switch to `feat/donations-mailchimp` branch of `newspack-plugin`
2. Switch to `feat/lists-getters-and-contact-adding` branch from `newspack-newsletters`
3. Configure Reader Revenue to use Stripe as the platform
4. Create a page with a Donate block, visit the front-end
5. Observe that after unravelling the form fields (clicking the "Donate" button) there is _no_ signup checkbox
3. Configure Newspack Newsletters to use Mailchimp as ESP
4. Visit the Reader Revenue wizard, choose a contacts list in the "Newsletters" settings section
5. On the frontend, observe that after unravelling the form there's a "Sign up for our newsletter" checkbox (checked by default)
6. Submit a test donation* using an email you have access to, and observe a Mailchimp subscription confirmation message
7. Confirm subscription and observe a new contact added in Mailchimp. It should have donation metadata ("merge fields" assigned (see "Profile information" section in Mailchimp UI))
7. Submit a test donation with "Sign up for our newsletter" unchecked, observe no subscription confirmation is sent
8. Change the Newsletters provider to Campaign Monitor and repeat the process (without the confirmation email, Campaign Monitor does not require it. Also, the metadata is listed under "Custom fields" in subscriber view).
9. Deactivate the Newspack Newsletters plugin and observe that both admin and frontend handle it gracefully (error message in admin, no checkbox in frontend)  

\* Use card `4242 4242 4242 4242`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->