### PR TITLE
fix: only show category link anchor tags if the category has a link

### DIFF
--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -294,7 +294,7 @@ class Edit extends Component {
 													</span>
 												) }
 												{ showCategory &&
-													post.newspack_category_info.length &&
+													0 < post.newspack_category_info.length &&
 													! post.newspack_post_sponsors && (
 														<div className="cat-links">
 															<a href="#">{ decodeEntities( post.newspack_category_info ) }</a>

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -128,9 +128,14 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 							if ( $attributes['showCategory'] && $category ) :
 								?>
 								<div class="cat-links">
-									<a href="<?php echo esc_url( get_category_link( $category->term_id ) ); ?>">
+									<?php $category_link = get_category_link( $category->term_id ); ?>
+									<?php if ( ! empty( $category_link ) ) : ?>
+										<a href="<?php echo esc_url( get_category_link( $category->term_id ) ); ?>">
+									<?php endif; ?>
 										<?php echo esc_html( $category->name ); ?>
+									<?php if ( ! empty( $category_link ) ) : ?>
 									</a>
+									<?php endif; ?>
 								</div>
 								<?php
 							endif;

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -173,11 +173,13 @@ class Edit extends Component {
 							<span className="flag">{ post.newspack_post_sponsors[ 0 ].flag }</span>
 						</span>
 					) }
-					{ showCategory && post.newspack_category_info.length && ! post.newspack_post_sponsors && (
-						<div className="cat-links">
-							<a href="#">{ decodeEntities( post.newspack_category_info ) }</a>
-						</div>
-					) }
+					{ showCategory &&
+						0 < post.newspack_category_info.length &&
+						! post.newspack_post_sponsors && (
+							<div className="cat-links">
+								<a href="#">{ decodeEntities( post.newspack_category_info ) }</a>
+							</div>
+						) }
 					{ RichText.isEmpty( sectionHeader ) ? (
 						<h2 className="entry-title" key="title">
 							{ post.newspack_post_format === 'aside' ? postTitle : <a href="#">{ postTitle }</a> }

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -93,10 +93,15 @@ call_user_func(
 					</span>
 				</span>
 			<?php elseif ( $attributes['showCategory'] && $category ) : ?>
+				<?php $category_link = get_category_link( $category->term_id ); ?>
 				<div class="cat-links">
-					<a href="<?php echo esc_url( get_category_link( $category->term_id ) ); ?>">
+					<?php if ( ! empty( $category_link ) ) : ?>
+						<a href="<?php echo esc_url( $category_link ); ?>">
+					<?php endif; ?>
 						<?php echo esc_html( $category->name ); ?>
-					</a>
+					<?php if ( ! empty( $category_link ) ) : ?>
+						</a>
+					<?php endif; ?>
 				</div>
 				<?php
 			endif;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Homepage Posts and Post Carousel front-end templates render category terms with a link. This omits the `a` anchor tag in the unlikely event that a term lacks a link. This could happen if the term being rendered is a "pseudo term", or a term that's appended programmatically to a post's term output based on some condition other than a true taxonomy term applied to the post. 

The use case this comes from: a "featured" post meta toggle which programmatically shows a "featured" category label alongside the post's other categories. In this case the "featured" category label is not tied to a true category term, therefore it has no term link.

Bonus: also ensures that if a post with no categories (not even "Uncategorized") gets rendered by Homepage Posts or Post Carousel with categories enabled, the editor renders nothing instead of `0`.

### How to test the changes in this Pull Request:

1. Set up code to add a "pseudo term" to a post. In your theme's `functions.php`, temporarily add the following filter:

```php
function newspack_add_pseudo_label( $categories ) {
	$pseudo_term = new \WP_Term(
		(object) [
			'name'     => 'Pseudo Category',
			'slug'     => 'my-fake-category',
			'taxonomy' => 'category',
		]
	);

	// Add pseudo label in front of true categories.
	array_unshift( $categories, $pseudo_term );

	return $categories;
}
add_filter( 'get_the_categories', 'newspack_add_pseudo_label' );
```

2. Add Homepage Posts and Post Carousel blocks to a post. Ensure that both blocks render some posts.
3. On `master`, observe on the front-end that the "Pseudo Category" labels get rendered with empty anchor tags (`<a href="">Pseudo Category</a>`).
4. Check out this branch, refresh, observe that the "Pseudo Category" labels are rendered as styled plain text without links.

#### Test no categories

1. Modify your filter above to render no categories, not even the default category:

```php
function newspack_add_pseudo_label( $categories ) {
	return [];
}
add_filter( 'get_the_categories', 'newspack_add_pseudo_label' );
```
2. Add Homepage Posts and Post Carousel blocks to a post. Ensure that both blocks render some posts and that "Show Categories" is turned on.
3. On `master`, observe that items in the editor show `0` in place of categories:

<img width="816" alt="Screen Shot 2021-09-08 at 12 02 34 PM" src="https://user-images.githubusercontent.com/2230142/132561145-51c6ba44-2057-4b08-a7c9-49db0b02fee7.png">

4. Check out this branch, refresh the editor, confirm that nothing is shown instead of `0`.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
