### PR TITLE
fix: ensure amount is always defined for totalAmount calculation

### DIFF
--- a/src/blocks/donate/streamlined/utils.ts
+++ b/src/blocks/donate/streamlined/utils.ts
@@ -121,7 +121,7 @@ export const getTotalAmount = (
 	{ convertToSubunit } = { convertToSubunit: false }
 ) => {
 	const settings = getSettings( formElement );
-	const { amount, agree_to_pay_fees: paysFees } = getDonationFormValues( formElement );
+	const { amount = '0', agree_to_pay_fees: paysFees } = getDonationFormValues( formElement );
 
 	const processAmount = ( amountToProcess: number ) =>
 		convertToSubunit


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Looks like #1201 introduced a small bug due to removing the fallback/default value of `0` for `amount` when calculating the total donation amount plus Stripe fees.

Closes #1226.

### How to test the changes in this Pull Request:

Confirm that #1226 is not replicable.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
