### PR TITLE
feat(homepage-posts): enable showing previously rendered posts too

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -465,14 +465,21 @@ class Newspack_Blocks {
 			$args['orderby']  = 'post__in';
 		} else {
 			$args['posts_per_page'] = $posts_to_show;
-			if ( count( $newspack_blocks_all_specific_posts_ids ) ) {
-				$args['post__not_in'] = $newspack_blocks_all_specific_posts_ids;
+
+			$show_rendered_posts = apply_filters( 'newspack_blocks_homepage_shown_rendered_posts', false );
+			if ( $show_rendered_posts ) {
+				$args['post__not_in'] = [ get_the_ID() ];
+			} else {
+				if ( count( $newspack_blocks_all_specific_posts_ids ) ) {
+					$args['post__not_in'] = $newspack_blocks_all_specific_posts_ids;
+				}
+				$args['post__not_in'] = array_merge(
+					$args['post__not_in'] ?? [],
+					array_keys( $newspack_blocks_post_id ),
+					get_the_ID() ? [ get_the_ID() ] : []
+				);
 			}
-			$args['post__not_in'] = array_merge(
-				$args['post__not_in'] ?? [],
-				array_keys( $newspack_blocks_post_id ),
-				get_the_ID() ? [ get_the_ID() ] : []
-			);
+
 			if ( $authors && count( $authors ) ) {
 				$co_authors_names = [];
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This is needed when we do use the homepage-posts block in an overlay, we need to show all the filtered posts even if they were rendered in another block previously

### How to test the changes in this Pull Request:

Technically this PR just adds a filter so nothing should change with this. If the filter is enabled, in the homepage-posts block, we'll render all filtered posts including the ones previously rendered. We needed this since the overlay prompts from the `newspack-popups` act as another content layer.

1. Create a prompt with placement before header, with a `homepage-posts` block, and filter the posts by a category.
2. Create an overlay prompt with a `homepage-posts` block, and filter the posts by the same category from 1.
3. Load the homepage and observe that the posts loaded in the overlay don't include the ones rendered in the before header prompt.
4. Checkout this, and in the `newspack-popups` checkout https://github.com/Automattic/newspack-popups/pull/630 since the filter is added when rendering an overlay.
5. Clear your cache, or re-open an incognito window and load the homepage.
6. Observe that the overlay prompt does include also the posts rendered in the before header prompt.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
