### PR TITLE
Re-add column vertical spacing

### DIFF
--- a/src/block-styles/core/columns/view.scss
+++ b/src/block-styles/core/columns/view.scss
@@ -70,8 +70,7 @@
 		> .wp-block-column,
 		> .wp-block-column:not( :first-child ),
 		> .wp-block-column:nth-child( 2n ) {
-			margin-left: 16px;
-			margin-right: 16px;
+			margin: 0 16px;
 		}
 
 		&.is-style-borders > .wp-block-column {
@@ -87,12 +86,30 @@
 	}
 
 	&:not( .is-not-stacked-on-mobile ) {
+		> .wp-block-column {
+			margin-bottom: 32px;
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
+
+		&.is-style-borders {
+			> .wp-block-column {
+				margin-bottom: 64px;
+
+				&:last-child {
+					margin-bottom: 0;
+				}
+			}
+		}
+
 		@include media( mobile ) {
+			&.is-style-border > .wp-block-columns,
 			> .wp-block-column,
 			> .wp-block-column:not( :first-child ),
 			> .wp-block-column:nth-child( 2n ) {
-				margin-left: 16px;
-				margin-right: 16px;
+				margin: 0 16px;
 			}
 		}
 	}

--- a/src/block-styles/core/columns/view.scss
+++ b/src/block-styles/core/columns/view.scss
@@ -101,7 +101,7 @@
 		}
 
 		@include media( mobile ) {
-			&.is-style-border > .wp-block-column,
+			&.is-style-borders > .wp-block-column,
 			> .wp-block-column,
 			> .wp-block-column:not( :first-child ),
 			> .wp-block-column:nth-child( 2n ) {

--- a/src/block-styles/core/columns/view.scss
+++ b/src/block-styles/core/columns/view.scss
@@ -101,7 +101,7 @@
 		}
 
 		@include media( mobile ) {
-			&.is-style-border > .wp-block-columns,
+			&.is-style-border > .wp-block-column,
 			> .wp-block-column,
 			> .wp-block-column:not( :first-child ),
 			> .wp-block-column:nth-child( 2n ) {

--- a/src/block-styles/core/columns/view.scss
+++ b/src/block-styles/core/columns/view.scss
@@ -14,10 +14,6 @@
 		max-width: calc( 100% + 32px );
 		width: calc( 100% + 32px );
 
-		.wp-block-column {
-			margin-bottom: 0;
-		}
-
 		&.is-style-first-col-to-second .wp-block-column:nth-child( 2 ) {
 			order: -1;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Changes in #1018 incorrectly added the bottom margin between columns that's needed on mobile. This PR reinstates it.

### How to test the changes in this Pull Request:

1. On a test site running 5.9, set up some columns, with and without the border style, and with and without 'Stack on mobile' checked. View on mobile sized screens. 
2. Note that when the columns don't have borders, they don't have space between them on mobile:

![image](https://user-images.githubusercontent.com/177561/150030797-df50cb89-5ba6-4e9d-9cc1-bb89b764133a.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the columns now have space when stacked on mobile, and that no extra space is added on desktop, or between columns with borders:

![image](https://user-images.githubusercontent.com/177561/150030624-f6bd0a75-d333-40a2-970b-a010f01f1f55.png)

5. Test on a site running 5.8 and confirm that this change did not cause visual regressions. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
