### PR TITLE
Fix/post statuses in query

### DIFF
--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -335,6 +335,7 @@ class Newspack_Blocks_API {
 				'newspack_has_custom_excerpt'     => self::newspack_blocks_has_custom_excerpt( $data ),
 				'newspack_post_format'            => self::newspack_blocks_post_format( $data ),
 				'newspack_post_sponsors'          => self::newspack_blocks_sponsor_info( $data ),
+				'post_status'                     => $post->post_status,
 				'post_type'                       => $post->post_type,
 				'post_link'                       => Newspack_Blocks::get_post_link( $post->ID ),
 			];

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -1266,5 +1266,23 @@ class Newspack_Blocks {
 		ob_end_clean();
 		return $contents;
 	}
+
+	/**
+	 * Get post status label.
+	 */
+	public static function get_post_status_label() {
+		$post_status          = get_post_status();
+		$post_statuses_labels = [
+			'draft'  => __( 'Draft', 'newspack-blocks' ),
+			'future' => __( 'Scheduled', 'newspack-blocks' ),
+		];
+		if ( 'publish' !== $post_status ) {
+			ob_start();
+			?>
+				<div class="newspack-preview-label"><?php echo esc_html( $post_statuses_labels[ $post_status ] ); ?></div>
+			<?php
+			return ob_get_clean();
+		}
+	}
 }
 Newspack_Blocks::init();

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -527,7 +527,11 @@ class Newspack_Blocks {
 			);
 		}
 
-		$post_type           = isset( $attributes['postType'] ) ? $attributes['postType'] : [ 'post' ];
+		$post_type              = isset( $attributes['postType'] ) ? $attributes['postType'] : [ 'post' ];
+		$included_post_statuses = [ 'publish' ];
+		if ( current_user_can( 'edit_others_posts' ) && isset( $attributes['includedPostStatuses'] ) ) {
+			$included_post_statuses = $attributes['includedPostStatuses'];
+		}
 		$authors             = isset( $attributes['authors'] ) ? $attributes['authors'] : array();
 		$categories          = isset( $attributes['categories'] ) ? $attributes['categories'] : array();
 		$tags                = isset( $attributes['tags'] ) ? $attributes['tags'] : array();
@@ -538,7 +542,7 @@ class Newspack_Blocks {
 		$specific_mode       = isset( $attributes['specificMode'] ) ? intval( $attributes['specificMode'] ) : false;
 		$args                = array(
 			'post_type'           => $post_type,
-			'post_status'         => 'publish',
+			'post_status'         => $included_post_statuses,
 			'suppress_filters'    => false,
 			'ignore_sticky_posts' => true,
 			'has_password'        => false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "newspack-blocks",
+	"name": "@automattic/newspack-blocks",
 	"version": "1.48.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "newspack-blocks",
+			"name": "@automattic/newspack-blocks",
 			"version": "1.48.0",
 			"hasInstallScript": true,
 			"license": "GPL-3.0-or-later",

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -18,7 +18,6 @@ import {
 	BaseControl,
 	Button,
 	ButtonGroup,
-	CheckboxControl,
 	PanelBody,
 	PanelRow,
 	Placeholder,
@@ -34,6 +33,7 @@ import { decodeEntities } from '@wordpress/html-entities';
  * Internal dependencies
  */
 import QueryControls from '../../components/query-controls';
+import { PostTypesPanel } from '../../components/editor-panels';
 import createSwiper from './create-swiper';
 import {
 	formatAvatars,
@@ -143,14 +143,7 @@ class Edit extends Component {
 	}
 
 	render() {
-		const {
-			attributes,
-			availablePostTypes,
-			className,
-			setAttributes,
-			latestPosts,
-			isUIDisabled,
-		} = this.props;
+		const { attributes, className, setAttributes, latestPosts, isUIDisabled } = this.props;
 		const {
 			aspectRatio,
 			authors,
@@ -280,7 +273,7 @@ class Edit extends Component {
 														alt=""
 													/>
 												) : (
-													<div className="wp-block-newspack-blocks-carousel__placeholder"></div>
+													<div className="wp-block-newspack-blocks-carousel__placeholder" />
 												) }
 											</a>
 										</figure>
@@ -530,28 +523,7 @@ class Edit extends Component {
 							</PanelRow>
 						) }
 					</PanelBody>
-					<PanelBody title={ __( 'Post Types', 'newspack-blocks' ) }>
-						{ availablePostTypes &&
-							availablePostTypes.map( ( { name, slug } ) => (
-								<PanelRow key={ slug }>
-									<CheckboxControl
-										label={ name }
-										checked={ postType.indexOf( slug ) > -1 }
-										onChange={ value => {
-											const cleanPostType = [ ...new Set( postType ) ];
-											if ( value && cleanPostType.indexOf( slug ) === -1 ) {
-												cleanPostType.push( slug );
-											} else if ( ! value && cleanPostType.indexOf( slug ) > -1 ) {
-												cleanPostType.splice( cleanPostType.indexOf( slug ), 1 );
-											}
-											setAttributes( {
-												postType: cleanPostType,
-											} );
-										} }
-									/>
-								</PanelRow>
-							) ) }
-					</PanelBody>
+					<PostTypesPanel attributes={ attributes } setAttributes={ setAttributes } />
 				</InspectorControls>
 			</Fragment>
 		);

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -40,6 +40,7 @@ import {
 	formatByline,
 	formatSponsorLogos,
 	formatSponsorByline,
+	getPostStatusLabel,
 } from '../../shared/js/utils';
 // Use same posts store as Homepage Posts block.
 import { postsBlockSelector, postsBlockDispatch, shouldReflow } from '../homepage-articles/utils';
@@ -264,11 +265,7 @@ class Edit extends Component {
 										}` }
 										key={ post.id }
 									>
-										{ post.post_status !== 'publish' && (
-											<div className="newspack-preview-label">
-												{ __( 'Preview', 'newspack-blocks' ) }
-											</div>
-										) }
+										{ getPostStatusLabel( post ) }
 										<figure className="post-thumbnail">
 											<a href="#" rel="bookmark">
 												{ post.newspack_featured_image_src ? (

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -33,7 +33,7 @@ import { decodeEntities } from '@wordpress/html-entities';
  * Internal dependencies
  */
 import QueryControls from '../../components/query-controls';
-import { PostTypesPanel } from '../../components/editor-panels';
+import { PostTypesPanel, PostStatusesPanel } from '../../components/editor-panels';
 import createSwiper from './create-swiper';
 import {
 	formatAvatars,
@@ -264,6 +264,11 @@ class Edit extends Component {
 										}` }
 										key={ post.id }
 									>
+										{ post.post_status !== 'publish' && (
+											<div className="newspack-preview-label">
+												{ __( 'Preview', 'newspack-blocks' ) }
+											</div>
+										) }
 										<figure className="post-thumbnail">
 											<a href="#" rel="bookmark">
 												{ post.newspack_featured_image_src ? (
@@ -386,7 +391,6 @@ class Edit extends Component {
 										const isCurrent = aspectRatio === option.value;
 										return (
 											<Button
-												isLarge
 												isPrimary={ isCurrent }
 												aria-pressed={ isCurrent }
 												aria-label={ option.label }
@@ -421,7 +425,6 @@ class Edit extends Component {
 									aria-label={ __( 'Image Fit', 'newspack-blocks' ) }
 								>
 									<Button
-										isLarge
 										isPrimary={ 'cover' === imageFit }
 										aria-pressed={ 'cover' === imageFit }
 										aria-label={ __( 'Cover', 'newspack-blocks' ) }
@@ -430,7 +433,6 @@ class Edit extends Component {
 										{ __( 'Cover', 'newspack-blocks' ) }
 									</Button>
 									<Button
-										isLarge
 										isPrimary={ 'contain' === imageFit }
 										aria-pressed={ 'contain' === imageFit }
 										aria-label={ __( 'Contain', 'newspack-blocks' ) }
@@ -524,6 +526,7 @@ class Edit extends Component {
 						) }
 					</PanelBody>
 					<PostTypesPanel attributes={ attributes } setAttributes={ setAttributes } />
+					<PostStatusesPanel attributes={ attributes } setAttributes={ setAttributes } />
 				</InspectorControls>
 			</Fragment>
 		);

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -115,6 +115,11 @@ export const settings = {
 			type: 'number',
 			default: 0.75,
 		},
+		includedPostStatuses: {
+			type: 'array',
+			default: [ 'publish' ],
+			items: { type: 'string' },
+		},
 	},
 	supports: {
 		html: false,

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -76,9 +76,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 			?>
 
 			<article data-post-id="<?php echo esc_attr( $post_id ); ?>" class="<?php echo esc_attr( implode( ' ', $article_classes ) . ' ' . $post_type ); ?>">
-				<?php if ( 'publish' !== get_post_status() ) : ?>
-					<div class="newspack-preview-label"><?php echo esc_html__( 'Preview', 'newspack-blocks' ); ?></div>
-				<?php endif; ?>
+				<?php echo Newspack_Blocks::get_post_status_label(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<figure class="post-thumbnail">
 					<?php if ( $post_link ) : ?>
 					<a href="<?php echo esc_url( $post_link ); ?>" rel="bookmark">

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -76,6 +76,9 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 			?>
 
 			<article data-post-id="<?php echo esc_attr( $post_id ); ?>" class="<?php echo esc_attr( implode( ' ', $article_classes ) . ' ' . $post_type ); ?>">
+				<?php if ( 'publish' !== get_post_status() ) : ?>
+					<div class="newspack-preview-label"><?php echo esc_html__( 'Preview', 'newspack-blocks' ); ?></div>
+				<?php endif; ?>
 				<figure class="post-thumbnail">
 					<?php if ( $post_link ) : ?>
 					<a href="<?php echo esc_url( $post_link ); ?>" rel="bookmark">

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -1,6 +1,7 @@
 @import '../../shared/sass/variables';
 @import '../../shared/sass/mixins';
 @import '../../shared/sass/colors';
+@import '../../shared/sass/preview';
 
 .wpnbpc {
 	position: relative;

--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -156,6 +156,11 @@
     "textAlign": {
       "type": "string",
       "default": "left"
+    },
+    "includedPostStatuses": {
+      "type": "array",
+      "default": [ "publish" ],
+      "items": { "type": "string" }
     }
   }
 }

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -737,7 +737,6 @@ class Edit extends Component {
 								value={ moreButtonText }
 								onChange={ value => setAttributes( { moreButtonText: value } ) }
 								className="wp-block-button__link"
-								keepPlaceholderOnFocus
 								allowedFormats={ [] }
 							/>
 						</div>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -10,6 +10,7 @@ import {
 	formatByline,
 	formatSponsorLogos,
 	formatSponsorByline,
+	getPostStatusLabel,
 } from '../../shared/js/utils';
 import { PostTypesPanel, PostStatusesPanel } from '../../components/editor-panels';
 
@@ -148,9 +149,7 @@ class Edit extends Component {
 		const dateFormat = __experimentalGetSettings().formats.date;
 		return (
 			<article className={ postClasses } key={ post.id } style={ styles }>
-				{ isNotPublished && (
-					<div className="newspack-preview-label">{ __( 'Preview', 'newspack-blocks' ) }</div>
-				) }
+				{ getPostStatusLabel( post ) }
 				{ showImage && post.newspack_featured_image_src && (
 					<figure className="post-thumbnail" key="thumbnail">
 						<a href="#">

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -11,7 +11,7 @@ import {
 	formatSponsorLogos,
 	formatSponsorByline,
 } from '../../shared/js/utils';
-import { PostTypesPanel } from '../../components/editor-panels';
+import { PostTypesPanel, PostStatusesPanel } from '../../components/editor-panels';
 
 /**
  * External dependencies
@@ -134,6 +134,8 @@ class Edit extends Component {
 				minHeight / 5 + 'vh',
 		};
 
+		const isNotPublished = post.post_status !== 'publish';
+
 		const postClasses = classNames(
 			{
 				'post-has-image': post.newspack_featured_image_src,
@@ -146,6 +148,9 @@ class Edit extends Component {
 		const dateFormat = __experimentalGetSettings().formats.date;
 		return (
 			<article className={ postClasses } key={ post.id } style={ styles }>
+				{ isNotPublished && (
+					<div className="newspack-preview-label">{ __( 'Preview', 'newspack-blocks' ) }</div>
+				) }
 				{ showImage && post.newspack_featured_image_src && (
 					<figure className="post-thumbnail" key="thumbnail">
 						<a href="#">
@@ -321,6 +326,7 @@ class Edit extends Component {
 						onSpecificModeChange={ _specificMode =>
 							setAttributes( { specificMode: _specificMode } )
 						}
+						// TODO: handle includedPostStatuses to allow fetching drafts etc?
 						specificPosts={ specificPosts }
 						onSpecificPostsChange={ _specificPosts =>
 							setAttributes( { specificPosts: _specificPosts } )
@@ -557,6 +563,7 @@ class Edit extends Component {
 					) }
 				</PanelBody>
 				<PostTypesPanel attributes={ attributes } setAttributes={ setAttributes } />
+				<PostStatusesPanel attributes={ attributes } setAttributes={ setAttributes } />
 			</Fragment>
 		);
 	};

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -325,7 +325,6 @@ class Edit extends Component {
 						onSpecificModeChange={ _specificMode =>
 							setAttributes( { specificMode: _specificMode } )
 						}
-						// TODO: handle includedPostStatuses to allow fetching drafts etc?
 						specificPosts={ specificPosts }
 						onSpecificPostsChange={ _specificPosts =>
 							setAttributes( { specificPosts: _specificPosts } )

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -11,6 +11,7 @@ import {
 	formatSponsorLogos,
 	formatSponsorByline,
 } from '../../shared/js/utils';
+import { PostTypesPanel } from '../../components/editor-panels';
 
 /**
  * External dependencies
@@ -35,7 +36,6 @@ import {
 import {
 	Button,
 	ButtonGroup,
-	CheckboxControl,
 	PanelBody,
 	PanelRow,
 	RangeControl,
@@ -246,7 +246,7 @@ class Edit extends Component {
 	};
 
 	renderInspectorControls = () => {
-		const { attributes, availablePostTypes, setAttributes, textColor, setTextColor } = this.props;
+		const { attributes, setAttributes, textColor, setTextColor } = this.props;
 
 		const {
 			authors,
@@ -556,28 +556,7 @@ class Edit extends Component {
 						</PanelRow>
 					) }
 				</PanelBody>
-				<PanelBody title={ __( 'Post Types', 'newspack-blocks' ) }>
-					{ availablePostTypes &&
-						availablePostTypes.map( ( { name, slug } ) => (
-							<PanelRow key={ slug }>
-								<CheckboxControl
-									label={ name }
-									checked={ postType.indexOf( slug ) > -1 }
-									onChange={ value => {
-										const cleanPostType = [ ...new Set( postType ) ];
-										if ( value && cleanPostType.indexOf( slug ) === -1 ) {
-											cleanPostType.push( slug );
-										} else if ( ! value && cleanPostType.indexOf( slug ) > -1 ) {
-											cleanPostType.splice( cleanPostType.indexOf( slug ), 1 );
-										}
-										setAttributes( {
-											postType: cleanPostType,
-										} );
-									} }
-								/>
-							</PanelRow>
-						) ) }
-				</PanelBody>
+				<PostTypesPanel attributes={ attributes } setAttributes={ setAttributes } />
 			</Fragment>
 		);
 	};

--- a/src/blocks/homepage-articles/store.js
+++ b/src/blocks/homepage-articles/store.js
@@ -9,7 +9,7 @@ import { set } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { registerGenericStore, select } from '@wordpress/data';
+import { register, select } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -176,7 +176,7 @@ const createFetchPostsSaga = blockNames => {
 };
 
 export const registerQueryStore = blockNames => {
-	registerGenericStore( STORE_NAMESPACE, genericStore );
+	register( { name: STORE_NAMESPACE, instantiate: () => genericStore } );
 
 	// Run the saga ✨
 	sagaMiddleware.run( createFetchPostsSaga( blockNames ) );

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -76,6 +76,9 @@ call_user_func(
 		style="<?php echo esc_attr( $styles ); ?>"
 		<?php endif; ?>
 		>
+		<?php if ( 'publish' !== get_post_status() ) : ?>
+			<div class="newspack-preview-label"><?php echo esc_html__( 'Preview', 'newspack-blocks' ); ?></div>
+		<?php endif; ?>
 		<?php if ( has_post_thumbnail() && $attributes['showImage'] && $attributes['imageShape'] ) : ?>
 			<figure class="post-thumbnail">
 				<?php if ( $post_link ) : ?>

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -76,9 +76,7 @@ call_user_func(
 		style="<?php echo esc_attr( $styles ); ?>"
 		<?php endif; ?>
 		>
-		<?php if ( 'publish' !== get_post_status() ) : ?>
-			<div class="newspack-preview-label"><?php echo esc_html__( 'Preview', 'newspack-blocks' ); ?></div>
-		<?php endif; ?>
+		<?php echo Newspack_Blocks::get_post_status_label(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 		<?php if ( has_post_thumbnail() && $attributes['showImage'] && $attributes['imageShape'] ) : ?>
 			<figure class="post-thumbnail">
 				<?php if ( $post_link ) : ?>

--- a/src/blocks/homepage-articles/utils.js
+++ b/src/blocks/homepage-articles/utils.js
@@ -168,7 +168,6 @@ const generatePreviewPost = id => {
 const getPreviewPosts = attributes => times( attributes.postsToShow, generatePreviewPost );
 
 export const postsBlockSelector = ( select, { clientId, attributes } ) => {
-	const { getPostTypes } = select( 'core' );
 	const { getEditorBlocks } = select( 'core/editor' );
 	const { getBlocks } = select( 'core/block-editor' );
 	const editorBlocksIds = getEditorBlocksIds( getEditorBlocks() );
@@ -182,9 +181,6 @@ export const postsBlockSelector = ( select, { clientId, attributes } ) => {
 		isUIDisabled: isUIDisabled(),
 		error: getError( { clientId } ),
 		topBlocksClientIdsInOrder: getBlocks().map( block => block.clientId ),
-		availablePostTypes: getPostTypes( { per_page: -1 } )?.filter(
-			( { supports: { newspack_blocks: newspackBlocks } } ) => newspackBlocks
-		),
 	};
 
 	if ( isEditorBlock ) {

--- a/src/blocks/homepage-articles/utils.js
+++ b/src/blocks/homepage-articles/utils.js
@@ -36,6 +36,7 @@ const POST_QUERY_ATTRIBUTES = [
 	'tagExclusions',
 	'categoryExclusions',
 	'postType',
+	'includedPostStatuses',
 ];
 
 /**
@@ -73,6 +74,7 @@ export const queryCriteriaFromAttributes = attributes => {
 		specificMode,
 		tagExclusions,
 		categoryExclusions,
+		includedPostStatuses,
 	} = pick( attributes, POST_QUERY_ATTRIBUTES );
 
 	const cleanPosts = sanitizePostList( specificPosts );
@@ -92,6 +94,7 @@ export const queryCriteriaFromAttributes = attributes => {
 					tagExclusions,
 					categoryExclusions,
 					postType,
+					includedPostStatuses,
 			  },
 		value => ! isUndefined( value )
 	);

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -758,3 +758,17 @@ amp-script .wpnbha.has-more-button.is-error {
 	}
 }
 /* stylelint-enable */
+
+// Also used by the Carousel block.
+.newspack-preview-label {
+	position: absolute;
+	top: 5px;
+	left: 5px;
+	z-index: 1;
+	font-family: sans-serif;
+	font-size: 10px;
+	text-transform: uppercase;
+	background: #ffc000;
+	padding: 0 4px;
+	border-radius: 2px;
+}

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -1,5 +1,6 @@
 @import '../../shared/sass/variables';
 @import '../../shared/sass/mixins';
+@import '../../shared/sass/preview';
 
 .wpnbha {
 	margin-bottom: 1em;
@@ -758,17 +759,3 @@ amp-script .wpnbha.has-more-button.is-error {
 	}
 }
 /* stylelint-enable */
-
-// Also used by the Carousel block.
-.newspack-preview-label {
-	position: absolute;
-	top: 5px;
-	left: 5px;
-	z-index: 1;
-	font-family: sans-serif;
-	font-size: 10px;
-	text-transform: uppercase;
-	background: #ffc000;
-	padding: 0 4px;
-	border-radius: 2px;
-}

--- a/src/components/editor-panels.js
+++ b/src/components/editor-panels.js
@@ -51,7 +51,7 @@ export const PostTypesPanel = ( { attributes, setAttributes } ) => {
 
 export const PostStatusesPanel = ( { attributes, setAttributes } ) => {
 	return (
-		<PanelBody title={ __( 'Post Statuses', 'newspack-blocks' ) }>
+		<PanelBody title={ __( 'Additional Post Statuses', 'newspack-blocks' ) }>
 			<PanelRow>
 				<i>
 					{ __(

--- a/src/components/editor-panels.js
+++ b/src/components/editor-panels.js
@@ -63,7 +63,6 @@ export const PostStatusesPanel = ( { attributes, setAttributes } ) => {
 			<CheckboxesGroup
 				values={ attributes.includedPostStatuses }
 				options={ [
-					{ name: 'Published', slug: 'publish' },
 					{ name: 'Draft', slug: 'draft' },
 					{ name: 'Scheduled', slug: 'future' },
 				] }

--- a/src/components/editor-panels.js
+++ b/src/components/editor-panels.js
@@ -2,8 +2,31 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { CheckboxControl, PanelBody, PanelRow } from '@wordpress/components';
+import { Spinner, CheckboxControl, PanelBody, PanelRow } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+
+const CheckboxesGroup = ( { options, values, onChange } ) => {
+	if ( ! Array.isArray( options ) ) {
+		return <Spinner />;
+	}
+	return options.map( ( { name, slug } ) => (
+		<PanelRow key={ slug }>
+			<CheckboxControl
+				label={ name }
+				checked={ values.indexOf( slug ) > -1 }
+				onChange={ value => {
+					const cleanPostType = [ ...new Set( values ) ];
+					if ( value && cleanPostType.indexOf( slug ) === -1 ) {
+						cleanPostType.push( slug );
+					} else if ( ! value && cleanPostType.indexOf( slug ) > -1 ) {
+						cleanPostType.splice( cleanPostType.indexOf( slug ), 1 );
+					}
+					onChange( cleanPostType );
+				} }
+			/>
+		</PanelRow>
+	) );
+};
 
 export const PostTypesPanel = ( { attributes, setAttributes } ) => {
 	const { availablePostTypes } = useSelect( select => {
@@ -17,27 +40,35 @@ export const PostTypesPanel = ( { attributes, setAttributes } ) => {
 
 	return (
 		<PanelBody title={ __( 'Post Types', 'newspack-blocks' ) }>
-			{ availablePostTypes &&
-				availablePostTypes.map( ( { name, slug } ) => (
-					<PanelRow key={ slug }>
-						<CheckboxControl
-							label={ name }
-							checked={ attributes.postType.indexOf( slug ) > -1 }
-							onChange={ value => {
-								const cleanPostType = [ ...new Set( attributes.postType ) ];
-								if ( value && cleanPostType.indexOf( slug ) === -1 ) {
-									cleanPostType.push( slug );
-								} else if ( ! value && cleanPostType.indexOf( slug ) > -1 ) {
-									cleanPostType.splice( cleanPostType.indexOf( slug ), 1 );
-								}
-								setAttributes( {
-									postType: cleanPostType,
-								} );
-							} }
-						/>
-					</PanelRow>
-				) ) }
+			<CheckboxesGroup
+				options={ availablePostTypes }
+				values={ attributes.postType }
+				onChange={ postType => setAttributes( { postType } ) }
+			/>
 		</PanelBody>
 	);
 };
 
+export const PostStatusesPanel = ( { attributes, setAttributes } ) => {
+	return (
+		<PanelBody title={ __( 'Post Statuses', 'newspack-blocks' ) }>
+			<PanelRow>
+				<i>
+					{ __(
+						'Selection here has effect only for editors, regular users will only see published posts.',
+						'newspack'
+					) }
+				</i>
+			</PanelRow>
+			<CheckboxesGroup
+				values={ attributes.includedPostStatuses }
+				options={ [
+					{ name: 'Published', slug: 'publish' },
+					{ name: 'Draft', slug: 'draft' },
+					{ name: 'Scheduled', slug: 'future' },
+				] }
+				onChange={ includedPostStatuses => setAttributes( { includedPostStatuses } ) }
+			/>
+		</PanelBody>
+	);
+};

--- a/src/components/editor-panels.js
+++ b/src/components/editor-panels.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { CheckboxControl, PanelBody, PanelRow } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+
+export const PostTypesPanel = ( { attributes, setAttributes } ) => {
+	const { availablePostTypes } = useSelect( select => {
+		const { getPostTypes } = select( 'core' );
+		return {
+			availablePostTypes: getPostTypes( { per_page: -1 } )?.filter(
+				( { supports: { newspack_blocks: newspackBlocks } } ) => newspackBlocks
+			),
+		};
+	} );
+
+	return (
+		<PanelBody title={ __( 'Post Types', 'newspack-blocks' ) }>
+			{ availablePostTypes &&
+				availablePostTypes.map( ( { name, slug } ) => (
+					<PanelRow key={ slug }>
+						<CheckboxControl
+							label={ name }
+							checked={ attributes.postType.indexOf( slug ) > -1 }
+							onChange={ value => {
+								const cleanPostType = [ ...new Set( attributes.postType ) ];
+								if ( value && cleanPostType.indexOf( slug ) === -1 ) {
+									cleanPostType.push( slug );
+								} else if ( ! value && cleanPostType.indexOf( slug ) > -1 ) {
+									cleanPostType.splice( cleanPostType.indexOf( slug ), 1 );
+								}
+								setAttributes( {
+									postType: cleanPostType,
+								} );
+							} }
+						/>
+					</PanelRow>
+				) ) }
+		</PanelBody>
+	);
+};
+

--- a/src/shared/js/utils.js
+++ b/src/shared/js/utils.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { RawHTML, Fragment } from '@wordpress/element';
 
 export const formatAvatars = authorInfo =>
@@ -69,3 +70,14 @@ export const formatSponsorByline = sponsorInfo => (
 		}, [] ) }
 	</span>
 );
+
+export const getPostStatusLabel = ( post = {} ) =>
+	post.post_status !== 'publish' ? (
+		<div className="newspack-preview-label">
+			{
+				{ draft: __( 'Draft', 'newspack' ), future: __( 'Scheduled', 'newspack' ) }[
+					post.post_status
+				]
+			}
+		</div>
+	) : null;

--- a/src/shared/sass/_preview.scss
+++ b/src/shared/sass/_preview.scss
@@ -1,0 +1,12 @@
+.newspack-preview-label {
+	position: absolute;
+	top: 5px;
+	left: 5px;
+	z-index: 1;
+	font-family: sans-serif;
+	font-size: 10px;
+	text-transform: uppercase;
+	background: #ffc000;
+	padding: 0 4px;
+	border-radius: 2px;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #38

A question – is checking for `edit_others_posts` capability a safe-enough check? 

For design review – the label which marks non-published posts: 

<img width="479" alt="image" src="https://user-images.githubusercontent.com/7383192/163977780-814a935b-1e4e-43ac-a9c5-d373844eee16.png">

### How to test the changes in this Pull Request:

1. Insert Homepage Posts and Carousel blocks on a page
2. Ensure you have some recent draft and scheduled posts 
3. For both, observe a new panel in block settings – "Post Statuses". Set different values for this attribute, and observe the post list is updated – non-published posts should be displayed with a label
4. Publish and visit the page as the logged-in editor user – observe the posts are shown as in the editor
5. Visit the page as a non-logged-in user – observe only published posts are displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->