### PR TITLE
fix: allow all img tag attributes in avatar output

### DIFF
--- a/src/templates/author-profile-card.php
+++ b/src/templates/author-profile-card.php
@@ -53,7 +53,24 @@ call_user_func(
 			<?php if ( $attributes['showAvatar'] && isset( $author['avatar'] ) ) : ?>
 				<div class="wp-block-newspack-blocks-author-profile__avatar">
 					<figure style="border-radius: <?php echo esc_attr( $attributes['avatarBorderRadius'] ); ?>; height: <?php echo esc_attr( $attributes['avatarSize'] ); ?>px; width: <?php echo esc_attr( $attributes['avatarSize'] ); ?>px;">
-						<?php echo wp_kses_post( $author['avatar'] ); ?>
+						<?php
+						echo wp_kses(
+							$author['avatar'],
+							[
+								'img' => [
+									'alt'      => true,
+									'class'    => true,
+									'data-*'   => true,
+									'decoding' => true,
+									'height'   => true,
+									'sizes'    => true,
+									'src'      => true,
+									'srcset'   => true,
+									'width'    => true,
+								],
+							]
+						);
+						?>
 					</figure>
 				</div>
 			<?php endif; ?>

--- a/src/templates/author-profile-card.php
+++ b/src/templates/author-profile-card.php
@@ -63,6 +63,7 @@ call_user_func(
 									'data-*'   => true,
 									'decoding' => true,
 									'height'   => true,
+									'loading'  => true,
 									'sizes'    => true,
 									'src'      => true,
 									'srcset'   => true,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an overzealous sanitization function in the Author Profile and Author List blocks that prevented avatar images from loading all their attributes, resulting in low-res images being rendered in high-DPI environments (due to the `srcset` and `sizes` attributes being stripped).

Closes `1203451787793554/1203512877120434`.

### How to test the changes in this Pull Request:

1. Create a guest author and add a high-res avatar image.
2. Add an Author Profile or Author List block to a post and set it to show the guest author with its avatar.
3. On `master`, view the block front-end on a high-DPI device (such as mobile or a MacBook Pro) and observe that the avatar image looks blurry—this is because the default image is 72dpi, while the missing `srcset` is supposed to ensure that higher-DPI images are rendered when appropriate. You can also observe using dev tools that the `img` element for the avatar is missing `srcset` and `sizes` attributes.
4. Check out this branch and refresh. Confirm that the image rendered is now sharp and that the `sizes` and `srcset` attributes appear on the `img` tag.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
