### PR TITLE
fix: make sure block exists before unregistering

### DIFF
--- a/src/setup/unregister-blocks.js
+++ b/src/setup/unregister-blocks.js
@@ -1,12 +1,14 @@
 'use strict';
 
-import { unregisterBlockType } from '@wordpress/blocks';
+import { getBlockType, unregisterBlockType } from '@wordpress/blocks';
 import domReady from '@wordpress/dom-ready';
 
 const removeBlocks = [ 'jetpack/donations' ];
 
 domReady( function () {
 	removeBlocks.forEach( function ( blockName ) {
-		unregisterBlockType( blockName );
+		if ( getBlockType( blockName ) ) {
+			unregisterBlockType( blockName );
+		}
 	} );
 } );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If Jetpack is not installed it currently attempts to unregister a non-existing block and throws an error. This PR adds a check to only unregister a block that is registered.

### How to test the changes in this Pull Request:

1. While on the master branch, deactivate Jetpack
2. Edit any post/page and confirm the error on the browser console
3. Check out this branch, build and confirm the error is gone
4. Reactivate Jetpack and confirm the block is not available, as it's still being unregistered successfully

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
