### PR TITLE
Feat/customise donate button streamlined

### DIFF
--- a/src/blocks/donate/block.json
+++ b/src/blocks/donate/block.json
@@ -32,6 +32,10 @@
 			"type": "string",
 			"default": "Donate with card"
 		},
+		"paymentRequestType": {
+			"type": "string",
+			"default": "donate"
+		},
 		"defaultFrequency": {
 			"type": "string",
 			"default": "month"

--- a/src/blocks/donate/block.json
+++ b/src/blocks/donate/block.json
@@ -28,6 +28,10 @@
 			"type": "string",
 			"default": "Donate Now"
 		},
+		"buttonWithCCText": {
+			"type": "string",
+			"default": "Donate with card"
+		},
 		"defaultFrequency": {
 			"type": "string",
 			"default": "month"

--- a/src/blocks/donate/edit.tsx
+++ b/src/blocks/donate/edit.tsx
@@ -51,6 +51,8 @@ type OverridableConfiguration = {
 type DonateBlockAttributes = OverridableConfiguration & {
 	buttonText: string;
 	buttonWithCCText: string;
+	// https://stripe.com/docs/stripe-js/elements/payment-request-button
+	paymentRequestType: 'donate' | 'default' | 'book' | 'buy';
 	buttonColor: string;
 	thanksText: string;
 	defaultFrequency: FrequencySlug;
@@ -78,6 +80,16 @@ const TIER_LABELS = [
 	__( 'Mid-tier', 'newspack' ),
 	__( 'High-tier', 'newspack' ),
 	__( 'Other', 'newspack' ),
+];
+
+const PAYMENT_REQUEST_BUTTON_TYPE_OPTIONS: {
+	label: string;
+	value: DonateBlockAttributes[ 'paymentRequestType' ];
+}[] = [
+	{ label: 'Donate', value: 'donate' },
+	{ label: 'Pay', value: 'default' },
+	{ label: 'Book', value: 'book' },
+	{ label: 'Buy', value: 'buy' },
 ];
 
 const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
@@ -397,6 +409,13 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 		</button>
 	);
 
+	const selectedPaymentRequestTypeOption = PAYMENT_REQUEST_BUTTON_TYPE_OPTIONS.find(
+		option => option.value === attributes.paymentRequestType
+	);
+	const selectedPaymentRequestType = selectedPaymentRequestTypeOption
+		? selectedPaymentRequestTypeOption.value
+		: 'donate';
+
 	const renderFooter = () => (
 		<>
 			<p className="wp-block-newspack-blocks-donate__thanks thanks">
@@ -412,7 +431,14 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 					<div className="stripe-payment__row stripe-payment__row--flex stripe-payment__footer">
 						<div className="stripe-payment__methods">
 							<div className="stripe-payment__request-button">
-								{ __( 'Apple/Google Pay Button', 'newspack-blocks' ) }
+								<SelectControl
+									options={ PAYMENT_REQUEST_BUTTON_TYPE_OPTIONS }
+									value={ selectedPaymentRequestType }
+									onChange={ (
+										paymentRequestType: DonateBlockAttributes[ 'paymentRequestType' ]
+									) => setAttributes( { paymentRequestType } ) }
+								/>
+								{ __( 'with Apple/Google Pay', 'newspack-blocks' ) }
 							</div>
 							{ renderButton() }
 						</div>

--- a/src/blocks/donate/edit.tsx
+++ b/src/blocks/donate/edit.tsx
@@ -50,6 +50,7 @@ type OverridableConfiguration = {
 
 type DonateBlockAttributes = OverridableConfiguration & {
 	buttonText: string;
+	buttonWithCCText: string;
 	buttonColor: string;
 	thanksText: string;
 	defaultFrequency: FrequencySlug;
@@ -379,7 +380,12 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 			} }
 		>
 			{ isRenderingStreamlinedBlock() ? (
-				__( 'Donate with card', 'newspack-blocks' )
+				<RichText
+					onChange={ ( value: string ) => setAttributes( { buttonWithCCText: value } ) }
+					placeholder={ __( 'Button text…', 'newspack-blocks' ) }
+					value={ attributes.buttonWithCCText }
+					tagName="span"
+				/>
 			) : (
 				<RichText
 					onChange={ ( value: string ) => setAttributes( { buttonText: value } ) }

--- a/src/blocks/donate/editor.scss
+++ b/src/blocks/donate/editor.scss
@@ -46,12 +46,18 @@
 			}
 		}
 		&__request-button {
+			display: flex;
+			align-items: center;
+			gap: 0.8em;
 			font-size: 0.8em;
 			border-radius: 5px;
 			color: colors.$color__secondary;
 			border: colors.$color__secondary 1px dashed;
 			padding: 0 20px;
 			opacity: 0.5;
+			.components-base-control__field {
+				margin: 0;
+			}
 		}
 	}
 }

--- a/src/blocks/donate/streamlined/index.js
+++ b/src/blocks/donate/streamlined/index.js
@@ -157,7 +157,7 @@ export const processStreamlinedElements = ( parentElement = document ) =>
 					paymentRequest,
 					style: {
 						paymentRequestButton: {
-							type: 'donate',
+							type: settings.paymentRequestType,
 							height: '46px',
 						},
 					},

--- a/src/blocks/donate/streamlined/utils.js
+++ b/src/blocks/donate/streamlined/utils.js
@@ -53,6 +53,7 @@ export const getSettings = formElement => {
 		feeMultiplier,
 		feeStatic,
 		stripePublishableKey,
+		paymentRequestType,
 	] = JSON.parse( formElement.getAttribute( 'data-settings' ) );
 	return {
 		currency: currency.toLowerCase(),
@@ -64,6 +65,7 @@ export const getSettings = formElement => {
 		feeMultiplier: parseFloat( feeMultiplier ),
 		feeStatic: parseFloat( feeStatic ),
 		stripePublishableKey,
+		paymentRequestType,
 	};
 };
 

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -136,7 +136,7 @@ function newspack_blocks_render_block_donate_footer( $attributes ) {
 					<div class="stripe-payment__methods">
 						<div class="stripe-payment__request-button stripe-payment--hidden stripe-payment__request-button--invisible stripe-payment--transition"></div>
 						<button type='submit' <?php echo $button_style_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-							<?php echo esc_html__( 'Donate with card', 'newspack-blocks' ); ?>
+							<?php echo esc_html( $attributes['buttonWithCCText'] ); ?>
 						</button>
 					</div>
 				</div>

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -298,6 +298,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 			$stripe_data['fee_multiplier'],
 			$stripe_data['fee_static'],
 			$stripe_data['usedPublishableKey'],
+			$attributes['paymentRequestType'],
 		];
 	} else {
 		$configuration_for_frontend = [];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1145.

### How to test the changes in this Pull Request:

1. On `master`, insert a streamlined Donate block (Stripe has to be set as the Reader Revenue platform)
2. Switch to this branch, observe the block rendering as before
3. In the editor, observe the "Donate with card" button is editable, and that the payment request (Apple/Google Pay) has a select allowing to choose a variant
4. Observe the credit card button text and payment request button variant are reflected on the frontend*

\* for the latter, you'll need a browser configured for such payments, which can be done with browserstack.com

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->