### PR TITLE
fix: update CI orb newspack-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  newspack: adekbadek/newspack@1.4.1
+  newspack: adekbadek/newspack@1.4.2
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  newspack: adekbadek/newspack@1.4.2
+  newspack: adekbadek/newspack@1.4.3
 
 workflows:
   version: 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"html-entities": "^2.3.3",
 				"identity-obj-proxy": "^3.0.0",
 				"lint-staged": "^13.0.3",
-				"newspack-scripts": "^4.3.7",
+				"newspack-scripts": "^4.3.8",
 				"postcss-scss": "^4.0.5",
 				"prettier": "npm:wp-prettier@^2.6.2-beta-1",
 				"stylelint": "^14.9.1"
@@ -153,6 +153,7 @@
 		},
 		"node_modules/@babel/compat-data": {
 			"version": "7.16.4",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -160,6 +161,7 @@
 		},
 		"node_modules/@babel/core": {
 			"version": "7.16.5",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.16.0",
@@ -188,6 +190,7 @@
 		},
 		"node_modules/@babel/core/node_modules/semver": {
 			"version": "6.3.0",
+			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -197,6 +200,7 @@
 			"version": "7.18.7",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.7.tgz",
 			"integrity": "sha512-shck+7VLlY72a2w9c3zYWuE1pwOKEiQHV7GTUbSnhyl5eu3i04t30tBY82ZRWrDfo3gkakCFtevExnxbkf2a3A==",
+			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.18.7",
 				"@jridgewell/gen-mapping": "^0.3.2",
@@ -232,6 +236,7 @@
 		},
 		"node_modules/@babel/helper-compilation-targets": {
 			"version": "7.16.7",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/compat-data": "^7.16.4",
@@ -248,6 +253,7 @@
 		},
 		"node_modules/@babel/helper-compilation-targets/node_modules/semver": {
 			"version": "6.3.0",
+			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -319,6 +325,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.6.tgz",
 			"integrity": "sha512-8n6gSfn2baOY+qlp+VSzsosjCVGFqWKmDF0cCWOybh52Dw3SEyoWR1KrhMJASjLwIEkkAufZ0xvr+SxLHSpy2Q==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -338,6 +345,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.6.tgz",
 			"integrity": "sha512-0mWMxV1aC97dhjCah5U5Ua7668r5ZmSC2DLfH2EZnf9c3/dHZKiFa5pRLMH5tjSl471tY6496ZWk/kjNONBxhw==",
+			"dev": true,
 			"dependencies": {
 				"@babel/template": "^7.18.6",
 				"@babel/types": "^7.18.6"
@@ -350,6 +358,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
 			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.18.6"
 			},
@@ -381,6 +390,7 @@
 		},
 		"node_modules/@babel/helper-module-transforms": {
 			"version": "7.16.7",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.16.7",
@@ -447,6 +457,7 @@
 		},
 		"node_modules/@babel/helper-simple-access": {
 			"version": "7.16.7",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/types": "^7.16.7"
@@ -470,6 +481,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
 			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.18.6"
 			},
@@ -489,6 +501,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
 			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -509,6 +522,7 @@
 		},
 		"node_modules/@babel/helpers": {
 			"version": "7.16.5",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/template": "^7.16.0",
@@ -536,6 +550,7 @@
 			"version": "7.18.8",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.8.tgz",
 			"integrity": "sha512-RSKRfYX20dyH+elbJK2uqAkVyucL+xXzhqlMD5/ZXx+dAAwpyB7HsvnHe/ZUGOF+xLr5Wx9/JoXVTj6BQE2/oA==",
+			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -1826,6 +1841,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
 			"integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
+			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.18.6",
 				"@babel/parser": "^7.18.6",
@@ -1839,6 +1855,7 @@
 			"version": "7.18.8",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.8.tgz",
 			"integrity": "sha512-UNg/AcSySJYR/+mIcJQDCv00T+AqRO7j/ZEJLzpaYtgM48rMg5MnkJgyNqkzo88+p4tfRvZJCEiwwfG6h4jkRg==",
+			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.18.6",
 				"@babel/generator": "^7.18.7",
@@ -3508,6 +3525,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
 			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"dev": true,
 			"dependencies": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -3521,6 +3539,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
 			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -3529,6 +3548,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -3536,12 +3556,14 @@
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.17",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
 			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "3.1.0",
 				"@jridgewell/sourcemap-codec": "1.4.14"
@@ -8903,26 +8925,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/array.prototype.filter": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.2.tgz",
-			"integrity": "sha512-us+UrmGOilqttSOgoWZTpOvHu68vZT2YCjc/H4vhu56vzZpaDFBhB+Se2UwqWzMKbDv7Myq5M5pcZLAtUvTQdQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
-				"es-array-method-boxes-properly": "^1.0.0",
-				"is-string": "^1.0.7"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/array.prototype.find": {
 			"version": "2.1.2",
 			"license": "MIT",
@@ -9486,6 +9488,7 @@
 		},
 		"node_modules/browserslist": {
 			"version": "4.17.6",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"caniuse-lite": "^1.0.30001274",
@@ -9673,6 +9676,7 @@
 			"version": "1.0.30001363",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001363.tgz",
 			"integrity": "sha512-HpQhpzTGGPVMnCjIomjt+jvyUu8vNFo3TaDiZ/RcoTrlOq/5+tC8zHdsbgFB6MxmaY+jCpsH09aD80Bb4Ow3Sg==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -9773,188 +9777,6 @@
 			"version": "0.7.0",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/cheerio": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-			"integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"cheerio-select": "^2.1.0",
-				"dom-serializer": "^2.0.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1",
-				"htmlparser2": "^8.0.1",
-				"parse5": "^7.0.0",
-				"parse5-htmlparser2-tree-adapter": "^7.0.0"
-			},
-			"engines": {
-				"node": ">= 6"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-			}
-		},
-		"node_modules/cheerio-select": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-			"integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"boolbase": "^1.0.0",
-				"css-select": "^5.1.0",
-				"css-what": "^6.1.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
-			}
-		},
-		"node_modules/cheerio-select/node_modules/css-select": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"boolbase": "^1.0.0",
-				"css-what": "^6.1.0",
-				"domhandler": "^5.0.2",
-				"domutils": "^3.0.1",
-				"nth-check": "^2.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
-			}
-		},
-		"node_modules/cheerio-select/node_modules/css-what": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">= 6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
-			}
-		},
-		"node_modules/cheerio-select/node_modules/dom-serializer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"entities": "^4.2.0"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-			}
-		},
-		"node_modules/cheerio-select/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true
-		},
-		"node_modules/cheerio-select/node_modules/domutils": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-			"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"dom-serializer": "^2.0.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domutils?sponsor=1"
-			}
-		},
-		"node_modules/cheerio-select/node_modules/nth-check": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"boolbase": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/nth-check?sponsor=1"
-			}
-		},
-		"node_modules/cheerio/node_modules/dom-serializer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"entities": "^4.2.0"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-			}
-		},
-		"node_modules/cheerio/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true
-		},
-		"node_modules/cheerio/node_modules/domutils": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-			"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"dom-serializer": "^2.0.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domutils?sponsor=1"
-			}
-		},
-		"node_modules/cheerio/node_modules/parse5": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-			"integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"entities": "^4.4.0"
-			},
-			"funding": {
-				"url": "https://github.com/inikulin/parse5?sponsor=1"
-			}
 		},
 		"node_modules/chokidar": {
 			"version": "3.5.2",
@@ -11405,6 +11227,7 @@
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
 			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dev": true,
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -11663,13 +11486,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/discontinuous-range": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-			"integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/doctrine": {
 			"version": "3.0.0",
 			"dev": true,
@@ -11760,35 +11576,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/domhandler": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0"
-			},
-			"engines": {
-				"node": ">= 4"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domhandler?sponsor=1"
-			}
-		},
-		"node_modules/domhandler/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true
-		},
 		"node_modules/domutils": {
 			"version": "1.7.0",
 			"dev": true,
@@ -11871,6 +11658,7 @@
 		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.3.890",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/emittery": {
@@ -11935,19 +11723,6 @@
 				"node": ">=8.6"
 			}
 		},
-		"node_modules/entities": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-			"integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
 		"node_modules/env-ci": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz",
@@ -11971,40 +11746,6 @@
 			},
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/enzyme": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
-			"integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"array.prototype.flat": "^1.2.3",
-				"cheerio": "^1.0.0-rc.3",
-				"enzyme-shallow-equal": "^1.0.1",
-				"function.prototype.name": "^1.1.2",
-				"has": "^1.0.3",
-				"html-element-map": "^1.2.0",
-				"is-boolean-object": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-number-object": "^1.0.4",
-				"is-regex": "^1.0.5",
-				"is-string": "^1.0.5",
-				"is-subset": "^0.1.1",
-				"lodash.escape": "^4.0.1",
-				"lodash.isequal": "^4.5.0",
-				"object-inspect": "^1.7.0",
-				"object-is": "^1.0.2",
-				"object.assign": "^4.1.0",
-				"object.entries": "^1.1.1",
-				"object.values": "^1.1.1",
-				"raf": "^3.4.1",
-				"rst-selector-parser": "^2.2.3",
-				"string.prototype.trim": "^1.2.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/enzyme-matchers": {
@@ -12051,13 +11792,6 @@
 			"version": "16.13.1",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/enzyme/node_modules/lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/equivalent-key-map": {
 			"version": "0.2.2",
@@ -12118,13 +11852,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/es-array-method-boxes-properly": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/es-module-lexer": {
 			"version": "0.9.3",
 			"dev": true,
@@ -12173,6 +11900,7 @@
 		},
 		"node_modules/escalade": {
 			"version": "3.1.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -13640,6 +13368,7 @@
 		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -13884,6 +13613,7 @@
 		},
 		"node_modules/globals": {
 			"version": "11.12.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
@@ -14238,20 +13968,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/html-element-map": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
-			"integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"array.prototype.filter": "^1.0.0",
-				"call-bind": "^1.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "2.0.1",
 			"dev": true,
@@ -14283,69 +13999,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/htmlparser2": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-			"integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
-			"dev": true,
-			"funding": [
-				"https://github.com/fb55/htmlparser2?sponsor=1",
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"domutils": "^3.0.1",
-				"entities": "^4.3.0"
-			}
-		},
-		"node_modules/htmlparser2/node_modules/dom-serializer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"entities": "^4.2.0"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-			}
-		},
-		"node_modules/htmlparser2/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true
-		},
-		"node_modules/htmlparser2/node_modules/domutils": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-			"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"dom-serializer": "^2.0.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domutils?sponsor=1"
 			}
 		},
 		"node_modules/http-proxy-agent": {
@@ -17981,6 +17634,7 @@
 		},
 		"node_modules/jsesc": {
 			"version": "2.5.2",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"jsesc": "bin/jsesc"
@@ -18024,6 +17678,7 @@
 		},
 		"node_modules/json5": {
 			"version": "2.2.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"minimist": "^1.2.5"
@@ -18608,25 +18263,11 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/lodash.escape": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-			"integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/lodash.escaperegexp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
 			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
 			"dev": true
-		},
-		"node_modules/lodash.flattendeep": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/lodash.isarguments": {
 			"version": "3.1.0",
@@ -19297,6 +18938,7 @@
 		},
 		"node_modules/minimist": {
 			"version": "1.2.5",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/minimist-options": {
@@ -19430,19 +19072,13 @@
 				"node": "*"
 			}
 		},
-		"node_modules/moo": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-			"integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/mousetrap": {
 			"version": "1.6.5",
 			"license": "Apache-2.0 WITH LLVM-exception"
 		},
 		"node_modules/ms": {
 			"version": "2.1.2",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/mute-stream": {
@@ -19494,36 +19130,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/nearley": {
-			"version": "2.20.1",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-			"integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"commander": "^2.19.0",
-				"moo": "^0.5.0",
-				"railroad-diagrams": "^1.0.0",
-				"randexp": "0.4.6"
-			},
-			"bin": {
-				"nearley-railroad": "bin/nearley-railroad.js",
-				"nearley-test": "bin/nearley-test.js",
-				"nearley-unparse": "bin/nearley-unparse.js",
-				"nearleyc": "bin/nearleyc.js"
-			},
-			"funding": {
-				"type": "individual",
-				"url": "https://nearley.js.org/#give-to-nearley"
-			}
-		},
-		"node_modules/nearley/node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/neo-async": {
 			"version": "2.6.2",
 			"dev": true,
@@ -19566,20 +19172,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/newspack-components/node_modules/react": {
-			"version": "16.14.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-			"integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/newspack-components/node_modules/react-daterange-picker": {
 			"version": "2.0.1",
 			"license": "Apache-2.0",
@@ -19601,35 +19193,10 @@
 				"react-dom": "0.14.x || 15.x.x || 16.x.x"
 			}
 		},
-		"node_modules/newspack-components/node_modules/react-dom": {
-			"version": "16.14.0",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-			"integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2",
-				"scheduler": "^0.19.1"
-			},
-			"peerDependencies": {
-				"react": "^16.14.0"
-			}
-		},
-		"node_modules/newspack-components/node_modules/scheduler": {
-			"version": "0.19.1",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-			"integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1"
-			}
-		},
 		"node_modules/newspack-scripts": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.3.7.tgz",
-			"integrity": "sha512-twxZz9tRnxCIAUlfdppxaFiClt7WJIOoQv57+d4GU5sPQk6zOdXNtqZkWXoptRICWbgzsLzDxoSilKCvV7Ivtw==",
+			"version": "4.3.8",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.3.8.tgz",
+			"integrity": "sha512-3nK3HKSLUjjkC+wP83DGfc9DKf7uLSN5zYhn6138oL0KEmwn8roP+DUY+ePuywV9MocT8X8sBP7hxvMqInlDHA==",
 			"dev": true,
 			"dependencies": {
 				"@automattic/calypso-build": "^10.0.0",
@@ -20838,6 +20405,7 @@
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.1",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/normalize-package-data": {
@@ -23926,33 +23494,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/parse5-htmlparser2-tree-adapter": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-			"integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domhandler": "^5.0.2",
-				"parse5": "^7.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/inikulin/parse5?sponsor=1"
-			}
-		},
-		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-			"integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"entities": "^4.4.0"
-			},
-			"funding": {
-				"url": "https://github.com/inikulin/parse5?sponsor=1"
-			}
-		},
 		"node_modules/pascal-case": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
@@ -24037,6 +23578,7 @@
 		},
 		"node_modules/picocolors": {
 			"version": "1.0.0",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
@@ -25901,27 +25443,6 @@
 				"performance-now": "^2.1.0"
 			}
 		},
-		"node_modules/railroad-diagrams": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-			"integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/randexp": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"discontinuous-range": "1.0.0",
-				"ret": "~0.1.10"
-			},
-			"engines": {
-				"node": ">=0.12"
-			}
-		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
 			"dev": true,
@@ -27043,17 +26564,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/rst-selector-parser": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
-			"integrity": "sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"lodash.flattendeep": "^4.4.0",
-				"nearley": "^2.7.10"
 			}
 		},
 		"node_modules/rsvp": {
@@ -28674,24 +28184,6 @@
 				"internal-slot": "^1.0.3",
 				"regexp.prototype.flags": "^1.3.1",
 				"side-channel": "^1.0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/string.prototype.trim": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.6.tgz",
-			"integrity": "sha512-8lMR2m+U0VJTPp6JjvJTtGyc4FIGq9CdRt7O9p6T0e6K4vjU+OP+SQJpbe/SBmRcCUIvNUnjsbmY6lnMp8MhsQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.19.5"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -31025,10 +30517,12 @@
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.16.4"
+			"version": "7.16.4",
+			"dev": true
 		},
 		"@babel/core": {
 			"version": "7.16.5",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.16.0",
 				"@babel/generator": "^7.16.5",
@@ -31048,7 +30542,8 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "6.3.0"
+					"version": "6.3.0",
+					"dev": true
 				}
 			}
 		},
@@ -31056,6 +30551,7 @@
 			"version": "7.18.7",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.7.tgz",
 			"integrity": "sha512-shck+7VLlY72a2w9c3zYWuE1pwOKEiQHV7GTUbSnhyl5eu3i04t30tBY82ZRWrDfo3gkakCFtevExnxbkf2a3A==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.18.7",
 				"@jridgewell/gen-mapping": "^0.3.2",
@@ -31081,6 +30577,7 @@
 		},
 		"@babel/helper-compilation-targets": {
 			"version": "7.16.7",
+			"dev": true,
 			"requires": {
 				"@babel/compat-data": "^7.16.4",
 				"@babel/helper-validator-option": "^7.16.7",
@@ -31089,7 +30586,8 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "6.3.0"
+					"version": "6.3.0",
+					"dev": true
 				}
 			}
 		},
@@ -31139,7 +30637,8 @@
 		"@babel/helper-environment-visitor": {
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.6.tgz",
-			"integrity": "sha512-8n6gSfn2baOY+qlp+VSzsosjCVGFqWKmDF0cCWOybh52Dw3SEyoWR1KrhMJASjLwIEkkAufZ0xvr+SxLHSpy2Q=="
+			"integrity": "sha512-8n6gSfn2baOY+qlp+VSzsosjCVGFqWKmDF0cCWOybh52Dw3SEyoWR1KrhMJASjLwIEkkAufZ0xvr+SxLHSpy2Q==",
+			"dev": true
 		},
 		"@babel/helper-explode-assignable-expression": {
 			"version": "7.16.7",
@@ -31152,6 +30651,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.6.tgz",
 			"integrity": "sha512-0mWMxV1aC97dhjCah5U5Ua7668r5ZmSC2DLfH2EZnf9c3/dHZKiFa5pRLMH5tjSl471tY6496ZWk/kjNONBxhw==",
+			"dev": true,
 			"requires": {
 				"@babel/template": "^7.18.6",
 				"@babel/types": "^7.18.6"
@@ -31161,6 +30661,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
 			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.18.6"
 			}
@@ -31182,6 +30683,7 @@
 		},
 		"@babel/helper-module-transforms": {
 			"version": "7.16.7",
+			"dev": true,
 			"requires": {
 				"@babel/helper-environment-visitor": "^7.16.7",
 				"@babel/helper-module-imports": "^7.16.7",
@@ -31231,6 +30733,7 @@
 		},
 		"@babel/helper-simple-access": {
 			"version": "7.16.7",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.16.7"
 			}
@@ -31246,6 +30749,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
 			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.18.6"
 			}
@@ -31258,7 +30762,8 @@
 		"@babel/helper-validator-option": {
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw=="
+			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+			"dev": true
 		},
 		"@babel/helper-wrap-function": {
 			"version": "7.16.7",
@@ -31272,6 +30777,7 @@
 		},
 		"@babel/helpers": {
 			"version": "7.16.5",
+			"dev": true,
 			"requires": {
 				"@babel/template": "^7.16.0",
 				"@babel/traverse": "^7.16.5",
@@ -31291,7 +30797,8 @@
 		"@babel/parser": {
 			"version": "7.18.8",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.8.tgz",
-			"integrity": "sha512-RSKRfYX20dyH+elbJK2uqAkVyucL+xXzhqlMD5/ZXx+dAAwpyB7HsvnHe/ZUGOF+xLr5Wx9/JoXVTj6BQE2/oA=="
+			"integrity": "sha512-RSKRfYX20dyH+elbJK2uqAkVyucL+xXzhqlMD5/ZXx+dAAwpyB7HsvnHe/ZUGOF+xLr5Wx9/JoXVTj6BQE2/oA==",
+			"dev": true
 		},
 		"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
 			"version": "7.16.7",
@@ -32056,6 +31563,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
 			"integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.18.6",
 				"@babel/parser": "^7.18.6",
@@ -32066,6 +31574,7 @@
 			"version": "7.18.8",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.8.tgz",
 			"integrity": "sha512-UNg/AcSySJYR/+mIcJQDCv00T+AqRO7j/ZEJLzpaYtgM48rMg5MnkJgyNqkzo88+p4tfRvZJCEiwwfG6h4jkRg==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.18.6",
 				"@babel/generator": "^7.18.7",
@@ -32493,8 +32002,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.1.tgz",
 			"integrity": "sha512-aG20vknL4/YjQF9BSV7ts4EWm/yrjagAN7OWBNmlbEOUiu0llj4OGrFoOKK3g2vey4/p2omKCoHrWtPxSwV3HA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@discoveryjs/json-ext": {
 			"version": "0.5.5",
@@ -32649,8 +32157,7 @@
 		"@emotion/use-insertion-effect-with-fallbacks": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
-			"integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
-			"requires": {}
+			"integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A=="
 		},
 		"@emotion/utils": {
 			"version": "1.0.0"
@@ -33243,6 +32750,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
 			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"dev": true,
 			"requires": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -33252,22 +32760,26 @@
 		"@jridgewell/resolve-uri": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true
 		},
 		"@jridgewell/set-array": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"dev": true
 		},
 		"@jridgewell/sourcemap-codec": {
 			"version": "1.4.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true
 		},
 		"@jridgewell/trace-mapping": {
 			"version": "0.3.17",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
 			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+			"dev": true,
 			"requires": {
 				"@jridgewell/resolve-uri": "3.1.0",
 				"@jridgewell/sourcemap-codec": "1.4.14"
@@ -33443,8 +32955,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
 			"integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@octokit/plugin-rest-endpoint-methods": {
 			"version": "6.7.0",
@@ -34057,8 +33568,7 @@
 			"version": "14.4.3",
 			"resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
 			"integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@tootallnate/once": {
 			"version": "1.1.2",
@@ -34595,8 +34105,7 @@
 		},
 		"@webpack-cli/configtest": {
 			"version": "1.1.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@webpack-cli/info": {
 			"version": "1.4.0",
@@ -34607,8 +34116,7 @@
 		},
 		"@webpack-cli/serve": {
 			"version": "1.6.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@wojtekmaj/enzyme-adapter-react-17": {
 			"version": "0.6.5",
@@ -34667,8 +34175,7 @@
 		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
 			"version": "3.1.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@wordpress/babel-preset-default": {
 			"version": "6.5.0",
@@ -37356,13 +36863,11 @@
 		},
 		"acorn-import-assertions": {
 			"version": "1.8.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"acorn-walk": {
 			"version": "7.2.0",
@@ -37414,8 +36919,7 @@
 		},
 		"ajv-keywords": {
 			"version": "3.5.2",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"alphanum-sort": {
 			"version": "1.0.2",
@@ -37534,20 +37038,6 @@
 		"array-unique": {
 			"version": "0.3.2",
 			"dev": true
-		},
-		"array.prototype.filter": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.2.tgz",
-			"integrity": "sha512-us+UrmGOilqttSOgoWZTpOvHu68vZT2YCjc/H4vhu56vzZpaDFBhB+Se2UwqWzMKbDv7Myq5M5pcZLAtUvTQdQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
-				"es-array-method-boxes-properly": "^1.0.0",
-				"is-string": "^1.0.7"
-			}
 		},
 		"array.prototype.find": {
 			"version": "2.1.2",
@@ -37921,6 +37411,7 @@
 		},
 		"browserslist": {
 			"version": "4.17.6",
+			"dev": true,
 			"requires": {
 				"caniuse-lite": "^1.0.30001274",
 				"electron-to-chromium": "^1.3.886",
@@ -38051,7 +37542,8 @@
 		"caniuse-lite": {
 			"version": "1.0.30001363",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001363.tgz",
-			"integrity": "sha512-HpQhpzTGGPVMnCjIomjt+jvyUu8vNFo3TaDiZ/RcoTrlOq/5+tC8zHdsbgFB6MxmaY+jCpsH09aD80Bb4Ow3Sg=="
+			"integrity": "sha512-HpQhpzTGGPVMnCjIomjt+jvyUu8vNFo3TaDiZ/RcoTrlOq/5+tC8zHdsbgFB6MxmaY+jCpsH09aD80Bb4Ow3Sg==",
+			"dev": true
 		},
 		"capital-case": {
 			"version": "1.0.4",
@@ -38123,144 +37615,6 @@
 		"chardet": {
 			"version": "0.7.0",
 			"dev": true
-		},
-		"cheerio": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-			"integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"cheerio-select": "^2.1.0",
-				"dom-serializer": "^2.0.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1",
-				"htmlparser2": "^8.0.1",
-				"parse5": "^7.0.0",
-				"parse5-htmlparser2-tree-adapter": "^7.0.0"
-			},
-			"dependencies": {
-				"dom-serializer": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-					"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.2",
-						"entities": "^4.2.0"
-					}
-				},
-				"domelementtype": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-					"dev": true,
-					"peer": true
-				},
-				"domutils": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-					"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"dom-serializer": "^2.0.0",
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.1"
-					}
-				},
-				"parse5": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-					"integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"entities": "^4.4.0"
-					}
-				}
-			}
-		},
-		"cheerio-select": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-			"integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"boolbase": "^1.0.0",
-				"css-select": "^5.1.0",
-				"css-what": "^6.1.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1"
-			},
-			"dependencies": {
-				"css-select": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-					"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"boolbase": "^1.0.0",
-						"css-what": "^6.1.0",
-						"domhandler": "^5.0.2",
-						"domutils": "^3.0.1",
-						"nth-check": "^2.0.1"
-					}
-				},
-				"css-what": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-					"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-					"dev": true,
-					"peer": true
-				},
-				"dom-serializer": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-					"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.2",
-						"entities": "^4.2.0"
-					}
-				},
-				"domelementtype": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-					"dev": true,
-					"peer": true
-				},
-				"domutils": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-					"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"dom-serializer": "^2.0.0",
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.1"
-					}
-				},
-				"nth-check": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-					"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"boolbase": "^1.0.0"
-					}
-				}
-			}
 		},
 		"chokidar": {
 			"version": "3.5.2",
@@ -38823,8 +38177,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.2.0.tgz",
 			"integrity": "sha512-NkANeMnaHrlaSSlpKGyvn2R4rqUDeE/9E5YHx+b4nwo0R8dZyAqcih8/gxpCZvqWP9Vf6xuLpMSzSgdVEIM78g==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"create-react-class": {
 			"version": "15.7.0",
@@ -39283,6 +38636,7 @@
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
 			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dev": true,
 			"requires": {
 				"ms": "2.1.2"
 			}
@@ -39443,13 +38797,6 @@
 		"direction": {
 			"version": "1.0.4"
 		},
-		"discontinuous-range": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-			"integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-			"dev": true,
-			"peer": true
-		},
 		"doctrine": {
 			"version": "3.0.0",
 			"dev": true,
@@ -39510,25 +38857,6 @@
 				"webidl-conversions": {
 					"version": "5.0.0",
 					"dev": true
-				}
-			}
-		},
-		"domhandler": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"domelementtype": "^2.3.0"
-			},
-			"dependencies": {
-				"domelementtype": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-					"dev": true,
-					"peer": true
 				}
 			}
 		},
@@ -39600,7 +38928,8 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.890"
+			"version": "1.3.890",
+			"dev": true
 		},
 		"emittery": {
 			"version": "0.8.1",
@@ -39642,13 +38971,6 @@
 				"ansi-colors": "^4.1.1"
 			}
 		},
-		"entities": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-			"integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-			"dev": true,
-			"peer": true
-		},
 		"env-ci": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz",
@@ -39663,46 +38985,6 @@
 		"envinfo": {
 			"version": "7.8.1",
 			"dev": true
-		},
-		"enzyme": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
-			"integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"array.prototype.flat": "^1.2.3",
-				"cheerio": "^1.0.0-rc.3",
-				"enzyme-shallow-equal": "^1.0.1",
-				"function.prototype.name": "^1.1.2",
-				"has": "^1.0.3",
-				"html-element-map": "^1.2.0",
-				"is-boolean-object": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-number-object": "^1.0.4",
-				"is-regex": "^1.0.5",
-				"is-string": "^1.0.5",
-				"is-subset": "^0.1.1",
-				"lodash.escape": "^4.0.1",
-				"lodash.isequal": "^4.5.0",
-				"object-inspect": "^1.7.0",
-				"object-is": "^1.0.2",
-				"object.assign": "^4.1.0",
-				"object.entries": "^1.1.1",
-				"object.values": "^1.1.1",
-				"raf": "^3.4.1",
-				"rst-selector-parser": "^2.2.3",
-				"string.prototype.trim": "^1.2.1"
-			},
-			"dependencies": {
-				"lodash.isequal": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-					"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-					"dev": true,
-					"peer": true
-				}
-			}
 		},
 		"enzyme-matchers": {
 			"version": "7.1.2",
@@ -39782,13 +39064,6 @@
 				"unbox-primitive": "^1.0.2"
 			}
 		},
-		"es-array-method-boxes-properly": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-			"dev": true,
-			"peer": true
-		},
 		"es-module-lexer": {
 			"version": "0.9.3",
 			"dev": true
@@ -39825,7 +39100,8 @@
 			}
 		},
 		"escalade": {
-			"version": "3.1.1"
+			"version": "3.1.1",
+			"dev": true
 		},
 		"escape-html": {
 			"version": "1.0.3",
@@ -40011,8 +39287,7 @@
 		},
 		"eslint-config-prettier": {
 			"version": "8.3.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -40780,7 +40055,8 @@
 			"version": "1.2.2"
 		},
 		"gensync": {
-			"version": "1.0.0-beta.2"
+			"version": "1.0.0-beta.2",
+			"dev": true
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
@@ -40948,7 +40224,8 @@
 			}
 		},
 		"globals": {
-			"version": "11.12.0"
+			"version": "11.12.0",
+			"dev": true
 		},
 		"globby": {
 			"version": "11.1.0",
@@ -41197,17 +40474,6 @@
 			"version": "1.0.0",
 			"dev": true
 		},
-		"html-element-map": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
-			"integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"array.prototype.filter": "^1.0.0",
-				"call-bind": "^1.0.2"
-			}
-		},
 		"html-encoding-sniffer": {
 			"version": "2.0.1",
 			"dev": true,
@@ -41228,52 +40494,6 @@
 			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
 			"integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
 			"dev": true
-		},
-		"htmlparser2": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-			"integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"domutils": "^3.0.1",
-				"entities": "^4.3.0"
-			},
-			"dependencies": {
-				"dom-serializer": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-					"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.2",
-						"entities": "^4.2.0"
-					}
-				},
-				"domelementtype": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-					"dev": true,
-					"peer": true
-				},
-				"domutils": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-					"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"dom-serializer": "^2.0.0",
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.1"
-					}
-				}
-			}
 		},
 		"http-proxy-agent": {
 			"version": "4.0.1",
@@ -41313,8 +40533,7 @@
 		},
 		"icss-utils": {
 			"version": "5.1.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"identity-obj-proxy": {
 			"version": "3.0.0",
@@ -43084,8 +42303,7 @@
 		},
 		"jest-pnp-resolver": {
 			"version": "1.2.2",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"jest-regex-util": {
 			"version": "27.4.0",
@@ -43670,7 +42888,8 @@
 			}
 		},
 		"jsesc": {
-			"version": "2.5.2"
+			"version": "2.5.2",
+			"dev": true
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
@@ -43701,6 +42920,7 @@
 		},
 		"json5": {
 			"version": "2.2.0",
+			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -44072,25 +43292,11 @@
 			"version": "4.0.8",
 			"dev": true
 		},
-		"lodash.escape": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-			"integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
-			"dev": true,
-			"peer": true
-		},
 		"lodash.escaperegexp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
 			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
 			"dev": true
-		},
-		"lodash.flattendeep": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
-			"dev": true,
-			"peer": true
 		},
 		"lodash.isarguments": {
 			"version": "3.1.0",
@@ -44552,7 +43758,8 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.5"
+			"version": "1.2.5",
+			"dev": true
 		},
 		"minimist-options": {
 			"version": "4.1.0",
@@ -44632,18 +43839,12 @@
 				"moment": ">= 2.9.0"
 			}
 		},
-		"moo": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-			"integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-			"dev": true,
-			"peer": true
-		},
 		"mousetrap": {
 			"version": "1.6.5"
 		},
 		"ms": {
-			"version": "2.1.2"
+			"version": "2.1.2",
+			"dev": true
 		},
 		"mute-stream": {
 			"version": "0.0.7",
@@ -44681,28 +43882,6 @@
 			"version": "1.4.0",
 			"dev": true
 		},
-		"nearley": {
-			"version": "2.20.1",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-			"integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"commander": "^2.19.0",
-				"moo": "^0.5.0",
-				"railroad-diagrams": "^1.0.0",
-				"randexp": "0.4.6"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-					"dev": true,
-					"peer": true
-				}
-			}
-		},
 		"neo-async": {
 			"version": "2.6.2",
 			"dev": true
@@ -44737,17 +43916,6 @@
 						"side-channel": "^1.0.4"
 					}
 				},
-				"react": {
-					"version": "16.14.0",
-					"resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-					"integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-					"peer": true,
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1",
-						"prop-types": "^15.6.2"
-					}
-				},
 				"react-daterange-picker": {
 					"version": "2.0.1",
 					"requires": {
@@ -44758,35 +43926,13 @@
 						"prop-types": "^15.6.0",
 						"react-addons-pure-render-mixin": "^15.6.2"
 					}
-				},
-				"react-dom": {
-					"version": "16.14.0",
-					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-					"integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-					"peer": true,
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1",
-						"prop-types": "^15.6.2",
-						"scheduler": "^0.19.1"
-					}
-				},
-				"scheduler": {
-					"version": "0.19.1",
-					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-					"integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-					"peer": true,
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1"
-					}
 				}
 			}
 		},
 		"newspack-scripts": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.3.7.tgz",
-			"integrity": "sha512-twxZz9tRnxCIAUlfdppxaFiClt7WJIOoQv57+d4GU5sPQk6zOdXNtqZkWXoptRICWbgzsLzDxoSilKCvV7Ivtw==",
+			"version": "4.3.8",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.3.8.tgz",
+			"integrity": "sha512-3nK3HKSLUjjkC+wP83DGfc9DKf7uLSN5zYhn6138oL0KEmwn8roP+DUY+ePuywV9MocT8X8sBP7hxvMqInlDHA==",
 			"dev": true,
 			"requires": {
 				"@automattic/calypso-build": "^10.0.0",
@@ -45375,8 +44521,7 @@
 				},
 				"eslint-plugin-react-hooks": {
 					"version": "4.3.0",
-					"dev": true,
-					"requires": {}
+					"dev": true
 				},
 				"espree": {
 					"version": "9.3.0",
@@ -45647,7 +44792,8 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "2.0.1"
+			"version": "2.0.1",
+			"dev": true
 		},
 		"normalize-package-data": {
 			"version": "3.0.3",
@@ -47765,29 +46911,6 @@
 			"version": "6.0.1",
 			"dev": true
 		},
-		"parse5-htmlparser2-tree-adapter": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-			"integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"domhandler": "^5.0.2",
-				"parse5": "^7.0.0"
-			},
-			"dependencies": {
-				"parse5": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-					"integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"entities": "^4.4.0"
-					}
-				}
-			}
-		},
 		"pascal-case": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
@@ -47848,7 +46971,8 @@
 			"dev": true
 		},
 		"picocolors": {
-			"version": "1.0.0"
+			"version": "1.0.0",
+			"dev": true
 		},
 		"picomatch": {
 			"version": "2.3.1",
@@ -48171,8 +47295,7 @@
 		},
 		"postcss-focus-within": {
 			"version": "5.0.1",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-loader": {
 			"version": "6.2.0",
@@ -48393,8 +47516,7 @@
 		},
 		"postcss-modules-extract-imports": {
 			"version": "3.0.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-modules-local-by-default": {
 			"version": "4.0.0",
@@ -48793,15 +47915,13 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
 			"integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-scss": {
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.5.tgz",
 			"integrity": "sha512-F7xpB6TrXyqUh3GKdyB4Gkp3QL3DDW1+uI+gxx/oJnUt/qXI4trj5OGlp9rOKdoABGULuqtqeG+3HEVQk4DjmA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-selector-parser": {
 			"version": "6.0.10",
@@ -49046,24 +48166,6 @@
 				"performance-now": "^2.1.0"
 			}
 		},
-		"railroad-diagrams": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-			"integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-			"dev": true,
-			"peer": true
-		},
-		"randexp": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"discontinuous-range": "1.0.0",
-				"ret": "~0.1.10"
-			}
-		},
 		"randombytes": {
 			"version": "2.1.0",
 			"dev": true,
@@ -49128,8 +48230,7 @@
 			}
 		},
 		"react-colorful": {
-			"version": "5.5.0",
-			"requires": {}
+			"version": "5.5.0"
 		},
 		"react-dates": {
 			"version": "17.2.0",
@@ -49201,8 +48302,7 @@
 			}
 		},
 		"react-resize-aware": {
-			"version": "3.1.1",
-			"requires": {}
+			"version": "3.1.1"
 		},
 		"react-router": {
 			"version": "5.2.1",
@@ -49255,8 +48355,7 @@
 			}
 		},
 		"react-use-gesture": {
-			"version": "9.1.3",
-			"requires": {}
+			"version": "9.1.3"
 		},
 		"react-with-direction": {
 			"version": "1.4.0",
@@ -49449,8 +48548,7 @@
 			}
 		},
 		"reakit-utils": {
-			"version": "0.15.2",
-			"requires": {}
+			"version": "0.15.2"
 		},
 		"reakit-warning": {
 			"version": "0.6.2",
@@ -49842,17 +48940,6 @@
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
-			}
-		},
-		"rst-selector-parser": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
-			"integrity": "sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"lodash.flattendeep": "^4.4.0",
-				"nearley": "^2.7.10"
 			}
 		},
 		"rsvp": {
@@ -51036,18 +50123,6 @@
 				"side-channel": "^1.0.4"
 			}
 		},
-		"string.prototype.trim": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.6.tgz",
-			"integrity": "sha512-8lMR2m+U0VJTPp6JjvJTtGyc4FIGq9CdRt7O9p6T0e6K4vjU+OP+SQJpbe/SBmRcCUIvNUnjsbmY6lnMp8MhsQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.19.5"
-			}
-		},
 		"string.prototype.trimend": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
@@ -51265,15 +50340,13 @@
 		},
 		"stylelint-config-prettier": {
 			"version": "9.0.3",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"stylelint-config-recommended": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
 			"integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"stylelint-config-recommended-scss": {
 			"version": "5.0.2",
@@ -52103,8 +51176,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
 			"integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"use-lilius": {
 			"version": "2.0.3",
@@ -52116,15 +51188,13 @@
 			}
 		},
 		"use-memo-one": {
-			"version": "1.1.2",
-			"requires": {}
+			"version": "1.1.2"
 		},
 		"use-sync-external-store": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
 			"integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
@@ -52458,8 +51528,7 @@
 		},
 		"ws": {
 			"version": "7.5.5",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"html-entities": "^2.3.3",
 		"identity-obj-proxy": "^3.0.0",
 		"lint-staged": "^13.0.3",
-		"newspack-scripts": "^4.3.7",
+		"newspack-scripts": "^4.3.8",
 		"postcss-scss": "^4.0.5",
 		"prettier": "npm:wp-prettier@^2.6.2-beta-1",
 		"stylelint": "^14.9.1"


### PR DESCRIPTION
Update `newspack-scripts` and CI orb. The latest version combo will handle building JS files on CI better:

- version `1.4.2` of the orb adds setting node version according to the project's `.nvmrc` file prior to installing npm modules and building the JS files
- version `4.3.8` of `newspack-scripts` removes a hacky partial fix for issues caused by node version mismatch