### PR TITLE
feat: use reCaptcha v3 to secure Stripe donate forms

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -13,7 +13,9 @@ class Newspack_Blocks {
 	/**
 	 * Script handle for the streamlined donate block script.
 	 */
-	const DONATE_STREAMLINED_SCRIPT_HANDLE = 'newspack-blocks-donate-streamlined';
+	const DONATE_STREAMLINED_SCRIPT_HANDLE     = 'newspack-blocks-donate-streamlined';
+	const DONATE_STREAMLINED_CAPTCHA_HANDLE    = 'newspack-blocks-recaptcha';
+	const DONATE_STREAMLINED_CAPTCHA_THRESHOLD = 0.5;
 
 	/**
 	 * Regex pattern we can use to search for and remove custom SQL statements.
@@ -75,7 +77,7 @@ class Newspack_Blocks {
 	 * @param string $handle The script handle.
 	 */
 	public static function mark_view_script_as_amp_plus_allowed( $tag, $handle ) {
-		if ( self::DONATE_STREAMLINED_SCRIPT_HANDLE === $handle ) {
+		if ( self::DONATE_STREAMLINED_SCRIPT_HANDLE === $handle || self::DONATE_STREAMLINED_CAPTCHA_HANDLE === $handle ) {
 			return str_replace( '<script', '<script data-amp-plus-allowed', $tag );
 		}
 		return $tag;

--- a/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
+++ b/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
@@ -147,8 +147,8 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 
 			// If the reCaptcha verification score is below our threshold for valid user input.
 			if (
-			isset( $captcha_verify['score'] ) &&
-			Newspack_Blocks::DONATE_STREAMLINED_CAPTCHA_THRESHOLD > floatval( $captcha_verify['score'] )
+				isset( $captcha_verify['score'] ) &&
+				Newspack_Blocks::DONATE_STREAMLINED_CAPTCHA_THRESHOLD > floatval( $captcha_verify['score'] )
 			) {
 				return rest_ensure_response(
 					[

--- a/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
+++ b/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
@@ -100,11 +100,11 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 	 */
 	public function api_process_donation( $request ) {
 		// If reCaptcha is available, verify the user action.
-		$use_captcha     = \Newspack\Stripe_Connection::can_use_captcha();
-		$stripe_settings = \Newspack\Stripe_Connection::get_stripe_data();
-		$captcha_secret  = $stripe_settings['captchaSiteSecret'];
+		$use_captcha = \Newspack\Stripe_Connection::can_use_captcha();
 		if ( $use_captcha ) {
-			$captcha_token = $request->get_param( 'captchaToken' );
+			$stripe_settings = \Newspack\Stripe_Connection::get_stripe_data();
+			$captcha_secret  = $stripe_settings['captchaSiteSecret'];
+			$captcha_token   = $request->get_param( 'captchaToken' );
 
 			if ( ! $captcha_token ) {
 				return rest_ensure_response(

--- a/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
+++ b/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
@@ -100,9 +100,12 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 	 */
 	public function api_process_donation( $request ) {
 		// If reCaptcha is available, verify the user action.
-		$use_captcha = \Newspack\Stripe_Connection::can_use_captcha();
+		$use_captcha     = \Newspack\Stripe_Connection::can_use_captcha();
+		$stripe_settings = \Newspack\Stripe_Connection::get_stripe_data();
+		$captcha_secret  = $stripe_settings['captchaSiteSecret'];
 		if ( $use_captcha ) {
 			$captcha_token = $request->get_param( 'captchaToken' );
+
 			if ( ! $captcha_token ) {
 				return rest_ensure_response(
 					[
@@ -114,7 +117,7 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 			$captcha_verify = wp_safe_remote_post(
 				add_query_arg(
 					[
-						'secret'   => '6LeJz2QhAAAAAH6pcdlSuC0XcKLmpb2vL-0IAsw6',
+						'secret'   => $captcha_secret,
 						'response' => $captcha_token,
 					],
 					'https://www.google.com/recaptcha/api/siteverify'

--- a/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
+++ b/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
@@ -41,6 +41,10 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => [ $this, 'api_process_donation' ],
 					'args'                => [
+						'captchaToken'      => [
+							'sanitize_callback' => 'sanitize_text_field',
+							'required'          => false,
+						],
 						'tokenData'         => [
 							'type'       => 'object',
 							'properties' => [
@@ -95,6 +99,63 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function api_process_donation( $request ) {
+		// If reCaptcha is available, verify the user action.
+		$use_captcha = \Newspack\Stripe_Connection::can_use_captcha();
+		if ( $use_captcha ) {
+			$captcha_token = $request->get_param( 'captchaToken' );
+			if ( ! $captcha_token ) {
+				return rest_ensure_response(
+					[
+						'error' => __( 'Missing or invalid captcha token.', 'newspack-blocks' ),
+					]
+				);
+			}
+
+			$captcha_verify = wp_safe_remote_post(
+				add_query_arg(
+					[
+						'secret'   => '6LeJz2QhAAAAAH6pcdlSuC0XcKLmpb2vL-0IAsw6',
+						'response' => $captcha_token,
+					],
+					'https://www.google.com/recaptcha/api/siteverify'
+				)
+			);
+
+			// If the reCaptcha verification request fails.
+			if ( is_wp_error( $captcha_verify ) ) {
+				return rest_ensure_response(
+					[
+						'error' => wp_strip_all_tags( $captcha_verify->get_error_message() ),
+					]
+				);
+			}
+
+			$captcha_verify = json_decode( $captcha_verify['body'], true );
+
+			// If the reCaptcha verification request succeeds, but with error.
+			if ( ! boolval( $captcha_verify['success'] ) ) {
+				$error = isset( $captcha_verify['error-codes'] ) ? reset( $captcha_verify['error-codes'] ) : __( 'Error validating captcha.', 'newspack-blocks' );
+				return rest_ensure_response(
+					[
+						// Translators: error message for reCaptcha.
+						'error' => sprintf( __( 'reCaptcha error: %s', 'newspack-blocks' ), $error ),
+					]
+				);
+			}
+
+			// If the reCaptcha verification score is below our threshold for valid user input.
+			if (
+			isset( $captcha_verify['score'] ) &&
+			Newspack_Blocks::DONATE_STREAMLINED_CAPTCHA_THRESHOLD > floatval( $captcha_verify['score'] )
+			) {
+				return rest_ensure_response(
+					[
+						'error' => __( 'User action failed captcha challenge.', 'newspack-blocks' ),
+					]
+				);
+			}
+		}
+
 		$payment_metadata = [
 			'referer' => wp_get_referer(),
 		];

--- a/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
+++ b/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
@@ -102,10 +102,7 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 		// If reCaptcha is available, verify the user action.
 		$use_captcha = \Newspack\Stripe_Connection::can_use_captcha();
 		if ( $use_captcha ) {
-			$stripe_settings = \Newspack\Stripe_Connection::get_stripe_data();
-			$captcha_secret  = $stripe_settings['captchaSiteSecret'];
-			$captcha_token   = $request->get_param( 'captchaToken' );
-
+			$captcha_token = $request->get_param( 'captchaToken' );
 			if ( ! $captcha_token ) {
 				return rest_ensure_response(
 					[
@@ -114,7 +111,9 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 				);
 			}
 
-			$captcha_verify = wp_safe_remote_post(
+			$stripe_settings = \Newspack\Stripe_Connection::get_stripe_data();
+			$captcha_secret  = $stripe_settings['captchaSiteSecret'];
+			$captcha_verify  = wp_safe_remote_post(
 				add_query_arg(
 					[
 						'secret'   => $captcha_secret,

--- a/src/blocks/donate/streamlined/index.js
+++ b/src/blocks/donate/streamlined/index.js
@@ -28,6 +28,20 @@ export const processStreamlinedElements = ( parentElement = document ) =>
 		const enableForm = () => el.classList.remove( 'stripe-payment--disabled' );
 		enableForm();
 
+		const getCaptchaToken = async reCaptchaKey => {
+			return new Promise( ( res, rej ) => {
+				const { grecaptcha } = window;
+				grecaptcha.ready( async () => {
+					try {
+						const token = await grecaptcha.execute( reCaptchaKey, { action: 'submit' } );
+						return res( token );
+					} catch ( e ) {
+						rej( e );
+					}
+				} );
+			} );
+		};
+
 		// Universal payment handling, for both card and payment request button flows.
 		// In card flow, this will happen after user submits their card data in the HTML form.
 		// In payment request flow, this will happen after the user validates the payment in
@@ -41,8 +55,24 @@ export const processStreamlinedElements = ( parentElement = document ) =>
 			 */
 			requestPayloadOverrides = {}
 		) => {
+			// Add reCaptcha challenge to form submission, if available.
+			const reCaptchaKey = settings?.captchaSiteKey;
+			let reCaptchaToken;
+			if ( reCaptchaKey ) {
+				try {
+					reCaptchaToken = await getCaptchaToken( reCaptchaKey );
+				} catch ( e ) {
+					const errorMessage =
+						e instanceof Error
+							? e.message
+							: __( 'Error processing captcha request.', 'newspack-blocks' );
+					utils.renderMessages( [ errorMessage ], messagesEl );
+					return { error: true };
+				}
+			}
 			const formValues = utils.getFormValues( formElement );
 			const apiRequestPayload = {
+				captchaToken: reCaptchaToken,
 				tokenData: token,
 				amount: utils.getTotalAmount( formElement ),
 				email: formValues.email,

--- a/src/blocks/donate/streamlined/index.js
+++ b/src/blocks/donate/streamlined/index.js
@@ -31,6 +31,11 @@ export const processStreamlinedElements = ( parentElement = document ) =>
 		const getCaptchaToken = async reCaptchaKey => {
 			return new Promise( ( res, rej ) => {
 				const { grecaptcha } = window;
+
+				if ( ! grecaptcha?.ready ) {
+					rej( __( 'Error loading the reCaptcha library.', 'newspack-blocks' ) );
+				}
+
 				grecaptcha.ready( async () => {
 					try {
 						const token = await grecaptcha.execute( reCaptchaKey, { action: 'submit' } );

--- a/src/blocks/donate/streamlined/style.scss
+++ b/src/blocks/donate/streamlined/style.scss
@@ -109,6 +109,7 @@
 				&.type-success {
 					background-color: rgba( colors.$color__success, 0.075 );
 					border-color: colors.$color__success;
+					margin: 1.12rem;
 				}
 			}
 		}

--- a/src/blocks/donate/streamlined/utils.js
+++ b/src/blocks/donate/streamlined/utils.js
@@ -29,6 +29,10 @@ export const renderMessages = ( messages, el, type = 'error' ) => {
 		messageEl.innerHTML = message;
 		el.appendChild( messageEl );
 	} );
+
+	if ( 'success' === type ) {
+		el.parentElement.replaceWith( el );
+	}
 };
 
 const getCookies = () =>
@@ -53,6 +57,7 @@ export const getSettings = formElement => {
 		feeMultiplier,
 		feeStatic,
 		stripePublishableKey,
+		captchaSiteKey,
 	] = JSON.parse( formElement.getAttribute( 'data-settings' ) );
 	return {
 		currency: currency.toLowerCase(),
@@ -64,6 +69,7 @@ export const getSettings = formElement => {
 		feeMultiplier: parseFloat( feeMultiplier ),
 		feeStatic: parseFloat( feeStatic ),
 		stripePublishableKey,
+		captchaSiteKey,
 	};
 };
 
@@ -162,7 +168,7 @@ export const sendAPIRequest = async ( endpoint, data, method = 'POST' ) =>
 	} );
 
 export const renderSuccessMessageWithEmail = ( emailAddress, messagesEl ) => {
-	const successMessge = sprintf(
+	const successMessage = sprintf(
 		/* Translators: %s is the email address of the current user. */
 		__(
 			'Your payment has been processed. Thank you for your contribution! You will receive a confirmation email at %s.',
@@ -170,5 +176,5 @@ export const renderSuccessMessageWithEmail = ( emailAddress, messagesEl ) => {
 		),
 		emailAddress
 	);
-	renderMessages( [ successMessge ], messagesEl, 'success' );
+	renderMessages( [ successMessage ], messagesEl, 'success' );
 };

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -175,7 +175,7 @@ function newspack_blocks_enqueue_streamlined_donate_block_scripts() {
 			// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 			wp_register_script(
 				Newspack_Blocks::DONATE_STREAMLINED_CAPTCHA_HANDLE,
-				'https://www.google.com/recaptcha/api.js?render=' . $captcha_site_key,
+				esc_url( 'https://www.google.com/recaptcha/api.js?render=' . $captcha_site_key ),
 				null,
 				null,
 				true

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -166,11 +166,29 @@ function newspack_blocks_render_block_donate_footer( $attributes ) {
  */
 function newspack_blocks_enqueue_streamlined_donate_block_scripts() {
 	if ( Newspack_Blocks::is_rendering_streamlined_block() ) {
+		$dependencies = [ 'wp-i18n' ];
+
+		if ( \Newspack\Stripe_Connection::can_use_captcha() ) {
+			$stripe_settings  = \Newspack\Stripe_Connection::get_stripe_data();
+			$captcha_site_key = $stripe_settings['captchaSiteKey'];
+
+			// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+			wp_register_script(
+				Newspack_Blocks::DONATE_STREAMLINED_CAPTCHA_HANDLE,
+				'https://www.google.com/recaptcha/api.js?render=' . $captcha_site_key,
+				null,
+				null,
+				true
+			);
+
+			$dependencies[] = Newspack_Blocks::DONATE_STREAMLINED_CAPTCHA_HANDLE;
+		}
+
 		$script_data = Newspack_Blocks::script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . '/donateStreamlined.js' );
 		wp_enqueue_script(
 			Newspack_Blocks::DONATE_STREAMLINED_SCRIPT_HANDLE,
 			$script_data['script_path'],
-			[ 'wp-i18n' ],
+			$dependencies,
 			$script_data['version'],
 			true
 		);
@@ -299,6 +317,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 			$stripe_data['fee_multiplier'],
 			$stripe_data['fee_static'],
 			$stripe_data['usedPublishableKey'],
+			\Newspack\Stripe_Connection::can_use_captcha() ? $stripe_data['captchaSiteKey'] : null,
 		];
 	} else {
 		$configuration_for_frontend = [];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Implements reCaptcha v3 to secure Stripe donation forms. Relies on reCaptcha v3 credentials entered into the UI implemented in https://github.com/Automattic/newspack-plugin/pull/1879.

If reCaptcha is enabled and credentials are stored, then all form submissions via the Stripe donate block will be tested against the reCaptcha v3 API before we attempt to process the transaction with Stripe. If the reCaptcha test returns a score lower than `0.5` (the default threshold for likely valid/human interactions), then we will fail the test and stop the transaction with an error message.

Note that reCaptcha v3 is an "invisible" form of captcha and doesn't involve any front-end user input, so the change will be totally invisible to most valid users. [More info here](https://developers.google.com/recaptcha/docs/v3).

Closes #1209.

### How to test the changes in this Pull Request:

1. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/1879.
2. Do a gut check first, without saving any credentials or changing any settings: enable Stripe as your donation platform, and submit a test donation via the streamlined donate block. Confirm that the donation succeeds as expected.
3. Go to https://www.google.com/recaptcha/admin/create and create a set of reCaptcha v3 keys for your test site.
4. In the WP dashboard, go to Newspack > Reader Revenue > Stripe Settings, enable reCaptcha v3, and enter your site key and secret into the relevant fields. Save.
5. In a new front-end session, submit another test donation and confirm that it succeeds—since you're submitting via direct HTML form interaction, it should pass the reCaptcha test and the transaction should go through.
6. As a test, temporarily change the threshold value on [this line](https://github.com/Automattic/newspack-blocks/compare/release...hotfix/recaptcha-for-stripe?expand=1#diff-5349f9a82b35a56353d631adcc470a92d4a82347acddd0695b7f803cbd38f144R18) to `1.0`, which is a perfect score and nearly impossible to achieve.
7. Submit another test donation and confirm that the transaction fails with an error message.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
