### PR TITLE
fix: handle inactive newspack-popups

### DIFF
--- a/src/blocks/donate/streamlined/utils.js
+++ b/src/blocks/donate/streamlined/utils.js
@@ -80,7 +80,7 @@ export const getFormValues = formElement => {
 	if ( ! formValues.amount ) {
 		formValues.amount = formValues[ `${ valueKey }_untiered` ];
 	}
-	if ( formValues.cid.indexOf( 'CLIENT_ID' ) === 0 ) {
+	if ( formValues.cid && formValues.cid.indexOf( 'CLIENT_ID' ) === 0 ) {
 		// In non-AMP environment, the value will not be dynamically substituted by AMP runtime.
 		formValues.cid = getCookies()[ 'newspack-cid' ];
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug. Should be followed by a hotfix, since the bug is released on `alpha`.

### How to test the changes in this Pull Request:

1. Set up streamlined Donate block
2. Deactivate `newspack-popups` 
3. Observe the Donate block does not fully load on the front-end

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->