### PR TITLE
feat(donate): add current_page_url to client metadata

### DIFF
--- a/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
+++ b/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
@@ -136,9 +136,10 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 				'full_name'         => $full_name,
 				'amount'            => $request->get_param( 'amount' ),
 				'client_metadata'   => [
-					'clientId'        => $request->get_param( 'clientId' ),
-					'newsletterOptIn' => $request->get_param( 'newsletter_opt_in' ),
-					'userId'          => $user_id,
+					'clientId'         => $request->get_param( 'clientId' ),
+					'newsletterOptIn'  => $request->get_param( 'newsletter_opt_in' ),
+					'userId'           => $user_id,
+					'current_page_url' => \wp_get_referer(),
 				],
 				'payment_metadata'  => $payment_metadata,
 				'payment_method_id' => $request->get_param( 'payment_method_id' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds the current page URL to the client metadata. I'm aware of the inconsistent casing, but the camelcased properties were meant for Stripe and are processed as such, while this new property is meant for Reader Activation and already processed as snakecased.

### How to test the changes in this Pull Request:

_Follow instructions in https://github.com/Automattic/newspack-plugin/pull/1841 or just smoke test._

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->