### PR TITLE
Homepage Posts: fix column spacing and add control 

### DIFF
--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -74,6 +74,10 @@
       "type": "integer",
       "default": 3
     },
+    "colGap": {
+      "type": "integer",
+      "default": 3
+    },
     "postsToShow": {
       "type": "integer",
       "default": 3

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -267,6 +267,7 @@ class Edit extends Component {
 			postsToShow,
 			categories,
 			columns,
+			colGap,
 			postType,
 			showImage,
 			showCaption,
@@ -322,6 +323,24 @@ class Edit extends Component {
 			},
 		];
 
+		const colGapOptions = [
+			{
+				value: 1,
+				label: /* translators: label for small size option */ __( 'Small', 'newspack-blocks' ),
+				shortName: /* translators: abbreviation for small size */ __( 'S', 'newspack-blocks' ),
+			},
+			{
+				value: 2,
+				label: /* translators: label for medium size option */ __( 'Medium', 'newspack-blocks' ),
+				shortName: /* translators: abbreviation for medium size */ __( 'M', 'newspack-blocks' ),
+			},
+			{
+				value: 3,
+				label: /* translators: label for large size option */ __( 'Large', 'newspack-blocks' ),
+				shortName: /* translators: abbreviation for large size */ __( 'L', 'newspack-blocks' ),
+			},
+		];
+
 		return (
 			<Fragment>
 				<PanelBody title={ __( 'Display Settings', 'newspack-blocks' ) } initialOpen={ true }>
@@ -357,14 +376,44 @@ class Edit extends Component {
 						postType={ postType }
 					/>
 					{ postLayout === 'grid' && (
-						<RangeControl
-							label={ __( 'Columns', 'newspack-blocks' ) }
-							value={ columns }
-							onChange={ _columns => setAttributes( { columns: _columns } ) }
-							min={ 2 }
-							max={ 6 }
-							required
-						/>
+						<Fragment>
+							<RangeControl
+								label={ __( 'Columns', 'newspack-blocks' ) }
+								value={ columns }
+								onChange={ _columns => setAttributes( { columns: _columns } ) }
+								min={ 2 }
+								max={ 6 }
+								required
+							/>
+
+							<BaseControl
+								label={ __( 'Columns Gap', 'newspack-blocks' ) }
+								id="newspackcolumns-col-gap"
+							>
+								<PanelRow>
+									<ButtonGroup
+										id="newspackcolumns-col-gap"
+										aria-label={ __( 'Columns Gap', 'newspack-blocks' ) }
+									>
+										{ colGapOptions.map( option => {
+											const isCurrent = colGap === option.value;
+											return (
+												<Button
+													isLarge
+													isPrimary={ isCurrent }
+													aria-pressed={ isCurrent }
+													aria-label={ option.label }
+													key={ option.value }
+													onClick={ () => setAttributes( { colGap: option.value } ) }
+												>
+													{ option.shortName }
+												</Button>
+											);
+										} ) }
+									</ButtonGroup>
+								</PanelRow>
+							</BaseControl>
+						</Fragment>
 					) }
 					{ ! specificMode && isBlogPrivate() ? (
 						/*
@@ -603,6 +652,7 @@ class Edit extends Component {
 			moreButton,
 			moreButtonText,
 			columns,
+			colGap,
 			typeScale,
 			imageScale,
 			mobileStack,
@@ -617,6 +667,7 @@ class Edit extends Component {
 			'is-grid': postLayout === 'grid',
 			'show-image': showImage,
 			[ `columns-${ columns }` ]: postLayout === 'grid',
+			[ `colgap-${ colGap }` ]: postLayout === 'grid',
 			[ `ts-${ typeScale }` ]: typeScale !== '5',
 			[ `image-align${ mediaPosition }` ]: showImage,
 			[ `is-${ imageScale }` ]: imageScale !== '1' && showImage,

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -29,7 +29,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 		$classes .= ' is-grid';
 	}
 	if ( isset( $attributes['columns'] ) && 'grid' === $attributes['postLayout'] ) {
-		$classes .= ' columns-' . $attributes['columns'];
+		$classes .= ' columns-' . $attributes['columns'] . ' colgap-' . $attributes['colGap'];
 	}
 	if ( $attributes['showImage'] ) {
 		$classes .= ' show-image';

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -3,12 +3,12 @@
 @use '../../shared/sass/preview';
 
 :root {
-	--wpnbha-gap: 16px;
+	--wpnbha-gap: 1em;
 }
 
 @include mixins.media( mobile ) {
 	:root {
-		--wpnbha-gap: 24px;
+		--wpnbha-gap: 16px;
 	}
 }
 
@@ -19,15 +19,15 @@
 }
 
 .colgap-2 {
-	--wpnbha-gap: 12px;
-
-	@include mixins.media( tablet ) {
+	@include mixins.media( mobile ) {
 		--wpnbha-gap: 16px;
 	}
 }
 
 .colgap-1 {
-	--wpnbha-gap: 8px;
+	@include mixins.media( mobile ) {
+		--wpnbha-gap: 8px;
+	}
 }
 
 .wpnbha {

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -3,10 +3,18 @@
 @use '../../shared/sass/preview';
 
 :root {
-	--wpnbha-gap: 8px;
+	--wpnbha-gap: 16px;
+}
 
-	@include mixins.media( tablet ) {
-		--wpnbha-gap: 12px;
+@include mixins.media( mobile ) {
+	:root {
+		--wpnbha-gap: 24px;
+	}
+}
+
+@include mixins.media( tablet ) {
+	:root {
+		--wpnbha-gap: 32px;
 	}
 }
 
@@ -18,16 +26,8 @@
 	}
 }
 
-.colgap-3 {
-	--wpnbha-gap: 16px;
-
-	@include mixins.media( mobile ) {
-		--wpnbha-gap: 24px;
-	}
-
-	@include mixins.media( tablet ) {
-		--wpnbha-gap: 32px;
-	}
+.colgap-1 {
+	--wpnbha-gap: 8px;
 }
 
 .wpnbha {

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -3,17 +3,29 @@
 @use '../../shared/sass/preview';
 
 :root {
-	--wpnbha-gap: 16px;
-}
+	--wpnbha-gap: 8px;
 
-@include mixins.media( mobile ) {
-	:root {
-		--wpnbha-gap: 24px;
+	@include mixins.media( tablet ) {
+		--wpnbha-gap: 12px;
 	}
 }
 
-@include mixins.media( tablet ) {
-	:root {
+.colgap-2 {
+	--wpnbha-gap: 12px;
+
+	@include mixins.media( tablet ) {
+		--wpnbha-gap: 16px;
+	}
+}
+
+.colgap-3 {
+	--wpnbha-gap: 16px;
+
+	@include mixins.media( mobile ) {
+		--wpnbha-gap: 24px;
+	}
+
+	@include mixins.media( tablet ) {
 		--wpnbha-gap: 32px;
 	}
 }

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -3,30 +3,30 @@
 @use '../../shared/sass/preview';
 
 :root {
-	--wpnbha-gap: 1em;
+	--wpnbha-col-gap: 1em;
 }
 
 @include mixins.media( mobile ) {
 	:root {
-		--wpnbha-gap: 16px;
+		--wpnbha-col-gap: 16px;
 	}
 }
 
 @include mixins.media( tablet ) {
 	:root {
-		--wpnbha-gap: 32px;
+		--wpnbha-col-gap: 32px;
 	}
 }
 
 .colgap-2 {
 	@include mixins.media( mobile ) {
-		--wpnbha-gap: 16px;
+		--wpnbha-col-gap: 16px;
 	}
 }
 
 .colgap-1 {
 	@include mixins.media( mobile ) {
-		--wpnbha-gap: 8px;
+		--wpnbha-col-gap: 8px;
 	}
 }
 
@@ -59,7 +59,7 @@
 			flex-wrap: wrap;
 			justify-content: flex-start;
 			flex-direction: row;
-			gap: var( --wpnbha-gap );
+			gap: var( --wpnbha-col-gap );
 			padding: 0;
 			list-style: none;
 		}
@@ -70,31 +70,32 @@
 		}
 
 		.article-section-title {
-			margin-bottom: calc( 1em - var( --wpnbha-gap ) );
+			margin-bottom: calc( 1em - var( --wpnbha-col-gap ) );
 		}
 	}
 
 	@include mixins.media( mobile ) {
+		// width of column - ( column gap / number of columns * number of gaps )
 		&.columns-3 article,
 		&.columns-6 article {
-			flex-basis: calc( 33.33% - ( var( --wpnbha-gap ) / 3 * 2 ) );
+			flex-basis: calc( 33.33% - ( var( --wpnbha-col-gap ) / 3 * 2 ) );
 		}
 
 		&.is-style-borders.columns-3 article,
 		&.is-style-borders.columns-6 article {
-			flex-basis: calc( 33.33% - ( 2 * var( --wpnbha-gap ) / 3 * 2 ) - 1px );
+			flex-basis: calc( 33.33% - ( 2 * var( --wpnbha-col-gap ) / 3 * 2 ) - 1px );
 		}
 
 		&.columns-2 article,
 		&.columns-4 article,
 		&.columns-5 article {
-			flex-basis: calc( 50% - ( var( --wpnbha-gap ) / 2 ) );
+			flex-basis: calc( 50% - ( var( --wpnbha-col-gap ) / 2 ) );
 		}
 
 		&.is-style-borders.columns-2 article,
 		&.is-style-borders.columns-4 article,
 		&.is-style-borders.columns-5 article {
-			flex-basis: calc( 50% - ( 2 * var( --wpnbha-gap ) / 2 ) - 1px );
+			flex-basis: calc( 50% - ( 2 * var( --wpnbha-col-gap ) / 2 ) - 1px );
 		}
 
 		&.columns-5 article:last-of-type,
@@ -105,29 +106,29 @@
 
 	@include mixins.media( tablet ) {
 		&.columns-4 article {
-			flex-basis: calc( 25% - ( var( --wpnbha-gap ) / 4 * 3 ) );
+			flex-basis: calc( 25% - ( var( --wpnbha-col-gap ) / 4 * 3 ) );
 		}
 
 		&.is-style-borders.columns-4 article {
-			flex-basis: calc( 25% - ( 2 * var( --wpnbha-gap ) / 4 * 3 ) - 1px );
+			flex-basis: calc( 25% - ( 2 * var( --wpnbha-col-gap ) / 4 * 3 ) - 1px );
 		}
 
 		&.columns-5 article,
 		&.columns-5 article:last-of-type {
-			flex-basis: calc( 20% - ( var( --wpnbha-gap ) / 5 * 4 ) );
+			flex-basis: calc( 20% - ( var( --wpnbha-col-gap ) / 5 * 4 ) );
 		}
 
 		&.is-style-borders.columns-5 article,
 		&.is-style-borders.columns-5 article:last-of-type {
-			flex-basis: calc( 20% - ( 2 * var( --wpnbha-gap ) / 5 * 4 ) - 1px );
+			flex-basis: calc( 20% - ( 2 * var( --wpnbha-col-gap ) / 5 * 4 ) - 1px );
 		}
 
 		&.columns-6 article {
-			flex-basis: calc( 16.66667% - ( var( --wpnbha-gap ) / 6 * 5 ) );
+			flex-basis: calc( 16.66667% - ( var( --wpnbha-col-gap ) / 6 * 5 ) );
 		}
 
 		&.is-style-borders.columns-6 article {
-			flex-basis: calc( 16.66667% - ( 2 * var( --wpnbha-gap ) / 6 * 5 ) - 1px );
+			flex-basis: calc( 16.66667% - ( 2 * var( --wpnbha-col-gap ) / 6 * 5 ) - 1px );
 		}
 	}
 
@@ -780,7 +781,7 @@ amp-script .wpnbha {
 		&.columns-5 {
 			article:nth-of-type( odd ):not( :last-of-type ) {
 				border-width: 0 1px 0 0;
-				padding-right: var( --wpnbha-gap );
+				padding-right: var( --wpnbha-col-gap );
 			}
 		}
 
@@ -790,7 +791,7 @@ amp-script .wpnbha {
 				&:nth-of-type( 3n + 1 ):not( :last-of-type ),
 				&:nth-of-type( 3n + 2 ):not( :last-of-type ) {
 					border-width: 0 1px 0 0;
-					padding-right: var( --wpnbha-gap );
+					padding-right: var( --wpnbha-col-gap );
 				}
 			}
 		}
@@ -800,7 +801,7 @@ amp-script .wpnbha {
 		&.is-grid {
 			article {
 				border-width: 0 1px 0 0;
-				padding-right: var( --wpnbha-gap );
+				padding-right: var( --wpnbha-col-gap );
 			}
 		}
 

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -2,6 +2,22 @@
 @use '../../shared/sass/mixins';
 @use '../../shared/sass/preview';
 
+:root {
+	--wpnbha-gap: 16px;
+}
+
+@include mixins.media( mobile ) {
+	:root {
+		--wpnbha-gap: 24px;
+	}
+}
+
+@include mixins.media( tablet ) {
+	:root {
+		--wpnbha-gap: 32px;
+	}
+}
+
 .wpnbha {
 	margin-bottom: 1em;
 
@@ -25,49 +41,81 @@
 	}
 
 	/* Column styles */
-	&.is-grid > div {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: flex-start;
-		flex-direction: row;
-		gap: 16px;
-		padding: 0;
-		list-style: none;
-	}
-
 	&.is-grid {
+		> div {
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: flex-start;
+			flex-direction: row;
+			gap: var( --wpnbha-gap );
+			padding: 0;
+			list-style: none;
+		}
+
 		article {
 			flex-basis: 100%;
+			margin-bottom: 0;
+		}
 
-			@include mixins.media( tablet ) {
-				margin-bottom: 1em;
-			}
+		.article-section-title {
+			margin-bottom: calc( 1em - var( --wpnbha-gap ) );
 		}
 	}
 
 	@include mixins.media( mobile ) {
 		&.columns-3 article,
 		&.columns-6 article {
-			flex-basis: calc( 33.333% - 16px );
+			flex-basis: calc( 33.33% - ( var( --wpnbha-gap ) / 3 * 2 ) );
+		}
+
+		&.is-style-borders.columns-3 article,
+		&.is-style-borders.columns-6 article {
+			flex-basis: calc( 33.33% - ( 2 * var( --wpnbha-gap ) / 3 * 2 ) - 1px );
 		}
 
 		&.columns-2 article,
 		&.columns-4 article,
 		&.columns-5 article {
-			flex-basis: calc( 50% - 16px );
+			flex-basis: calc( 50% - ( var( --wpnbha-gap ) / 2 ) );
 		}
 
-		&.columns-5 article:last-of-type {
+		&.is-style-borders.columns-2 article,
+		&.is-style-borders.columns-4 article,
+		&.is-style-borders.columns-5 article {
+			flex-basis: calc( 50% - ( 2 * var( --wpnbha-gap ) / 2 ) - 1px );
+		}
+
+		&.columns-5 article:last-of-type,
+		&.is-style-borders.columns-5 article:last-of-type {
 			flex-basis: 100%;
 		}
 	}
 
 	@include mixins.media( tablet ) {
-		@for $i from 2 through 6 {
-			&.columns-#{ $i } article,
-			&.columns-#{ $i } article:last-of-type {
-				flex-basis: calc( ( 100% / #{$i} ) - 16px );
-			}
+		&.columns-4 article {
+			flex-basis: calc( 25% - ( var( --wpnbha-gap ) / 4 * 3 ) );
+		}
+
+		&.is-style-borders.columns-4 article {
+			flex-basis: calc( 25% - ( 2 * var( --wpnbha-gap ) / 4 * 3 ) - 1px );
+		}
+
+		&.columns-5 article,
+		&.columns-5 article:last-of-type {
+			flex-basis: calc( 20% - ( var( --wpnbha-gap ) / 5 * 4 ) );
+		}
+
+		&.is-style-borders.columns-5 article,
+		&.is-style-borders.columns-5 article:last-of-type {
+			flex-basis: calc( 20% - ( 2 * var( --wpnbha-gap ) / 5 * 4 ) - 1px );
+		}
+
+		&.columns-6 article {
+			flex-basis: calc( 16.66667% - ( var( --wpnbha-gap ) / 6 * 5 ) );
+		}
+
+		&.is-style-borders.columns-6 article {
+			flex-basis: calc( 16.66667% - ( 2 * var( --wpnbha-gap ) / 6 * 5 ) - 1px );
 		}
 	}
 
@@ -698,48 +746,41 @@ amp-script .wpnbha {
 	article {
 		border: solid rgba( 0, 0, 0, 0.2 );
 		border-width: 0 0 1px;
-		margin-bottom: 1em;
+		box-sizing: content-box;
 		padding-bottom: 1em;
 
 		&:last-of-type {
 			&:not( :first-of-type ) {
 				border-bottom: 0;
+				padding-right: 0;
 			}
 		}
 	}
 
 	@include mixins.media( mobile ) {
-		@for $i from 2 through 6 {
-			&.columns-#{ $i } article {
-				padding-right: calc( ( 16px * #{$i} ) / ( #{$i} - 1 ) );
-			}
+		&.is-grid article {
+			border-width: 0;
+			padding-right: 0;
 		}
 
 		&.columns-2,
 		&.columns-4,
 		&.columns-5 {
-			article {
-				border-width: 0;
-				&:nth-of-type( odd ) {
-					border-width: 0 1px 0 0;
-				}
+			article:nth-of-type( odd ):not( :last-of-type ) {
+				border-width: 0 1px 0 0;
+				padding-right: var( --wpnbha-gap );
 			}
 		}
 
 		&.columns-3,
 		&.columns-6 {
 			article {
-				border-width: 0;
-
-				&:nth-of-type( 3n + 1 ),
-				&:nth-of-type( 3n + 2 ) {
+				&:nth-of-type( 3n + 1 ):not( :last-of-type ),
+				&:nth-of-type( 3n + 2 ):not( :last-of-type ) {
 					border-width: 0 1px 0 0;
+					padding-right: var( --wpnbha-gap );
 				}
 			}
-		}
-
-		&.is-grid article:last-of-type {
-			border: 0;
 		}
 	}
 
@@ -747,6 +788,7 @@ amp-script .wpnbha {
 		&.is-grid {
 			article {
 				border-width: 0 1px 0 0;
+				padding-right: var( --wpnbha-gap );
 			}
 		}
 
@@ -758,6 +800,7 @@ amp-script .wpnbha {
 		&.columns-5 article:nth-of-type( 5n ),
 		&.columns-6 article:nth-of-type( 6n ) {
 			border: 0;
+			padding-right: 0;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR tackles a couple changes to how the column spacing works with the Homepage Posts block:

* It fixes an issue with the columns no longer filling the whole space (#1213)
* It fixes an issue with the last item wrapping when pairing the grid and border settings in the editor (#1233)
* The columns used to be spaced out a a bit haphazardly by using `justify-content: space-between`; this PR updates the default gap to be 32px to match the columns block; it also adds an option to reduce the gap if needed (#638).

Closes #1233, #1213 and #638.

### How to test the changes in this Pull Request:

1. Switch your site to the default Newspack theme -- this makes it easiest to see if the columns span the full space, because the accent header fills the whole space. 
2. Create a post and add an assortment of Homepage Posts blocks to the editor -- you'll want to include all of the different column settings (2-6) with and without borders. You can also copy the following example blocks and paste them into the code view of the editor (it also includes some Homepage Posts in columns to compare the spacing):

<details>
<summary>Example Homepage Posts blocks</summary>

```
<!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"postLayout":"grid","columns":2,"postsToShow":2,"typeScale":3,"sectionHeader":"Two Column via Block Settings"} /-->

<!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"postLayout":"grid","columns":2,"typeScale":3,"sectionHeader":"Two Column -  via Block Settings"} /-->

<!-- wp:newspack-blocks/homepage-articles {"className":"is-style-borders","showExcerpt":false,"showAvatar":false,"showCategory":true,"postLayout":"grid","columns":2,"postsToShow":2,"typeScale":3,"sectionHeader":"Two Column - via Block Settings"} /-->

<!-- wp:group -->
<div class="wp-block-group"><!-- wp:heading {"className":"accent-header"} -->
<h2 class="accent-header">Two Columns in Columns</h2>
<!-- /wp:heading -->

<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"postsToShow":1,"typeScale":3} /--></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"showAvatar":false,"showCategory":true,"postsToShow":1,"typeScale":3} /--></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:columns {"className":"is-style-borders"} -->
<div class="wp-block-columns is-style-borders"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"postsToShow":1,"typeScale":3} /--></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"showAvatar":false,"showCategory":true,"postsToShow":1,"typeScale":3} /--></div>
<!-- /wp:column --></div>
<!-- /wp:columns --></div>
<!-- /wp:group -->

<!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"showAvatar":false,"showCategory":true,"postLayout":"grid","typeScale":3,"sectionHeader":"Three Column -  via Block Settings"} /-->

<!-- wp:newspack-blocks/homepage-articles {"className":"is-style-borders","showExcerpt":false,"showAvatar":false,"showCategory":true,"postLayout":"grid","typeScale":3,"sectionHeader":"Three Column -  via Block Settings"} /-->

<!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"showAvatar":false,"showCategory":true,"postLayout":"grid","columns":4,"postsToShow":4,"typeScale":3,"sectionHeader":"Four Column"} /-->

<!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"postLayout":"grid","columns":4,"postsToShow":6,"typeScale":3,"sectionHeader":"Four Column"} /-->

<!-- wp:newspack-blocks/homepage-articles {"className":"is-style-borders","showExcerpt":false,"showAvatar":false,"showCategory":true,"postLayout":"grid","columns":4,"postsToShow":4,"typeScale":3,"sectionHeader":"Four Column - Via Block Settings"} /-->

<!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"showAvatar":false,"postLayout":"grid","columns":5,"postsToShow":5,"typeScale":2,"sectionHeader":"Five Column - Via Column Settings "} /-->

<!-- wp:newspack-blocks/homepage-articles {"className":"is-style-borders","showExcerpt":false,"showAvatar":false,"showCategory":true,"postLayout":"grid","columns":5,"postsToShow":5,"typeScale":2,"sectionHeader":"Five Column - Via Column Settings "} /-->

<!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"showAvatar":false,"showCategory":true,"postLayout":"grid","columns":6,"postsToShow":6,"typeScale":2,"sectionHeader":"six Column"} /-->

<!-- wp:newspack-blocks/homepage-articles {"className":"is-style-borders","showExcerpt":false,"showAvatar":false,"showCategory":true,"postLayout":"grid","columns":6,"postsToShow":6,"typeScale":2,"sectionHeader":"six Column"} /-->
```

</details>

3. Note how the last post in each row of block with borders wraps to a new line in editor:

4. Publish the page and view on the front end -- note that the posts don't quite fill all of the horizontal space, and that the borders are not evenly spaced:

![image](https://user-images.githubusercontent.com/177561/185260676-2874c3f2-8732-4d70-a845-cd8d0bdec584.png)

![image](https://user-images.githubusercontent.com/177561/185260657-c123643b-4d1c-4e9c-ae97-1c3a03a7570f.png)

![image](https://user-images.githubusercontent.com/177561/185260724-99956cdd-321f-4d65-897c-7a2228656311.png)

5. Compare the Homepage Posts grid display to Homepage Posts in the columns block; note that the spacing is not the same:

Columns:
![image](https://user-images.githubusercontent.com/177561/185260869-4869cc13-9839-471b-974a-284d23d0e11e.png)

Homepage Posts Block settings:
![image](https://user-images.githubusercontent.com/177561/185260889-51b38ee4-8919-48c5-8914-6da7d5f9e584.png)

6. Apply the PR and run `npm run build`. 
7. Refresh the page; confirm that the blocks now fill the available horizontal space, and the borders are evenly distributed:

![image](https://user-images.githubusercontent.com/177561/185262250-a44b7eb3-1eee-45a7-bc73-42173833b908.png)

![image](https://user-images.githubusercontent.com/177561/185262267-9fd59062-14a0-46f0-9bae-f4c76aa8b35d.png)

8. Confirm that the gap between the posts in the Homepage Posts block matches the gap in the Columns block:

Columns:
![image](https://user-images.githubusercontent.com/177561/185262491-c917bb9e-fc23-4bf4-b78c-712f54dc947e.png)

Homepage Posts with grid setting:
![image](https://user-images.githubusercontent.com/177561/185262299-d47fd39b-2b9d-4fe5-aef3-39b708715099.png)

9. Test at different screen sizes and confirm things look okay.
10. Edit the page and confirm the post-wrapping-when-grid-is-on issue is resolved:

![image](https://user-images.githubusercontent.com/177561/185262206-3b1373a9-8903-42f7-8060-fd6e78c247d8.png)

11. Review the posts in the editor and confirm there are no display issues. 
12. In the right sidebar, under the Columns number control, confirm that there's now an option to change the Column Gap, and it's defaulted to 'L' (32px). If you switch the block from Grid to Block layout, this option should go away:

![image](https://user-images.githubusercontent.com/177561/185262071-7dc4a1e7-79fc-4c9c-9a69-1d9166075844.png)

13. Edit your block so you have at least one block with an without borders set to the large gap size, at least one block with an without borders set to the medium gap size, and at least one block with an without borders set to the small gap size.
14. Test the blocks in the editor and on the front end, at different break points; make sure things display as expected:

Large
![image](https://user-images.githubusercontent.com/177561/185264795-dd506af9-d9a1-4467-bb44-ed182eeea30e.png)

Medium
![image](https://user-images.githubusercontent.com/177561/185264804-d3caa4c1-c30e-4d63-bc40-98c416892ef3.png)

Small
![image](https://user-images.githubusercontent.com/177561/185264874-d457e0d7-60fd-4f3c-a288-e21905ea455b.png)

**Note:** The 'image behind' placement, grid layout and border style don't work together, with or without this PR. I've filed a separate issue for this (https://github.com/Automattic/newspack-blocks/issues/1246). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
