### PR TITLE
Donate Block: make 'thank you' text editable

### DIFF
--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -331,10 +331,17 @@ class Edit extends Component {
 	}
 
 	renderFooter() {
+		const { attributes, setAttributes } = this.props;
+		const { thanksText } = attributes;
 		return (
 			<>
 				<p className="wp-block-newspack-blocks-donate__thanks thanks">
-					{ __( 'Your contribution is appreciated.', 'newspack-blocks' ) }
+					<RichText
+						onChange={ value => setAttributes( { thanksText: value } ) }
+						placeholder={ __( 'Thank you text…', 'newspack-blocks' ) }
+						value={ thanksText }
+						tagName="span"
+					/>
 				</p>
 				{ this.isRenderingStreamlinedBlock() ? (
 					<div className="wp-block-newspack-blocks-donate__stripe stripe-payment">

--- a/src/blocks/donate/index.js
+++ b/src/blocks/donate/index.js
@@ -53,6 +53,10 @@ export const settings = {
 		campaign: {
 			type: 'string',
 		},
+		thanksText: {
+			type: 'string',
+			default: __( 'Your contribution is appreciated.', 'newspack-blocks' ),
+		},
 		buttonText: {
 			type: 'string',
 			default: __( 'Donate now!', 'newspack-blocks' ),

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -21,6 +21,7 @@ function newspack_blocks_render_block_donate_footer( $attributes ) {
 			$is_rendering_newsletter_list_opt_in = isset( $payment_data['newsletter_list_id'] ) && ! empty( $payment_data['newsletter_list_id'] );
 		}
 	}
+	$thanks_text = $attributes['thanksText'];
 	$button_text = $attributes['buttonText'];
 	$campaign    = $attributes['campaign'] ?? false;
 	$client_id   = '';
@@ -32,7 +33,7 @@ function newspack_blocks_render_block_donate_footer( $attributes ) {
 
 	?>
 		<p class='wp-block-newspack-blocks-donate__thanks thanks'>
-			<?php echo esc_html__( 'Your contribution is appreciated.', 'newspack-blocks' ); ?>
+			<?php echo wp_kses_post( $thanks_text ); ?>
 		</p>
 
 		<?php if ( $is_streamlined ) : ?>
@@ -336,6 +337,10 @@ function newspack_blocks_register_donate() {
 				],
 				'campaign'                => [
 					'type' => 'string',
+				],
+				'thanksText'              => [
+					'type'    => 'string',
+					'default' => __( 'Your contribution is appreciated.', 'newspack-blocks' ),
 				],
 				'buttonText'              => [
 					'type'    => 'string',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes the "Thank you for your contribution." text editable, similar to how the donate block button text works. 

Closes #545

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Add a donate block to the editor; try clicking on the 'Thank you' text and editing it; confirm you can make edits. 
3. Publish the page.
4. Confirm that your updated text appears on the front-end. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
