### PR TITLE
fix(donate): override defaults with manual config

### DIFF
--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
@@ -65,17 +65,13 @@ abstract class Newspack_Blocks_Donate_Renderer_Base {
 				$configuration['amounts'] = $attributes['amounts'];
 			}
 
-			if ( isset( $attributes['disabledFrequencies'] ) ) {
-				foreach ( $attributes['disabledFrequencies'] as $frequency_slug => $is_disabled ) {
-					if ( $is_disabled ) {
-						$configuration['disabledFrequencies'][ $frequency_slug ] = true;
-					}
-				}
-			}
-
 			if ( isset( $attributes['minimumDonation'] ) ) {
 				$configuration['minimumDonation'] = $attributes['minimumDonation'];
 			}
+
+			// Override defaults with manual config.
+			$configuration['defaultFrequency']    = $attributes['defaultFrequency'];
+			$configuration['disabledFrequencies'] = $attributes['disabledFrequencies'];
 		}
 
 		// Ensure default frequency is valid (not disabled).


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In the Donate block, if manually configured the manual settings don't fully override the default settings in the Reader Revenue wizard as you would expect. If a frequency is disabled in Reader Revenue, that frequency will remain disabled in a manually configured block, even if that frequency is manually enabled. 

This branch tweaks the logic so that if a block is manually configured, its manual settings completely override the settings in Reader Revenue.

Also overrides the default frequency if the manual setting differs from the default settings.

Closes /0/1200550061930446/1203385734865005.

### How to test the changes in this Pull Request:

1. Toggle off the One-Time option in Reader Revenue → Donations. Keep Monthly and Annual enabled.
2. Create a new page. Add the Donate Block.
3. Toggle on the option to Configure Manually.
4. Enable One-Time in block settings, and disable Monthly. 
5. Note that the one-time option does appear in the editor.
6. Publish the page. 
7. Notice that the One-time option isn't available on the front-end.
8. Check out this branch, refresh. Confirm that the One-Time and Annual tabs are available (only those configured in manual settings).
9. In block settings, set the default frequency to something other than it is in Reader Revenue.
10. Confirm on the front-end that the default frequency matches the manual setting, not the Reader Revenue setting.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
