### PR TITLE
fix: make sure correct avatar is loaded when guests and users share IDs

### DIFF
--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -96,19 +96,9 @@ class Newspack_Blocks_API {
 			$authors = get_coauthors();
 
 			foreach ( $authors as $author ) {
-				// Check if this is a guest author post type.
-				if ( 'guest-author' === get_post_type( $author->ID ) ) {
-					// If yes, make sure the author actually has an avatar set; otherwise, coauthors_get_avatar returns a featured image.
-					if ( get_post_thumbnail_id( $author->ID ) ) {
-						$author_avatar = coauthors_get_avatar( $author, 48 );
-					} else {
-						// If there is no avatar, force it to return the current fallback image.
-						$author_avatar = get_avatar( ' ' );
-					}
-				} else {
-					$author_avatar = coauthors_get_avatar( $author, 48 );
-				}
-				$author_link = null;
+				$author_avatar = coauthors_get_avatar( $author, 48 );
+				$author_link   = null;
+
 				if ( function_exists( 'coauthors_posts_links' ) ) {
 					$author_link = get_author_posts_url( $author->ID, $author->user_nicename );
 				}

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -728,7 +728,7 @@ class Newspack_Blocks {
 			$authors = get_coauthors();
 			foreach ( $authors as $author ) {
 				$author->avatar = coauthors_get_avatar( $author, 48 );
-				$author->url = get_author_posts_url( $author->ID, $author->user_nicename );
+				$author->url    = get_author_posts_url( $author->ID, $author->user_nicename );
 			}
 			return $authors;
 		}

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -727,18 +727,7 @@ class Newspack_Blocks {
 		if ( function_exists( 'coauthors_posts_links' ) && ! empty( get_coauthors() ) ) {
 			$authors = get_coauthors();
 			foreach ( $authors as $author ) {
-				// Check if this is a guest author post type.
-				if ( 'guest-author' === get_post_type( $author->ID ) ) {
-					// If yes, make sure the author actually has an avatar set; otherwise, coauthors_get_avatar returns a featured image.
-					if ( get_post_thumbnail_id( $author->ID ) ) {
-						$author->avatar = coauthors_get_avatar( $author, 48 );
-					} else {
-						// If there is no avatar, force it to return the current fallback image.
-						$author->avatar = get_avatar( ' ' );
-					}
-				} else {
-					$author->avatar = coauthors_get_avatar( $author, 48 );
-				}
+				$author->avatar = coauthors_get_avatar( $author, 48 );
 				$author->url = get_author_posts_url( $author->ID, $author->user_nicename );
 			}
 			return $authors;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR resolves an issue where WP Users were having their avatars overridden if their ID was the same as a Guest Author's.

The underlying issue was coming from an old fix that looks like it's no longer needed. When the Homepage Posts block was originally developed, guest authors would pick up featured images as avatars when they didn't have one assigned -- this is no longer reproduceable without the fix, so it's safe to remove. 

Closes 1200133283606042-as-1203598624455770

### How to test the changes in this Pull Request:

To test this, you need to have a site where a Guest Author and WP User share the same ID. If you don't already have this, you can create it by: 

1. Spin up a new Newspack site (opting NOT to install the demo content)
2. Adding a Guest Author. 
3. Checking the Guest Author's ID -- on a new site, it should be pretty low, like 5-6. 
4. Create new WP Users until you match that ID.

Then to test the PR:

1. Make sure your "ID twin" Guest Author doesn't have an avatar assigned, but your "ID twin" WP user does (this can be done through Gravatar, or the Simple Avatars plugin).
2. Assign at least one story to your "ID twin" WP user.
3. Add a Homepage Posts block to a page, and make sure the above story is displayed in it. 
4. View in the editor and on the front-end -- note that rather than using its assigned avatar, your "ID twin" WP User is using the fallback avatar, same as your "ID twin" guest author. 
5. Repeat steps 3 and 4 but with the Post Carousel, and note the same issue.
6. Apply the PR and run `npm run build`.
7. Confirm that the correct avatar is now being used in both blocks for the "ID twin" WP User. 
8. Confirm that users without avatars assigned are using the correct fallback avatar, and are not picking up their post's featured image. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
