### PR TITLE
fix: authors and guest authors in homepage posts

### DIFF
--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -286,6 +286,10 @@ class Newspack_Blocks_API {
 			$args['post__not_in'] = $attributes['exclude'];
 		}
 
+		if ( $attributes['include'] && count( $attributes['include'] ) ) {
+			$args['post__in'] = $attributes['include'];
+		}
+
 		$query = new WP_Query( $args );
 		$posts = [];
 

--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -279,77 +279,17 @@ class Newspack_Blocks_API {
 	 * @return WP_REST_Response.
 	 */
 	public static function posts_endpoint( $request ) {
-		$params   = $request->get_params();
-		$per_page = $request['per_page'];
-		$args     = [
-			'post_type'           => 'post',
-			'post_status'         => 'publish',
-			'posts_per_page'      => $per_page,
-			'suppress_filters'    => false,
-			'ignore_sticky_posts' => true,
-			'has_password'        => false,
-		];
+		$attributes = $request->get_params();
+		$args       = Newspack_Blocks::build_articles_query( $attributes, apply_filters( 'newspack_blocks_block_name', 'newspack-blocks/homepage-articles' ) );
 
-		if ( $params['categories'] && count( $params['categories'] ) ) {
-			$args['category__in'] = $params['categories'];
-		}
-		if ( $params['categories_exclude'] && count( $params['categories_exclude'] ) ) {
-			$args['category__not_in'] = $params['categories_exclude'];
-		}
-		if ( $params['tags'] && count( $params['tags'] ) ) {
-			$args['tag__in'] = $params['tags'];
-		}
-		if ( $params['tags_exclude'] && count( $params['tags_exclude'] ) ) {
-			$args['tag__not_in'] = $params['tags_exclude'];
-		}
-		if ( $params['author'] && count( $params['author'] ) ) {
-			$authors_ids      = $params['author'];
-			$co_authors_names = [];
-
-			if ( class_exists( 'CoAuthors_Guest_Authors' ) ) {
-				$co_authors_guest_authors = new CoAuthors_Guest_Authors();
-
-				foreach ( $authors_ids as $index => $author_id ) {
-					$co_author = $co_authors_guest_authors->get_guest_author_by( 'id', $author_id );
-					if ( $co_author ) {
-						$co_authors_names[] = $co_author->user_nicename;
-						unset( $authors_ids[ $index ] );
-					}
-				}
-			}
-
-			if ( count( $co_authors_names ) ) {
-				// look for authors and co-authors posts.
-				Newspack_Blocks::filter_posts_clauses_when_co_authors( $authors_ids, $co_authors_names );
-			} else {
-				$args['author__in'] = $authors_ids;
-			}
-		}
-		if ( $params['include'] && count( $params['include'] ) ) {
-			$args['post__in'] = $params['include'];
-			$args['orderby']  = 'post__in';
-			$args['order']    = 'ASC';
-		}
-		if ( $params['exclude'] && count( $params['exclude'] ) ) {
-			$args['post__not_in'] = $params['exclude'];
-		}
-		if ( $params['post_type'] && count( $params['post_type'] ) ) {
-			$args['post_type'] = $params['post_type'];
+		if ( $attributes['exclude'] && count( $attributes['exclude'] ) ) {
+			$args['post__not_in'] = $attributes['exclude'];
 		}
 
-		if ( isset( $params['show_excerpt'], $params['excerpt_length'] ) ) {
-			$block_attributes = [
-				'showExcerpt'   => $params['show_excerpt'],
-				'excerptLength' => $params['excerpt_length'],
-			];
-			Newspack_Blocks::filter_excerpt( $block_attributes );
-		}
+		$query = new WP_Query( $args );
+		$posts = [];
 
-		$query        = new WP_Query();
-		$query_result = $query->query( $args );
-		$posts        = [];
-
-		foreach ( $query_result as $post ) {
+		foreach ( $query->posts as $post ) {
 			$GLOBALS['post'] = $post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 			setup_postdata( $post );
 
@@ -403,7 +343,6 @@ class Newspack_Blocks_API {
 		}
 
 		Newspack_Blocks::remove_excerpt_filter();
-		Newspack_Blocks::remove_filter_posts_clauses_when_co_authors_filter();
 
 		return new \WP_REST_Response( $posts );
 	}
@@ -424,11 +363,11 @@ class Newspack_Blocks_API {
 		$args = [
 			'post_status'           => 'publish',
 			'title_wildcard_search' => esc_sql( $params['search'] ),
-			'posts_per_page'        => $params['per_page'],
+			'posts_per_page'        => $params['postsToShow'],
 		];
 
-		if ( $params['post_type'] && count( $params['post_type'] ) ) {
-			$args['post_type'] = $params['post_type'];
+		if ( $params['postType'] && count( $params['postType'] ) ) {
+			$args['post_type'] = $params['postType'];
 		} else {
 			$args['post_type'] = 'post';
 		}

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -17,9 +17,9 @@ class Newspack_Blocks {
 
 	/**
 	 * Regex pattern we can use to search for and remove custom SQL statements.
-	 * Custom statements added by this class are wrapped by `capwhere` comments.
+	 * Custom statements added by this class are wrapped by `newspack-blocks` comments.
 	 */
-	const SQL_PATTERN = '/\/\* capwhere \*\/(.|\n)*\/\* \/capwhere \*\//';
+	const SQL_PATTERN = '/\/\* newspack-blocks \*\/(.|\n)*\/\* \/newspack-blocks \*\//';
 
 	/**
 	 * Class property to store user IDs and CAP guest author names for building
@@ -1135,16 +1135,16 @@ class Newspack_Blocks {
 		if ( false === strpos( $tax_query['where'], ' 0 = 1' ) ) {
 			// Append to the current join parts. The JOIN statment only needs to exist in the clause once.
 			if ( false === strpos( $clauses['join'], $tax_query['join'] ) ) {
-				$clauses['join'] .= '/* capwhere */ ' . $tax_query['join'] . ' /* /capwhere */';
+				$clauses['join'] .= '/* newspack-blocks */ ' . $tax_query['join'] . ' /* /newspack-blocks */';
 			}
 
 			$clauses['where'] .= sprintf(
 			// The tax query SQL comes prepended with AND.
 				'%s AND ( %s ( 1=1 %s ) ) %s',
-				'/* capwhere */',
+				'/* newspack-blocks */',
 				empty( $authors_ids ) ? '' : $authors . ' OR',
 				$tax_query['where'],
-				'/* /capwhere */'
+				'/* /newspack-blocks */'
 			);
 		}
 		return $clauses;

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -542,11 +542,20 @@ class Newspack_Blocks {
 					foreach ( $authors as $index => $author_id ) {
 						$co_author = $co_authors_guest_authors->get_guest_author_by( 'id', $author_id );
 						if ( $co_author ) {
+							if ( ! empty( $co_author->linked_account ) ) {
+								$linked_account = get_user_by( 'login', $co_author->linked_account );
+								if ( $linked_account ) {
+									$authors[] = $linked_account->ID;
+								}
+							}
 							$co_authors_names[] = $co_author->user_nicename;
 							unset( $authors[ $index ] );
 						}
 					}
 				}
+
+				// Reset numeric indexes.
+				$authors = array_values( $authors );
 
 				if ( count( $co_authors_names ) ) {
 					// look for authors and co-authors posts.
@@ -1006,8 +1015,8 @@ class Newspack_Blocks {
 				$csv     = implode( ',', wp_parse_id_list( (array) $authors_ids ) );
 				$authors = " {$wpdb->posts}.post_author IN ( $csv ) ";
 
-				// Make sure the authors are set and the tax query is valid (doesn't contain 0 = 1).
-				if ( false === strpos( $tax_query['where'], ' 0 = 1' ) ) {
+				// Make sure the authors are set, the tax query is valid (doesn't contain 0 = 1), and the JOIN clause hasn't alreaady been added.
+				if ( false === strpos( $tax_query['where'], ' 0 = 1' ) && false === strpos( $clauses['join'], $tax_query['join'] ) ) {
 					// Append to the current join/where parts.
 					$clauses['join']  .= $tax_query['join'];
 					$clauses['where'] .= sprintf(

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -66,6 +66,13 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 							),
 							'default' => array(),
 						],
+						'include' => [
+							'type'    => 'array',
+							'items'   => array(
+								'type' => 'integer',
+							),
+							'default' => array(),
+						],
 					]
 				),
 				'permission_callback' => function() {

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -56,77 +56,18 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ 'Newspack_Blocks_API', 'posts_endpoint' ],
-				'args'                => [
-					'author'             => [
-						'type'    => 'array',
-						'items'   => array(
-							'type' => 'integer',
-						),
-						'default' => array(),
-					],
-					'categories'         => [
-						'type'    => 'array',
-						'items'   => array(
-							'type' => 'integer',
-						),
-						'default' => array(),
-					],
-					'categories_exclude' => [
-						'type'    => 'array',
-						'items'   => array(
-							'type' => 'integer',
-						),
-						'default' => array(),
-					],
-					'excerpt_length'     => [
-						'type'    => 'integer',
-						'default' => 55,
-					],
-					'exclude'            => [
-						'type'    => 'array',
-						'items'   => array(
-							'type' => 'integer',
-						),
-						'default' => array(),
-					],
-					'include'            => [
-						'type'    => 'array',
-						'items'   => array(
-							'type' => 'integer',
-						),
-						'default' => array(),
-					],
-					'orderby'            => [
-						'sanitize_callback' => 'sanitize_text_field',
-					],
-					'per_page'           => [
-						'sanitize_callback' => 'absint',
-					],
-					'show_excerpt'       => [
-						'type' => 'boolean',
-					],
-					'tags'               => [
-						'type'    => 'array',
-						'items'   => array(
-							'type' => 'integer',
-						),
-						'default' => array(),
-					],
-					'tags_exclude'       => [
-						'type'    => 'array',
-						'items'   => array(
-							'type' => 'integer',
-						),
-						'default' => array(),
-					],
-					'post_type'          => [
-						'type'    => 'array',
-						'items'   => array(
-							'type' => 'string',
-						),
-						'default' => array(),
-					],
-				],
+				'args'                => array_merge(
+					$this->get_attribute_schema(),
+					[
+						'exclude' => [ // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
+							'type'    => 'array',
+							'items'   => array(
+								'type' => 'integer',
+							),
+							'default' => array(),
+						],
+					]
+				),
 				'permission_callback' => function() {
 					return current_user_can( 'edit_posts' );
 				},
@@ -141,13 +82,13 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ 'Newspack_Blocks_API', 'specific_posts_endpoint' ],
 				'args'                => [
-					'search'    => [
+					'search'      => [
 						'sanitize_callback' => 'sanitize_text_field',
 					],
-					'per_page'  => [
+					'postsToShow' => [
 						'sanitize_callback' => 'absint',
 					],
-					'post_type' => [
+					'postType'    => [
 						'type'    => 'array',
 						'items'   => array(
 							'type' => 'string',

--- a/src/blocks/homepage-articles/utils.js
+++ b/src/blocks/homepage-articles/utils.js
@@ -81,22 +81,22 @@ export const queryCriteriaFromAttributes = attributes => {
 		isSpecificPostModeActive
 			? {
 					include: cleanPosts,
-					per_page: specificPosts.length,
-					post_type: postType,
+					postsToShow: specificPosts.length,
+					postType,
 			  }
 			: {
-					per_page: postsToShow,
+					postsToShow,
 					categories,
-					author: authors,
+					authors,
 					tags,
-					tags_exclude: tagExclusions,
-					categories_exclude: categoryExclusions,
-					post_type: postType,
+					tagExclusions,
+					categoryExclusions,
+					postType,
 			  },
 		value => ! isUndefined( value )
 	);
-	criteria.excerpt_length = excerptLength;
-	criteria.show_excerpt = showExcerpt;
+	criteria.excerptLength = excerptLength;
+	criteria.showExcerpt = showExcerpt;
 	return criteria;
 };
 

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -22,6 +22,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	do_action( 'newspack_blocks_render_homepage_articles' );
 
 	$article_query = new WP_Query( Newspack_Blocks::build_articles_query( $attributes, apply_filters( 'newspack_blocks_block_name', 'newspack-blocks/homepage-articles' ) ) );
+	Newspack_Blocks::remove_filter_posts_clauses_when_co_authors_filter();
 
 	$classes = Newspack_Blocks::block_classes( 'homepage-articles', $attributes, [ 'wpnbha' ] );
 

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -22,7 +22,6 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	do_action( 'newspack_blocks_render_homepage_articles' );
 
 	$article_query = new WP_Query( Newspack_Blocks::build_articles_query( $attributes, apply_filters( 'newspack_blocks_block_name', 'newspack-blocks/homepage-articles' ) ) );
-	Newspack_Blocks::remove_filter_posts_clauses_when_co_authors_filter();
 
 	$classes = Newspack_Blocks::block_classes( 'homepage-articles', $attributes, [ 'wpnbha' ] );
 

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -31,10 +31,10 @@ class QueryControls extends Component {
 		return apiFetch( {
 			url: addQueryArgs( restUrl, {
 				search,
-				per_page: 20,
+				postsToShow: 20,
 				_fields: 'id,title',
 				type: 'post',
-				post_type: postType,
+				postType,
 			} ),
 		} ).then( function ( posts ) {
 			const result = posts.map( post => ( {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR supersedes #1082. Testing instructions remain the same except for an additional testing step at the end (see bolded header below). 8ddcee8 is the only new commit in this branch vs #1082, if that helps with code review.

Fixes four bugs related to author querying:

1. A SQL syntax error when filtering Homepage Posts blocks by authors and including at least one Co-Authors Plus guest author
2. When filtering Homepage Posts blocks by CAP guest authors, posts by linked user accounts are not included in the results
3. An unhandled `include` query param when fetching saved authors to display in the block sidebar controls
4. When filtering by a WP user, posts that were created by that user but are attributed to an unrelated CAP guest author are also fetched

### How to test the changes in this Pull Request:

#### SQL syntax error and linked accounts

1. On `master`, add several Homepage Posts blocks to a post and filter them by a regular WP user, a guest author with no linked account, and a guest author with a linked account. For ease of testing, use the same authors in all blocks and add separators between block instances so you can easily see where one block ends and the next begins.
2. Observe that the posts shown in the editor vs. the front-end are different, and that the front-end blocks in particular don't show all of the posts you would expect:
  - Likely only the first block instance will show any posts at all.
  - For the guest author with linked account, posts that are attributed to the linked account are not shown—only posts directly attributed to the guest author.
  - In the debug log, you'll probably see a SQL syntax error similar to this:

```
WordPress database error Not unique table/alias: 'wp_term_relationships' for query SELECT SQL_CALC_FOUND_ROWS  wp_posts.ID FROM wp_posts  LEFT JOIN wp_term_relationships ON (wp_posts.ID = wp_term_relationships.object_id)
```

3. Check out this branch and refresh both editor and front-end. Confirm that both environments show all the posts you would expect and that the posts match in editor vs. front-end. Confirm that the issues outlined in step 4 no longer apply.

#### Saved authors in block sidebar controls

1. Switch back to `master` and refresh the editor with your test blocks.
2. Select one of the blocks and expand the "Display Settings" sidebar. Observe that in the Authors field, not all of the authors you had saved before are shown here.
3. Check out this branch and refresh. Confirm that you now see all WP users and guest authors in the Authors field.

#### Unrelated CAP guest author posts

1. Log in as a WP user and publish a brand new post, then assign an unrelated/unlinked CAP guest author to the post (removing the WP user from the authors UI).
2. Switch back to `master`. In one of the test Homepage Posts blocks, filter by the WP user in step 1. Observe that in the editor and on the front-end, the block displays post(s) created by the WP user but assigned to unrelated guest authors.
3. Check out this branch, refresh, confirm that the block only shows posts that are directly attributed to the WP user.

#### Posts Carousel block

No changes were made to the Posts Carousel block, but it uses some of the same query functions and endpoints, so we should test it in the editor and on the front-end to ensure it still behaves as expected.

### NEW TEST CASE: subsequent non-author queries

8ddcee8 introduces a fix for an unsolved bug present in #1082. In that PR, any WP queries _after_ the wpuser+coauthors queries would inherit the `join` and `where` clause filtering done by those queries, even if the filter callback is removed. This fix now simplifies the use of the `posts_clauses` filter callback and preemtively strips all custom `join` and `where` modifications before each query.

1. On `hotfix/author-query-in-homepage-posts`, add two Homepage Posts blocks to a page: one with an author filter containing both WP users and CAP guest authors, and the other with no filters.
2. On the front-end, observe that the second block renders no posts. This is because it's inheriting the clause filtering from the previous block.
3. Check out this branch and confirm that all blocks render the expected posts.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
