### PR TITLE
fix(donate): use first & last name as default name

### DIFF
--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -71,7 +71,7 @@ function newspack_blocks_render_block_donate_footer( $attributes ) {
 	$user_display_name = '';
 	if ( 0 !== $current_user->ID ) {
 		$user_email        = $current_user->user_email;
-		$user_display_name = $current_user->display_name;
+		$user_display_name = trim( $current_user->first_name . ' ' . $current_user->last_name );
 	}
 
 	$button_color      = $attributes['buttonColor'];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a small issue with the Donate block: deriving name from registration email is overly optimistic and might be confusing. Until the user explicitly provides their full name, this should not be prefilled. 

### How to test the changes in this Pull Request:

1. Enable Reader Activation and set Stripe as the RR platform
1. Register as a new reader and visit a page with a Donate block
2. On `master`, observe the name field in the form is pre-filled with a name derived from the registration email
3. Switch to this branch and observe the name is not pre-filled
4. Visit the My Account page (you'll have to verify the account) and update the first & last name
5. Visit a page with a Donate block and observe the name is pre-filled correctly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->