### PR TITLE
Add text alignment option when image featured image is at the top

### DIFF
--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -148,6 +148,10 @@
       "type": "array",
       "default": [ "post" ],
       "items": { "type": "string" }
-    }
+    },
+    "textAlign": {
+      "type": "string",
+	  "default": "left"
+	}
   }
 }

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -30,6 +30,7 @@ import {
 	PanelColorSettings,
 	RichText,
 	withColors,
+	AlignmentControl,
 } from '@wordpress/block-editor';
 import {
 	Button,
@@ -608,6 +609,7 @@ class Edit extends Component {
 			showCaption,
 			showCategory,
 			specificMode,
+			textAlign,
 		} = attributes;
 
 		const classes = classNames( className, {
@@ -622,6 +624,7 @@ class Edit extends Component {
 			'has-text-color': textColor.color !== '',
 			'show-caption': showCaption,
 			'show-category': showCategory,
+			[ `has-text-align-${ textAlign }` ]: textAlign,
 			wpnbha: true,
 		} );
 
@@ -751,6 +754,14 @@ class Edit extends Component {
 					<Toolbar controls={ blockControls } />
 					{ showImage && <Toolbar controls={ blockControlsImages } /> }
 					{ showImage && <Toolbar controls={ blockControlsImageShape } /> }
+					{ showImage && mediaPosition === 'top' && (
+						<AlignmentControl
+							value={ textAlign }
+							onChange={ nextAlign => {
+								setAttributes( { textAlign: nextAlign } );
+							} }
+						/>
+					) }
 				</BlockControls>
 				<InspectorControls>{ this.renderInspectorControls() }</InspectorControls>
 			</Fragment>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -751,17 +751,17 @@ class Edit extends Component {
 				) }
 
 				<BlockControls>
-					<Toolbar controls={ blockControls } />
-					{ showImage && <Toolbar controls={ blockControlsImages } /> }
-					{ showImage && <Toolbar controls={ blockControlsImageShape } /> }
-					{ showImage && mediaPosition === 'top' && (
+					<Toolbar>
 						<AlignmentControl
 							value={ textAlign }
 							onChange={ nextAlign => {
 								setAttributes( { textAlign: nextAlign } );
 							} }
 						/>
-					) }
+					</Toolbar>
+					<Toolbar controls={ blockControls } />
+					{ showImage && <Toolbar controls={ blockControlsImages } /> }
+					{ showImage && <Toolbar controls={ blockControlsImageShape } /> }
 				</BlockControls>
 				<InspectorControls>{ this.renderInspectorControls() }</InspectorControls>
 			</Fragment>

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -58,6 +58,9 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	if ( isset( $attributes['className'] ) ) {
 		$classes .= ' ' . $attributes['className'];
 	}
+	if ( $attributes['textAlign'] ) {
+		$classes .= ' has-text-align-' . $attributes['textAlign'];
+	}
 
 	if ( '' !== $attributes['textColor'] || '' !== $attributes['customTextColor'] ) {
 		$classes .= ' has-text-color';

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -302,6 +302,7 @@
 			padding: 0 1rem;
 			position: absolute;
 			right: 0;
+			text-align: right;
 			text-overflow: ellipsis;
 			z-index: 2;
 
@@ -382,7 +383,6 @@
 			justify-content: flex-end;
 		}
 
-		&.image-alignbehind figcaption,
 		figcaption {
 			text-align: inherit;
 		}

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -256,26 +256,6 @@
 					width: 100% !important;
 				}
 
-				figcaption {
-					bottom: 1em;
-					/* autoprefixer: ignore next */
-					-webkit-box-orient: vertical;
-					color: rgba( white, 0.9 );
-					display: -webkit-box;
-					font-style: italic;
-					left: 0;
-					-webkit-line-clamp: 1;
-					margin: 0;
-					max-height: 1.6em;
-					overflow: hidden;
-					padding: 0 1em;
-					position: absolute;
-					right: 0;
-					text-align: right;
-					text-overflow: ellipsis;
-					z-index: 2;
-				}
-
 				&::after {
 					background: rgba( 0, 0, 0, 0.5 );
 					bottom: 0;
@@ -289,12 +269,12 @@
 			}
 
 			.entry-wrapper {
-				padding: 2em 1em;
+				padding: 2rem 1rem;
 				position: relative;
 				z-index: 2;
 
 				@include media( desktop ) {
-					padding: 2em 1.5em;
+					padding: 2rem 1.5rem;
 				}
 			}
 
@@ -304,6 +284,29 @@
 			.entry-meta .byline a,
 			.cat-links a {
 				color: #fff;
+			}
+		}
+
+		figcaption {
+			bottom: 1em;
+			/* autoprefixer: ignore next */
+			-webkit-box-orient: vertical;
+			color: rgba( white, 0.9 );
+			display: -webkit-box;
+			font-style: italic;
+			left: 0;
+			-webkit-line-clamp: 1;
+			margin: 0;
+			max-height: 1.6em;
+			overflow: hidden;
+			padding: 0 1rem;
+			position: absolute;
+			right: 0;
+			text-overflow: ellipsis;
+			z-index: 2;
+
+			@include media( desktop ) {
+				padding: 0 1.5rem;
 			}
 		}
 	}
@@ -365,12 +368,13 @@
 			margin: 0;
 		}
 
-		&.image-alignbehind .post-has-image .post-thumbnail figcaption,
+		&.image-alignbehind figcaption,
 		figcaption {
 			text-align: inherit;
 		}
 	}
 
+	// Ensure right alignment when selected.
 	&.has-text-align-right {
 		.cat-links,
 		.entry-meta,
@@ -378,14 +382,16 @@
 			justify-content: flex-end;
 		}
 
+		&.image-alignbehind figcaption,
 		figcaption {
 			text-align: inherit;
 		}
 
-		.wpnbha .entry-meta .byline:not( :last-child ) {
-			margin: 0 0 0 1.5em;
+		.entry-date:not( :first-child ) {
+			margin-left: 1.5em;
 		}
 
+		.entry-meta .byline:not( :last-child ),
 		.sponsor-logos > * {
 			margin: 0;
 		}

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -365,13 +365,9 @@
 			margin: 0;
 		}
 
+		&.image-alignbehind .post-has-image .post-thumbnail figcaption,
 		figcaption {
 			text-align: inherit;
-		}
-
-		button {
-			margin-left: auto;
-			margin-right: auto;
 		}
 	}
 

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -352,6 +352,18 @@
 		position: relative;
 		width: auto;
 	}
+
+	// Ensure centre alignment when selected.
+	&.has-text-align-center {
+		.cat-links {
+			display: block;
+		}
+
+		button {
+			margin-left: auto;
+			margin-right: auto;
+		}
+	}
 }
 
 /* stylelint-disable selector-type-no-unknown  */

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -355,13 +355,43 @@
 
 	// Ensure centre alignment when selected.
 	&.has-text-align-center {
-		.cat-links {
-			display: block;
+		.cat-links,
+		.entry-meta,
+		.sponsor-logos {
+			justify-content: center;
+		}
+
+		.sponsor-logos > * {
+			margin: 0;
+		}
+
+		figcaption {
+			text-align: inherit;
 		}
 
 		button {
 			margin-left: auto;
 			margin-right: auto;
+		}
+	}
+
+	&.has-text-align-right {
+		.cat-links,
+		.entry-meta,
+		.sponsor-logos {
+			justify-content: flex-end;
+		}
+
+		figcaption {
+			text-align: inherit;
+		}
+
+		.wpnbha .entry-meta .byline:not( :last-child ) {
+			margin: 0 0 0 1.5em;
+		}
+
+		.sponsor-logos > * {
+			margin: 0;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds an alignment control to the block when the featured image is shown and the image position is "top", allowing users to centre-align the block text when using that particular image style.

Closes #847.

### How to test the changes in this Pull Request:

1. Apply the PR and add a block, selecting the combination mentioned above for feature image
2. Observe the alignment control (dis-)appearing as you change the options
3. Observe that the correct CSS class is applied and the text is aligned accordingly.

![Screenshot from 2021-09-21 15-13-26](https://user-images.githubusercontent.com/136342/134187430-b10c4c62-2c01-477f-bb14-b212b5796cff.png)
![Screenshot from 2021-09-21 15-13-13](https://user-images.githubusercontent.com/136342/134187432-b25caa40-13da-434e-98a0-a1feff57478e.png)
![Screenshot from 2021-09-21 15-13-00](https://user-images.githubusercontent.com/136342/134187436-499d99ad-8ea3-4336-9744-5e232e13ad1c.png)

One note: there is no horizontal line between the alignment control and the three dots - I wasn't sure why or how to correct that.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
