### PR TITLE
feat: allow some html in the homepage posts subtitle

### DIFF
--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -124,9 +124,31 @@ call_user_func(
 			?>
 			<?php
 			if ( $attributes['showSubtitle'] ) :
+				$subtitle = get_post_meta( $post_id, 'newspack_post_subtitle', true );
+
 				?>
 				<div class="newspack-post-subtitle newspack-post-subtitle--in-homepage-block">
-					<?php echo esc_html( get_post_meta( $post_id, 'newspack_post_subtitle', true ) ); ?>
+					<?php
+					echo wp_kses(
+						$subtitle,
+						[
+							'b'      => true,
+							'strong' => true,
+							'i'      => true,
+							'em'     => true,
+							'mark'   => true,
+							'u'      => true,
+							'small'  => true,
+							'sub'    => true,
+							'sup'    => true,
+							'a'      => array(
+								'href'   => true,
+								'target' => true,
+								'rel'    => true,
+							),
+						]
+					);
+					?>
 				</div>
 			<?php endif; ?>
 			<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR switches the Article Subtitle to allow the same HTML that's allowed in the Newspack theme. Otherwise, you can add HTML and have it display nicely from the theme, but when it's coming from the block, the HTML is encoded and visible. 

See https://github.com/Automattic/newspack-theme/issues/1500

### How to test the changes in this Pull Request:

1. Edit a post and add some basic HTML to the Article Subtitle field. (strong, em, small...)
2. Publish the post and note that it's visible on the front-end. 
3. Add the same post to a Homepage Posts block and enable the Article Subtitle.
4. Note that your HTML tags are visible rather than being applied (eg. text isn't **bold**, but looks like `<strong>bold</strong>`):

![image](https://user-images.githubusercontent.com/177561/133311648-b49157ca-f929-4cf1-a056-b796a4aeeb51.png)

5. Apply the PR.
6. Confirm that the HTML code is no longer visible, and the tags are actually applied: 

![image](https://user-images.githubusercontent.com/177561/133311699-1a3183a7-5c6b-4d70-8b8c-fe6d5ddbf381.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
