### PR TITLE
fix: show all saved post types in specific posts field

### DIFF
--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -45,11 +45,14 @@ class QueryControls extends Component {
 		} );
 	};
 	fetchSavedPosts = postIDs => {
+		const { postType } = this.props;
+		const restUrl = window.newspack_blocks_data.posts_rest_url;
 		return apiFetch( {
-			path: addQueryArgs( '/wp/v2/posts', {
+			url: addQueryArgs( restUrl, {
 				per_page: 100,
 				include: postIDs.join( ',' ),
 				_fields: 'id,title',
+				post_type: postType,
 			} ),
 		} ).then( function ( posts ) {
 			return posts.map( post => ( {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a minor but editorially annoying bug with the Specific Posts selector field for Homepage Posts and Post Carousel blocks, discovered during GDG launch.

### How to test the changes in this Pull Request:

1. On `master`, add a Homepage Posts and/or Post Carousel block to a post or page.
2. Under **Post Types**, choose "Posts" and at least one other post type.
3. Under **Display Settings**, turn on Specific Posts and choose some posts (of the actual `post` post type) as well as posts of post types other than `post`. Save/update.
4. Refresh the editor. Select the block and expand **Display Settings**. Observe that in the Specific Posts field, only titles for saved posts with the post type of `post` are shown in the field. This means it's not possible to remove the posts of other post types from this block.
5. Check out this branch, repeat step 4, confirm that saved posts of all post types are now shown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
