### PR TITLE
Sponsors plugin integration: echo closing link tags on sponsor bylines

### DIFF
--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -184,7 +184,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 										}
 										echo esc_html( $byline['name'] );
 										if ( '' !== $byline['url'] ) {
-											'</a>';
+											echo '</a>';
 										}
 										echo '</span>' . esc_html( $byline['sep'] );
 									}

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -203,7 +203,7 @@ call_user_func(
 							}
 							echo esc_html( $byline['name'] );
 							if ( '' !== $byline['url'] ) {
-								'</a>';
+								echo '</a>';
 							}
 							echo '</span>' . esc_html( $byline['sep'] );
 						}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In the Sponsors markup, the code is missing an `echo` on the closing link on the byline for both the Homepage Posts and Post Carousel blocks. I think this flew under the radar because it doesn't seem to cause issues when AMP is enabled (AMP seems to be correcting the malformed HTML), but when AMP is disabled, it causes visual issues. 

Closes #1151.

### How to test the changes in this Pull Request:

1. Start with a test site with a number of sponsored posts.
2. Set up a Post Carousel and Homepage Posts block that each display at least one of your sponsored posts that has a native sponsor; enable dates on both blocks.
3. View on the front end and disable AMP.
4. If your blocks have dates displaying, they should be incorrectly picking up the sponsor byline's link; failing that, you can also inspect the page and see that the sponsor byline link seems to appear more than once (depending on how your browser handles malformed HTML). 

![image](https://user-images.githubusercontent.com/177561/171254203-8b548d17-cf75-4165-ad4c-1aaf003c558f.png)

![image](https://user-images.githubusercontent.com/177561/171254302-7afa2781-7adf-4c71-93cd-dd617cb29c3d.png)

6. Apply the PR.
7. Confirm that the links are now correctly formed in both the Post Carousel and Homepage Post blocks. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
