### PR TITLE
fix: add wptexturize to the article subtitle

### DIFF
--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -129,25 +129,24 @@ call_user_func(
 				?>
 				<div class="newspack-post-subtitle newspack-post-subtitle--in-homepage-block">
 					<?php
-					echo wp_kses(
-						$subtitle,
-						[
-							'b'      => true,
-							'strong' => true,
-							'i'      => true,
-							'em'     => true,
-							'mark'   => true,
-							'u'      => true,
-							'small'  => true,
-							'sub'    => true,
-							'sup'    => true,
-							'a'      => array(
-								'href'   => true,
-								'target' => true,
-								'rel'    => true,
-							),
-						]
+					$allowed_tags = array(
+						'b'      => true,
+						'strong' => true,
+						'i'      => true,
+						'em'     => true,
+						'mark'   => true,
+						'u'      => true,
+						'small'  => true,
+						'sub'    => true,
+						'sup'    => true,
+						'a'      => array(
+							'href'   => true,
+							'target' => true,
+							'rel'    => true,
+						),
 					);
+
+					echo wptexturize( wp_kses( $subtitle, $allowed_tags ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					?>
 				</div>
 			<?php endif; ?>


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds [`wptexturize`](https://developer.wordpress.org/reference/functions/wptexturize/) to the article subtitle.

See https://github.com/Automattic/newspack-theme/issues/1570

### How to test the changes in this Pull Request:

1. Add a subtitle to a post; make sure to include a quote or apostrophe, or `--`.
2. Add a homepage posts block that includes that article, and set the Article Subtitle to be visible in the right sidebar. 
3. View the block on the front-end -- in the subtitle, the quotes/apostrophes will be straight up-and-down, and your `--` will look like `--` (when it's normally transformed to a proper m-dash when added through the post editor).
4. Apply the PR.
5. Refresh the page with the homepage posts block; you should now have smartquotes, and/or a proper m-dash (&mdash;).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
