### PR TITLE
fix: if a post has a custom excerpt, use it

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -776,13 +776,15 @@ class Newspack_Blocks {
 		}
 
 		self::$newspack_blocks_excerpt_closure = function( $text = '', $post = null ) use ( $attributes ) {
+			$post        = get_post( $post );
+			$text        = $post->post_excerpt;
 			$raw_excerpt = $text;
 
-			$post = get_post( $post );
-			$text = get_the_content( '', false, $post );
-
-			$text = strip_shortcodes( $text );
-			$text = excerpt_remove_blocks( $text );
+			if ( empty( $text ) ) {
+				$text = get_the_content( '', false, $post );
+				$text = strip_shortcodes( $text );
+				$text = excerpt_remove_blocks( $text );
+			}
 
 			/** This filter is documented in wp-includes/post-template.php */
 			$text = apply_filters( 'the_content', $text ); // phpcs:ignore


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#874 added functionality to ensure that generated excerpts adhere to the length attribute set in Homepage Posts blocks. However, it seems that it causes every post to show a generated excerpt, even if it has a custom excerpt. This fix checks for a custom excerpt and uses it if it exists, before generating one.

### How to test the changes in this Pull Request:

1. Publish a post with a lengthy custom excerpt and some different post content.
2. On `master`, add a Homepage Posts block that will show this post to a page and enable "Show Excerpt."
3. Observe that your post is shown with a generated excerpt, not with your custom one, in both the editor and on the front-end.
4. Switch to this branch, confirm that the editor and front-end now show your custom excerpt, but trimmed according to the Excerpt Length setting in block attributes.
5. Also confirm that posts with no custom excerpt display an excerpt generated from the post content, trimmed according to the Excerpt Length attribute.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
