### PR TITLE
fix: correct clash between centered text and image behind alignment

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -271,6 +271,7 @@
 			.entry-wrapper {
 				padding: 2rem 1rem;
 				position: relative;
+				width: 100%;
 				z-index: 2;
 
 				@include media( desktop ) {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR makes sure the 'content' area of the Homepage Posts block is wide enough when you're using the 'image behind' featured image placement. By default it'll stretch to fit its contents, which isn't noticeable when the text is aligned right, but is obviously not all of the available space when you've aligned the text centred or right. 

Closes #894

### How to test the changes in this Pull Request:

1. Ideally you'll be starting with a couple stories with shorter titles. 
2. Add the Homepage Posts block to the homepage; make sure it's not in a column block so it can span the full width of the page. Give it the following settings:
     * Switch it to featured image behind
     * Centre the text
     * Hide the excerpt (so we're mostly relying on the width of the title)
3. View on the front-end and in the editor; note that the text all seems to be bunched to the side:

![image](https://user-images.githubusercontent.com/177561/137982473-c9d1b0fd-d94f-4d1d-94bd-6395a7e4c715.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the text seems to actually be centred on the front-end and in the editor; confirm the same for the right text alignment:

![image](https://user-images.githubusercontent.com/177561/137982350-ae267912-bc93-43b2-90ae-60cc574e8023.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
