### PR TITLE
feat: handle 'other' reader revenue platform in the editor

### DIFF
--- a/src/blocks/donate/edit/index.tsx
+++ b/src/blocks/donate/edit/index.tsx
@@ -60,6 +60,7 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 		tiered: false,
 		disabledFrequencies: {},
 		minimumDonation: 5,
+		platform: '',
 	} );
 
 	useEffect( () => {
@@ -73,6 +74,7 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 					tiered: donationSettings.tiered,
 					disabledFrequencies: donationSettings.disabledFrequencies,
 					minimumDonation: donationSettings.minimumDonation,
+					platform: donationSettings.platform,
 				} );
 
 				if ( isEmpty( attributes.disabledFrequencies ) ) {
@@ -113,6 +115,20 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 			<Placeholder icon="warning" label={ __( 'Error', 'newspack-blocks' ) } instructions={ error }>
 				<ExternalLink href="/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/donations">
 					{ __( 'Go to donation settings to troubleshoot.', 'newspack-blocks' ) }
+				</ExternalLink>
+			</Placeholder>
+		);
+	}
+
+	if ( settings.platform === 'other' ) {
+		return (
+			<Placeholder
+				icon="warning"
+				label={ __( 'The Donate block will not be rendered.', 'newspack-blocks' ) }
+				instructions={ __( 'The Reader Revenue platform is set to "other".', 'newspack' ) }
+			>
+				<ExternalLink href="/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/donations">
+					{ __( 'Go to donation settings to update the platform.', 'newspack-blocks' ) }
 				</ExternalLink>
 			</Placeholder>
 		);

--- a/src/blocks/donate/types.ts
+++ b/src/blocks/donate/types.ts
@@ -40,11 +40,12 @@ export type DonationSettings = {
 	disabledFrequencies: {
 		[ Key in DonationFrequencySlug as string ]: boolean;
 	};
+	platform: string;
 };
 
 export type EditState = Pick<
 	DonationSettings,
-	'amounts' | 'currencySymbol' | 'tiered' | 'disabledFrequencies' | 'minimumDonation'
+	'amounts' | 'currencySymbol' | 'tiered' | 'disabledFrequencies' | 'minimumDonation' | 'platform'
 >;
 
 export type DonationAmounts = {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

See https://github.com/Automattic/newspack-plugin/pull/2160

### How to test the changes in this Pull Request:

1. Switch the main plugin to `feat/rr-other-option` branch (https://github.com/Automattic/newspack-plugin/pull/2160)
2. Insert a Donate block on a post or page, observe that it displays an error in the editor:

<img width="762" alt="image" src="https://user-images.githubusercontent.com/7383192/205604262-2428d33f-258e-4253-8ca1-403cca65df1a.png">

3. Switch the platform to a different one, observe the block is rendered correctly in the editor


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->