### PR TITLE
fix(homepage-posts): post fetch for widget blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 			"dependencies": {
 				"@stripe/stripe-js": "^1.24.0",
 				"classnames": "^2.3.1",
+				"lodash": "^4.17.21",
 				"newspack-components": "^2.0.3",
 				"react": "^17.0.2",
 				"redux": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 	"dependencies": {
 		"@stripe/stripe-js": "^1.24.0",
 		"classnames": "^2.3.1",
+		"lodash": "^4.17.21",
 		"newspack-components": "^2.0.3",
 		"react": "^17.0.2",
 		"redux": "^4.1.2",

--- a/src/blocks/homepage-articles/store.js
+++ b/src/blocks/homepage-articles/store.js
@@ -125,7 +125,17 @@ const createFetchPostsSaga = blockNames => {
 
 		yield put( { type: 'DISABLE_UI' } );
 
-		const blockQueries = getBlockQueries( getBlocks(), blockNames );
+		// Ensure innerBlocks are populated for widget area blocks.
+		// See https://github.com/WordPress/gutenberg/issues/32607#issuecomment-890728216.
+		const blocks = getBlocks().map( block => {
+			const innerBlocks = select( 'core/block-editor' ).getBlocks( block.clientId );
+			return {
+				...block,
+				innerBlocks,
+			};
+		} );
+
+		const blockQueries = getBlockQueries( blocks, blockNames );
 
 		// Use requested specific posts ids as the starting state of exclusion list.
 		const specificPostsId = blockQueries.reduce( ( acc, { postsQuery } ) => {

--- a/src/blocks/homepage-articles/utils.js
+++ b/src/blocks/homepage-articles/utils.js
@@ -173,7 +173,8 @@ export const postsBlockSelector = ( select, { clientId, attributes } ) => {
 	const { getBlocks } = select( 'core/block-editor' );
 	const editorBlocksIds = getEditorBlocksIds( getEditorBlocks() );
 	// The block might be rendered in the block styles preview, not in the editor.
-	const isEditorBlock = editorBlocksIds.indexOf( clientId ) >= 0;
+	const isWidgetEditor = getBlocks().some( block => block.name === 'core/widget-area' );
+	const isEditorBlock = editorBlocksIds.indexOf( clientId ) >= 0 || isWidgetEditor;
 
 	const { getPosts, getError, isUIDisabled } = select( STORE_NAMESPACE );
 	const props = {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

While adding a Homepage Posts or Carousel block to a widget area through the new block-based UI you get placeholder content instead of fetching actual posts.

This PR makes the necessary changes for these blocks to perform the posts fetch on the widget editor.

| Current | This PR |
| --- | --- |
| <img width="732" alt="image" src="https://user-images.githubusercontent.com/820752/157888670-ef9efd8b-04d0-48d7-901b-f2ede7cc7398.png"> | <img width="731" alt="image" src="https://user-images.githubusercontent.com/820752/157889258-bbb8e6dd-1514-4841-9789-e0ba2af1afa8.png"> |

### How to test the changes in this Pull Request:

1. If you are running Newspack plugin, check out https://github.com/Automattic/newspack-plugin/pull/1550 to enable the block-based widget editor
2. While on master, visit Appearance -> Widgets and place a Homepage Posts and a Carousel block
3. Confirm you only see placeholder demo content
4. Check out this branch, run `npm run build` and confirm the posts are fetched
5. Edit a post/page and also add and edit the blocks to confirm there are no issues with its regular usage

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
