### PR TITLE
refactor: handle reCAPTCHA settings and methods move to RAS

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -13,9 +13,7 @@ class Newspack_Blocks {
 	/**
 	 * Script handle for the streamlined donate block script.
 	 */
-	const DONATE_STREAMLINED_SCRIPT_HANDLE     = 'newspack-blocks-donate-streamlined';
-	const DONATE_STREAMLINED_CAPTCHA_HANDLE    = 'newspack-blocks-recaptcha';
-	const DONATE_STREAMLINED_CAPTCHA_THRESHOLD = 0.5;
+	const DONATE_STREAMLINED_SCRIPT_HANDLE = 'newspack-blocks-donate-streamlined';
 
 	/**
 	 * Regex pattern we can use to search for and remove custom SQL statements.
@@ -77,7 +75,7 @@ class Newspack_Blocks {
 	 * @param string $handle The script handle.
 	 */
 	public static function mark_view_script_as_amp_plus_allowed( $tag, $handle ) {
-		if ( self::DONATE_STREAMLINED_SCRIPT_HANDLE === $handle || self::DONATE_STREAMLINED_CAPTCHA_HANDLE === $handle ) {
+		if ( self::DONATE_STREAMLINED_SCRIPT_HANDLE === $handle ) {
 			return str_replace( '<script', '<script data-amp-plus-allowed', $tag );
 		}
 		return $tag;

--- a/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
+++ b/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
@@ -99,9 +99,9 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function api_process_donation( $request ) {
-		$captcha_token = $request->get_param( 'captchaToken' );
-		if ( ! empty( $captcha_token ) ) {
-			$captcha_result = \Newspack\Reader_Activation::verify_captcha( $captcha_token );
+		if ( method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha() ) {
+			$captcha_token  = $request->get_param( 'captchaToken' );
+			$captcha_result = \Newspack\Recaptcha::verify_captcha( $captcha_token );
 			if ( \is_wp_error( $captcha_result ) ) {
 				return rest_ensure_response(
 					[

--- a/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
+++ b/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
@@ -31,14 +31,14 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 	 * @access public
 	 */
 	public function register_routes() {
-		self::$current_user_id = get_current_user_id();
+		self::$current_user_id = \get_current_user_id();
 
-		register_rest_route(
+		\register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base,
 			[
 				[
-					'methods'             => WP_REST_Server::EDITABLE,
+					'methods'             => \WP_REST_Server::EDITABLE,
 					'callback'            => [ $this, 'api_process_donation' ],
 					'args'                => [
 						'captchaToken'      => [
@@ -103,16 +103,16 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 			$captcha_token  = $request->get_param( 'captchaToken' );
 			$captcha_result = \Newspack\Recaptcha::verify_captcha( $captcha_token );
 			if ( \is_wp_error( $captcha_result ) ) {
-				return rest_ensure_response(
+				return \rest_ensure_response(
 					[
-						'error' => wp_strip_all_tags( $captcha_result->get_error_message() ),
+						'error' => \esc_html( $captcha_result->get_error_message() ),
 					]
 				);
 			}
 		}
 
 		$payment_metadata = [
-			'referer' => wp_get_referer(),
+			'referer' => \wp_get_referer(),
 		];
 		if ( class_exists( 'Newspack\NRH' ) && method_exists( 'Newspack\NRH', 'get_nrh_config' ) ) {
 			$nrh_config = \Newspack\NRH::get_nrh_config();
@@ -136,12 +136,12 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 					$full_name,
 					$frequency
 				);
-				if ( is_wp_error( $user_id ) ) {
-					return [ 'error' => wp_strip_all_tags( $user_id->get_error_message() ) ];
+				if ( \is_wp_error( $user_id ) ) {
+					return [ 'error' => \esc_html( $user_id->get_error_message() ) ];
 				}
 			}
 		} else {
-			$email_address = get_userdata( $user_id )->user_email;
+			$email_address = \get_userdata( $user_id )->user_email;
 		}
 
 		$response = \Newspack\Stripe_Connection::handle_donation(
@@ -162,6 +162,6 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 			]
 		);
 
-		return rest_ensure_response( $response );
+		return \rest_ensure_response( $response );
 	}
 }

--- a/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
+++ b/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
@@ -99,60 +99,13 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function api_process_donation( $request ) {
-		// If reCaptcha is available, verify the user action.
-		$use_captcha = \Newspack\Stripe_Connection::can_use_captcha();
-		if ( $use_captcha ) {
-			$captcha_token = $request->get_param( 'captchaToken' );
-			if ( ! $captcha_token ) {
+		$captcha_token = $request->get_param( 'captchaToken' );
+		if ( ! empty( $captcha_token ) ) {
+			$captcha_result = \Newspack\Reader_Activation::verify_captcha( $captcha_token );
+			if ( \is_wp_error( $captcha_result ) ) {
 				return rest_ensure_response(
 					[
-						'error' => __( 'Missing or invalid captcha token.', 'newspack-blocks' ),
-					]
-				);
-			}
-
-			$stripe_settings = \Newspack\Stripe_Connection::get_stripe_data();
-			$captcha_secret  = $stripe_settings['captchaSiteSecret'];
-			$captcha_verify  = wp_safe_remote_post(
-				add_query_arg(
-					[
-						'secret'   => $captcha_secret,
-						'response' => $captcha_token,
-					],
-					'https://www.google.com/recaptcha/api/siteverify'
-				)
-			);
-
-			// If the reCaptcha verification request fails.
-			if ( is_wp_error( $captcha_verify ) ) {
-				return rest_ensure_response(
-					[
-						'error' => wp_strip_all_tags( $captcha_verify->get_error_message() ),
-					]
-				);
-			}
-
-			$captcha_verify = json_decode( $captcha_verify['body'], true );
-
-			// If the reCaptcha verification request succeeds, but with error.
-			if ( ! boolval( $captcha_verify['success'] ) ) {
-				$error = isset( $captcha_verify['error-codes'] ) ? reset( $captcha_verify['error-codes'] ) : __( 'Error validating captcha.', 'newspack-blocks' );
-				return rest_ensure_response(
-					[
-						// Translators: error message for reCaptcha.
-						'error' => sprintf( __( 'reCaptcha error: %s', 'newspack-blocks' ), $error ),
-					]
-				);
-			}
-
-			// If the reCaptcha verification score is below our threshold for valid user input.
-			if (
-				isset( $captcha_verify['score'] ) &&
-				Newspack_Blocks::DONATE_STREAMLINED_CAPTCHA_THRESHOLD > floatval( $captcha_verify['score'] )
-			) {
-				return rest_ensure_response(
-					[
-						'error' => __( 'User action failed captcha challenge.', 'newspack-blocks' ),
+						'error' => wp_strip_all_tags( $captcha_result->get_error_message() ),
 					]
 				);
 			}

--- a/src/blocks/donate/streamlined/index.ts
+++ b/src/blocks/donate/streamlined/index.ts
@@ -53,17 +53,20 @@ export const processStreamlinedElements = ( parentElement = document ) =>
 			}
 		};
 
-		const getCaptchaToken = async ( reCaptchaKey: string ) => {
+		const getCaptchaToken = async ( captchaSiteKey: string ) => {
 			return new Promise( ( res, rej ) => {
 				const { grecaptcha } = window;
+				if ( ! grecaptcha ) {
+					return res( '' );
+				}
 
-				if ( ! grecaptcha?.ready ) {
+				if ( ! grecaptcha?.ready || ! captchaSiteKey ) {
 					rej( __( 'Error loading the reCaptcha library.', 'newspack-blocks' ) );
 				}
 
 				grecaptcha.ready( async () => {
 					try {
-						const token = await grecaptcha.execute( reCaptchaKey, { action: 'submit' } );
+						const token = await grecaptcha.execute( captchaSiteKey, { action: 'submit' } );
 						return res( token );
 					} catch ( e ) {
 						rej( e );
@@ -90,23 +93,23 @@ export const processStreamlinedElements = ( parentElement = document ) =>
 			}
 
 			// Add reCaptcha challenge to form submission, if available.
-			const reCaptchaKey = settings?.captchaSiteKey;
-			let reCaptchaToken;
-			if ( reCaptchaKey ) {
+			const captchaSiteKey = settings?.captchaSiteKey;
+			let captchaToken;
+			if ( captchaSiteKey ) {
 				try {
-					reCaptchaToken = await getCaptchaToken( reCaptchaKey );
+					captchaToken = await getCaptchaToken( captchaSiteKey );
 				} catch ( e ) {
 					const errorMessage =
 						e instanceof Error
 							? e.message
-							: __( 'Error processing captcha request.', 'newspack-blocks' );
+							: __( 'Error processing captcha request.', 'newspackblocks' );
 					utils.renderMessages( [ errorMessage ], messagesEl );
 					return { error: true };
 				}
 			}
 			const formValues = utils.getDonationFormValues( formElement );
 			const apiRequestPayload = {
-				captchaToken: reCaptchaToken,
+				captchaToken,
 				tokenData: token,
 				amount: utils.getTotalAmount( formElement ),
 				email: formValues.email,

--- a/src/blocks/donate/streamlined/index.ts
+++ b/src/blocks/donate/streamlined/index.ts
@@ -102,7 +102,7 @@ export const processStreamlinedElements = ( parentElement = document ) =>
 					const errorMessage =
 						e instanceof Error
 							? e.message
-							: __( 'Error processing captcha request.', 'newspackblocks' );
+							: __( 'Error processing captcha request.', 'newspack-blocks' );
 					utils.renderMessages( [ errorMessage ], messagesEl );
 					return { error: true };
 				}

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -169,7 +169,7 @@ function newspack_blocks_enqueue_streamlined_donate_block_scripts() {
 	if ( Newspack_Blocks::is_rendering_streamlined_block() ) {
 		$dependencies = [ 'wp-i18n' ];
 
-		if ( \Newspack\Recaptcha::can_use_captcha() ) {
+		if ( method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha() ) {
 			$dependencies[] = \Newspack\Recaptcha::RECAPTCHA_SCRIPT_HANDLE;
 		}
 

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -169,20 +169,8 @@ function newspack_blocks_enqueue_streamlined_donate_block_scripts() {
 	if ( Newspack_Blocks::is_rendering_streamlined_block() ) {
 		$dependencies = [ 'wp-i18n' ];
 
-		if ( \Newspack\Stripe_Connection::can_use_captcha() ) {
-			$stripe_settings  = \Newspack\Stripe_Connection::get_stripe_data();
-			$captcha_site_key = $stripe_settings['captchaSiteKey'];
-
-			// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
-			wp_register_script(
-				Newspack_Blocks::DONATE_STREAMLINED_CAPTCHA_HANDLE,
-				esc_url( 'https://www.google.com/recaptcha/api.js?render=' . $captcha_site_key ),
-				null,
-				null,
-				true
-			);
-
-			$dependencies[] = Newspack_Blocks::DONATE_STREAMLINED_CAPTCHA_HANDLE;
+		if ( \Newspack\Recaptcha::can_use_captcha() ) {
+			$dependencies[] = \Newspack\Recaptcha::RECAPTCHA_SCRIPT_HANDLE;
 		}
 
 		$script_data = Newspack_Blocks::script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . '/donateStreamlined.js' );
@@ -193,6 +181,7 @@ function newspack_blocks_enqueue_streamlined_donate_block_scripts() {
 			$script_data['version'],
 			true
 		);
+
 		$style_path = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'donateStreamlined' . ( is_rtl() ? '.rtl' : '' ) . '.css';
 		wp_enqueue_style(
 			Newspack_Blocks::DONATE_STREAMLINED_SCRIPT_HANDLE,
@@ -310,8 +299,14 @@ function newspack_blocks_render_block_donate( $attributes ) {
 	$uid = wp_rand( 10000, 99999 ); // Unique identifier to prevent labels colliding with other instances of Donate block.
 
 	if ( Newspack_Blocks::is_rendering_streamlined_block() ) {
-		$stripe_data                = \Newspack\Stripe_Connection::get_stripe_data();
-		$currency                   = $stripe_data['currency'];
+		$stripe_data      = \Newspack\Stripe_Connection::get_stripe_data();
+		$currency         = $stripe_data['currency'];
+		$captcha_site_key = null;
+
+		if ( method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha() ) {
+			$captcha_site_key = \Newspack\Recaptcha::get_setting( 'site_key' );
+		}
+
 		$configuration_for_frontend = [
 			$currency,
 			$configuration['currencySymbol'],
@@ -323,7 +318,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 			$stripe_data['fee_static'],
 			$stripe_data['usedPublishableKey'],
 			$attributes['paymentRequestType'],
-			\Newspack\Stripe_Connection::can_use_captcha() ? $stripe_data['captchaSiteKey'] : null,
+			$captcha_site_key,
 			$configuration['minimumDonation'],
 		];
 	} else {

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -170,7 +170,7 @@ function newspack_blocks_enqueue_streamlined_donate_block_scripts() {
 		$dependencies = [ 'wp-i18n' ];
 
 		if ( method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha() ) {
-			$dependencies[] = \Newspack\Recaptcha::RECAPTCHA_SCRIPT_HANDLE;
+			$dependencies[] = \Newspack\Recaptcha::SCRIPT_HANDLE;
 		}
 
 		$script_data = Newspack_Blocks::script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . '/donateStreamlined.js' );

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -8,6 +8,7 @@ declare global {
 			is_rendering_streamlined_block?: boolean;
 		};
 		grecaptcha: any;
+		newspack_recaptcha_data: any,
 		newspackReaderActivation: {
 			on: function;
 			off: function;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -8,7 +8,6 @@ declare global {
 			is_rendering_streamlined_block?: boolean;
 		};
 		grecaptcha: any;
-		newspack_recaptcha_data: any,
 		newspackReaderActivation: {
 			on: function;
 			off: function;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Refactor required to handle the migration of reCAPTCHA settings to the Reader Activation wizard in https://github.com/Automattic/newspack-plugin/pull/1910.

### How to test the changes in this Pull Request:

This is technically a pure refactor. To test, check out this PR and https://github.com/Automattic/newspack-plugin/pull/1910 and follow the testing steps in https://github.com/Automattic/newspack-plugin/pull/1910 to confirm that reCAPTCHA still works as expected on streamlined donate blocks.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
