### PR TITLE
Sponsors: make sure sponsor flag previews in blocks in the editor

### DIFF
--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -285,26 +285,25 @@ class Edit extends Component {
 											showAuthor ||
 											showDate ) && (
 											<div className="entry-wrapper">
-												{ ( post.newspack_post_sponsors || showCategory ) &&
-													0 < post.newspack_category_info.length &&
-													( ! post.newspack_post_sponsors ||
-														post.newspack_sponsors_show_categories ) && (
-														<div
-															className={
-																'cat-links' +
-																( post.newspack_post_sponsors ? ' sponsor-label' : '' )
-															}
-														>
-															{ post.newspack_post_sponsors && (
-																<span className="flag">
-																	{ post.newspack_post_sponsors[ 0 ].flag }
-																</span>
-															) }
-															{ showCategory && (
+												{ ( post.newspack_post_sponsors ||
+													( showCategory && 0 < post.newspack_category_info.length ) ) && (
+													<div
+														className={
+															'cat-links' + ( post.newspack_post_sponsors ? ' sponsor-label' : '' )
+														}
+													>
+														{ post.newspack_post_sponsors && (
+															<span className="flag">
+																{ post.newspack_post_sponsors[ 0 ].flag }
+															</span>
+														) }
+														{ showCategory &&
+															( ! post.newspack_post_sponsors ||
+																post.newspack_sponsors_show_categories ) && (
 																<a href="#">{ decodeEntities( post.newspack_category_info ) }</a>
 															) }
-														</div>
-													) }
+													</div>
+												) }
 												{ showTitle && (
 													<h3 className="entry-title">
 														<a href="#">{ decodeEntities( post.title.rendered.trim() ) }</a>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -171,20 +171,20 @@ class Edit extends Component {
 				) }
 
 				<div className="entry-wrapper">
-					{ ( post.newspack_post_sponsors || showCategory ) &&
-						0 < post.newspack_category_info.length &&
-						( ! post.newspack_post_sponsors || post.newspack_sponsors_show_categories ) && (
-							<div
-								className={ 'cat-links' + ( post.newspack_post_sponsors ? ' sponsor-label' : '' ) }
-							>
-								{ post.newspack_post_sponsors && (
-									<span className="flag">{ post.newspack_post_sponsors[ 0 ].flag }</span>
-								) }
-								{ showCategory && (
+					{ ( post.newspack_post_sponsors ||
+						( showCategory && 0 < post.newspack_category_info.length ) ) && (
+						<div
+							className={ 'cat-links' + ( post.newspack_post_sponsors ? ' sponsor-label' : '' ) }
+						>
+							{ post.newspack_post_sponsors && (
+								<span className="flag">{ post.newspack_post_sponsors[ 0 ].flag }</span>
+							) }
+							{ showCategory &&
+								( ! post.newspack_post_sponsors || post.newspack_sponsors_show_categories ) && (
 									<a href="#">{ decodeEntities( post.newspack_category_info ) }</a>
 								) }
-							</div>
-						) }
+						</div>
+					) }
 					{ RichText.isEmpty( sectionHeader ) ? (
 						<h2 className="entry-title" key="title">
 							<a href="#">{ postTitle }</a>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Sponsors flag wasn't previewing in the editor in the Homepage Posts or Post Carousel blocks, unless the category was also set to display with that sponsor. This PR tweaks the logic so it should line up with how things display on the front-end.

Closes #1277

### How to test the changes in this Pull Request:

1. Create two sponsors: one with the default settings, and one with "Sponsorship Category Display" set to Sponsors and Categories in the sidebar.
2. Assign each sponsor to a category, and make sure that category is assigned to at least four posts. 
3. Set up six homepage posts blocks, with the following settings:
    * Two blocks that display one post each, from the Sponsored category that's set to show the sponsor flag and category. In the block settings, set Show Category on one of these blocks.
    * Two blocks that display one post each, from the Sponsored category that's set to only show the Sponsor flag. In the block settings, set Show Category on one of these blocks.
    * Two blocks that display one post each, that are not sponsored. In the block settings, set Show Category on one of these blocks.
4. Set up six Post Carousel blocks, with similar settings:
    * Two blocks that display one post each from the Sponsored category that's set to show the sponsor flag and category. In the block settings, set Show Category on one of these blocks.
    * Two blocks that display one post each from the Sponsored category that's set to only show the Sponsor flag. In the block settings, set Show Category on one of these blocks.
    * Two blocks that display one post each that are not sponsored. In the block settings, set Show Category on one of these blocks.
5. View in the editor; note that only the sponsors that have the category set to display are displaying the Sponsor flag -- in my screenshots, the first two rows of posts are sponsored, but only the first row shows the flags:

**Homepage Posts:**

![image](https://user-images.githubusercontent.com/177561/191867757-9a8bb8b1-1b72-4302-9539-5e2fc5aa1435.png)

**Post Carousel:**

![image](https://user-images.githubusercontent.com/177561/191868626-44c1ece9-29f1-4ec3-9604-87577cb7bdd3.png)

6. Apply the PR and run `npm run build`.
7. Confirm that all of the sponsored posts display the sponsor flag, without messing up the category behaviour (in my screenshots the first two rows are all sponsored, only the first post in the first row, and the first post in the last row should have the category showing). This should line up with how the posts look on the front-end:

**Homepage Posts:**

![image](https://user-images.githubusercontent.com/177561/191867993-d6327bd0-0143-446a-96c6-0af202037bb6.png)

**Post Carousel:**

![image](https://user-images.githubusercontent.com/177561/191868313-51bf1f04-1e17-4aac-8fac-05ecb91b925e.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
