### PR TITLE
Post Carousel: add simplified CSS class to carousel to reduce style size

### DIFF
--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -174,6 +174,7 @@ class Edit extends Component {
 		const classes = classnames(
 			className,
 			'wp-block-newspack-blocks-carousel', // Default to make styles work for third-party consumers.
+			'wpnbpc', // Shortened version of the default classname.
 			'slides-per-view-' + slidesPerView,
 			'swiper',
 			{

--- a/src/blocks/carousel/editor.scss
+++ b/src/blocks/carousel/editor.scss
@@ -1,6 +1,6 @@
 @import '../../shared/sass/placeholder';
 
-.wp-block-newspack-blocks-carousel {
+.wpnbpc {
 	.swiper-wrapper {
 		height: auto;
 		pointer-events: none;
@@ -47,16 +47,7 @@
 		}
 	}
 }
-.editor-block-list__layout
-	.editor-block-list__block
-	.wp-block-newspack-blocks-carousel
-	.entry-title
-	a,
-.editor-block-list__layout
-	.editor-block-list__block
-	.wp-block-newspack-blocks-carousel
-	.entry-meta
-	.byline
-	a {
+.editor-block-list__layout .editor-block-list__block .wpnbpc .entry-title a,
+.editor-block-list__layout .editor-block-list__block .wpnbpc .entry-meta .byline a {
 	color: inherit;
 }

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -30,6 +30,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 		$other[] = 'wp-block-newspack-blocks-carousel__autoplay-playing';
 	}
 	$other[] = 'slides-per-view-' . $attributes['slidesPerView'];
+	$other[] = 'wpnbpc';
 	$classes = Newspack_Blocks::block_classes( 'carousel', $attributes, $other );
 
 	$article_query = new WP_Query( Newspack_Blocks::build_articles_query( $attributes, apply_filters( 'newspack_blocks_block_name', 'newspack-blocks/carousel' ) ) );

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -2,7 +2,7 @@
 @import '../../shared/sass/mixins';
 @import '../../shared/sass/colors';
 
-.wp-block-newspack-blocks-carousel {
+.wpnbpc {
 	position: relative;
 	margin-top: 0;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a simplified CSS class to the Post Carousel block (`wpnbpc`, to replace the longer `wp-block-newspack-blocks-carousel` class in the CSS. 

This helps reduce the amount of CSS loaded by AMP, especially since this class is included in every style associated with this block -- something similar was done with the Homepage Posts block early on. In my testing, it reduces the CSS by 1.7% when the controls are visible:

With controls before changes: 7,183b = 9.6% of 75kb
With controls after changes: 5,996b = 7.9% of 75kb

There's probably more that can be done here but it's a start!

### How to test the changes in this Pull Request:

1. Set up a Post Carousel block, and check your AMP CSS usage.
2. Apply the PR and run `npm run build.`
3. Clear your browser cache; make sure the post carousel looks right with and without AMP enabled, on the front-end and in the editor. 
4. Re-check your AMP CSS usage; confirm it's gone done ~1.5ish percent. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
