### PR TITLE
fix: add Author List block to manifest of blocks to build in production

### DIFF
--- a/block-list.json
+++ b/block-list.json
@@ -1,3 +1,3 @@
 {
-  "production": [ "author-profile", "carousel", "donate", "homepage-articles", "video-playlist", "iframe" ]
+  "production": [ "author-list", "author-profile", "carousel", "donate", "homepage-articles", "video-playlist", "iframe" ]
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds the `author-list` block to the manifest of blocks to be built for production (`block-list.json`). Without it, automated build jobs won't include the new block. This wasn't caught previously because the `watch` command will include all block source files regardless of what's in the manifest.

### How to test the changes in this Pull Request:

1. On `master`, delete the `dist` folder (`rm -r dist`) and rebuild using `npm run build`.
2. Observe that you can't add an Author List block to any post or page.
3. Check out this branch, repeat step 1, confirm that you can now add the Author List block and view it on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
