### PR TITLE
feat: unregister Jetpack Subscriptions block to avoid confusion with Newspack blocks

### DIFF
--- a/src/setup/unregister-blocks.js
+++ b/src/setup/unregister-blocks.js
@@ -3,7 +3,7 @@
 import { getBlockType, unregisterBlockType } from '@wordpress/blocks';
 import domReady from '@wordpress/dom-ready';
 
-const removeBlocks = [ 'jetpack/donations' ];
+const removeBlocks = [ 'jetpack/donations', 'jetpack/subscriptions' ];
 
 domReady( function () {
 	removeBlocks.forEach( function ( blockName ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Unregisters the Jetpack Subscriptions block, which could be easily confused with Newspack's similarly-named and similar-looking block.

Closes `1203451787793554/1203589724907791`.

### How to test the changes in this Pull Request:

1. Enable the Jetpack Subscriptions feature as [described here](https://jetpack.com/support/subscriptions/).
2. On `master`, observe that you can add a Jetpack Subscribe block to a post or page.
3. Check out this branch, confirm that you can no longer add the block and that any existing instances won't render in the editor or on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
