### PR TITLE
Homepage Posts Block: Disable share buttons when disabled for page

### DIFF
--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -161,7 +161,13 @@ call_user_func(
 			<?php endif; ?>
 			<?php
 			if ( $attributes['showExcerpt'] ) :
+				if ( ! empty( $data['jetpack_share_buttons_disabled'] ) ) {
+					add_filter( 'sharing_show', '__return_false' );
+				}
 				the_excerpt();
+				if ( ! empty( $data['jetpack_share_buttons_disabled'] ) ) {
+					remove_filter( 'sharing_show', '__return_false' );
+				}
 			endif;
 			if ( $post_link && ( $attributes['showReadMore'] ) ) :
 				?>

--- a/src/blocks/homepage-articles/templates/articles-loop.php
+++ b/src/blocks/homepage-articles/templates/articles-loop.php
@@ -18,13 +18,26 @@ call_user_func(
 
 		Newspack_Blocks::filter_excerpt( $attributes );
 
+		$jetpack_share_buttons_disabled = false;
+		if ( function_exists( 'sharing_maybe_enqueue_scripts' )
+			&& ! sharing_maybe_enqueue_scripts() ) {
+			$jetpack_share_buttons_disabled = true;
+		}
+
 		$enable_post_duplication = apply_filters( 'newspack_blocks_homepage_enable_duplication', false );
 		while ( $article_query->have_posts() ) {
 			$article_query->the_post();
 			if ( ! $enable_post_duplication ) {
 				$newspack_blocks_post_id[ get_the_ID() ] = true;
 			}
-			echo Newspack_Blocks::template_inc( __DIR__ . '/article.php', array( 'attributes' => $attributes ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo Newspack_Blocks::template_inc(
+				__DIR__ . '/article.php',
+				array(
+					'attributes'                     => $attributes,
+					'jetpack_share_buttons_disabled' => $jetpack_share_buttons_disabled,
+				)
+			);
 		}
 
 		Newspack_Blocks::remove_excerpt_filter();


### PR DESCRIPTION
The `sharing_maybe_enqueue_scripts()` function is our best source of truth for whether or not share buttons should appear on the page.

Fixes https://github.com/Automattic/wp-calypso/issues/46634 and https://github.com/Automattic/wp-calypso/issues/52347

An alternative to https://github.com/Automattic/jetpack/pull/24896. Please see discussion on that pull request.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Uses the `sharing_maybe_enqueue_scripts()` function in Jetpack (https://github.com/Automattic/jetpack/blob/2447e267e40f2d133a5c15c2320b776e4c395ec8/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php#L771) to determine whether or not Share Buttons are meant to be displayed for the page.

Before the change, if Sharing Buttons were disabled for Pages, they'd still appear without their styling:

<img width="846" alt="image" src="https://user-images.githubusercontent.com/36432/176534382-7d40f4bf-6e8d-451c-8156-9f968ec7a635.png">

<img width="977" alt="image" src="https://user-images.githubusercontent.com/36432/176534408-dbaa6b11-52c3-4ad0-94bc-eec2897004d3.png">

With this change, the buttons only appear when enabled for Pages.

### How to test the changes in this Pull Request:

1. Add a 'Homepage Posts' Block to a Page.
2. Enable Share Buttons for Pages:

<img width="967" alt="image" src="https://user-images.githubusercontent.com/36432/176534951-d3ae0228-fa5f-442f-9924-f99999338c67.png">

3. Observe Share Buttons on your Homepage Posts Block when you visit the Page:

<img width="1088" alt="image" src="https://user-images.githubusercontent.com/36432/176534891-ee271017-50bc-4934-9146-57bf2425c6ef.png">

4. Disable Share Buttons for Pages:

<img width="777" alt="image" src="https://user-images.githubusercontent.com/36432/176535052-e58bb23d-09fb-455a-8d96-03986fd7876d.png">

5. Observe no Share Buttons on your Homepage Posts Block:

<img width="1160" alt="image" src="https://user-images.githubusercontent.com/36432/176535111-068706d2-8fcb-46eb-be72-f72a1a4e9ebe.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
