### PR TITLE
Fix/initialise stripe only if visible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
 				"html-entities": "^2.3.3",
 				"identity-obj-proxy": "^3.0.0",
 				"lint-staged": "^13.1.0",
-				"newspack-scripts": "^4.3.8",
+				"newspack-scripts": "^4.6.0",
 				"postcss-scss": "^4.0.6",
 				"prettier": "npm:wp-prettier@^2.6.2-beta-1",
 				"stylelint": "^14.9.1"
@@ -19638,9 +19638,9 @@
 			}
 		},
 		"node_modules/newspack-scripts": {
-			"version": "4.3.8",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.3.8.tgz",
-			"integrity": "sha512-3nK3HKSLUjjkC+wP83DGfc9DKf7uLSN5zYhn6138oL0KEmwn8roP+DUY+ePuywV9MocT8X8sBP7hxvMqInlDHA==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.6.0.tgz",
+			"integrity": "sha512-Ci5zOTYcJRfqLSBK9oAFLU55uMCUzzbynjuZpUmcdl1nlwyp8E1jBXXcbq+LwEoyqxUbED/B+F/a3YGQiPLeIg==",
 			"dev": true,
 			"dependencies": {
 				"@automattic/calypso-build": "^10.0.0",
@@ -44806,9 +44806,9 @@
 			}
 		},
 		"newspack-scripts": {
-			"version": "4.3.8",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.3.8.tgz",
-			"integrity": "sha512-3nK3HKSLUjjkC+wP83DGfc9DKf7uLSN5zYhn6138oL0KEmwn8roP+DUY+ePuywV9MocT8X8sBP7hxvMqInlDHA==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.6.0.tgz",
+			"integrity": "sha512-Ci5zOTYcJRfqLSBK9oAFLU55uMCUzzbynjuZpUmcdl1nlwyp8E1jBXXcbq+LwEoyqxUbED/B+F/a3YGQiPLeIg==",
 			"dev": true,
 			"requires": {
 				"@automattic/calypso-build": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"html-entities": "^2.3.3",
 		"identity-obj-proxy": "^3.0.0",
 		"lint-staged": "^13.1.0",
-		"newspack-scripts": "^4.3.8",
+		"newspack-scripts": "^4.6.0",
 		"postcss-scss": "^4.0.6",
 		"prettier": "npm:wp-prettier@^2.6.2-beta-1",
 		"stylelint": "^14.9.1"

--- a/src/blocks/donate/streamlined/index.ts
+++ b/src/blocks/donate/streamlined/index.ts
@@ -277,7 +277,13 @@ export const processStreamlinedElements = ( parentElement = document ) =>
 			el.classList.remove( 'stripe-payment--invisible' );
 		};
 
-		initStripe();
+		// Initialise Stripe once the element is visible.
+		const observer = new IntersectionObserver( entries => {
+			if ( entries[ 0 ].isIntersecting ) {
+				initStripe();
+			}
+		} );
+		observer.observe( el );
 
 		// Card form unravelling.
 		const submitButtonEl: HTMLButtonElement | null = el.querySelector( 'button[type="submit"]' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

With this change, Stripe's JS will be loaded only if the donation form is visible, instead of on page load. 

See 1203286553017186-as-1203447234567378

### How to test the changes in this Pull Request:

1. Configure Newspack with Stripe as the Reader Revenue platform
2. Create a page and insert a Donate block a few paragraphs below the fold (so it's not visible on page load)
3. Load the page, filter the netwock devtools tab by "stripe"
4. Observe nothing is loaded
5. Scroll to the Donate block, observe Stripe's JS is loaded only then

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->