### PR TITLE
Homepage & Carousel block: skip linked images when navigating by keyboard

### DIFF
--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -79,7 +79,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 				<?php echo Newspack_Blocks::get_post_status_label(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<figure class="post-thumbnail">
 					<?php if ( $post_link ) : ?>
-					<a href="<?php echo esc_url( $post_link ); ?>" rel="bookmark">
+					<a href="<?php echo esc_url( $post_link ); ?>" rel="bookmark" tabindex="-1" aria-hidden="true">
 					<?php endif; ?>
 						<?php if ( $has_featured_image ) : ?>
 							<?php

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -81,7 +81,7 @@ call_user_func(
 		<?php if ( has_post_thumbnail() && $attributes['showImage'] && $attributes['imageShape'] ) : ?>
 			<figure class="post-thumbnail">
 				<?php if ( $post_link ) : ?>
-				<a href="<?php echo esc_url( $post_link ); ?>" rel="bookmark">
+				<a href="<?php echo esc_url( $post_link ); ?>" rel="bookmark" tabindex="-1" aria-hidden="true">
 				<?php endif; ?>
 					<?php the_post_thumbnail( $image_size, $thumbnail_args ); ?>
 				<?php if ( $post_link ) : ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds `tabindex="-1"` and `aria-hidden="true"` to the linked images in the Homepage Posts Block and Post Carousel block. This uses a similar approach to the theme's [archive and search markup](https://github.com/Automattic/newspack-theme/blob/8f47f1b03ec557279295f6a7ce6339513cf8c218/newspack-theme/inc/template-tags.php#L394). 

It's in part to fix #1116; but it also reduces the number of elements you need to tab through on each story when you're navigating the page by keyboard -- the photo in the Homepage posts block and Post Carousel have the same links as the titles in these blocks, so as is it creates an extra step you have to "get past" to navigate through each story (this was a recommendation that came out of the same accessibility review as #1116). 

Closes #1116.

### How to test the changes in this Pull Request:

1. Set up a page with a couple different Homepage posts blocks (with different image settings) and at least one Post Carousel block.
2. Navigate through the page using your keyboard; note that for each post in the blocks, the focus goes first to the image, then the title, then author before moving on to the next.
3. Apply the PR. 
4. Repeat step two and confirm that the focus skips the image in each block. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
