### PR TITLE
fix: correct Donate thank you message alignment

### DIFF
--- a/src/blocks/donate/view.scss
+++ b/src/blocks/donate/view.scss
@@ -62,7 +62,7 @@
 		display: none;
 
 		@include mixins.media( mobile ) {
-			display: inline;
+			display: block;
 		}
 		@include mixins.media( tablet ) {
 			margin-left: 1.5rem;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In the latest release of the Newspack Blocks, the thank you message is sitting beside the Donate Block button instead of above it, and some styles from the theme are causing an odd vertical alignment. 

This PR switches the Thank You message from `display: inline` to `display: block`, to stack it above the button again. 

Closes #1257

### How to test the changes in this Pull Request:

1. Add the Donate Block to a page and publish. 
2. View on the front end and note that the thank you message is next to the button, and weirdly aligned (in the editor the vertical alignment is a bit better, but the placement is different than in the 1.55 release:

![image](https://user-images.githubusercontent.com/177561/186993125-6253c35e-b1bd-431a-831d-9e6b09f99029.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the thank you message is now above the donate block button:

![image](https://user-images.githubusercontent.com/177561/186992939-7249cd51-1e19-42c2-bec1-539bdafe77d9.png)

5. Cycle through the different Donate Block styles and confirm that no display issues are introduced. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
