### PR TITLE
Add 3 new subscribe patterns

### DIFF
--- a/includes/class-newspack-blocks-patterns.php
+++ b/includes/class-newspack-blocks-patterns.php
@@ -118,7 +118,10 @@ class Newspack_Blocks_Patterns {
 					'subscribe-3',
 					'subscribe-4',
 					'subscribe-5',
-					'subscribe-6'
+					'subscribe-6',
+					'subscribe-7',
+					'subscribe-8',
+					'subscribe-9'
 				);
 			}
 

--- a/src/block-patterns/subscribe-7.php
+++ b/src/block-patterns/subscribe-7.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Subscribe Pattern 7.
+ *
+ * @package Newspack_Blocks
+ */
+
+return array(
+	'title'      => esc_html__( 'Subscribe Pattern 7', 'newspack-blocks' ),
+	'content'    => "<!-- wp:group {\"templateLock\":\"all\",\"className\":\"newspack-pattern subscribe__style-7\"} -->\n<div class=\"wp-block-group newspack-pattern subscribe__style-7\"><!-- wp:media-text {\"mediaId\":999,\"mediaLink\":\"https://newspackdev.mystagingwebsite.com/prompts-patterns/pexels-brotin-biswas-518543/\",\"mediaType\":\"image\",\"imageFill\":true} -->\n<div class=\"wp-block-media-text alignwide is-stacked-on-mobile is-image-fill\"><figure class=\"wp-block-media-text__media\" style=\"background-image:url(https://newspackdev.mystagingwebsite.com/wp-content/uploads/2022/03/pexels-brotin-biswas-518543-1024x683.jpeg);background-position:50% 50%\"><img src=\"https://newspackdev.mystagingwebsite.com/wp-content/uploads/2022/03/pexels-brotin-biswas-518543-1024x683.jpeg\" alt=\"\" class=\"wp-image-999 size-full\"/></figure><div class=\"wp-block-media-text__content\"><!-- wp:heading {\"lock\":{\"remove\":false},\"level\":4,\"className\":\"newspack-pattern__heading\"} -->\n<h4 class=\"newspack-pattern__heading\">" . esc_html__( 'Subscribe to our Newsletter', 'newspack-blocks' ) . "</h4>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph {\"lock\":{\"remove\":false}} -->\n<p>" . esc_html__( 'Be the first to know about breaking news, articles, and updates.', 'newspack-blocks' ) . "</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:jetpack/mailchimp {\"consentText\":\"" . esc_html__( 'By subscribing, you agree to share your email address with us. Use the unsubscribe link in those emails to opt out at any time.', 'newspack-blocks' ) . "\"} -->\n<!-- wp:jetpack/button {\"element\":\"button\",\"uniqueId\":\"mailchimp-widget-id\",\"text\":\"" . esc_html__( 'Subscribe', 'newspack-blocks' ) . "\",\"width\":\"100%\"} /-->\n<!-- /wp:jetpack/mailchimp --></div></div>\n<!-- /wp:media-text --></div>\n<!-- /wp:group -->",
+	'categories' => array( 'newspack-subscribe' ),
+);

--- a/src/block-patterns/subscribe-8.php
+++ b/src/block-patterns/subscribe-8.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Subscribe Pattern 8.
+ *
+ * @package Newspack_Blocks
+ */
+
+return array(
+	'title'      => esc_html__( 'Subscribe Pattern 8', 'newspack-blocks' ),
+	'content'    => "<!-- wp:group {\"templateLock\":\"all\",\"className\":\"newspack-pattern subscribe__style-8\"} -->\n<div class=\"wp-block-group newspack-pattern subscribe__style-8\"><!-- wp:image {\"lock\":{\"remove\":false},\"id\":999} -->\n<figure class=\"wp-block-image\"><img src=\"https://newspack.newspackstaging.com/wp-content/uploads/2022/03/pexels-brotin-biswas-518543-crop-scaled.jpg\" alt=\"\" class=\"wp-image-999\"/></figure>\n<!-- /wp:image -->\n\n<!-- wp:group {\"className\":\"newspack-pattern__inner\"} -->\n<div class=\"wp-block-group newspack-pattern__inner\"><!-- wp:heading {\"lock\":{\"remove\":false},\"level\":4,\"className\":\"newspack-pattern__heading\"} -->\n<h4 class=\"newspack-pattern__heading\">" . esc_html__( 'Subscribe to our Newsletter', 'newspack-blocks' ) . "</h4>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph {\"lock\":{\"remove\":false}} -->\n<p>" . esc_html__( 'Be the first to know about breaking news, articles, and updates.', 'newspack-blocks' ) . "</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:jetpack/mailchimp {\"consentText\":\"" . esc_html__( 'By subscribing, you agree to share your email address with us. Use the unsubscribe link in those emails to opt out at any time.', 'newspack-blocks' ) . "\"} -->\n<!-- wp:jetpack/button {\"element\":\"button\",\"uniqueId\":\"mailchimp-widget-id\",\"text\":\"" . esc_html__( 'Subscribe', 'newspack-blocks' ) . "\"} /-->\n<!-- /wp:jetpack/mailchimp --></div>\n<!-- /wp:group --></div>\n<!-- /wp:group -->",
+	'categories' => array( 'newspack-subscribe' ),
+);

--- a/src/block-patterns/subscribe-9.php
+++ b/src/block-patterns/subscribe-9.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Subscribe Pattern 9.
+ *
+ * @package Newspack_Blocks
+ */
+
+return array(
+	'title'      => esc_html__( 'Subscribe Pattern 9', 'newspack-blocks' ),
+	'content'    => "<!-- wp:group {\"templateLock\":\"all\",\"className\":\"newspack-pattern subscribe__style-9\"} -->\n<div class=\"wp-block-group newspack-pattern subscribe__style-9\"><!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column {\"templateLock\":\"all\"} -->\n<div class=\"wp-block-column\"><!-- wp:heading {\"lock\":{\"remove\":false},\"level\":4,\"className\":\"newspack-pattern__heading\"} -->\n<h4 class=\"newspack-pattern__heading\">" . esc_html__( 'Subscribe to our Newsletter', 'newspack-blocks' ) . "</h4>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph {\"lock\":{\"remove\":false}} -->\n<p>" . esc_html__( 'Be the first to know about breaking news, articles, and updates.', 'newspack-blocks' ) . "</p>\n<!-- /wp:paragraph --></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"templateLock\":\"all\"} -->\n<div class=\"wp-block-column\"><!-- wp:jetpack/mailchimp {\"consentText\":\"" . esc_html__( 'By subscribing, you agree to share your email address with us. Use the unsubscribe link in those emails to opt out at any time.', 'newspack-blocks' ) . "\"} -->\n<!-- wp:jetpack/button {\"element\":\"button\",\"uniqueId\":\"mailchimp-widget-id\",\"text\":\"" . esc_html__( 'Subscribe', 'newspack-blocks' ) . "\"} /-->\n<!-- /wp:jetpack/mailchimp --></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns --></div>\n<!-- /wp:group -->",
+	'categories' => array( 'newspack-subscribe' ),
+);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds 3 new subscribe patterns. These are slightly different from the previous ones. They use `templateLock: all` on the main `Group` and `lock:{remove:false}` on the heading and copy.

This means that these patterns are kind of locked yet there's still some flexibility with its customisation.

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Insert the various patterns to a page and/or a prompt

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
