### PR TITLE
fix: handle unavailable Newspack plugin

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -34,3 +34,4 @@ node_modules
 /release
 /tests
 /bin
+.cache

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -1089,9 +1089,8 @@ class Newspack_Blocks {
 	 * Disable Jetpack's donate block when using Newspack donations.
 	 */
 	public static function disable_jetpack_donate() {
-
-		// Do nothing if Jetpack's blocks aren't being used.
-		if ( ! class_exists( 'Jetpack_Gutenberg' ) ) {
+		// Do nothing if Jetpack's blocks or Newspack aren't being used.
+		if ( ! class_exists( 'Jetpack_Gutenberg' ) || ! class_exists( 'Newspack' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1. Handles the case of Newspack plugin unavailable
2. Adds `.cache` directory (npm-related) to `.distignore` file, so it won't be included in the released ZIP 

### How to test the changes in this Pull Request:

1. On `master`, deactivate the Newspack Plugin 
2. Try to add a new page in Newspack admin, observe a PHP fatal `Fatal error:  Uncaught Error: Class 'Newspack\Donations' not found` thrown
3. Switch to this branch, observe no fatal thrown

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->