### PR TITLE
Update Column Block styles for WordPress 5.9.

### DIFF
--- a/src/block-styles/core/columns/editor.scss
+++ b/src/block-styles/core/columns/editor.scss
@@ -40,7 +40,7 @@
 					bottom: 15px;
 					content: '';
 					position: absolute;
-					right: -20px;
+					right: -18px;
 					top: 15px;
 				}
 

--- a/src/block-styles/core/columns/editor.scss
+++ b/src/block-styles/core/columns/editor.scss
@@ -37,11 +37,11 @@
 
 				&::after {
 					border-right: 1px solid $color__border;
-					bottom: 0;
+					bottom: 15px;
 					content: '';
 					position: absolute;
-					right: -30px;
-					top: 0;
+					right: -20px;
+					top: 15px;
 				}
 
 				&:nth-child( odd )::after {

--- a/src/block-styles/core/columns/editor.scss
+++ b/src/block-styles/core/columns/editor.scss
@@ -3,7 +3,7 @@
 
 .wp-block-columns {
 	@include media( mobile ) {
-		&[class*='is-style-first-col-to'] [data-type='core/column']:first-child {
+		&[class*='is-style-first-col-to'] [data-type='core/column'] {
 			margin-left: 2em;
 		}
 

--- a/src/block-styles/core/columns/editor.scss
+++ b/src/block-styles/core/columns/editor.scss
@@ -3,18 +3,15 @@
 
 .wp-block-columns {
 	@include media( mobile ) {
-		&[class*='is-style-first-col-to'] [data-type='core/column'] {
-			margin-left: 46px;
+		&[class*='is-style-first-col-to'] [data-type='core/column']:first-child {
+			margin-left: 2em;
 		}
 
 		&[class*='is-style-first-col-to'] [data-type='core/column']:nth-child( 2 ) {
 			margin-left: 0;
 		}
 
-		&.is-style-first-col-to-second [data-type='core/column']:nth-child( 2 ) {
-			order: -1;
-		}
-
+		&.is-style-first-col-to-second [data-type='core/column']:nth-child( 2 ),
 		&.is-style-first-col-to-third [data-type='core/column']:nth-child( 2 ),
 		&.is-style-first-col-to-third [data-type='core/column']:nth-child( 3 ) {
 			order: -1;

--- a/src/block-styles/core/columns/view.scss
+++ b/src/block-styles/core/columns/view.scss
@@ -2,12 +2,12 @@
 @import '../../../shared/sass/mixins';
 
 .wp-block-columns {
-	.wp-block-column {
-		margin-bottom: 32px;
+	--wp--style--block-gap: 8px;
 
-		&:last-child {
-			margin-bottom: 0;
-		}
+	&.is-not-stack-on-mobile {
+		margin-left: -16px;
+		max-width: calc( 100% + 32px );
+		width: calc( 100% + 32px );
 	}
 
 	@include media( mobile ) {
@@ -29,32 +29,6 @@
 		&.is-style-first-col-to-third .wp-block-column:nth-child( 2 ),
 		&.is-style-first-col-to-third .wp-block-column:nth-child( 3 ) {
 			order: -1;
-		}
-	}
-
-	@include media( tablet ) {
-		&.is-style-borders {
-			margin-left: -24px;
-			max-width: calc( 100% + 48px );
-			width: calc( 100% + 48px );
-
-			> .wp-block-column {
-				margin-left: 24px;
-				margin-right: 24px;
-			}
-		}
-	}
-
-	@include media( desktop ) {
-		&.is-style-borders {
-			margin-left: -32px;
-			max-width: calc( 100% + 64px );
-			width: calc( 100% + 64px );
-
-			> .wp-block-column {
-				margin-left: 32px;
-				margin-right: 32px;
-			}
 		}
 	}
 
@@ -93,17 +67,36 @@
 					top: 0;
 				}
 			}
+		}
+	}
 
-			@include media( tablet ) {
-				&::after {
-					right: -24px;
-				}
+	&.is-not-stacked-on-mobile {
+		> .wp-block-column:not( :first-child ),
+		> .wp-block-column {
+			margin-left: 16px;
+			margin-right: 16px;
+		}
+
+		&.is-style-borders > .wp-block-column {
+			margin-bottom: 0;
+
+			&::after {
+				border-right-width: 1px;
+				border-top-width: 0;
+				bottom: 0;
+				left: auto;
+				right: -16px;
+				top: 0;
 			}
+		}
+	}
 
-			@include media( desktop ) {
-				&::after {
-					right: -32px;
-				}
+	&:not( .is-not-stacked-on-mobile ) {
+		@include media( mobile ) {
+			> .wp-block-column:not( :first-child ),
+			> .wp-block-column:nth-child( 2n ) {
+				margin-left: 16px;
+				margin-right: 16px;
 			}
 		}
 	}

--- a/src/block-styles/core/columns/view.scss
+++ b/src/block-styles/core/columns/view.scss
@@ -2,8 +2,6 @@
 @import '../../../shared/sass/mixins';
 
 .wp-block-columns {
-	--wp--style--block-gap: 8px;
-
 	&.is-not-stack-on-mobile {
 		margin-left: -16px;
 		max-width: calc( 100% + 32px );
@@ -18,8 +16,6 @@
 
 		.wp-block-column {
 			margin-bottom: 0;
-			margin-left: 16px;
-			margin-right: 16px;
 		}
 
 		&.is-style-first-col-to-second .wp-block-column:nth-child( 2 ) {
@@ -71,15 +67,14 @@
 	}
 
 	&.is-not-stacked-on-mobile {
+		> .wp-block-column,
 		> .wp-block-column:not( :first-child ),
-		> .wp-block-column {
+		> .wp-block-column:nth-child( 2n ) {
 			margin-left: 16px;
 			margin-right: 16px;
 		}
 
 		&.is-style-borders > .wp-block-column {
-			margin-bottom: 0;
-
 			&::after {
 				border-right-width: 1px;
 				border-top-width: 0;
@@ -93,10 +88,50 @@
 
 	&:not( .is-not-stacked-on-mobile ) {
 		@include media( mobile ) {
+			> .wp-block-column,
 			> .wp-block-column:not( :first-child ),
 			> .wp-block-column:nth-child( 2n ) {
 				margin-left: 16px;
 				margin-right: 16px;
+			}
+		}
+	}
+
+	&:not( .is-not-stacked-on-mobile ),
+	&.is-not-stacked-on-mobile {
+		&.is-style-borders {
+			@include media( tablet ) {
+				margin-left: -24px;
+				max-width: calc( 100% + 48px );
+				width: calc( 100% + 48px );
+
+				> .wp-block-column,
+				> .wp-block-column:not( :first-child ),
+				> .wp-block-column:nth-child( 2n ) {
+					margin-left: 24px;
+					margin-right: 24px;
+
+					&::after {
+						right: -24px;
+					}
+				}
+			}
+
+			@include media( desktop ) {
+				margin-left: -32px;
+				max-width: calc( 100% + 64px );
+				width: calc( 100% + 64px );
+
+				> .wp-block-column,
+				> .wp-block-column:not( :first-child ),
+				> .wp-block-column:nth-child( 2n ) {
+					margin-left: 32px;
+					margin-right: 32px;
+
+					&::after {
+						right: -32px;
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In the Newspack Blocks suite, we have some column block styles that:

1. Update the default column block styles, to not wrap until they hit the mobile breakpoint.
2. Allow you to add borders to the columns.
3. Allow you to reorder the columns on desktop.

Changes coming in WP 5.9 to add the option to not wrap columns on mobile have overridden some of our own styles. This PR hopefully sorts them out and gets them working again, without causing issues in 5.8.

Closes #1018 and #1019

### How to test the changes in this Pull Request:

This will be easiest to test if you can work with two test sites and compare them: one running WordPress 5.8.X, and the other running the 5.9 RC.

1. In the test site running 5.9 RC, copy [this test content](https://github.com/Automattic/newspack-blocks/files/7885188/columns-59.txt) to the editor, or add a bunch of column blocks with different settings. Change the page you test to use the one column wide template.
2. In the test site running 5.8.X, copy [this test content](https://github.com/Automattic/newspack-blocks/files/7885189/columns-58.txt) to the editor, or add a bunch of column blocks with different settings. Change the page you test to use the one column wide template.
3. Apply this PR to both sites and run `npm run build`.
4. Apply this theme PR to both sites and run `npm run build` - it updates a couple styles in the theme: https://github.com/Automattic/newspack-theme/pull/1670
5. View and compare both posts at different breakpoints. Things to look for include:

* Making sure the columns block doesn't wrap on mobile when its set not to on the 5.9 site.
* That the columns styles and spacing look consistent between the different sections.
* That the border styles and spacing look consistent between the different sections.

Here are some examples of how things should look:

**WordPress 5.9**

Regular columns:
![image](https://user-images.githubusercontent.com/177561/149848990-77e41a05-d5d2-445e-af18-e4adfc94fa10.png)

"Don't stack on mobile" setting (the first column doesn't have this checked, and the second one does)

![image](https://user-images.githubusercontent.com/177561/149849068-4f0f9dc8-3320-4d16-a05d-d8bd4286c3d9.png)

Reordered blocks: 

![image](https://user-images.githubusercontent.com/177561/149849131-53442edd-ac4f-4056-90ac-8722ebbc3507.png)

Columns blocks with borders: 

![image](https://user-images.githubusercontent.com/177561/149849113-5f2f656d-7504-4c66-8558-2f65a7c9c606.png)

**WordPress 5.8**

Regular columns:
![image](https://user-images.githubusercontent.com/177561/149849032-fac194a8-48cb-4b64-b55a-4685491ca737.png)

Reordered columns:

![image](https://user-images.githubusercontent.com/177561/149849158-0b88427b-896e-47bb-b4af-f2701411c347.png)

Columns with borders: 

![image](https://user-images.githubusercontent.com/177561/149849180-d3aa92a8-1cf8-4db8-a805-1445c5213f46.png)

6. Review things in the editor and make sure things look fairly consistent between the two versions.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
