### PR TITLE
Donate Block: correct tab spacing in editor

### DIFF
--- a/src/blocks/donate/view.scss
+++ b/src/blocks/donate/view.scss
@@ -28,6 +28,7 @@
 
 	.freq-label {
 		background: $color__background-body;
+		box-sizing: border-box;
 		color: $color__text-light;
 		line-height: $font__line-height-body;
 		overflow: hidden;
@@ -369,7 +370,6 @@
 		.freq-label {
 			background: $color__background-screen;
 			border-color: $color__background-screen;
-			box-sizing: border-box;
 			border-width: 1px;
 			padding: calc( 0.57rem + 1px ) 0.76rem;
 

--- a/src/blocks/donate/view.scss
+++ b/src/blocks/donate/view.scss
@@ -369,6 +369,7 @@
 		.freq-label {
 			background: $color__background-screen;
 			border-color: $color__background-screen;
+			box-sizing: border-box;
 			border-width: 1px;
 			padding: calc( 0.57rem + 1px ) 0.76rem;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

As of WordPress 6.0, something changed in the editor styles causing the Donate Block tabs to exceed their normal width -- in WP 5.9.3, the tabs were picking up `box-sizing: border-box;` thanks to a style `.edit-post-visual-editor * { box-sizing: inherit; }`; as of 6.0 that style appears to be gone. 

This PR fixes the issue by adding `box-sizing: border-box;` to the tabs directly. 

(You can test the appearance of the Donate Block before and after the WordPress 6.0 update by installing the [Core Rollback](https://wordpress.org/plugins/core-rollback/) plugin and switching your test site back to 5.9.3). 

**WordPress 5.9.3:**

![image](https://user-images.githubusercontent.com/177561/171264519-684a15c6-fdbe-43ce-b74d-28d0120acff4.png)

**WordPress 6.0**

![image](https://user-images.githubusercontent.com/177561/171264574-ccc1cce4-1685-487b-982e-51db9c8425ea.png)

### How to test the changes in this Pull Request:

1. Add a donate block to the editor and note its appearance: 

![image](https://user-images.githubusercontent.com/177561/171265089-1a32bbd2-3b1c-480c-bfc1-a2925315206e.png)

2. Apply the PR and run `npm run build`.
3. Confirm that the tabs are no longer 'sticking out'.

![image](https://user-images.githubusercontent.com/177561/171267824-cd765821-1897-41d2-bb6f-32dfc2b6826c.png)

4. Cycle through the different Donate Block styles (Alternative; Minimal) and confirm they all look correct.
5. Confirm that this change does not impact the appearance of the block on the front end. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
