### PR TITLE
feat(donate-stripe): hide fee checkbox if fees are zero

### DIFF
--- a/src/blocks/donate/streamlined.js
+++ b/src/blocks/donate/streamlined.js
@@ -135,7 +135,7 @@ export const processStreamlinedElements = ( parentElement = document ) =>
 			if ( feesAmountEl ) {
 				const formValues = Object.fromEntries( new FormData( formElement ) );
 				const feeAmount = getFeeAmount( formElement );
-				feesAmountEl.innerHTML = `(${ CURRENCY_SYMBOL }${ feeAmount } ${ FREQUENCIES[
+				feesAmountEl.innerHTML = `(${ CURRENCY_SYMBOL }${ feeAmount.toFixed( 2 ) } ${ FREQUENCIES[
 					formValues.donation_frequency
 				].toLowerCase() })`;
 			}

--- a/src/blocks/donate/streamlined.js
+++ b/src/blocks/donate/streamlined.js
@@ -60,6 +60,12 @@ const getAmount = formValues => {
 	return parseFloat( formValues.amount );
 };
 
+export const computeFeeAmount = ( amount, feeMultiplier, feeStatic ) => {
+	return parseFloat(
+		( ( ( amount + feeStatic ) / ( 100 - feeMultiplier ) ) * 100 - amount ).toFixed( 2 )
+	);
+};
+
 const getFeeAmount = formElement => {
 	const formValues = Object.fromEntries( new FormData( formElement ) );
 	const amount = getAmount( formValues );
@@ -67,12 +73,7 @@ const getFeeAmount = formElement => {
 	const [ CURRENCY_SYMBOL, FREQUENCIES, FEE_MULTIPLIER, FEE_STATIC ] = JSON.parse(
 		formElement.getAttribute( 'data-settings' )
 	);
-	return parseFloat(
-		(
-			( ( amount + parseFloat( FEE_STATIC ) ) / ( 100 - parseFloat( FEE_MULTIPLIER ) ) ) * 100 -
-			amount
-		).toFixed( 2 )
-	);
+	return computeFeeAmount( amount, parseFloat( FEE_MULTIPLIER ), parseFloat( FEE_STATIC ) );
 };
 
 export const processStreamlinedElements = ( parentElement = document ) =>

--- a/src/blocks/donate/streamlined.test.js
+++ b/src/blocks/donate/streamlined.test.js
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock-jest';
 import { encode } from 'html-entities';
 
-import { processStreamlinedElements } from './streamlined';
+import { processStreamlinedElements, computeFeeAmount } from './streamlined';
 
 const MONTHLY_AMOUNT = 7;
 
@@ -41,6 +41,21 @@ const createDOM = settings => {
 	document.body.appendChild( parentElement );
 	return document.body;
 };
+
+describe( 'fee computation', () => {
+	it( 'computes fee with default values', () => {
+		expect( computeFeeAmount( 1, 2.9, 0.3 ) ).toBe( 0.34 );
+		expect( computeFeeAmount( 15, 2.9, 0.3 ) ).toBe( 0.76 );
+		expect( computeFeeAmount( 100, 2.9, 0.3 ) ).toBe( 3.3 );
+	} );
+	it( 'computes fee with other values', () => {
+		expect( computeFeeAmount( 15, 0, 0 ) ).toBe( 0 );
+		expect( computeFeeAmount( 15, 2.3, 0.3 ) ).toBe( 0.66 );
+		expect( computeFeeAmount( 15, 2.3, 0 ) ).toBe( 0.35 );
+		expect( computeFeeAmount( 15, 50, 0 ) ).toBe( 15 );
+		expect( computeFeeAmount( 15, 50, 10 ) ).toBe( 35 );
+	} );
+} );
 
 describe( 'Streamlined Donate block processing', () => {
 	fetchMock.post( '/wp-json/newspack-blocks/v1/donate', () => {

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -6,20 +6,6 @@
  */
 
 /**
- * Get fee multiplier.
- */
-function newspack_blocks_render_get_fee_multiplier() {
-	return get_option( 'newspack_blocks_donate_fee_multiplier', '2.9' );
-}
-
-/**
- * Get fee static portion.
- */
-function newspack_blocks_render_get_fee_static() {
-	return get_option( 'newspack_blocks_donate_fee_static', '0.3' );
-}
-
-/**
  * Renders the footer of the donation form.
  *
  * @param array $attributes The block attributes.
@@ -43,9 +29,8 @@ function newspack_blocks_render_block_donate_footer( $attributes ) {
 		$client_id = Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME;
 	}
 
-	$fee_muliplier             = (float) newspack_blocks_render_get_fee_multiplier();
-	$fee_static                = (float) newspack_blocks_render_get_fee_static();
-	$is_rendering_fee_checkbox = 0 < $fee_muliplier + $fee_static;
+	$stripe_data               = \Newspack\Stripe_Connection::get_stripe_data();
+	$is_rendering_fee_checkbox = 0 < (float) $stripe_data['fee_multiplier'] + (float) $stripe_data['fee_static'];
 
 	ob_start();
 
@@ -179,13 +164,12 @@ function newspack_blocks_render_block_donate( $attributes ) {
 	$form_footer = newspack_blocks_render_block_donate_footer( $attributes );
 
 	if ( Newspack_Blocks::is_rendering_streamlined_block() ) {
-		$fee_muliplier         = newspack_blocks_render_get_fee_multiplier();
-		$fee_static            = newspack_blocks_render_get_fee_static();
+		$stripe_data           = \Newspack\Stripe_Connection::get_stripe_data();
 		$settings_for_frontend = [
 			$settings['currencySymbol'],
 			$frequencies,
-			$fee_muliplier,
-			$fee_static,
+			$stripe_data['fee_multiplier'],
+			$stripe_data['fee_static'],
 		];
 	} else {
 		$settings_for_frontend = [];

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -6,6 +6,20 @@
  */
 
 /**
+ * Get fee multiplier.
+ */
+function newspack_blocks_render_get_fee_multiplier() {
+	return get_option( 'newspack_blocks_donate_fee_multiplier', '2.9' );
+}
+
+/**
+ * Get fee static portion.
+ */
+function newspack_blocks_render_get_fee_static() {
+	return get_option( 'newspack_blocks_donate_fee_static', '0.3' );
+}
+
+/**
  * Renders the footer of the donation form.
  *
  * @param array $attributes The block attributes.
@@ -28,6 +42,10 @@ function newspack_blocks_render_block_donate_footer( $attributes ) {
 	if ( class_exists( 'Newspack_Popups_Segmentation' ) ) {
 		$client_id = Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME;
 	}
+
+	$fee_muliplier             = (float) newspack_blocks_render_get_fee_multiplier();
+	$fee_static                = (float) newspack_blocks_render_get_fee_static();
+	$is_rendering_fee_checkbox = 0 < $fee_muliplier + $fee_static;
 
 	ob_start();
 
@@ -53,13 +71,15 @@ function newspack_blocks_render_block_donate_footer( $attributes ) {
 							</label>
 						</div>
 					<?php endif; ?>
-					<div class="stripe-payment__row stripe-payment__row--small">
-						<label class="stripe-payment__checkbox">
-							<input type="checkbox" name="agree_to_pay_fees" checked value="true"><?php echo esc_html__( 'Agree to pay fees?', 'newspack-blocks' ); ?>
-							<span id="stripe-fees-amount">($0)</span>
-						</label>
-						<div class="stripe-payment__info"><?php echo esc_html__( 'Paying the transaction fee is not required, but it directs more money in support of our mission.', 'newspack-blocks' ); ?></div>
-					</div>
+					<?php if ( $is_rendering_fee_checkbox ) : ?>
+						<div class="stripe-payment__row stripe-payment__row--small">
+							<label class="stripe-payment__checkbox">
+								<input type="checkbox" name="agree_to_pay_fees" checked value="true"><?php echo esc_html__( 'Agree to pay fees?', 'newspack-blocks' ); ?>
+								<span id="stripe-fees-amount">($0)</span>
+							</label>
+							<div class="stripe-payment__info"><?php echo esc_html__( 'Paying the transaction fee is not required, but it directs more money in support of our mission.', 'newspack-blocks' ); ?></div>
+						</div>
+					<?php endif; ?>
 					<div class="stripe-payment__messages">
 						<div class="type-error"></div>
 						<div class="type-success"></div>
@@ -159,8 +179,8 @@ function newspack_blocks_render_block_donate( $attributes ) {
 	$form_footer = newspack_blocks_render_block_donate_footer( $attributes );
 
 	if ( Newspack_Blocks::is_rendering_streamlined_block() ) {
-		$fee_muliplier         = get_option( 'newspack_blocks_donate_fee_multiplier', '2.9' );
-		$fee_static            = get_option( 'newspack_blocks_donate_fee_static', '0.3' );
+		$fee_muliplier         = newspack_blocks_render_get_fee_multiplier();
+		$fee_static            = newspack_blocks_render_get_fee_static();
 		$settings_for_frontend = [
 			$settings['currencySymbol'],
 			$frequencies,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Allows hiding of cover-fees checkbox (#928) if the fees amount to 0.

### How to test the changes in this Pull Request:

_Follow steps in https://github.com/Automattic/newspack-plugin/pull/1376_

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->