### PR TITLE
Blog Post Block: Fix grid so items are aligned when an odd number of posts are inserted

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -28,7 +28,9 @@
 	&.is-grid > div {
 		display: flex;
 		flex-wrap: wrap;
-		justify-content: space-between;
+		justify-content: flex-start;
+		flex-direction: row;
+		gap: 16px;
 		padding: 0;
 		list-style: none;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
Blog post block uses a flexbox to render items in a grid and use `justify-content: space between` to determine how the items are laid out. This however causes the flexbox to force empty space between some items when there is an odd number of items in the grid. This fix changes how items are laid out using  `justify-content: flex-start` so items are properly aligned when rendered and instead of allowing flexbox to determine the space we specify a `gap` between each item.

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1171.
Original issue https://github.com/Automattic/wp-calypso/issues/62318

### How to test the changes in this Pull Request:

1. Create a number of posts (about 5)
2. Create another post and add Blog Post Block with the posts created from 1 above. use a 3 * 3 grid 
3. Verify the posts are properly aligned with no empty space between.

Before:
<img width="624" alt="Markup 2022-03-28 at 13 03 55" src="https://user-images.githubusercontent.com/77308634/160495648-f1c08b9c-5d0f-4534-bcc6-695727cd32c4.png">

After:
![Screenshot 2022-06-15 at 6 14 29 PM](https://user-images.githubusercontent.com/47489215/173957535-99317127-d475-4031-9e5f-000d2d5a52f1.png)


### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
