### PR TITLE
feat: if donation via a prompt, add prompt ID to Stripe payment metadata

### DIFF
--- a/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
+++ b/src/blocks/donate/class-wp-rest-newspack-donate-controller.php
@@ -85,6 +85,9 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 						'payment_method_id' => [
 							'sanitize_callback' => 'sanitize_text_field',
 						],
+						'origin'            => [
+							'sanitize_callback' => 'sanitize_text_field',
+						],
 					],
 					'permission_callback' => '__return_true',
 				],
@@ -123,6 +126,7 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 
 		$frequency = $request->get_param( 'frequency' );
 		$full_name = $request->get_param( 'full_name' );
+		$origin    = $request->get_param( 'origin' );
 
 		$user_id = self::$current_user_id;
 
@@ -156,6 +160,7 @@ class WP_REST_Newspack_Donate_Controller extends WP_REST_Controller {
 					'newsletterOptIn'  => $request->get_param( 'newsletter_opt_in' ),
 					'userId'           => $user_id,
 					'current_page_url' => \wp_get_referer(),
+					'origin'           => $origin,
 				],
 				'payment_metadata'  => $payment_metadata,
 				'payment_method_id' => $request->get_param( 'payment_method_id' ),

--- a/src/blocks/donate/streamlined/index.test.js
+++ b/src/blocks/donate/streamlined/index.test.js
@@ -123,6 +123,7 @@ describe( 'Streamlined Donate block processing', () => {
 					newsletter_opt_in: false,
 					clientId: 'amp-123',
 					payment_method_id: 'pm_123',
+					origin: null,
 				},
 			},
 			'post'

--- a/src/blocks/donate/streamlined/index.ts
+++ b/src/blocks/donate/streamlined/index.ts
@@ -108,6 +108,14 @@ export const processStreamlinedElements = ( parentElement = document ) =>
 				}
 			}
 			const formValues = utils.getDonationFormValues( formElement );
+			const promptOrigin = formElement.closest( '.newspack-popup' );
+
+			// If the donation originated from a Campaigns prompt, append the prompt ID to the event label.
+			const origin =
+				promptOrigin && promptOrigin.hasAttribute( 'amp-access' )
+					? promptOrigin.getAttribute( 'amp-access' )
+					: null;
+
 			const apiRequestPayload = {
 				captchaToken,
 				tokenData: token,
@@ -117,8 +125,10 @@ export const processStreamlinedElements = ( parentElement = document ) =>
 				frequency: formValues.donation_frequency,
 				newsletter_opt_in: Boolean( formValues.newsletter_opt_in ),
 				clientId: formValues.cid,
+				origin,
 				...requestPayloadOverrides,
 			};
+
 			const chargeResultData = await utils.sendAPIRequest( '/donate', apiRequestPayload );
 
 			// Error handling.

--- a/src/blocks/donate/streamlined/index.ts
+++ b/src/blocks/donate/streamlined/index.ts
@@ -108,7 +108,7 @@ export const processStreamlinedElements = ( parentElement = document ) =>
 				}
 			}
 			const formValues = utils.getDonationFormValues( formElement );
-			const promptOrigin = formElement.closest( '.newspack-popup' );
+			const promptOrigin = formElement.closest( 'amp-layout.newspack-popup' );
 
 			// If the donation originated from a Campaigns prompt, append the prompt ID to the event label.
 			const origin =


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Detects if a donation happened from inside a Newspack Campaigns prompt, and if it did, adds the prompt's unique ID to the payment metadata sent to Stripe for processing payment. This will get picked up by https://github.com/Automattic/newspack-plugin/pull/1928 to append the prompt ID to the label attached to the GA event for the donation.

### How to test the changes in this Pull Request:

Follow testing instructions in https://github.com/Automattic/newspack-plugin/pull/1928.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
