### PR TITLE
fix(video-playlist): youtube embeds fetching

### DIFF
--- a/src/blocks/video-playlist/view.php
+++ b/src/blocks/video-playlist/view.php
@@ -99,7 +99,7 @@ function newspack_blocks_get_video_playlist_videos( $args ) {
 	$query_args = array(
 		'post_type'      => 'post',
 		'post_status'    => 'publish',
-		's'              => 'core-embed/youtube',
+		's'              => 'youtube',
 		'posts_per_page' => $args['videosToShow'],
 	);
 
@@ -113,8 +113,9 @@ function newspack_blocks_get_video_playlist_videos( $args ) {
 		$blocks         = parse_blocks( $post->post_content );
 		$youtube_blocks = array_filter(
 			$blocks,
-			function( $blocks ) {
-				return 'core-embed/youtube' === $blocks['blockName'];
+			function( $block ) {
+				return ( 'core/embed' === $block['blockName'] && 'youtube' === $block['attrs']['providerNameSlug'] )
+					|| 'core-embed/youtube' === $block['blockName'];
 			}
 		);
 		foreach ( $youtube_blocks as $youtube_block ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #577

### How to test the changes in this Pull Request:

1. Insert some youtube embeds in some posts
2. Insert the "Video Playlist" block on a page
3. Observe the embeds from other posts are compiled to a playlist on this block

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->