### PR TITLE
fix: specify whitespace between author prefix and byline

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -221,7 +221,7 @@ function newspack_blocks_format_byline( $author_info ) {
 	$index    = -1;
 	$elements = array_merge(
 		[
-			'<span class="author-prefix">' . esc_html_x( 'by', 'post author', 'newspack-blocks' ) . ' </span>',
+			'<span class="author-prefix">' . esc_html_x( 'by', 'post author', 'newspack-blocks' ) . '</span> ',
 		],
 		array_reduce(
 			$author_info,

--- a/src/shared/js/utils.js
+++ b/src/shared/js/utils.js
@@ -15,7 +15,7 @@ export const formatAvatars = authorInfo =>
 
 export const formatByline = authorInfo => (
 	<span className="byline">
-		<span className="author-prefix">{ _x( 'by', 'post author', 'newspack-blocks' ) } </span>
+		<span className="author-prefix">{ _x( 'by', 'post author', 'newspack-blocks' ) }</span>{ ' ' }
 		{ authorInfo.reduce( ( accumulator, author, index ) => {
 			return [
 				...accumulator,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a minor visual bug in WP.com sites. Shouldn't affect anything on non-WP.com sites.

### How to test the changes in this Pull Request:

Ensure that the bylines in Post Carousel and Homepage Posts blocks still look as expected in the editor and on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
