### PR TITLE
fix: show HPP dates in correct timezone in editor

### DIFF
--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -301,6 +301,7 @@ class Newspack_Blocks_API {
 					'rendered' => post_password_required( $post ) ? '' : $content,
 				],
 				'date_gmt'       => mysql_to_rfc3339( $post_date_gmt ),
+				'date'           => mysql_to_rfc3339( $post->post_date ),
 				'excerpt'        => [
 					'rendered' => post_password_required( $post ) ? '' : $excerpt,
 				],

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -331,7 +331,7 @@ class Edit extends Component {
 														formatByline( post.newspack_author_info ) }
 													{ showDate && (
 														<time className="entry-date published" key="pub-date">
-															{ dateI18n( dateFormat, post.date_gmt ) }
+															{ dateI18n( dateFormat, post.date ) }
 														</time>
 													) }
 												</div>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -237,7 +237,7 @@ class Edit extends Component {
 
 						{ showDate && ! post.newspack_listings_hide_publish_date && (
 							<time className="entry-date published" key="pub-date">
-								{ dateI18n( dateFormat, post.date_gmt ) }
+								{ dateI18n( dateFormat, post.date ) }
 							</time>
 						) }
 					</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a minor edge case bug in the publish/modified dates shown in the Homepage Post block, only in the editor.

Closes 1200550061930446/1203550842074278.

### How to test the changes in this Pull Request:

1. In **Settings > General**, set your time zone to something other than UTC, and your date format to a custom format that contains a time, e.g. `F j, Y | g:i a`
2. Publish some posts and note the specific publish date and time.
3. Add a Homepage Posts block to a post and set it to display publish date. On `master`, observe that in the editor, the time shown is in UTC instead of the site's local time zone. Observe also that the time shown on the front-end is in the correct time zone.
4. Check out this branch and confirm that the time in the editor now matches the time shown on the front-end, in the correct local time zone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
