### PR TITLE
HPB: filter image sizes based on the maximum image width

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -421,8 +421,8 @@ class Newspack_Blocks {
 					900,
 				),
 				'medium' => array(
-					800,
 					600,
+					450,
 				),
 				'small'  => array(
 					400,
@@ -439,8 +439,8 @@ class Newspack_Blocks {
 					1200,
 				),
 				'medium' => array(
+					450,
 					600,
-					800,
 				),
 				'small'  => array(
 					300,
@@ -457,8 +457,8 @@ class Newspack_Blocks {
 					1200,
 				),
 				'medium' => array(
-					800,
-					800,
+					600,
+					600,
 				),
 				'small'  => array(
 					400,
@@ -492,9 +492,9 @@ class Newspack_Blocks {
 		add_image_size( 'newspack-article-block-portrait-large', 900, 1200, true );
 		add_image_size( 'newspack-article-block-square-large', 1200, 1200, true );
 
-		add_image_size( 'newspack-article-block-landscape-medium', 800, 600, true );
-		add_image_size( 'newspack-article-block-portrait-medium', 600, 800, true );
-		add_image_size( 'newspack-article-block-square-medium', 800, 800, true );
+		add_image_size( 'newspack-article-block-landscape-medium', 600, 450, true );
+		add_image_size( 'newspack-article-block-portrait-medium', 450, 600, true );
+		add_image_size( 'newspack-article-block-square-medium', 600, 600, true );
 
 		add_image_size( 'newspack-article-block-landscape-small', 400, 300, true );
 		add_image_size( 'newspack-article-block-portrait-small', 300, 400, true );

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -416,55 +416,67 @@ class Newspack_Blocks {
 	public static function image_size_for_orientation( $orientation = 'landscape' ) {
 		$sizes = array(
 			'landscape' => array(
-				'large'  => array(
+				'large'        => array(
 					1200,
 					900,
 				),
-				'medium' => array(
+				'medium'       => array(
+					800,
+					600,
+				),
+				'intermediate' => array(
 					600,
 					450,
 				),
-				'small'  => array(
+				'small'        => array(
 					400,
 					300,
 				),
-				'tiny'   => array(
+				'tiny'         => array(
 					200,
 					150,
 				),
 			),
 			'portrait'  => array(
-				'large'  => array(
+				'large'        => array(
 					900,
 					1200,
 				),
-				'medium' => array(
+				'medium'       => array(
+					600,
+					800,
+				),
+				'intermediate' => array(
 					450,
 					600,
 				),
-				'small'  => array(
+				'small'        => array(
 					300,
 					400,
 				),
-				'tiny'   => array(
+				'tiny'         => array(
 					150,
 					200,
 				),
 			),
 			'square'    => array(
-				'large'  => array(
+				'large'        => array(
 					1200,
 					1200,
 				),
-				'medium' => array(
+				'medium'       => array(
+					800,
+					800,
+				),
+				'intermediate' => array(
 					600,
 					600,
 				),
-				'small'  => array(
+				'small'        => array(
 					400,
 					400,
 				),
-				'tiny'   => array(
+				'tiny'         => array(
 					200,
 					200,
 				),
@@ -492,9 +504,13 @@ class Newspack_Blocks {
 		add_image_size( 'newspack-article-block-portrait-large', 900, 1200, true );
 		add_image_size( 'newspack-article-block-square-large', 1200, 1200, true );
 
-		add_image_size( 'newspack-article-block-landscape-medium', 600, 450, true );
-		add_image_size( 'newspack-article-block-portrait-medium', 450, 600, true );
-		add_image_size( 'newspack-article-block-square-medium', 600, 600, true );
+		add_image_size( 'newspack-article-block-landscape-medium', 800, 600, true );
+		add_image_size( 'newspack-article-block-portrait-medium', 600, 800, true );
+		add_image_size( 'newspack-article-block-square-medium', 800, 800, true );
+
+		add_image_size( 'newspack-article-block-landscape-intermediate', 600, 450, true );
+		add_image_size( 'newspack-article-block-portrait-intermediate', 450, 600, true );
+		add_image_size( 'newspack-article-block-square-intermediate', 600, 600, true );
 
 		add_image_size( 'newspack-article-block-landscape-small', 400, 300, true );
 		add_image_size( 'newspack-article-block-portrait-small', 300, 400, true );

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -39,6 +39,11 @@ call_user_func(
 			'data-hero-candidate' => true,
 			'alt'                 => trim( wp_strip_all_tags( get_the_title( $post_id ) ) ),
 		);
+
+		// This global will be used by the newspack_blocks_filter_hpb_srcset filter.
+		global $newspack_blocks_hpb_rendering_context;
+		$newspack_blocks_hpb_rendering_context = [ 'attrs' => $attributes ];
+
 		// If the image position is behind, pass the object-fit setting to maintain styles with AMP.
 		if ( 'behind' === $attributes['mediaPosition'] ) {
 			$thumbnail_args['object-fit'] = 'cover';
@@ -83,7 +88,11 @@ call_user_func(
 				<?php if ( $post_link ) : ?>
 				<a href="<?php echo esc_url( $post_link ); ?>" rel="bookmark" tabindex="-1" aria-hidden="true">
 				<?php endif; ?>
-					<?php the_post_thumbnail( $image_size, $thumbnail_args ); ?>
+				<?php add_filter( 'wp_calculate_image_srcset', 'newspack_blocks_filter_hpb_srcset' ); ?>
+				<?php add_filter( 'wp_calculate_image_sizes', 'newspack_blocks_filter_hpb_sizes' ); ?>
+				<?php the_post_thumbnail( $image_size, $thumbnail_args ); ?>
+				<?php remove_filter( 'wp_calculate_image_srcset', 'newspack_blocks_filter_hpb_srcset' ); ?>
+				<?php remove_filter( 'wp_calculate_image_sizes', 'newspack_blocks_filter_hpb_sizes' ); ?>
 				<?php if ( $post_link ) : ?>
 				</a>
 				<?php endif; ?>

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -88,10 +88,8 @@ call_user_func(
 				<?php if ( $post_link ) : ?>
 				<a href="<?php echo esc_url( $post_link ); ?>" rel="bookmark" tabindex="-1" aria-hidden="true">
 				<?php endif; ?>
-				<?php add_filter( 'wp_calculate_image_srcset', 'newspack_blocks_filter_hpb_srcset' ); ?>
 				<?php add_filter( 'wp_calculate_image_sizes', 'newspack_blocks_filter_hpb_sizes' ); ?>
 				<?php the_post_thumbnail( $image_size, $thumbnail_args ); ?>
-				<?php remove_filter( 'wp_calculate_image_srcset', 'newspack_blocks_filter_hpb_srcset' ); ?>
 				<?php remove_filter( 'wp_calculate_image_sizes', 'newspack_blocks_filter_hpb_sizes' ); ?>
 				<?php if ( $post_link ) : ?>
 				</a>

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -17,6 +17,11 @@ function newspack_blocks_hpb_maximum_image_width() {
 		if ( empty( $attributes ) ) {
 			return $max_width;
 		}
+		if ( isset( $attributes['align'] ) && in_array( $attributes['align'], [ 'full', 'wide' ], true ) ) {
+			// For full and wide alignments, the image width is more than 100% of the content width
+			// and depends on site width. Can't make assumptions about the site width.
+			return $max_width;
+		}
 		$site_content_width  = 1200;
 		$is_image_half_width = in_array( $attributes['mediaPosition'], [ 'left', 'right' ], true );
 		if ( 'grid' === $attributes['postLayout'] ) {

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -39,7 +39,7 @@ function newspack_blocks_hpb_maximum_image_width() {
  * @param array $sizes Sizes for the sizes attribute.
  */
 function newspack_blocks_filter_hpb_sizes( $sizes ) {
-	if ( defined( 'NEWSPACK_DISABLE_HPB_IMAGE_OPTIMISATION' ) || NEWSPACK_DISABLE_HPB_IMAGE_OPTIMISATION ) {
+	if ( defined( 'NEWSPACK_DISABLE_HPB_IMAGE_OPTIMISATION' ) && NEWSPACK_DISABLE_HPB_IMAGE_OPTIMISATION ) {
 		// Allow disabling the image optimisation per-site.
 		return $sizes;
 	}

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -39,6 +39,14 @@ function newspack_blocks_hpb_maximum_image_width() {
  * @param array $sizes Sizes for the sizes attribute.
  */
 function newspack_blocks_filter_hpb_sizes( $sizes ) {
+	global $newspack_blocks_hpb_current_theme;
+	if ( ! $newspack_blocks_hpb_current_theme ) {
+		$newspack_blocks_hpb_current_theme = wp_get_theme()->template;
+	}
+	if ( stripos( $newspack_blocks_hpb_current_theme, 'newspack' ) === false ) {
+		// Bail if not using a Newspack theme – assumptions about the site content width can't be made then.
+		return $sizes;
+	}
 	$max_width = newspack_blocks_hpb_maximum_image_width();
 	if ( 0 !== $max_width ) {
 		// >=782px is the desktop size – set width as computed.

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -39,6 +39,10 @@ function newspack_blocks_hpb_maximum_image_width() {
  * @param array $sizes Sizes for the sizes attribute.
  */
 function newspack_blocks_filter_hpb_sizes( $sizes ) {
+	if ( defined( 'NEWSPACK_DISABLE_HPB_IMAGE_OPTIMISATION' ) || NEWSPACK_DISABLE_HPB_IMAGE_OPTIMISATION ) {
+		// Allow disabling the image optimisation per-site.
+		return $sizes;
+	}
 	global $newspack_blocks_hpb_current_theme;
 	if ( ! $newspack_blocks_hpb_current_theme ) {
 		$newspack_blocks_hpb_current_theme = wp_get_theme()->template;

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -6,6 +6,71 @@
  */
 
 /**
+ * Calculate the maximum width of an image in the Homepage Posts block.
+ */
+function newspack_blocks_hpb_maximum_image_width() {
+	$max_width = 0;
+
+	global $newspack_blocks_hpb_rendering_context;
+	if ( isset( $newspack_blocks_hpb_rendering_context['attrs'] ) ) {
+		$attributes = $newspack_blocks_hpb_rendering_context['attrs'];
+		if ( empty( $attributes ) ) {
+			return $max_width;
+		}
+		$site_content_width  = 1200;
+		$is_image_half_width = in_array( $attributes['mediaPosition'], [ 'left', 'right' ], true );
+		if ( 'grid' === $attributes['postLayout'] ) {
+			$columns = $attributes['columns'];
+			if ( $is_image_half_width ) {
+				// If the media position is on left or right, the image is 50% of the column width.
+				$columns = $columns * 2;
+			}
+			return $site_content_width / $columns;
+		} elseif ( 'list' === $attributes['postLayout'] && $is_image_half_width ) {
+			return $site_content_width / 2;
+		}
+	}
+	return $max_width;
+}
+
+/**
+ * Remove unnecessary image sources based on the maximum image width.
+ *
+ * @param array $sources Sources for the srcset attribute.
+ */
+function newspack_blocks_filter_hpb_srcset( $sources ) {
+	$max_width = newspack_blocks_hpb_maximum_image_width();
+	if ( 0 !== $max_width ) {
+		foreach ( $sources as $key => $source ) {
+			if ( $max_width < $source['value'] ) {
+				unset( $sources[ $key ] );
+			}
+		}
+	}
+	return $sources;
+}
+
+/**
+ * Set image `sizes` attribute based on the maximum image width.
+ *
+ * @param array $sizes Sizes for the sizes attribute.
+ */
+function newspack_blocks_filter_hpb_sizes( $sizes ) {
+	$max_width = newspack_blocks_hpb_maximum_image_width();
+	if ( 0 !== $max_width ) {
+		// >=782px is the desktop size – set width as computed.
+		$sizes = '(min-width: 782px) ' . $max_width . 'px';
+		// Between 600-782px is the tablet size – all columns will collapse to two-column layout
+		// (assuming 5% padding on each side and between columns).
+		$sizes .= ', (min-width: 600px) 42.5vw';
+		// <=600px is the mobile size – columns will stack to full width
+		// (assumming 5% side padding on each side).
+		$sizes .= ', 90vw';
+	}
+	return $sizes;
+}
+
+/**
  * Renders the `newspack-blocks/homepage-posts` block on server.
  *
  * @param array $attributes The block attributes.

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -34,23 +34,6 @@ function newspack_blocks_hpb_maximum_image_width() {
 }
 
 /**
- * Remove unnecessary image sources based on the maximum image width.
- *
- * @param array $sources Sources for the srcset attribute.
- */
-function newspack_blocks_filter_hpb_srcset( $sources ) {
-	$max_width = newspack_blocks_hpb_maximum_image_width();
-	if ( 0 !== $max_width ) {
-		foreach ( $sources as $key => $source ) {
-			if ( $max_width < $source['value'] ) {
-				unset( $sources[ $key ] );
-			}
-		}
-	}
-	return $sources;
-}
-
-/**
  * Set image `sizes` attribute based on the maximum image width.
  *
  * @param array $sizes Sizes for the sizes attribute.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Improves performance by removing image sizes which are too large to load from the `srcset` attribute of the `img` tags rendered by the Homepage Posts block. 

### How to test the changes in this Pull Request:

1. On `master`,
1. Create a page with some Homepage Posts blocks, make sure all articles have featured images
2. Set one of the blocks to multiple columns
3. Load the page, observe all images are downloaded in the same size (inspect the Network devtools tab)
4. Switch to this branch and rebuild the thumbnails (`wp media regenerate`)
5. Load the page, observe more appropriate image sizes are loaded (this is most visible for a block with a few columns)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->