### PR TITLE
Homepage Posts, Post Carousel: Add span to 'by' in block bylines

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -221,7 +221,7 @@ function newspack_blocks_format_byline( $author_info ) {
 	$index    = -1;
 	$elements = array_merge(
 		[
-			'<span>' . esc_html_x( 'by', 'post author', 'newspack-blocks' ) . ' </span>',
+			'<span class="author-prefix">' . esc_html_x( 'by', 'post author', 'newspack-blocks' ) . ' </span>',
 		],
 		array_reduce(
 			$author_info,

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -221,7 +221,7 @@ function newspack_blocks_format_byline( $author_info ) {
 	$index    = -1;
 	$elements = array_merge(
 		[
-			esc_html_x( 'by', 'post author', 'newspack-blocks' ) . ' ',
+			'<span>' . esc_html_x( 'by', 'post author', 'newspack-blocks' ) . ' </span>',
 		],
 		array_reduce(
 			$author_info,

--- a/src/shared/js/utils.js
+++ b/src/shared/js/utils.js
@@ -15,7 +15,7 @@ export const formatAvatars = authorInfo =>
 
 export const formatByline = authorInfo => (
 	<span className="byline">
-		{ _x( 'by', 'post author', 'newspack-blocks' ) }{ ' ' }
+		<span>{ _x( 'by', 'post author', 'newspack-blocks' ) } </span>
 		{ authorInfo.reduce( ( accumulator, author, index ) => {
 			return [
 				...accumulator,

--- a/src/shared/js/utils.js
+++ b/src/shared/js/utils.js
@@ -15,7 +15,7 @@ export const formatAvatars = authorInfo =>
 
 export const formatByline = authorInfo => (
 	<span className="byline">
-		<span>{ _x( 'by', 'post author', 'newspack-blocks' ) } </span>
+		<span className="author-prefix">{ _x( 'by', 'post author', 'newspack-blocks' ) } </span>
 		{ authorInfo.reduce( ( accumulator, author, index ) => {
 			return [
 				...accumulator,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a `<span>` around the `by` text in the byline of the Post Carousel and Homepage Posts block.

It's to help us control this piece of the text differently with CSS, whether hiding (outstanding request), making it all caps or a different style, etc....

Closes #842.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Add a Homepage Posts and Post Carousel block to the editor. 
3. In the editor, inspect the blocks; confirm that the 'by' text in the byline is wrapped in a span, like `<span>by</span>`.
4. Publish the post. 
3. On the front-end, inspect the blocks; confirm that the 'by' text in the byline is wrapped in a span, like `<span>by</span>`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
