### PR TITLE
fix: limit excerpt lengths even for custom excerpts

### DIFF
--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -342,7 +342,7 @@ class Newspack_Blocks_API {
 				'showExcerpt'   => $params['show_excerpt'],
 				'excerptLength' => $params['excerpt_length'],
 			];
-			Newspack_Blocks::filter_excerpt_length( $block_attributes );
+			Newspack_Blocks::filter_excerpt( $block_attributes );
 		}
 
 		$query        = new WP_Query();
@@ -402,7 +402,7 @@ class Newspack_Blocks_API {
 			$posts[] = array_merge( $data, $add_ons );
 		}
 
-		Newspack_Blocks::remove_excerpt_length_filter();
+		Newspack_Blocks::remove_excerpt_filter();
 		Newspack_Blocks::remove_filter_posts_clauses_when_co_authors_filter();
 
 		return new \WP_REST_Response( $posts );

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -798,7 +798,7 @@ class Newspack_Blocks {
 	/**
 	 * Filter for excerpt length.
 	 *
-	 * @deprectated
+	 * @deprecated
 	 * @param array $attributes The block's attributes.
 	 */
 	public static function filter_excerpt_length( $attributes ) {
@@ -821,7 +821,7 @@ class Newspack_Blocks {
 	/**
 	 * Remove excerpt length filter after Homepage Posts block loop.
 	 *
-	 * @deprectated
+	 * @deprecated
 	 */
 	public static function remove_excerpt_length_filter() {
 		if ( self::$newspack_blocks_excerpt_length_closure ) {
@@ -844,7 +844,7 @@ class Newspack_Blocks {
 	/**
 	 * Filter for excerpt ellipsis.
 	 *
-	 * @deprectated
+	 * @deprecated
 	 * @param array $attributes The block's attributes.
 	 */
 	public static function filter_excerpt_more( $attributes ) {
@@ -857,7 +857,7 @@ class Newspack_Blocks {
 	/**
 	 * Remove excerpt ellipsis filter after Homepage Posts block loop.
 	 *
-	 * @deprectated
+	 * @deprecated
 	 */
 	public static function remove_excerpt_more_filter() {
 		remove_filter( 'excerpt_more', [ __CLASS__, 'more_excerpt' ], 999 );

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -202,8 +202,7 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 		$ids      = [];
 		$next_url = '';
 
-		Newspack_Blocks::filter_excerpt_length( $attributes );
-		Newspack_Blocks::filter_excerpt_more( $attributes );
+		Newspack_Blocks::filter_excerpt( $attributes );
 
 		// The Loop.
 		while ( $article_query->have_posts() ) {
@@ -222,8 +221,7 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 			$ids[]           = get_the_ID();
 		}
 
-		Newspack_Blocks::remove_excerpt_length_filter();
-		Newspack_Blocks::remove_excerpt_more_filter();
+		Newspack_Blocks::remove_excerpt_filter();
 
 		// Provide next URL if there are more pages.
 		$show_next_button = ! empty( $exclude_ids ) ? $article_query->max_num_pages > 1 : $article_query->max_num_pages > $next_page;

--- a/src/blocks/homepage-articles/templates/articles-loop.php
+++ b/src/blocks/homepage-articles/templates/articles-loop.php
@@ -16,8 +16,7 @@ call_user_func(
 		global $newspack_blocks_post_id;
 		do_action( 'newspack_blocks_homepage_posts_before_render' );
 
-		Newspack_Blocks::filter_excerpt_length( $attributes );
-		Newspack_Blocks::filter_excerpt_more( $attributes );
+		Newspack_Blocks::filter_excerpt( $attributes );
 
 		while ( $article_query->have_posts() ) {
 			$article_query->the_post();
@@ -25,8 +24,7 @@ call_user_func(
 			echo Newspack_Blocks::template_inc( __DIR__ . '/article.php', array( 'attributes' => $attributes ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
-		Newspack_Blocks::remove_excerpt_length_filter();
-		Newspack_Blocks::remove_excerpt_more_filter();
+		Newspack_Blocks::remove_excerpt_filter();
 
 		do_action( 'newspack_blocks_homepage_posts_after_render' );
 		wp_reset_postdata();


### PR DESCRIPTION
Trims excerpts even if it's a custom excerpt for a uniform look.

### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Deprecated excerpt_length and excerpt_more methods in favor of a comprehensive excerpt callback.

Core only allows to control the length of generated excerpts, assuming that authors want to keep their custom excerpts as they're written. This PR will apply the excerpt length limit to both types of excerpts for a more uniform look.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://github.com/Automattic/wp-calypso/issues/51415

### How to test the changes in this Pull Request:

1. Once you checked out the branch and built the block…
2. Add a custom excerpt to a post, preferably a rather long one.
3. In a different post, insert the Homepage Posts block and manipulate the excerpt length.
4. Preview the post to make sure the front-end works as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
