### PR TITLE
fix(NextGen Gallery): disable ngg shortcode manager

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -25,6 +25,19 @@ class Newspack_Blocks {
 		add_filter( 'script_loader_tag', [ __CLASS__, 'mark_view_script_as_amp_plus_allowed' ], 10, 2 );
 		add_action( 'jetpack_register_gutenberg_extensions', [ __CLASS__, 'disable_jetpack_donate' ], 99 );
 		add_filter( 'the_content', [ __CLASS__, 'hide_post_content_when_iframe_block_is_fullscreen' ] );
+
+		/**
+		 * Disable NextGEN's `C_NextGen_Shortcode_Manager`.
+		 *
+		 * The way it currently parses `the_content` conflicts with the REST API
+		 * request to save a post containing a Homepage Posts block. This is due to
+		 * how it uses output buffering through `ob_start()` on REST requests.
+		 *
+		 * @link https://plugins.trac.wordpress.org/browser/nextgen-gallery/tags/3.23/non_pope/class.nextgen_shortcode_manager.php#L193.
+		 */
+		if ( ! defined( 'NGG_DISABLE_SHORTCODE_MANAGER' ) ) {
+			define( 'NGG_DISABLE_SHORTCODE_MANAGER', true ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fix the NextGen Gallery and Homepage Posts block conflict by disabling NextGEN's `C_NextGen_Shortcode_Manager`. The way it currently parses `the_content` conflicts with the REST API request to save a post containing a Homepage Posts block. This is due to how it uses output buffering through `ob_start()` on REST requests.

https://plugins.trac.wordpress.org/browser/nextgen-gallery/tags/3.23/non_pope/class.nextgen_shortcode_manager.php#L193

Closes #665.

### How to test the changes in this Pull Request:

Reproduce the steps mentioned in #665 with this branch and confirm the post saves without errors.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
