### PR TITLE
fix: incorrect nesting of tax_query args

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -633,15 +633,17 @@ class Newspack_Blocks {
 
 					// Don't get any posts that are attributed to other CAP guest authors.
 					$args['tax_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-						'relation' => 'OR',
 						[
-							'taxonomy' => 'author',
-							'operator' => 'NOT EXISTS',
-						],
-						[
-							'field'    => 'name',
-							'taxonomy' => 'author',
-							'terms'    => $author_names,
+							'relation' => 'OR',
+							[
+								'taxonomy' => 'author',
+								'operator' => 'NOT EXISTS',
+							],
+							[
+								'field'    => 'name',
+								'taxonomy' => 'author',
+								'terms'    => $author_names,
+							],
 						],
 					];
 				} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug in the `tax_query` syntax when filtering Homepage Posts blocks by WP user and no CAP guest authors. The args were missing a level of array nesting, resulting in the `tax_query` being ignored by the query.

### How to test the changes in this Pull Request:

1. On `master`, add a Homepage Posts block to a post and filter it by:
  - A non-CAP WP user
  - A category exclusion
2. Observe that in both the editor and front-end, the block does not properly filter by the WP user. Instead, it shows posts by any user.
3. Check out this branch, confirm that the block now shows only posts by the WP user, without the excluded category.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
