### PR TITLE
Fix php linter errors caused by $sponsor_classes

### DIFF
--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -154,7 +154,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 						<div class="entry-meta">
 							<?php
 							if ( ! empty( $sponsors ) ) :
-								$sponsor_classes[] = 'entry-sponsors';
+								$sponsor_classes = [ 'entry-sponsors' ];
 								if ( Newspack_Blocks::newspack_display_sponsors_and_authors( $sponsors ) ) {
 									$sponsor_classes[] = 'plus-author';
 								}

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -172,7 +172,7 @@ call_user_func(
 				<div class="entry-meta">
 					<?php
 					if ( ! empty( $sponsors ) ) :
-						$sponsor_classes[] = 'entry-sponsors';
+						$sponsor_classes = [ 'entry-sponsors' ];
 						if ( Newspack_Blocks::newspack_display_sponsors_and_authors( $sponsors ) ) {
 							$sponsor_classes[] = 'plus-author';
 						}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updating the newspack-blocks in the editing toolkit causes php lint issues.
You can see the failing editing toolkit job on this PR here: 
https://github.com/Automattic/wp-calypso/pull/67870

This PR applies trivial fixes to unblock the related PR