### PR TITLE
fix: use release version number instead of filemtime for JS asset versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.60.1-hotfix.1](https://github.com/Automattic/newspack-blocks/compare/v1.60.0...v1.60.1-hotfix.1) (2023-01-12)
+
+
+### Bug Fixes
+
+* use release version number instead of filemtime for JS asset versions ([623b620](https://github.com/Automattic/newspack-blocks/commit/623b620ffa50c8bd7907188db7529b44cfdf9209))
+
 # [1.60.0](https://github.com/Automattic/newspack-blocks/compare/v1.59.1...v1.60.0) (2023-01-09)
 
 

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -7,7 +7,7 @@
  * Author URI:      https://newspack.blog/
  * Text Domain:     newspack-blocks
  * Domain Path:     /languages
- * Version:         1.60.0
+ * Version:         1.60.1-hotfix.1
  *
  * @package         Newspack_Blocks
  */
@@ -15,7 +15,7 @@
 define( 'NEWSPACK_BLOCKS__PLUGIN_FILE', __FILE__ );
 define( 'NEWSPACK_BLOCKS__BLOCKS_DIRECTORY', 'dist/' );
 define( 'NEWSPACK_BLOCKS__PLUGIN_DIR', plugin_dir_path( NEWSPACK_BLOCKS__PLUGIN_FILE ) );
-define( 'NEWSPACK_BLOCKS__VERSION', '1.60.0' );
+define( 'NEWSPACK_BLOCKS__VERSION', '1.60.1-hotfix.1' );
 
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'includes/class-newspack-blocks.php';
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'includes/class-newspack-blocks-api.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@automattic/newspack-blocks",
-	"version": "1.60.0",
+	"version": "1.60.1-hotfix.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@automattic/newspack-blocks",
-			"version": "1.60.0",
+			"version": "1.60.1-hotfix.1",
 			"hasInstallScript": true,
 			"license": "GPL-3.0-or-later",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/newspack-blocks",
-	"version": "1.60.0",
+	"version": "1.60.1-hotfix.1",
 	"author": "Automattic",
 	"devDependencies": {
 		"@rushstack/eslint-patch": "^1.2.0",

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer.php
@@ -52,7 +52,7 @@ class Newspack_Blocks_Donate_Renderer {
 			Newspack_Blocks::SCRIPT_HANDLES[ $handle_slug ],
 			$script_data['script_path'],
 			$dependencies,
-			$script_data['version'],
+			NEWSPACK_BLOCKS__VERSION,
 			true
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

v1.60.0 included some major changes to the Donate block's front-end JS as well as the Donate block's HTML markup. However, we've received reports from some end users that suggest they're still seeing an older cached version of the JS, which causes errors and breaks the streamlined Donate block since the JS no longer matches the HTML markup.

This change pegs the asset versions for front-end block JS to the plugin release number, which should ensure that the asset cache is busted every time a new release is deployed. We're already doing this for the front-end CSS, so the change is trivial and it seems to have fixed the issue on at least one site reporting the issues.

### How to test the changes in this Pull Request:

Publish a post with a streamlined donate block. In source code, verify that the `donateStreamlined.js` file is enqueued with a version number matching the currently active plugin version (e.g. `donateStreamlined.js?ver=1.60.1`).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
