### PR TITLE
feat(donate): display errors in the editor

### DIFF
--- a/src/blocks/donate/edit.js
+++ b/src/blocks/donate/edit.js
@@ -17,6 +17,7 @@ import {
 	SelectControl,
 	TextControl,
 	ToggleControl,
+	Notice,
 } from '@wordpress/components';
 import { InspectorControls, RichText } from '@wordpress/block-editor';
 
@@ -414,7 +415,16 @@ class Edit extends Component {
 		if ( ! manual && ( error.length || ! created ) ) {
 			return null;
 		}
-		return tiered ? this.renderTieredForm() : this.renderUntieredForm();
+		return (
+			<>
+				{ this.state.error ? (
+					<Notice status="error" isDismissible={ false }>
+						{ this.state.error }
+					</Notice>
+				) : null }
+				{ tiered ? this.renderTieredForm() : this.renderUntieredForm() }
+			</>
+		);
 	}
 
 	renderManualControls() {

--- a/src/blocks/donate/editor.scss
+++ b/src/blocks/donate/editor.scss
@@ -18,3 +18,9 @@
 		padding-right: 20px;
 	}
 }
+
+div[data-type='newspack-blocks/donate'] {
+	.components-notice {
+		margin: 0;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds error display for the Donate block.

### How to test the changes in this Pull Request:

1. On `master`, set up Newspack donation with WooCommerce (aka Newspack platform, in Reader Revenue wizard)
2. Add a Donate block to a page
3. Turn off the WooCommerce plugin
3. Open the page with the Donate block in the editor, observe no notification about the missing plugin
4. Switch to this branch, reload the editor - observe an error notice above the Donate block

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->