### PR TITLE
fix(author-profile): corrected CAP author links; linked WP users

### DIFF
--- a/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
+++ b/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
@@ -251,7 +251,7 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 			[
 				'post_type'      => 'guest-author',
 				'posts_per_page' => 1,
-				'meta_key'       => 'cap-linked_account',
+				'meta_key'       => 'cap-linked_account', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'meta_value'     => $user_login, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 			]
 		);

--- a/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
+++ b/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
@@ -90,12 +90,28 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 			$guest_author_args['p'] = $author_id;
 		}
 
-		$guest_authors      = new \WP_Query( $guest_author_args );
-		$guest_author_total = $guest_authors->found_posts;
+		$guest_authors      = get_posts( $guest_author_args );
+		$guest_author_total = count( $guest_authors );
+		$users              = []; // We'll only get standard WP users if no guest authors were found.
 
-		// Get standard WP users.
+		// If passed an author ID.
 		if ( $author_id ) {
-			$users = 0 === $guest_author_total ? [ get_user_by( 'id', $author_id ) ] : []; // If passed an author_id and we already found it as guest author, no need to run this query.
+			if ( 0 === $guest_author_total ) {
+				$user = get_user_by( 'id', $author_id ); // Get the WP user.
+
+				// We have a WP user, let's use it.
+				if ( $user ) {
+					// But wait, there's more! Let's see if this user is linked to a guest author.
+					$linked_guest_author = self::get_linked_guest_author( $user->user_login );
+
+					// If it is, let's use that instead.
+					if ( $linked_guest_author ) {
+						$guest_authors = [ $linked_guest_author ];
+					} else {
+						$users = [ $user ];
+					}
+				}
+			}
 		} else {
 			$user_args = [
 				'role__in' => [ 'Administrator', 'Editor', 'Author', 'Contributor' ],
@@ -118,7 +134,7 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 		// Format and combine results.
 		$combined_authors = array_merge(
 			array_reduce(
-				! empty( $guest_authors->posts ) ? $guest_authors->posts : [],
+				! empty( $guest_authors ) ? $guest_authors : [],
 				function( $acc, $guest_author ) use ( $fields ) {
 					if ( $guest_author ) {
 						if ( class_exists( 'CoAuthors_Guest_Authors' ) ) {
@@ -221,6 +237,26 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 		$response->header( 'x-wp-total', $user_total + $guest_author_total );
 
 		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Given a WP user login, get the linked guest author, if any.
+	 *
+	 * @param string $user_login WP user login name.
+	 *
+	 * @return WP_Post|boolean Linked guest author in post form, or false if none.
+	 */
+	public static function get_linked_guest_author( $user_login ) {
+		$linked_guest_authors = get_posts(
+			[
+				'post_type'      => 'guest-author',
+				'posts_per_page' => 1,
+				'meta_key'       => 'cap-linked_account',
+				'meta_value'     => $user_login, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			]
+		);
+
+		return 0 < count( $linked_guest_authors ) ? reset( $linked_guest_authors ) : false;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes two bugs:

* The front-end link rendered for guest authors' post archives depended on query args instead of "pretty" URLs. This works most of the time, unless the permalink slugs for guest authors contain non-URL-friendly characters (especially slashes), in which case the links result in 404s. This latter condition can really only happen if the `cap-user_login` meta field is set manually, for example during a data migration.
* When rendering WP users that are linked to CAP guest authors, the WP user's info and links are shown. This doesn't match CAP's behavior, which essentially replaces WP user info rendered on the front-end with the linked guest author.

Closes #903.

### How to test the changes in this Pull Request:

1. While on `master`, create a guest author and link it to a WP user. For ease of testing, the two authors should have different info so they're easily distinguished.
2. For the guest author, use WP CLI to set the login name to something that will result in a non-URL-friendly permalink, e.g. `wp post meta set <post_id> cap-user_login author/slug`
3. Add two Author Profile blocks to a post or page, one with the guest author and the other with the WP user.
4. Observe that in the editor and on the front-end, the two blocks display different info (the guest author block shows guest author info, the WP user block shows WP user info).
5. Observe that on the front-end, both blocks lead to 404s.
6. Check out out this branch.
7. Confirm that in the editor and on the front-end, both blocks now show the guest author info and are more or less indistinguishable from each other.
8. Confirm that on the front-end, both blocks link to the author's post archive.
 
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
