### PR TITLE
Homepage Posts & Carousel blocks: Improve alt text on images linked to posts

### DIFF
--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -88,6 +88,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 										'object-fit' => $attributes['imageFit'],
 										'layout'     => 'fill',
 										'class'      => 'contain' === $attributes['imageFit'] ? 'image-fit-contain' : 'image-fit-cover',
+										'alt'        => trim( strip_tags( get_the_title( $post_id ) ) ),
 									)
 								);
 							?>

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -88,7 +88,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 										'object-fit' => $attributes['imageFit'],
 										'layout'     => 'fill',
 										'class'      => 'contain' === $attributes['imageFit'] ? 'image-fit-contain' : 'image-fit-cover',
-										'alt'        => trim( strip_tags( get_the_title( $post_id ) ) ),
+										'alt'        => trim( wp_strip_all_tags( get_the_title( $post_id ) ) ),
 									)
 								);
 							?>

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -37,6 +37,7 @@ call_user_func(
 		}
 		$thumbnail_args = array(
 			'data-hero-candidate' => true,
+			'alt'                 => trim( strip_tags( get_the_title( $post_id ) ) ),
 		);
 		// If the image position is behind, pass the object-fit setting to maintain styles with AMP.
 		if ( 'behind' === $attributes['mediaPosition'] ) {

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -37,7 +37,7 @@ call_user_func(
 		}
 		$thumbnail_args = array(
 			'data-hero-candidate' => true,
-			'alt'                 => trim( strip_tags( get_the_title( $post_id ) ) ),
+			'alt'                 => trim( wp_strip_all_tags( get_the_title( $post_id ) ) ),
 		);
 		// If the image position is behind, pass the object-fit setting to maintain styles with AMP.
 		if ( 'behind' === $attributes['mediaPosition'] ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR replaces the author-provided alt text on the linked featured images with the post title. This helps give some context to where the link actually goes, to improve accessibility. Otherwise, descriptive text in this context isn't as helpful because it doesn't tell someone navigating the site via screenreader where the link on the image goes. 

Closes #1115

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Add a Homepage Posts and Post Carousel block to a page; make sure each block has at least one post with a featured image. 
3. Publish.
4. Inspect the source and confirm that the alt text on the featured image matches the post title.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
