### PR TITLE
fix: do not apply the_content filter to homepage post excerpts

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -787,7 +787,6 @@ class Newspack_Blocks {
 			}
 
 			/** This filter is documented in wp-includes/post-template.php */
-			$text = apply_filters( 'the_content', $text ); // phpcs:ignore
 			$text = str_replace( ']]>', ']]&gt;', $text );
 			$text = wp_trim_words( $text, $attributes['excerptLength'], static::more_excerpt() );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes the `the_content` filter applied to excerpts generated for Homepage Posts blocks, since it might result in unwanted behavior if other plugins are using that same filter.

### How to test the changes in this Pull Request:

1. On `master`, temporarily add a function to your theme's `functions.php` to append some content on the `the_content` hook:

```
function newspack_test_content_filter( $content ) {
	$content .= ' And this is my appended text!';
	return $content;
}
add_filter( 'the_content', newspack_test_content_filter, 0 );
```

2. Add a Homepage Posts block to a page and turn on "Show Excerpts". Observe that excerpts are affected by your test filter in the editor and on the front-end.
3. Check out this branch, confirm that your excerpts are unaffected by the content filter.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
