### PR TITLE
fix: make author block font sizing more specific

### DIFF
--- a/src/blocks/author-profile/editor.scss
+++ b/src/blocks/author-profile/editor.scss
@@ -26,8 +26,8 @@
 			font-size: 1em;
 		}
 
-		.wp-block-newspack-blocks-author-profile__employment {
-			font-size: 0.8em;
+		&__employment {
+			font-size: 0.8em !important;
 		}
 
 		&__bio {

--- a/src/blocks/author-profile/editor.scss
+++ b/src/blocks/author-profile/editor.scss
@@ -2,7 +2,7 @@
 @use '../../shared/sass/mixins';
 
 .editor-styles-wrapper {
-	.newspack-blocks-author-profile {
+	.wp-block-newspack-blocks-author-profile {
 		.components-notice {
 			margin: 0 0 2rem 0;
 			width: 100%;
@@ -20,6 +20,14 @@
 
 		a.no-op {
 			pointer-events: none;
+		}
+
+		p {
+			font-size: 1em;
+		}
+
+		.wp-block-newspack-blocks-author-profile__employment {
+			font-size: 0.8em;
 		}
 
 		&__bio {

--- a/src/blocks/author-profile/editor.scss
+++ b/src/blocks/author-profile/editor.scss
@@ -26,10 +26,6 @@
 			font-size: 1em;
 		}
 
-		&__employment {
-			font-size: 0.8em !important;
-		}
-
 		&__bio {
 			@include mixins.media( mobile ) {
 				flex: 4;

--- a/src/blocks/author-profile/view.scss
+++ b/src/blocks/author-profile/view.scss
@@ -14,8 +14,8 @@
 		margin-bottom: 0.5em;
 	}
 
-	p:not( &__employment ) {
-		font-size: 1em !important;
+	p {
+		font-size: 1em;
 	}
 
 	&.text-size-small {
@@ -66,9 +66,11 @@
 		margin-top: 0;
 		margin-bottom: 0;
 	}
-	&__employment {
-		font-size: 0.8em !important;
+
+	& &__employment {
+		font-size: 0.8em;
 	}
+
 	&__social-links {
 		display: flex;
 		flex-wrap: wrap;

--- a/src/blocks/author-profile/view.scss
+++ b/src/blocks/author-profile/view.scss
@@ -67,8 +67,8 @@
 		margin-bottom: 0;
 	}
 
-	& &__employment {
-		font-size: 0.8em;
+	&__employment {
+		font-size: 0.8em !important;
 	}
 
 	&__social-links {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Styles added for the Author Profile block are overriding custom font sizing on paragraph blocks in the editor and on the front-end.

When I originally noticed this I just assumed it was a block editor issue - I wish I had investigated sooner! 

@dkoo and @adekbadek - I'm adding you both as reviews specifically because it looks like [you co-authored the original PR](https://github.com/Automattic/newspack-blocks/pull/947) where this was added. I don't think I've broken anything, but the change to the editor styles -- specifically correcting the containing CSS class so they're getting picked up -- makes me a little nervous, I just want to make sure the other styles there are still working as expected!

See 1203536997639429-as-1203571822380539

### How to test the changes in this Pull Request:

1. Set up a page with few paragraph block with different sizing (both using the theme options and some manually entered values), and at least one Author Profile block. In the Author Profile, make sure the author's job title and employer is displayed.
2. Note that the paragraph blocks with custom font sizes are not previewing correctly.
3. Apply the PR and run `npm run build`.
4. Confirm that the paragraphs are now picking up the correct font sizes. 
5. Confirm that the author profile block is picking up the correct scaling - the Employer should be a bit smaller than the rest of the text, and the text should scale up and down on the front-end and in the editor when you change the Type Scale. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
