### PR TITLE
fix(iframe-block): handle errors from server-side fetch

### DIFF
--- a/src/blocks/iframe/class-wp-rest-newspack-iframe-controller.php
+++ b/src/blocks/iframe/class-wp-rest-newspack-iframe-controller.php
@@ -177,8 +177,12 @@ class WP_REST_Newspack_Iframe_Controller extends WP_REST_Controller {
 
 		// If we need to remove the previous document, it's a good place to do it here.
 		if ( array_key_exists( 'iframe_url', $data ) && ! empty( $data['iframe_url'] ) ) {
-			$content_type = wp_remote_head( $data['iframe_url'] )['headers']->offsetGet( 'content-type' );
-			if ( in_array( $content_type, array_keys( Newspack_Blocks::iframe_document_accepted_file_mimes() ), true ) ) {
+			$head = wp_safe_remote_head( $data['iframe_url'] );
+			if ( is_wp_error( $head ) ) {
+				return rest_ensure_response( $head );
+			}
+			$content_type = $head['headers']->offsetGet( 'content-type' );
+			if ( ! empty( $content_type ) && in_array( $content_type, array_keys( Newspack_Blocks::iframe_document_accepted_file_mimes() ), true ) ) {
 				$mode = 'document';
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Handle errors from server-side fetch of iframe URL for the iframe block:

<img width="845" alt="image" src="https://user-images.githubusercontent.com/820752/172651816-998cb693-8700-4bc0-ac33-b6679ab604a6.png">

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1160 

### How to test the changes in this Pull Request:

1. On the master branch, create a draft post and paste a random non-existent URL to an iframe block
2. Observe the error as described in #1160
3. Check out this branch, paste the URL again and confirm you see the error message returned from `wp_safe_remote_head()`, as shown above

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
