### PR TITLE
fix: view scripts in AMP Plus mode

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -290,9 +290,6 @@ class Newspack_Blocks {
 	 * @return bool True if AMP, false otherwise.
 	 */
 	public static function is_amp() {
-		if ( class_exists( 'Newspack\AMP_Enhancements' ) && method_exists( 'Newspack\AMP_Enhancements', 'should_use_amp_plus' ) && Newspack\AMP_Enhancements::should_use_amp_plus( 'gam' ) ) {
-			return false;
-		}
 		if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
 			return true;
 		}

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -9,6 +9,12 @@
  * Newspack blocks functionality
  */
 class Newspack_Blocks {
+
+	/**
+	 * Script handle for the streamlined donate block script.
+	 */
+	const DONATE_STREAMLINED_SCRIPT_HANDLE = 'newspack-blocks-donate-streamlined';
+
 	/**
 	 * Add hooks and filters.
 	 */
@@ -28,7 +34,7 @@ class Newspack_Blocks {
 	 * @param string $handle The script handle.
 	 */
 	public static function mark_view_script_as_amp_plus_allowed( $tag, $handle ) {
-		if ( 0 === stripos( $handle, 'newspack-blocks-' ) ) {
+		if ( self::DONATE_STREAMLINED_SCRIPT_HANDLE === $handle ) {
 			return str_replace( '<script', '<script data-amp-plus-allowed', $tag );
 		}
 		return $tag;

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -9,12 +9,6 @@
  * Newspack blocks functionality
  */
 class Newspack_Blocks {
-
-	/**
-	 * Script handle for the streamlined donate block script.
-	 */
-	const DONATE_STREAMLINED_SCRIPT_HANDLE = 'newspack-blocks-donate-streamlined';
-
 	/**
 	 * Add hooks and filters.
 	 */
@@ -34,7 +28,7 @@ class Newspack_Blocks {
 	 * @param string $handle The script handle.
 	 */
 	public static function mark_view_script_as_amp_plus_allowed( $tag, $handle ) {
-		if ( self::DONATE_STREAMLINED_SCRIPT_HANDLE === $handle ) {
+		if ( 0 === stripos( $handle, 'newspack-blocks-' ) ) {
 			return str_replace( '<script', '<script data-amp-plus-allowed', $tag );
 		}
 		return $tag;

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -23,7 +23,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 	$autoplay = isset( $attributes['autoplay'] ) ? $attributes['autoplay'] : false;
 	$delay    = isset( $attributes['delay'] ) ? absint( $attributes['delay'] ) : 3;
 	$authors  = isset( $attributes['authors'] ) ? $attributes['authors'] : array();
-	$is_amp   = Newspack_Blocks::is_amp();
+	$is_amp   = function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
 
 	$other = array();
 	if ( $autoplay ) {
@@ -274,8 +274,6 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 		);
 		$autoplay_ui = $autoplay ? newspack_blocks_carousel_block_autoplay_ui_amp( $newspack_blocks_carousel_id ) : '';
 	} else {
-		// Make sure the active class is present in the DOM, so AMP won't tree-shake it away in AMP Plus mode.
-		$buttons[0]  = str_replace( 'swiper-pagination-bullet', 'swiper-pagination-bullet swiper-pagination-bullet-active', $buttons[0] );
 		$selector    = sprintf(
 			'<div class="swiper-pagination-bullets amp-pagination" %1$s>%2$s</div>',
 			$attributes['hideControls'] ? 'aria-hidden="true"' : '',

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -23,7 +23,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 	$autoplay = isset( $attributes['autoplay'] ) ? $attributes['autoplay'] : false;
 	$delay    = isset( $attributes['delay'] ) ? absint( $attributes['delay'] ) : 3;
 	$authors  = isset( $attributes['authors'] ) ? $attributes['authors'] : array();
-	$is_amp   = function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
+	$is_amp   = Newspack_Blocks::is_amp();
 
 	$other = array();
 	if ( $autoplay ) {

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -23,7 +23,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 	$autoplay = isset( $attributes['autoplay'] ) ? $attributes['autoplay'] : false;
 	$delay    = isset( $attributes['delay'] ) ? absint( $attributes['delay'] ) : 3;
 	$authors  = isset( $attributes['authors'] ) ? $attributes['authors'] : array();
-	$is_amp   = function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
+	$is_amp   = Newspack_Blocks::is_amp();
 
 	$other = array();
 	if ( $autoplay ) {
@@ -274,6 +274,8 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 		);
 		$autoplay_ui = $autoplay ? newspack_blocks_carousel_block_autoplay_ui_amp( $newspack_blocks_carousel_id ) : '';
 	} else {
+		// Make sure the active class is present in the DOM, so AMP won't tree-shake it away in AMP Plus mode.
+		$buttons[0]  = str_replace( 'swiper-pagination-bullet', 'swiper-pagination-bullet swiper-pagination-bullet-active', $buttons[0] );
 		$selector    = sprintf(
 			'<div class="swiper-pagination-bullets amp-pagination" %1$s>%2$s</div>',
 			$attributes['hideControls'] ? 'aria-hidden="true"' : '',

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -94,7 +94,7 @@ function newspack_blocks_enqueue_streamlined_donate_block_scripts() {
 	if ( Newspack_Blocks::is_rendering_streamlined_block() ) {
 		$script_data = Newspack_Blocks::script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . '/donateStreamlined.js' );
 		wp_enqueue_script(
-			'newspack-blocks-donate-streamlined',
+			Newspack_Blocks::DONATE_STREAMLINED_SCRIPT_HANDLE,
 			$script_data['script_path'],
 			[ 'wp-i18n' ],
 			$script_data['version'],
@@ -102,7 +102,7 @@ function newspack_blocks_enqueue_streamlined_donate_block_scripts() {
 		);
 		$style_path = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'donateStreamlined' . ( is_rtl() ? '.rtl' : '' ) . '.css';
 		wp_enqueue_style(
-			'newspack-blocks-donate-streamlined',
+			Newspack_Blocks::DONATE_STREAMLINED_SCRIPT_HANDLE,
 			plugins_url( $style_path, NEWSPACK_BLOCKS__PLUGIN_FILE ),
 			[],
 			NEWSPACK_BLOCKS__VERSION

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -94,7 +94,7 @@ function newspack_blocks_enqueue_streamlined_donate_block_scripts() {
 	if ( Newspack_Blocks::is_rendering_streamlined_block() ) {
 		$script_data = Newspack_Blocks::script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . '/donateStreamlined.js' );
 		wp_enqueue_script(
-			Newspack_Blocks::DONATE_STREAMLINED_SCRIPT_HANDLE,
+			'newspack-blocks-donate-streamlined',
 			$script_data['script_path'],
 			[ 'wp-i18n' ],
 			$script_data['version'],
@@ -102,7 +102,7 @@ function newspack_blocks_enqueue_streamlined_donate_block_scripts() {
 		);
 		$style_path = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'donateStreamlined' . ( is_rtl() ? '.rtl' : '' ) . '.css';
 		wp_enqueue_style(
-			Newspack_Blocks::DONATE_STREAMLINED_SCRIPT_HANDLE,
+			'newspack-blocks-donate-streamlined',
 			plugins_url( $style_path, NEWSPACK_BLOCKS__PLUGIN_FILE ),
 			[],
 			NEWSPACK_BLOCKS__VERSION


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #953

Not all view scripts (JS loaded on the frontend) were handled in AMP Plus mode. This PR fixes that, ~so that the blocks' interactions in AMP Plus mode are as they do with AMP disabled.~ 
_Initially, this PR forced all blocks into behaving as with AMP disabled in AMP Plus. There's no need for this, though. The only block that really needs to use AMP Plus features is the streamlined version of the Donate block, because it needs to load additional scripts._

### How to test the changes in this Pull Request:

1. Observe that #953 is not reproducible
2. Confirm that Carousel block's frontend JS-reliant interactions work as expected with AMP Plus mode on, and exactly as with AMP enabled

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1200994000430649