### PR TITLE
Homepage Posts block: make sure More button inherits styles

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -140,7 +140,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 			if ( $has_more_button ) :
 				?>
-				<button type="button" data-next="<?php echo esc_url( $articles_rest_url ); ?>">
+				<button type="button" class="wp-block-button__link" data-next="<?php echo esc_url( $articles_rest_url ); ?>">
 				<?php
 				if ( ! empty( $attributes['moreButtonText'] ) ) {
 					echo esc_html( $attributes['moreButtonText'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The 'More' button in the Homepage Posts block has the `wp-block-button__link` class in the editor, but it doesn't have it on the front end. 

This isn't always a problem -- the button normally picks up the styles for the `button` HTML element -- but with FSE themes, there aren't styles generated for the `button` element by default. However, because the `wp-block-button__link` class is in the editor, the styles do match there.

This PR adds the `wp-block-button__link` to the front-end as well.

Closes #1070.

### How to test the changes in this Pull Request:

1. Switch to a FSE theme (like Twenty Twenty Two).
2. Add the Homepage Posts block to the editor, and turn on the 'Load More' posts button. Note the appearance in the editor (it will be picking up the theme's default dark grey background, and square corners):

![image](https://user-images.githubusercontent.com/177561/186267253-2c1c1dea-15bc-4475-960a-84c7f230c339.png)

3. Publish and view on the front-end; note that the button doesn't match the editor preview:

![image](https://user-images.githubusercontent.com/177561/186268229-321b5031-07ca-4110-9945-aa3a6aa4ff03.png)

4. Apply the PR; confirm that the button on the front-end now matches the editor preview.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
