### PR TITLE
Blocks: Unregister Jetpack's Donation Form block

### DIFF
--- a/src/setup/editor.js
+++ b/src/setup/editor.js
@@ -3,4 +3,5 @@
  */
 import './category';
 import './block-styles';
+import './unregister-blocks';
 import './editor.scss';

--- a/src/setup/unregister-blocks.js
+++ b/src/setup/unregister-blocks.js
@@ -1,0 +1,12 @@
+'use strict';
+
+import { unregisterBlockType } from '@wordpress/blocks';
+import domReady from '@wordpress/dom-ready';
+
+const removeBlocks = [ 'jetpack/donations' ];
+
+domReady( function () {
+	removeBlocks.forEach( function ( blockName ) {
+		unregisterBlockType( blockName );
+	} );
+} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR unregisters the [Jetpack Donations block](https://jetpack.com/support/jetpack-blocks/donations-block/), so it's not so easily confused with the Newspack Donate block.

Closes #1161.

### How to test the changes in this Pull Request:

1. Start on a test site running either a Jetpack Security or Jetpack Complete plan active (please ping me if you don't already have this plan and I can help!). 
2. Type `/donate` into the editor and note the blocks that appear:

![image](https://user-images.githubusercontent.com/177561/172702653-617fa00f-2580-4231-b1ec-46e416c2c902.png)

3. Apply the PR and run `npm run build`.
4. Repeat step 2 and confirm that the 'Donations Form' block no longer appears in the list.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
