### PR TITLE
fix(iframe-block): add a trailing slash to iframe URL

### DIFF
--- a/src/blocks/iframe/class-wp-rest-newspack-iframe-controller.php
+++ b/src/blocks/iframe/class-wp-rest-newspack-iframe-controller.php
@@ -165,7 +165,7 @@ class WP_REST_Newspack_Iframe_Controller extends WP_REST_Controller {
 			// check if iframe entry file is there.
 			if ( file_exists( path_join( $iframe_path, self::IFRAME_ENTRY_FILE ) ) ) {
 				$response = [
-					'src' => $wp_upload_dir['url'] . self::IFRAME_UPLOAD_DIR . $iframe_folder,
+					'src' => $wp_upload_dir['url'] . self::IFRAME_UPLOAD_DIR . $iframe_folder . DIRECTORY_SEPARATOR,
 					'dir' => path_join( $wp_upload_dir['subdir'] . self::IFRAME_UPLOAD_DIR, $iframe_folder ),
 				];
 
@@ -186,7 +186,7 @@ class WP_REST_Newspack_Iframe_Controller extends WP_REST_Controller {
 
 				if ( 1 === count( $archive_folders ) && file_exists( path_join( $archive_folders[0], self::IFRAME_ENTRY_FILE ) ) ) {
 					$response = [
-						'src' => $wp_upload_dir['url'] . self::IFRAME_UPLOAD_DIR . $iframe_folder . DIRECTORY_SEPARATOR . basename( $archive_folders[0] ),
+						'src' => $wp_upload_dir['url'] . self::IFRAME_UPLOAD_DIR . $iframe_folder . DIRECTORY_SEPARATOR . basename( $archive_folders[0] ) . DIRECTORY_SEPARATOR,
 						'dir' => path_join( $wp_upload_dir['subdir'] . self::IFRAME_UPLOAD_DIR, $iframe_folder . DIRECTORY_SEPARATOR ),
 					];
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Without the trailing slash, the iframe URL does a redirection to add the slash and set the request on HTTP which raises a mixed content issue, adding the trailing slash would stop the redirection and minimize the calls to the server. The issue was raised in the Atomic environment but I was able to reproduce it locally too.

### How to test the changes in this Pull Request:

1. If you don't have HTTPS use a temporary Atomic site.
2. On a new post, add the iframe block.
3. Upload a zip archive with at least an index.html file that will be the entry point to your iframe (I attached a zip archive for tests).
4. Notice that the iframe doesn't preview, and the console shows a mixed content error due to a redirection to HTTP.
5. Pull this PR.
6. Upload again the same archive and notice this time there is no redirection and the iframe loads as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
