### PR TITLE
ci: update apt-get before installing rsync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       - checkout_code
       - run:
           name: Install rsync
-          command: sudo apt install rsync
+          command: sudo apt-get update && sudo apt-get install rsync
       - run:
           name: Release new version
           command: npm run release


### PR DESCRIPTION
A [release job](https://app.circleci.com/pipelines/github/Automattic/newspack-blocks/1401/workflows/77f27c63-d8c0-46df-b449-534da29d0520/jobs/3028) has failed with the following error:
```
E: Unable to locate package rsync
```

In other repositories [`apt-get update` is ran](https://app.circleci.com/pipelines/github/Automattic/newspack-popups/1739/workflows/c56ece87-9e22-43e1-bf5d-12a4037516de/jobs/6701) before this command. Let's see if that fixes it.