### PR TITLE
fix: disambiguate WP users vs. guest authors with same ID

### DIFF
--- a/src/blocks/author-list/class-wp-rest-newspack-author-list-controller.php
+++ b/src/blocks/author-list/class-wp-rest-newspack-author-list-controller.php
@@ -37,19 +37,28 @@ class WP_REST_Newspack_Author_List_Controller extends WP_REST_Newspack_Authors_C
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => [ $this, 'api_get_all_authors' ],
 					'args'                => [
-						'author_id' => [
+						'author_id'     => [
 							'sanitize_callback' => 'absint',
 						],
-						'offset'    => [
+						'author_roles'  => [
+							'sanitize_callback' => 'WP_REST_Newspack_Author_List_Controller::sanitize_array',
+						],
+						'author_types'  => [
+							'sanitize_callback' => 'WP_REST_Newspack_Author_List_Controller::sanitize_array',
+						],
+						'exclude_empty' => [
 							'sanitize_callback' => 'absint',
 						],
-						'per_page'  => [
+						'offset'        => [
 							'sanitize_callback' => 'absint',
 						],
-						'search'    => [
+						'per_page'      => [
+							'sanitize_callback' => 'absint',
+						],
+						'search'        => [
 							'sanitize_callback' => 'sanitize_text_field',
 						],
-						'fields'    => [
+						'fields'        => [
 							'sanitize_callback' => 'sanitize_text_field',
 						],
 					],
@@ -57,6 +66,28 @@ class WP_REST_Newspack_Author_List_Controller extends WP_REST_Newspack_Authors_C
 				],
 			]
 		);
+	}
+
+	/**
+	 * Sanitize an array of text or number values.
+	 *
+	 * @param array $array Array of text or float values to be sanitized.
+	 * @return array Sanitized array.
+	 */
+	public static function sanitize_array( $array ) {
+		foreach ( $array as $value ) {
+			if ( is_array( $value ) ) {
+				$value = sanitize_array( $value );
+			} else {
+				if ( is_string( $value ) ) {
+					$value = sanitize_text_field( $value );
+				} else {
+					$value = floatval( $value );
+				}
+			}
+		}
+
+		return $array;
 	}
 
 	/**
@@ -99,23 +130,23 @@ class WP_REST_Newspack_Author_List_Controller extends WP_REST_Newspack_Authors_C
 	public function api_get_all_authors( $request ) {
 		$options = [];
 
-		if ( ! empty( $request->get_param( 'authorType' ) ) ) {
-			$options['author_type'] = $request->get_param( 'authorType' );
+		if ( ! empty( $request->get_param( 'author_type' ) ) ) {
+			$options['author_type'] = $request->get_param( 'author_type' );
 		}
 
-		if ( ! empty( $request->get_param( 'authorRoles' ) ) ) {
-			$options['author_roles'] = $request->get_param( 'authorRoles' );
+		if ( ! empty( $request->get_param( 'author_roles' ) ) ) {
+			$options['author_roles'] = $request->get_param( 'author_roles' );
 		}
 
 		if ( ! empty( $request->get_param( 'exclude' ) ) && is_array( $request->get_param( 'exclude' ) ) ) {
 			$options['exclude'] = $request->get_param( 'exclude' ); // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
 		}
 
-		if ( ! empty( $request->get_param( 'excludeEmpty' ) ) ) {
+		if ( ! empty( $request->get_param( 'exclude_empty' ) ) ) {
 			$options['exclude_empty'] = true;
 		}
 
-		if ( ! empty( $request->get_param( 'avatarHideDefault' ) ) ) {
+		if ( ! empty( $request->get_param( 'avatar_hide_default' ) ) ) {
 			$options['avatar_hide_default'] = true;
 		}
 

--- a/src/blocks/author-list/edit.js
+++ b/src/blocks/author-list/edit.js
@@ -84,17 +84,17 @@ const AuthorList = ( { attributes, clientId, setAttributes } ) => {
 		setIsLoading( true );
 		try {
 			const params = {
-				authorType,
-				authorRoles,
+				author_type: authorType,
+				author_roles: authorRoles,
 				exclude: exclude.map( exclusion => parseInt( exclusion.value ) ),
 			};
 
 			if ( excludeEmpty ) {
-				params.excludeEmpty = 1;
+				params.exclude_empty = 1;
 			}
 
 			if ( avatarHideDefault ) {
-				params.avatarHideDefault = 1;
+				params.avatar_hide_default = 1;
 			}
 
 			const response = await apiFetch( {

--- a/src/blocks/author-profile/block.json
+++ b/src/blocks/author-profile/block.json
@@ -10,6 +10,10 @@
 			"type": "number",
 			"default": 0
 		},
+		"isGuestAuthor": {
+			"type": "boolean",
+			"default": true
+		},
 		"showBio": {
 			"type": "boolean",
 			"default": true

--- a/src/blocks/author-profile/edit.js
+++ b/src/blocks/author-profile/edit.js
@@ -138,6 +138,7 @@ const AuthorProfile = ( { attributes, setAttributes } ) => {
 	const [ maxItemsToSuggest, setMaxItemsToSuggest ] = useState( 0 );
 	const {
 		authorId,
+		isGuestAuthor,
 		showBio,
 		showSocial,
 		showEmail,
@@ -161,12 +162,13 @@ const AuthorProfile = ( { attributes, setAttributes } ) => {
 		setIsLoading( true );
 		try {
 			const params = {
-				authorId,
+				author_id: authorId,
+				is_guest_author: isGuestAuthor ? 1 : 0,
 				fields: 'id,name,bio,email,social,avatar,url',
 			};
 
 			if ( avatarHideDefault ) {
-				params.avatarHideDefault = 1;
+				params.avatar_hide_default = 1;
 			}
 
 			const response = await apiFetch( {
@@ -397,6 +399,7 @@ const AuthorProfile = ( { attributes, setAttributes } ) => {
 									path: addQueryArgs( '/newspack-blocks/v1/authors', {
 										search,
 										offset,
+										isGuestAuthor: true,
 										fields: 'id,name',
 									} ),
 								} );
@@ -412,10 +415,16 @@ const AuthorProfile = ( { attributes, setAttributes } ) => {
 								return authors.map( _author => ( {
 									value: _author.id,
 									label: decodeEntities( _author.name ) || __( '(no name)', 'newspack' ),
+									isGuestAuthor: _author.is_guest,
 								} ) );
 							} }
 							maxItemsToSuggest={ maxItemsToSuggest }
-							onChange={ items => setAttributes( { authorId: parseInt( items[ 0 ].value ) } ) }
+							onChange={ items => {
+								setAttributes( {
+									authorId: parseInt( items[ 0 ]?.value || 0 ),
+									isGuestAuthor: items[ 0 ]?.isGuestAuthor || false,
+								} );
+							} }
 							postTypeLabel={ __( 'author', 'newspack-blocks' ) }
 							postTypeLabelPlural={ __( 'authors', 'newspack-blocks' ) }
 							selectedItems={ [] }

--- a/src/blocks/author-profile/view.php
+++ b/src/blocks/author-profile/view.php
@@ -29,14 +29,15 @@ function newspack_blocks_register_author_profile() {
  * @param int     $author_id Author ID to look up.
  * @param int     $avatar_size Size of the avatar image to fetch.
  * @param boolean $hide_default If true, don't show default avatars.
+ * @param boolean $is_guest_author If true, search for guest authors. If false, only search for WP users.
  * @return object|boolean Author object in standardized format, or false if none exists.
  */
-function newspack_blocks_get_author_or_guest_author( $author_id, $avatar_size = 128, $hide_default = false ) {
+function newspack_blocks_get_author_or_guest_author( $author_id, $avatar_size = 128, $hide_default = false, $is_guest_author = true ) {
 	$wp_user = get_user_by( 'id', $author_id );
 	$author  = false;
 
 	// First, see if the $author_id is a guest author.
-	if ( class_exists( 'CoAuthors_Guest_Authors' ) ) {
+	if ( class_exists( 'CoAuthors_Guest_Authors' ) && $is_guest_author ) {
 		// Check if the ID given is a WP user with linked guest author.
 		$linked_guest_author = false;
 
@@ -107,7 +108,7 @@ function newspack_blocks_render_block_author_profile( $attributes ) {
 	}
 
 	// Get the author by ID.
-	$author = newspack_blocks_get_author_or_guest_author( intval( $attributes['authorId'] ), intval( $attributes['avatarSize'] ), $attributes['avatarHideDefault'] );
+	$author = newspack_blocks_get_author_or_guest_author( intval( $attributes['authorId'] ), intval( $attributes['avatarSize'] ), $attributes['avatarHideDefault'], $attributes['isGuestAuthor'] );
 
 	// Bail if there's no author or guest author with the saved ID.
 	if ( empty( $author ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Accounts for a previously unhandled edge case where a CAP guest author and a WP user might have the same numeric ID in the DB. In this case, `master` will always choose the guest author over the WP user because we can't tell which type of author to fetch with only the ID.

This PR fixes the above issue by storing a new block attribute `isGuestAuthor` as part of the Author Profile block. If this is `true` (the default), the block's behavior will behave as it currently does (search guest authors first, and if none found, fall back to WP users). If it's `false`, it will only search WP users. This ensures that if a WP user is chosen which has the same ID as a CAP guest author, the WP user will be displayed in the editor and the front-end.

Note that this doesn't fix pre-existing instances of the Author Profile block affected by this issue, as there is no way to disambiguate the numeric IDs without the new `isGuestAuthor` attribute. These blocks will need to be manually rebuilt in the editor.

This PR also standardizes REST API parameters as snake case and properly lists and sanitizes all possible param values in the REST route registration. Otherwise, the Author List and Author Profile behavior should remain the same.

Closes #1134.

### How to test the changes in this Pull Request:

1. On a brand new site with no posts and Co-Authors Plus and Newspack Blocks (current release) installed, create enough WP users and CAP guest authors so that you have at least one guest author with the same ID as a WP user. **Hint:** if you run `wp site empty --yes` at CLI and then create a guest author, the ID will be `1` and the same as the main admin user.
2. Create some Author List blocks with various settings (for testing after the plugin upgrade).
3. Create an Author Profile block and attempt to select the WP user with an ID that overlaps with a guest author. Observe that the guest author is displayed in the editor and on the front-end despite your selection.
4. Install the Blocks plugin from this branch.
5. Recreate the Author Profile block in step 3 and confirm that it now displays the correct WP user in the editor and on the front-end.
6. Confirm that the Author List blocks still behave as before, and that both Author Profile and Author List blocks continue to behave as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
