### PR TITLE
feat: disabling image lazy load for homepage articles

### DIFF
--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -34,6 +34,10 @@
       "type": "boolean",
       "default": false
     },
+    "disableImageLazyLoad": {
+      "type": "boolean",
+      "default": false
+    },
     "imageShape": {
       "type": "string",
       "default": "landscape"

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -257,6 +257,7 @@ class Edit extends Component {
 			postType,
 			showImage,
 			showCaption,
+			disableImageLazyLoad,
 			imageScale,
 			mobileStack,
 			minHeight,
@@ -391,6 +392,20 @@ class Edit extends Component {
 								label={ __( 'Show Featured Image Caption', 'newspack-blocks' ) }
 								checked={ showCaption }
 								onChange={ () => setAttributes( { showCaption: ! showCaption } ) }
+							/>
+						</PanelRow>
+					) }
+
+					{ showImage && (
+						<PanelRow>
+							<ToggleControl
+								label={ __( 'Disable Featured Image Lazy Loading', 'newspack-blocks' ) }
+								help={ __(
+									'Improve Largest Contentful Paint (LCP) score if the block is on initial viewport.',
+									'newspack-blocks'
+								) }
+								checked={ disableImageLazyLoad }
+								onChange={ () => setAttributes( { disableImageLazyLoad: ! disableImageLazyLoad } ) }
 							/>
 						</PanelRow>
 					) }

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -35,10 +35,17 @@ call_user_func(
 		if ( has_post_thumbnail() && 'uncropped' !== $attributes['imageShape'] ) {
 			$image_size = Newspack_Blocks::image_size_for_orientation( $attributes['imageShape'] );
 		}
-		$thumbnail_args = '';
+		$thumbnail_args = array(
+			'data-hero-candidate' => true,
+		);
 		// If the image position is behind, pass the object-fit setting to maintain styles with AMP.
 		if ( 'behind' === $attributes['mediaPosition'] ) {
-			$thumbnail_args = array( 'object-fit' => 'cover' );
+			$thumbnail_args['object-fit'] = 'cover';
+		}
+		// Disable lazy loading by using an arbitraty `loading` attribute other than `lazy`.
+		// Empty string or `false` would still result in `lazy`.
+		if ( $attributes['disableImageLazyLoad'] ) {
+			$thumbnail_args['loading'] = 'none';
 		}
 		$category = false;
 		// Use Yoast primary category if set.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements Lazy Load toggle for the Homepage Posts block in order to improve [Largest Contentful Paint (LCP)](https://web.dev/i18n/en/lcp/) score for blocks above the fold.

It also implements by default the `data-hero-candidate` attribute to take advantage of AMP's prerendering features for LCP improvement.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #969.

### How to test the changes in this Pull Request:

With AMP Plus on:

1. Check out this branch and install it on a JN or behind ngrok.
2. Set up a page with a Homepage Posts as the first block. It should use "Show media behind" as the media position to take as much screen space as possible. 
3. Visit the page and notice the `<img />` contains the `loading="lazy"` attribute.
4. Obtain the page metrics at https://web.dev/measure
5. Edit the block on the "Featured Image Settings" toggle on the "Disable Featured Image Lazy Loading"
6. Visit the page and notice the `<img />` contains the `loading="none"` attribute.
7. Obtain and compare the page metrics at https://web.dev/measure. Make sure to use an arbitrary `?v=2` parameter for the second report to skip any cache.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
