### PR TITLE
Homepage Posts Block: Re-add excerpt length preview in editor

### DIFF
--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -281,6 +281,14 @@ class Newspack_Blocks_API {
 			$args['order']    = 'ASC';
 		}
 
+		if ( isset( $attributes['showExcerpt'], $attributes['excerptLength'] ) ) {
+			$block_attributes = [
+				'showExcerpt'   => $attributes['showExcerpt'],
+				'excerptLength' => $attributes['excerptLength'],
+			];
+			Newspack_Blocks::filter_excerpt( $block_attributes );
+		}
+
 		$query = new WP_Query( $args );
 		$posts = [];
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR re-adds the excerpt length preview that was accidentally removed in https://github.com/Automattic/newspack-blocks/pull/1083.

Closes #1094.

### How to test the changes in this Pull Request:

1. Add the Homepage Posts block to the editor, and change the excerpt length.
2. Note that the block reloads (becomes semi-transparent) but the excerpt length doesn't change -- however, if you publish your changes the new excerpt length will work on the front-end.
3. Apply this PR. 
4. Confirm that if you change excerpt length, it now previews correctly in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
