### PR TITLE
fix(posts-query): specific posts getting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.47.1-hotfix.1](https://github.com/Automattic/newspack-blocks/compare/v1.47.0...v1.47.1-hotfix.1) (2022-04-07)
+
+
+### Bug Fixes
+
+* **posts-query:** specific posts getting ([f9326db](https://github.com/Automattic/newspack-blocks/commit/f9326dbe931522f4e7c66b44d8aee3ed095a378a))
+
 # [1.47.0](https://github.com/Automattic/newspack-blocks/compare/v1.46.1...v1.47.0) (2022-04-05)
 
 

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -7,7 +7,7 @@
  * Author URI:      https://newspack.blog/
  * Text Domain:     newspack-blocks
  * Domain Path:     /languages
- * Version:         1.47.0
+ * Version:         1.47.1-hotfix.1
  *
  * @package         Newspack_Blocks
  */
@@ -15,7 +15,7 @@
 define( 'NEWSPACK_BLOCKS__PLUGIN_FILE', __FILE__ );
 define( 'NEWSPACK_BLOCKS__BLOCKS_DIRECTORY', 'dist/' );
 define( 'NEWSPACK_BLOCKS__PLUGIN_DIR', plugin_dir_path( NEWSPACK_BLOCKS__PLUGIN_FILE ) );
-define( 'NEWSPACK_BLOCKS__VERSION', '1.47.0' );
+define( 'NEWSPACK_BLOCKS__VERSION', '1.47.1-hotfix.1' );
 
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'includes/class-newspack-blocks.php';
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'includes/class-newspack-blocks-api.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "newspack-blocks",
-	"version": "1.47.0",
+	"version": "1.47.1-hotfix.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "newspack-blocks",
-			"version": "1.47.0",
+			"version": "1.47.1-hotfix.1",
 			"hasInstallScript": true,
 			"license": "GPL-3.0-or-later",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack-blocks",
-	"version": "1.47.0",
+	"version": "1.47.1-hotfix.1",
 	"author": "Automattic",
 	"devDependencies": {
 		"@rushstack/eslint-patch": "^1.1.1",

--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -155,7 +155,7 @@
     },
     "textAlign": {
       "type": "string",
-	  "default": "left"
-	}
+      "default": "left"
+    }
   }
 }

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -49,7 +49,8 @@ class QueryControls extends Component {
 		const restUrl = window.newspack_blocks_data.posts_rest_url;
 		return apiFetch( {
 			url: addQueryArgs( restUrl, {
-				per_page: 100,
+				// These params use the block query parameters (see Newspack_Blocks::build_articles_query).
+				postsToShow: 100,
 				include: postIDs.join( ',' ),
 				_fields: 'id,title',
 				postType,

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -52,7 +52,7 @@ class QueryControls extends Component {
 				per_page: 100,
 				include: postIDs.join( ',' ),
 				_fields: 'id,title',
-				post_type: postType,
+				postType,
 			} ),
 		} ).then( function ( posts ) {
 			return posts.map( post => ( {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1083 re-instated issue fixed by #857. There's some confusion around "post type" attribute's casing in `Newspack_Blocks::build_articles_query` method – if `post_type` is supplied in the `$attributes` argument (instead of `postType`), it will be overridden with the default value (`['post']`). 
This PR ensures that the call to the API always uses the camel-case `postType` (and not snake-cased `post_type`).

This confusion arises from the fact that `postType` is the block attribute, and `post_type` is the API call param.

### How to test the changes in this Pull Request:

1. Observe that the issue described in #857 is reproducible on `master`
2. Switch to this branch, observe the issue is not reproducible

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->