### PR TITLE
fix: donate block non-default styles grid breakpoint

### DIFF
--- a/src/blocks/donate/view.scss
+++ b/src/blocks/donate/view.scss
@@ -399,13 +399,10 @@
 			~ .tiers {
 				display: grid;
 				grid-gap: 0.56rem;
+				grid-template-columns: repeat( 2, 1fr );
 				margin: 1.12rem;
 
-				@include media( mobile ) {
-					grid-template-columns: repeat( 2, 1fr );
-				}
-
-				@include media( desktop ) {
+				@include media( tablet ) {
 					grid-template-columns: repeat( 4, 1fr );
 				}
 			}
@@ -560,13 +557,10 @@
 			~ .tiers {
 				display: grid;
 				grid-gap: 0.56rem;
+				grid-template-columns: repeat( 2, 1fr );
 				margin: 1.12rem 0;
 
-				@include media( mobile ) {
-					grid-template-columns: repeat( 2, 1fr );
-				}
-
-				@include media( desktop ) {
+				@include media( tablet ) {
 					grid-template-columns: repeat( 4, 1fr );
 				}
 			}

--- a/src/blocks/donate/view.scss
+++ b/src/blocks/donate/view.scss
@@ -398,12 +398,12 @@
 
 			~ .tiers {
 				display: grid;
-				grid-gap: 0.56rem;
-				grid-template-columns: repeat( 2, 1fr );
+				grid-gap: 0.28rem;
+				grid-template-columns: repeat( 4, 1fr );
 				margin: 1.12rem;
 
-				@include media( tablet ) {
-					grid-template-columns: repeat( 4, 1fr );
+				@include media( mobile ) {
+					grid-gap: 0.56rem;
 				}
 			}
 		}
@@ -555,12 +555,15 @@
 			}
 
 			~ .tiers {
-				display: grid;
-				grid-gap: 0.56rem;
-				grid-template-columns: repeat( 2, 1fr );
+				display: flex;
+				flex-wrap: wrap;
+				grid-gap: 1.12rem;
+				justify-content: center;
 				margin: 1.12rem 0;
 
-				@include media( tablet ) {
+				@include media( mobile ) {
+					display: grid;
+					grid-gap: 0.56rem;
 					grid-template-columns: repeat( 4, 1fr );
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR changes the Tiers Grid breakpoints for the Alternate and Minimal styles.

See #1077 

### How to test the changes in this Pull Request:

1. Add 2 donate blocks on a page, 1 with Alternate style, 1 with Minimal style
2. Resize your screen
3. Switch to this branch
4. Refresh page

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
