### PR TITLE
Donate block: make possible to navigate via keyboard

### DIFF
--- a/src/blocks/donate/view.scss
+++ b/src/blocks/donate/view.scss
@@ -92,16 +92,16 @@
 		}
 
 		input[type='radio'] {
-			&:checked + .tier-label {
-				background-color: $color__primary;
-				border-color: transparent;
-				color: $color__background-body;
-			}
-
 			&:focus + .tier-label {
 				background: $color__background-screen;
 				outline: 1px dotted currentColor;
 				outline-offset: -4px;
+			}
+
+			&:checked + .tier-label {
+				background-color: $color__primary;
+				border-color: transparent;
+				color: $color__background-body;
 			}
 		}
 

--- a/src/blocks/donate/view.scss
+++ b/src/blocks/donate/view.scss
@@ -100,7 +100,7 @@
 
 			&:focus + .tier-label {
 				background: $color__background-screen;
-				outline: 1px dotted black;
+				outline: 1px dotted currentColor;
 				outline-offset: -4px;
 			}
 		}
@@ -392,44 +392,38 @@
 			}
 		}
 
-		input[type='radio'] {
-			&:checked {
-				+ .freq-label {
-					&::after {
-						box-sizing: content-box;
-						background: white;
-						border-radius: 5px;
-						bottom: 0.19rem;
-						border: 0.19rem solid white;
-						box-shadow: 0 0 0 1px $color__border;
-						content: '';
-						display: block;
-						left: 0.19rem;
-						position: absolute;
-						right: 0.19rem;
-						top: 0.19rem;
-						z-index: -1;
-					}
-
-					&:hover {
-						background: $color__background-screen;
-					}
+		input[type='radio']:checked {
+			+ .freq-label {
+				&::after {
+					box-sizing: content-box;
+					background: white;
+					border-radius: 5px;
+					bottom: 0.19rem;
+					border: 0.19rem solid white;
+					box-shadow: 0 0 0 1px $color__border;
+					content: '';
+					display: block;
+					left: 0.19rem;
+					position: absolute;
+					right: 0.19rem;
+					top: 0.19rem;
+					z-index: -1;
 				}
 
-				~ .tiers {
-					display: grid;
-					grid-gap: 0.28rem;
-					grid-template-columns: repeat( 4, 1fr );
-					margin: 1.12rem;
-
-					@include media( mobile ) {
-						grid-gap: 0.56rem;
-					}
+				&:hover {
+					background: $color__background-screen;
 				}
 			}
-			&:focus + .freq-label {
-				outline: 1px dotted black;
-				outline-offset: 4px;
+
+			~ .tiers {
+				display: grid;
+				grid-gap: 0.28rem;
+				grid-template-columns: repeat( 4, 1fr );
+				margin: 1.12rem;
+
+				@include media( mobile ) {
+					grid-gap: 0.56rem;
+				}
 			}
 		}
 	}

--- a/src/blocks/donate/view.scss
+++ b/src/blocks/donate/view.scss
@@ -10,8 +10,10 @@
 	width: 100%;
 
 	input[type='radio'] {
-		display: none;
+		left: -99999em;
+		position: absolute;
 	}
+
 	input[readonly] {
 		background-color: $color__background-screen;
 		color: #666;
@@ -89,11 +91,17 @@
 			}
 		}
 
-		input[type='radio']:checked {
-			+ .tier-label {
+		input[type='radio'] {
+			&:checked + .tier-label {
 				background-color: $color__primary;
 				border-color: transparent;
 				color: $color__background-body;
+			}
+
+			&:focus + .tier-label {
+				background: $color__background-screen;
+				outline: 1px dotted black;
+				outline-offset: -4px;
 			}
 		}
 
@@ -245,26 +253,33 @@
 		}
 	}
 
-	input[type='radio']:checked {
-		+ .freq-label {
-			color: inherit;
+	input[type='radio'] {
+		&:checked {
+			+ .freq-label {
+				color: inherit;
 
-			&::before {
-				background: $color__text-main;
-				background-clip: content-box;
+				&::before {
+					background: $color__text-main;
+					background-clip: content-box;
+				}
+
+				@include media( tablet ) {
+					border-bottom-color: transparent;
+				}
+
+				&:hover {
+					background: $color__background-body;
+				}
 			}
 
-			@include media( tablet ) {
-				border-bottom-color: transparent;
-			}
-
-			&:hover {
-				background: $color__background-body;
+			~ .tiers {
+				display: flex;
 			}
 		}
 
-		~ .tiers {
-			display: flex;
+		&:focus + .freq-label {
+			text-decoration: underline;
+			text-decoration-style: dotted;
 		}
 	}
 
@@ -377,38 +392,44 @@
 			}
 		}
 
-		input[type='radio']:checked {
-			+ .freq-label {
-				&::after {
-					box-sizing: content-box;
-					background: white;
-					border-radius: 5px;
-					bottom: 0.19rem;
-					border: 0.19rem solid white;
-					box-shadow: 0 0 0 1px $color__border;
-					content: '';
-					display: block;
-					left: 0.19rem;
-					position: absolute;
-					right: 0.19rem;
-					top: 0.19rem;
-					z-index: -1;
+		input[type='radio'] {
+			&:checked {
+				+ .freq-label {
+					&::after {
+						box-sizing: content-box;
+						background: white;
+						border-radius: 5px;
+						bottom: 0.19rem;
+						border: 0.19rem solid white;
+						box-shadow: 0 0 0 1px $color__border;
+						content: '';
+						display: block;
+						left: 0.19rem;
+						position: absolute;
+						right: 0.19rem;
+						top: 0.19rem;
+						z-index: -1;
+					}
+
+					&:hover {
+						background: $color__background-screen;
+					}
 				}
 
-				&:hover {
-					background: $color__background-screen;
+				~ .tiers {
+					display: grid;
+					grid-gap: 0.28rem;
+					grid-template-columns: repeat( 4, 1fr );
+					margin: 1.12rem;
+
+					@include media( mobile ) {
+						grid-gap: 0.56rem;
+					}
 				}
 			}
-
-			~ .tiers {
-				display: grid;
-				grid-gap: 0.28rem;
-				grid-template-columns: repeat( 4, 1fr );
-				margin: 1.12rem;
-
-				@include media( mobile ) {
-					grid-gap: 0.56rem;
-				}
+			&:focus + .freq-label {
+				outline: 1px dotted black;
+				outline-offset: 4px;
 			}
 		}
 	}

--- a/src/blocks/donate/view.scss
+++ b/src/blocks/donate/view.scss
@@ -280,6 +280,7 @@
 		&:focus + .freq-label {
 			text-decoration: underline;
 			text-decoration-style: dotted;
+			text-decoration-thickness: 1px;
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR tweaks the Donate block styles so the radio buttons that aren't visible are no longer hidden with `display: none`, but with `position: absolute; left: -99999em` to push them off screen. This way, they can be tabbed to when navigating the site with a keyboard, so it improves the block's accessibility. 

The styles also add some visual changes when a tab/tier is focused on -- I stuck with `outline` so it wouldn't change things too much (since these are also visible when you click on a tab/tier) but we might want to look at something more noticeable down the road, as this is pretty low contrast. 

Closes #123

### How to test the changes in this Pull Request:

1. Add a donate block to a post or page and publish.
2. Try to "tab" through the page (you can 'Skip to Content' at the top). When you get to the block, note that the focus skips all of the tabs and jumps immediately to the Donate Now button.
3. Apply the PR and run `npm run build`.
4. Try to "tab" through the page again. When you hit the block, the current tab should get focus and get a little dotted 'underline'; for the tiers, the selected tier should get a dotted outline when it gets focus:

![image](https://user-images.githubusercontent.com/177561/164803451-395de718-4dec-4f9b-92af-3453e548002a.png)

![image](https://user-images.githubusercontent.com/177561/164803556-17bd8eb7-4764-46aa-8a46-5de368bbb641.png)

6. You should be able to tab from the frequency tabs to the tiers to the button, but not from frequency tab to frequency tab or from tier to tier -- this is "correct" behaviour for radio groups, so hopefully intuitive to folks who navigate sites with their keyboards. For each group of radio buttons, or "level" in the donate block (the tabs, or tiers) you should be able to use your up-down or left-right arrow keys to move between options.
7. If you select 'Other' in the tier options, the text field should appear and you should be able to tab from the 'Other' tier option to the field, change the value, and tab to the Donate Now button.
8. You should be able to shift-tab to move backwards through the block.
9. You should be able to submit the Donate form by hitting 'enter' when the button is focused on. 

Please run through the different block styles (Alternative and Minimal) and Simplified Donate block using the above steps as well, and confirm that you're able to move around using just the keyboard, and that you see some kind of visual feedback on the elements that have focus.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
