### PR TITLE
Disable Jetpack donations when using Newspack donations

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -23,6 +23,7 @@ class Newspack_Blocks {
 		add_post_type_support( 'post', 'newspack_blocks' );
 		add_post_type_support( 'page', 'newspack_blocks' );
 		add_filter( 'script_loader_tag', [ __CLASS__, 'mark_view_script_as_amp_plus_allowed' ], 10, 2 );
+		add_action( 'jetpack_register_gutenberg_extensions', [ __CLASS__, 'disable_jetpack_donate' ], 99 );
 	}
 
 	/**
@@ -935,6 +936,29 @@ class Newspack_Blocks {
 		];
 
 		return wp_kses( $svg, $allowed_html );
+	}
+
+	/**
+	 * Disable Jetpack's donate block when using Newspack donations.
+	 */
+	public static function disable_jetpack_donate() {
+
+		// Do nothing if Jetpack's blocks aren't being used.
+		if ( ! class_exists( 'Jetpack_Gutenberg' ) ) {
+			return;
+		}
+
+		// Allow Jetpack donations if Newspack donations isn't set up.
+		$donate_settings = Newspack\Donations::get_donation_settings();
+		if ( is_wp_error( $donate_settings ) || ! $donate_settings['created'] ) {
+			return;
+		}
+
+		// Tell Jetpack to mark the donations feature as unavailable.
+		Jetpack_Gutenberg::set_extension_unavailable(
+			'jetpack/donations',
+			esc_html__( 'Jetpack donations is disabled in favour of Newspack donations.', 'newspack-blocks' )
+		);
 	}
 }
 Newspack_Blocks::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When a publisher is using Newspack and has set up Newspack's donations feature, this addition will disabled Jetpack's donations block to avoid confusion when selecting the right block in the editor.

### How to test the changes in this Pull Request:

1. Ensure you see both the Jetpack and Newspack donate blocks in the block chooser
2. Apply the PR and reload the editor
3. Observe that Jetpack's block is no longer available when Newspack donations are configured.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
