### PR TITLE
fix(donate): handle zero fees

### DIFF
--- a/src/blocks/donate/streamlined/index.ts
+++ b/src/blocks/donate/streamlined/index.ts
@@ -281,6 +281,14 @@ export const processStreamlinedElements = ( parentElement = document ) =>
 			if ( feesAmountEl ) {
 				const formValues = Object.fromEntries( new FormData( formElement ) );
 				const feeAmount = utils.getFeeAmount( formElement );
+				if ( feeAmount === 0 ) {
+					const feesAmountContainerEl: HTMLElement | null = el.querySelector(
+						'#stripe-fees-amount-container'
+					);
+					if ( feesAmountContainerEl ) {
+						feesAmountContainerEl.style.display = 'none';
+					}
+				}
 				if ( typeof formValues.donation_frequency === 'string' ) {
 					feesAmountEl.innerHTML = `(${ settings.currencySymbol }${ feeAmount.toFixed(
 						2

--- a/src/blocks/donate/streamlined/utils.ts
+++ b/src/blocks/donate/streamlined/utils.ts
@@ -175,7 +175,12 @@ export const computeFeeAmount = ( amount: number, feeMultiplier: number, feeStat
  */
 export const getFeeAmount = ( formElement: HTMLFormElement ) => {
 	const { feeMultiplier, feeStatic } = getSettings( formElement );
-	if ( ! feeMultiplier || ! feeStatic ) {
+	if (
+		undefined === feeMultiplier ||
+		undefined === feeStatic ||
+		isNaN( feeMultiplier ) ||
+		isNaN( feeStatic )
+	) {
 		return 0;
 	}
 	const { amount } = getDonationFormValues( formElement );

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -112,7 +112,7 @@ function newspack_blocks_render_block_donate_footer( $attributes ) {
 					</div>
 				</div>
 				<?php if ( $is_rendering_fee_checkbox ) : ?>
-					<div class="stripe-payment__row stripe-payment__row--small">
+					<div class="stripe-payment__row stripe-payment__row--small" id="stripe-fees-amount-container">
 						<label class="stripe-payment__checkbox">
 							<input type="checkbox" name="agree_to_pay_fees" checked value="true"><?php echo esc_html__( 'Agree to pay fees?', 'newspack-blocks' ); ?>
 							<span id="stripe-fees-amount">($0)</span>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds zero fees handling for Simplified Donate block and closes https://github.com/Automattic/newspack-plugin/issues/1911

### How to test the changes in this Pull Request:

1. Configure the site to use Stripe as the Reader Revenue platform
2. On `master`, observe that setting just one of the fee-regulating values to 0 in the Reader Revenue wizards results in a fee of 0 being displayed
3. Switch to this branch, observe that the fee is properly calculated even if one of the fee-regulating values is 0
4. Set both values to 0, observe it resulting in no fees checkbox being displayed 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->