### PR TITLE
add a filter to enable duplicating posts

### DIFF
--- a/src/blocks/homepage-articles/templates/articles-loop.php
+++ b/src/blocks/homepage-articles/templates/articles-loop.php
@@ -19,9 +19,12 @@ call_user_func(
 		Newspack_Blocks::filter_excerpt_length( $attributes );
 		Newspack_Blocks::filter_excerpt_more( $attributes );
 
+		$enable_post_duplication = apply_filters( 'newspack_blocks_homepage_enable_duplication', false );
 		while ( $article_query->have_posts() ) {
 			$article_query->the_post();
-			$newspack_blocks_post_id[ get_the_ID() ] = true;
+			if ( ! $enable_post_duplication ) {
+				$newspack_blocks_post_id[ get_the_ID() ] = true;
+			}
 			echo Newspack_Blocks::template_inc( __DIR__ . '/article.php', array( 'attributes' => $attributes ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

since we have a deduplication process for posts, we can't show the same post in two different
homepage-posts blocks. Which should be good for all cases. Using the `newspack-popups` and setting a
popup with a homepage-posts block will show the non-duplicated posts on the homepage and the popup
in the first time we're loading the page, but the second time (we won't have the popup since it's
showed only once or once a day) we'll have missing (robbed) posts from the homepage-posts block of
the page as explained here https://github.com/Automattic/newspack-popups/issues/126. We need to add
an exception for the deduplication system for such case.

This is needed for this https://github.com/Automattic/newspack-popups/pull/630

### How to test the changes in this Pull Request:

Normally this shouldn't change how the homepage-posts block works.
1. Check out this.
2. Add two homepage-posts blocks with the same category filter.
3. Observe the deduplication system is still working and the posts are not duplicated on both blocks.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
