### PR TITLE
fix(donate): default value not below minimum donation

### DIFF
--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -369,7 +369,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 											type='number'
 											min='<?php echo esc_attr( $configuration['minimumDonation'] ); ?>'
 											name='donation_value_<?php echo esc_attr( $frequency_slug ); ?>_untiered'
-											value='<?php echo esc_attr( $formatted_amount ); ?>'
+											value='<?php echo esc_attr( max( $configuration['minimumDonation'], $formatted_amount ) ); ?>'
 											id='newspack-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-untiered-input'
 										/>
 									</div>

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -440,7 +440,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 												<input
 													type='radio'
 													name='donation_value_<?php echo esc_attr( $frequency_slug ); ?>'
-													value='<?php echo esc_attr( $amount ); ?>'
+													value='<?php echo esc_attr( max( $configuration['minimumDonation'], $amount ) ); ?>'
 													id='newspack-tier-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-<?php echo (int) $index; ?>'
 													<?php checked( 1, $index ); ?>
 												/>
@@ -448,7 +448,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 													class='tier-select-label tier-label'
 													for='newspack-tier-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-<?php echo (int) $index; ?>'
 												>
-													<?php echo esc_html( $configuration['currencySymbol'] . $amount ); ?>
+													<?php echo esc_html( $configuration['currencySymbol'] . max( $configuration['minimumDonation'], $amount ) ); ?>
 												</label>
 													<?php
 												endif;

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -430,7 +430,7 @@ function newspack_blocks_render_block_donate( $attributes ) {
 														type='number'
 														min='<?php echo esc_attr( $configuration['minimumDonation'] ); ?>'
 														name='donation_value_<?php echo esc_attr( $frequency_slug ); ?>_other'
-														value='<?php echo esc_attr( $amount ); ?>'
+														value='<?php echo esc_attr( max( $configuration['minimumDonation'], $amount ) ); ?>'
 														id='newspack-tier-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-other-input'
 													/>
 												</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR sets the default value rendered on the block to never be below the configured minimum. It would be unintuitive for the donor not to be able to donate with the proposed value on the form.

Although the settings can be saved with a lower value, the displayed warning should be enough to let the user know that it may not behave as expected.

### How to test the changes in this Pull Request:

1. On the master branch, configure Reader Revenue Donations settings with a minimum donation to 5 and tiers below that value
2. Visit the page with the block and confirm these values are rendered and you are unable to donate with the default values
3. Check out this branch and confirm the values are never rendered below 5 even though you are still able to store it that way and prompted with the warning

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
