### PR TITLE
feat(donate-block): defer Stripe scripts loading

### DIFF
--- a/src/blocks/donate/streamlined.js
+++ b/src/blocks/donate/streamlined.js
@@ -6,7 +6,7 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { loadStripe } from '@stripe/stripe-js';
+import { loadStripe } from '@stripe/stripe-js/pure';
 import 'regenerator-runtime'; // Required in WP >=5.8.
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

As per [docs](https://www.npmjs.com/package/@stripe/stripe-js):

> If you would like to use loadStripe in your application, but defer loading the Stripe.js script until loadStripe is first called, use the alternative @stripe/stripe-js/pure import path

### How to test the changes in this Pull Request:

1. On `master`, open a page with the Donate block in streamlined (Stripe) version*
2. Observe that Stripe's JS (`https://js.stripe.com/v3`) loads on page load 
3. Switch to this branch
4. Observe the Stripe JS loads after clicking the "Donate" button, which initiates the payment flow

\* Choose and configure Stripe as the platform in Reader Revenue wizard

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->