### PR TITLE
fix(donate-block): handle default frequency from attributes

### DIFF
--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -207,6 +207,8 @@ function newspack_blocks_render_block_donate( $attributes ) {
 		return '';
 	}
 
+	$configuration['defaultFrequency'] = $attributes['defaultFrequency'];
+
 	/* If block has additional CSS class(es)  */
 	if ( isset( $attributes['className'] ) ) {
 		$classname = $attributes['className'];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. On `master`, set a default frequency for a Donate block
2. Observe it's not respected on the front end
3. Switch to this branch, observe the default currency is set as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->