### PR TITLE
Post Carousel: update sizing for multiple slides, mobile

### DIFF
--- a/src/blocks/carousel/create-swiper.js
+++ b/src/blocks/carousel/create-swiper.js
@@ -115,9 +115,12 @@ export default function createSwiper( els, config = {} ) {
 		touchStartPreventDefault: false,
 		breakpoints: {
 			320: {
+				slidesPerView: 1,
+			},
+			782: {
 				slidesPerView: config.slidesPerView > 1 ? 2 : 1,
 			},
-			600: {
+			1168: {
 				slidesPerView: config.slidesPerView,
 			},
 		},

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -174,6 +174,7 @@ class Edit extends Component {
 		const classes = classnames(
 			className,
 			'wp-block-newspack-blocks-carousel', // Default to make styles work for third-party consumers.
+			'slides-per-view-' + slidesPerView,
 			'swiper',
 			{
 				'wp-block-newspack-blocks-carousel__autoplay-playing': autoplay,

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -29,6 +29,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 	if ( $autoplay ) {
 		$other[] = 'wp-block-newspack-blocks-carousel__autoplay-playing';
 	}
+	$other[] = 'slides-per-view-' . $attributes['slidesPerView'];
 	$classes = Newspack_Blocks::block_classes( 'carousel', $attributes, $other );
 
 	$article_query = new WP_Query( Newspack_Blocks::build_articles_query( $attributes, apply_filters( 'newspack_blocks_block_name', 'newspack-blocks/carousel' ) ) );

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -252,14 +252,14 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 	$slides_to_show  = $slides_per_view <= $counter ? $slides_per_view : $counter;
 
 	if ( $is_amp ) {
-		$selector    = sprintf(
+		$selector = sprintf(
 			'<amp-selector id="wp-block-newspack-carousel__amp-pagination__%1$d" class="swiper-pagination-bullets amp-pagination" on="select:wp-block-newspack-carousel__amp-carousel__%1$d.goToSlide(index=event.targetOption)" layout="container" %2$s>%3$s</amp-selector>',
 			absint( $newspack_blocks_carousel_id ),
 			$attributes['hideControls'] ? 'aria-hidden="true"' : '',
 			implode( '', $buttons )
 		);
 
-		$carousel    = sprintf(
+		$carousel = sprintf(
 			'<amp-base-carousel class="wp-block-newspack-carousel__amp-carousel" width="%1$s" height="%2$s" heights="%3$s" layout="responsive" snap="true" type="slides" data-next-button-aria-label="%4$s" data-prev-button-aria-label="%5$s" controls loop %6$s id="wp-block-newspack-carousel__amp-carousel__%7$s" on="slideChange:wp-block-newspack-carousel__amp-pagination__%7$s.toggle(index=event.index, value=true)" advance-count="1" visible-count="%8$s">%9$s</amp-base-carousel>',
 			$attributes['slidesPerView'] * 1,
 			$attributes['aspectRatio'],
@@ -273,7 +273,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 		);
 		$autoplay_ui = $autoplay ? newspack_blocks_carousel_block_autoplay_ui_amp( $newspack_blocks_carousel_id ) : '';
 	} else {
-		$selector    = sprintf(
+		$selector = sprintf(
 			'<div class="swiper-pagination-bullets amp-pagination" %1$s>%2$s</div>',
 			$attributes['hideControls'] ? 'aria-hidden="true"' : '',
 			implode( '', $buttons )
@@ -284,7 +284,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 			esc_attr__( 'Next Slide', 'newspack-blocks' ),
 			$attributes['hideControls'] ? 'aria-hidden="true"' : ''
 		);
-		$carousel    = sprintf(
+		$carousel = sprintf(
 			'<div class="swiper"><div class="swiper-wrapper">%s</div>%s</div>',
 			$slides,
 			$navigation

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -259,7 +259,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 			implode( '', $buttons )
 		);
 
-		$carousel = sprintf(
+		$carousel    = sprintf(
 			'<amp-base-carousel class="wp-block-newspack-carousel__amp-carousel" width="%1$s" height="%2$s" heights="%3$s" layout="responsive" snap="true" type="slides" data-next-button-aria-label="%4$s" data-prev-button-aria-label="%5$s" controls loop %6$s id="wp-block-newspack-carousel__amp-carousel__%7$s" on="slideChange:wp-block-newspack-carousel__amp-pagination__%7$s.toggle(index=event.index, value=true)" advance-count="1" visible-count="%8$s">%9$s</amp-base-carousel>',
 			$attributes['slidesPerView'] * 1,
 			$attributes['aspectRatio'],
@@ -273,7 +273,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 		);
 		$autoplay_ui = $autoplay ? newspack_blocks_carousel_block_autoplay_ui_amp( $newspack_blocks_carousel_id ) : '';
 	} else {
-		$selector = sprintf(
+		$selector    = sprintf(
 			'<div class="swiper-pagination-bullets amp-pagination" %1$s>%2$s</div>',
 			$attributes['hideControls'] ? 'aria-hidden="true"' : '',
 			implode( '', $buttons )
@@ -284,7 +284,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 			esc_attr__( 'Next Slide', 'newspack-blocks' ),
 			$attributes['hideControls'] ? 'aria-hidden="true"' : ''
 		);
-		$carousel = sprintf(
+		$carousel    = sprintf(
 			'<div class="swiper"><div class="swiper-wrapper">%s</div>%s</div>',
 			$slides,
 			$navigation

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -258,15 +258,17 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 			$attributes['hideControls'] ? 'aria-hidden="true"' : '',
 			implode( '', $buttons )
 		);
+
 		$carousel    = sprintf(
-			'<amp-base-carousel class="wp-block-newspack-carousel__amp-carousel" width="%1$s" height="%2$s" layout="responsive" snap="true" type="slides" data-next-button-aria-label="%3$s" data-prev-button-aria-label="%4$s" controls loop %5$s id="wp-block-newspack-carousel__amp-carousel__%6$s" on="slideChange:wp-block-newspack-carousel__amp-pagination__%6$s.toggle(index=event.index, value=true)" advance-count="1" visible-count="%7$s">%8$s</amp-base-carousel>',
+			'<amp-base-carousel class="wp-block-newspack-carousel__amp-carousel" width="%1$s" height="%2$s" heights="%3$s" layout="responsive" snap="true" type="slides" data-next-button-aria-label="%4$s" data-prev-button-aria-label="%5$s" controls loop %6$s id="wp-block-newspack-carousel__amp-carousel__%7$s" on="slideChange:wp-block-newspack-carousel__amp-pagination__%7$s.toggle(index=event.index, value=true)" advance-count="1" visible-count="%8$s">%9$s</amp-base-carousel>',
 			$attributes['slidesPerView'] * 1,
 			$attributes['aspectRatio'],
+			'(min-width: 1168px) ' . ( $attributes['aspectRatio'] / $slides_to_show * 100 ) . '% !important, (min-width: 782px) ' . ( $slides_to_show > 1 ? ( $attributes['aspectRatio'] / 2 * 100 ) . '% !important' : ( $attributes['aspectRatio'] * 100 ) . '% !important' ) . ', ' . ( $attributes['aspectRatio'] * 100 ) . '% !important',
 			esc_attr__( 'Next Slide', 'newspack-blocks' ),
 			esc_attr__( 'Previous Slide', 'newspack-blocks' ),
 			$autoplay ? 'auto-advance="true" auto-advance-interval=' . esc_attr( $delay * 1000 ) : '',
 			absint( $newspack_blocks_carousel_id ),
-			'(min-width: 600px) ' . $slides_to_show . ', ' . ( $slides_to_show > 1 ? 2 : 1 ),
+			'(min-width: 1168px) ' . $slides_to_show . ', (min-width: 782px) ' . ( $slides_to_show > 1 ? 2 : 1 ) . ', ' . 1,
 			$slides
 		);
 		$autoplay_ui = $autoplay ? newspack_blocks_carousel_block_autoplay_ui_amp( $newspack_blocks_carousel_id ) : '';

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -314,8 +314,8 @@
 		}
 	}
 
-	&[data-slides-per-view='3'] article,
-	&[data-slides-per-view='4'] article {
+	&.slides-per-view-3 article,
+	&.slides-per-view-4 article {
 		.entry-title {
 			@include media( tablet ) {
 				font-size: 1.2em;

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -305,4 +305,29 @@
 			visibility: hidden;
 		}
 	}
+
+	&[data-slides-per-view='2'] article {
+		.entry-title {
+			@include media( tablet ) {
+				font-size: 1.4em;
+			}
+		}
+	}
+
+	&[data-slides-per-view='3'] article,
+	&[data-slides-per-view='4'] article {
+		.entry-title {
+			@include media( tablet ) {
+				font-size: 1.2em;
+			}
+			@include media( desktop ) {
+				font-size: 1em;
+			}
+		}
+		.entry-meta {
+			@include media( tablet ) {
+				font-size: 0.7em;
+			}
+		}
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes some visual updates to the Post Carousel block:
* To scale down the title font size when displaying 3-4 slides at once
* To alter the number of posts shown on tablet and mobile-sized screens, so they don't get too croweded.
* To fix an issue with the aspect ratio getting smooshed on blocks displaying 3-4 slides, on smaller screen sizes. 

Closes #844.

### How to test the changes in this Pull Request:

1. Add four Post Carousel block to a page: one displaying one slide at a time, one displaying two, one displaying three and one displaying four. Publish. 
2. View on the front end; note the blocks showing 3-4 slides at a time are crowded: 

![image](https://user-images.githubusercontent.com/177561/143946229-44a11808-b009-4acc-9c7e-a6dd191e6429.png)

3. Scale down the browser window to roughly tablet and mobile sizes; note the appearance of the blocks, specifically how the text can get cut off on the 3-4 slide blocks, and how their aspect ratios seem squished when AMP is enabled: 

![image](https://user-images.githubusercontent.com/177561/143946275-ba3ab865-a59b-4f28-94cf-9b10757a936b.png)

![image](https://user-images.githubusercontent.com/177561/143946328-8fce3a1e-a2ab-4858-9100-a4ededdfb141.png)

4. Apply the PR and run `npm run build`.
5. Check your page on a desktop sized window and confirm the entry title scales down when the slide count is higher: 

![image](https://user-images.githubusercontent.com/177561/143946535-aabd9e2a-09a6-4cc0-97fa-9ab8348b371f.png)

6. Scale down the browser window to a tablet-sized screen; the font should scale down, and the blocks with 3-4 slides visible should drop to two visible slides, and maintain their aspect ratios when AMP is enabled: 

![image](https://user-images.githubusercontent.com/177561/143946675-cccef6fa-1a16-407c-b52f-15894626e51b.png)

7. Scale down the browser window to a mobile-sized screen; all blocks should only have one slide visible, and no aspect ratio issues: 

![image](https://user-images.githubusercontent.com/177561/143946764-76e238e2-39c3-4fe1-8f9c-7079ae98c5ed.png)

8. Check the page with AMP disabled, and make sure there aren't any visual issues.
9. Edit the page and try some different aspect ratios (like 1:1 and 16:9); confirm that they are used by your blocks without issue. (Note: the block has a max-height of 75vh, which is 75% of the current screen height. This means there are some cases where the aspect ratio won't be respected entirely -- for example, if you have a block displaying one slide with a 1:1 aspect ratio on desktop, it will probably be wider than it is tall. This is the expected behaviour with the max height that's set). 

![image](https://user-images.githubusercontent.com/177561/143947217-354dcb57-4117-47e1-af8c-6dad3a36bd1f.png)

![image](https://user-images.githubusercontent.com/177561/143947861-289453a0-bda8-4f9b-94b5-ffd81b8bca29.png)

(I did notice some combos -- like 16:9 with four slides in that last screenshot -- are still crowded. I think that's more of a case where we'd want to steer folks  away from using particular combinations of settings, rather than something we need to get to work well in all cases -- like in that case, it's probably best to only show the title, not the byline and date too. But I'm definitely open to feedback on that!)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
