### PR TITLE
iFrame Block: Add alignment classes and update options

### DIFF
--- a/src/blocks/iframe/index.js
+++ b/src/blocks/iframe/index.js
@@ -41,7 +41,7 @@ export const settings = {
 	attributes,
 	supports: {
 		html: false,
-		align: true,
+		align: [ 'wide', 'full' ],
 	},
 	edit,
 	save: () => null, // to use view.php

--- a/src/blocks/iframe/view.php
+++ b/src/blocks/iframe/view.php
@@ -50,10 +50,11 @@ function newspack_blocks_get_iframe( $args ) {
 		'height'       => '600px',
 		'width'        => '100%',
 		'isFullScreen' => false,
+		'align'        => '',
 	);
 	$args     = wp_parse_args( $args, $defaults );
 
-	return newspack_blocks_get_iframe_html( $args['mode'], $args['src'], $args['height'], $args['width'], $args['isFullScreen'] );
+	return newspack_blocks_get_iframe_html( $args['mode'], $args['src'], $args['height'], $args['width'], $args['isFullScreen'], $args['align'] );
 }
 
 /**
@@ -66,16 +67,21 @@ function newspack_blocks_get_iframe( $args ) {
  * @param boolean $is_full_screen If the Iframe should be rendered full screen.
  * @return string HTML embed.
  */
-function newspack_blocks_get_iframe_html( $mode, $src, $height, $width, $is_full_screen ) {
+function newspack_blocks_get_iframe_html( $mode, $src, $height, $width, $is_full_screen, $align ) {
 	$is_document = 'document' === $mode;
 	$height      = $is_full_screen ? '100' : $height;
 	$width       = $is_full_screen ? '100' : $width;
 	$style       = "height: $height; width: $width;";
 	$layout      = 'responsive';
 	$iframe_id   = 'newspack-iframe-' . wp_generate_password( 12, false );
+	$classes[]   = 'wp-block-newspack-blocks-iframe';
 
 	if ( empty( $src ) ) {
 		return;
+	}
+
+	if ( ! empty( $align ) ) {
+		$classes[] = 'align' . $align;
 	}
 
 	if ( $is_full_screen ) {
@@ -89,7 +95,7 @@ function newspack_blocks_get_iframe_html( $mode, $src, $height, $width, $is_full
 
 	ob_start();
 	?>
-	<figure class='wp-block-newspack-blocks-iframe'>
+	<figure class='<?php echo esc_attr( implode( ' ', $classes ) ); ?>'>
 		<div class='wp-block-embed__wrapper' style="height:<?php echo esc_attr( $height ); ?>; width:<?php echo esc_attr( $width ); ?>;">
 			<iframe
 				id = '<?php echo esc_attr( $iframe_id ); ?>'

--- a/src/blocks/iframe/view.php
+++ b/src/blocks/iframe/view.php
@@ -65,6 +65,7 @@ function newspack_blocks_get_iframe( $args ) {
  * @param string  $height Iframe Height.
  * @param string  $width Iframe width.
  * @param boolean $is_full_screen If the Iframe should be rendered full screen.
+ * @param string  $align Iframe block alignment.
  * @return string HTML embed.
  */
 function newspack_blocks_get_iframe_html( $mode, $src, $height, $width, $is_full_screen, $align ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes two changes to the iframe block: 

1. It makes sure that the alignment classes (alignwide, alignfull...) are added to the front-end of the site -- multiple alignments were available, but the styles weren't actually being applied. 
2. It pares down the alignment options from all (left, right, center, wide and full) to just wide and full. 

I am definitely open to feedback about the second change! My feeling is that the left, right and (to a lesser extent) centre alignments are less useful options for something like an embed. 

On top of that, none of them really work even with the right classes applied to the front-end: if an iframe is aligned left or right, it needs a fixed px width set so it doesn't "collapse" due to how the theme styles left and right-aligned blocks. If the iframe is centre aligned, even if it's made narrower (like 300px) it will sit to the left because the theme is apply the centre-aligned styles to the parent div, not the contents. If we do want to keep these alignments we'll need to pair this PR with one in the theme to get everything working.

Closes #1046

### How to test the changes in this Pull Request:

1. Create a new post or page and switch it to one of the one column template options. (Note: if switching to one of these templates on page creation, I'd recommend publishing and refreshing the editor, just so the right editor styles are loaded).
2. Add three iframe blocks, and make one 'wide' and one 'full' aligned.
3. Publish and view on the front-end. 
4. Note that while your wide and full alignment previewed fine in the editor, they don't work on the front-end.
5. Apply the PR and run `npm run build`.
6. Refresh your post/page; confirm that your alignments now work on the front end. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
