### PR TITLE
chore: update post-release job to pull changelog and semver changes to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,15 +68,12 @@ jobs:
     docker:
       - image: cimg/node:16.11.1
     steps:
-      - checkout_code
+      - checkout_with_workspace
       - run:
-          name: Set tip of alpha branch on top of release and force-push it to remote
+          name: Perform post-release chores
           command: |
-            git pull origin release
-            git checkout alpha
-            git reset --hard release --
-            git push "https://$GITHUB_TOKEN@github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git" --force
-
+            wget -O post-release.sh https://raw.githubusercontent.com/Automattic/newspack-scripts/master/post-release.sh
+            chmod 755 ./post-release.sh && ./post-release.sh
 workflows:
   version: 2
   all:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
     docker:
       - image: cimg/node:16.11.1
     steps:
-      - checkout_with_workspace
+      - checkout_code
       - run:
           name: Perform post-release chores
           command: |


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Per the new Git workflow for the Newspack team, this updates the `post_release` CI job to pull semver and changelog changes to `master` after a release is built.

### How to test the changes in this Pull Request:

Can't really test until the next release.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
