### PR TITLE
Homepage Post Block: allow HTML in custom excerpts

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -1044,22 +1044,36 @@ class Newspack_Blocks {
 		}
 
 		self::$newspack_blocks_excerpt_closure = function( $text = '', $post = null ) use ( $attributes ) {
-			$post        = get_post( $post );
-			$text        = $post->post_excerpt;
-			$raw_excerpt = $text;
-
-			if ( empty( $text ) ) {
-				$text = get_the_content( '', false, $post );
-				$text = strip_shortcodes( $text );
-				$text = excerpt_remove_blocks( $text );
+			// If we have a manually entered excerpt, use that and allow some tags.
+			if ( ! empty( $post->post_excerpt ) ) {
+				$excerpt = $post->post_excerpt;
+				$allowed_tags = '<em>,<i>,<strong>,<b>,<u>,<ul>,<ol>,<li>,<h1>,<h2>,<h3>,<h4>,<h5>,<h6>,<img>,<a>, <p>';
+			} else {
+				// If we don't, built an excerpt but allow no tags.
+				$excerpt = $post->post_content;
+				$allowed_tags = '';
 			}
 
-			/** This filter is documented in wp-includes/post-template.php */
-			$text = str_replace( ']]>', ']]&gt;', $text );
-			$text = wp_trim_words( $text, $attributes['excerptLength'], static::more_excerpt() );
+			// Recreate logic from wp_trim_excerpt (https://developer.wordpress.org/reference/functions/wp_trim_excerpt/).
+			$excerpt = strip_shortcodes( $excerpt );
+			$excerpt = excerpt_remove_blocks( $excerpt );
+			$excerpt = wpautop( $excerpt );
+			$excerpt = str_replace( ']]>', ']]&gt;', $excerpt );
 
-			/** This filter is documented in wp-includes/post-template.php */
-			return apply_filters( 'wp_trim_excerpt', $text, $raw_excerpt ); // phpcs:ignore
+			// Strip HTML tags except for the explicitly allowed tags.
+			$excerpt = strip_tags( $excerpt, $allowed_tags ); // phpcs:ignore WordPressVIPMinimum.Functions.StripTags.StripTagsTwoParameters
+
+			// Get excerpt length. If not provided a valid length, use the default excerpt length.
+			if ( empty( $attributes['excerptLength'] ) || ! is_int( $attributes['excerptLength'] ) ) {
+				$excerpt_length = 55;
+			} else {
+				$excerpt_length = $attributes['excerptLength'];
+			}
+
+			// Set excerpt length. (https://core.trac.wordpress.org/ticket/29533#comment:3)
+			$excerpt = force_balance_tags( html_entity_decode( wp_trim_words( htmlentities( $excerpt ), $attributes['excerptLength'], static::more_excerpt() ) ) );
+
+			return $excerpt;
 		};
 
 		add_filter( 'get_the_excerpt', self::$newspack_blocks_excerpt_closure, 11, 2 );

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -1064,7 +1064,7 @@ class Newspack_Blocks {
 			$excerpt = strip_tags( $excerpt, $allowed_tags ); // phpcs:ignore WordPressVIPMinimum.Functions.StripTags.StripTagsTwoParameters
 
 			// Get excerpt length. If not provided a valid length, use the default excerpt length.
-			if ( empty( $attributes['excerptLength'] ) || ! is_int( $attributes['excerptLength'] ) ) {
+			if ( empty( $attributes['excerptLength'] ) || ! is_numeric( $attributes['excerptLength'] ) ) {
 				$excerpt_length = 55;
 			} else {
 				$excerpt_length = $attributes['excerptLength'];
@@ -1075,7 +1075,6 @@ class Newspack_Blocks {
 
 			return $excerpt;
 		};
-
 		add_filter( 'get_the_excerpt', self::$newspack_blocks_excerpt_closure, 11, 2 );
 	}
 

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -1047,7 +1047,7 @@ class Newspack_Blocks {
 			// If we have a manually entered excerpt, use that and allow some tags.
 			if ( ! empty( $post->post_excerpt ) ) {
 				$excerpt = $post->post_excerpt;
-				$allowed_tags = '<em>,<i>,<strong>,<b>,<u>,<ul>,<ol>,<li>,<h1>,<h2>,<h3>,<h4>,<h5>,<h6>,<img>,<a>, <p>';
+				$allowed_tags = '<em>,<i>,<strong>,<b>,<u>,<ul>,<ol>,<li>,<h1>,<h2>,<h3>,<h4>,<h5>,<h6>,<img>,<a>,<p>';
 			} else {
 				// If we don't, built an excerpt but allow no tags.
 				$excerpt = $post->post_content;

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -1046,11 +1046,11 @@ class Newspack_Blocks {
 		self::$newspack_blocks_excerpt_closure = function( $text = '', $post = null ) use ( $attributes ) {
 			// If we have a manually entered excerpt, use that and allow some tags.
 			if ( ! empty( $post->post_excerpt ) ) {
-				$excerpt = $post->post_excerpt;
+				$excerpt      = $post->post_excerpt;
 				$allowed_tags = '<em>,<i>,<strong>,<b>,<u>,<ul>,<ol>,<li>,<h1>,<h2>,<h3>,<h4>,<h5>,<h6>,<img>,<a>,<p>';
 			} else {
 				// If we don't, built an excerpt but allow no tags.
-				$excerpt = $post->post_content;
+				$excerpt      = $post->post_content;
 				$allowed_tags = '';
 			}
 
@@ -1070,8 +1070,8 @@ class Newspack_Blocks {
 				$excerpt_length = $attributes['excerptLength'];
 			}
 
-			// Set excerpt length. (https://core.trac.wordpress.org/ticket/29533#comment:3)
-			$excerpt = force_balance_tags( html_entity_decode( wp_trim_words( htmlentities( $excerpt ), $attributes['excerptLength'], static::more_excerpt() ) ) );
+			// Set excerpt length (https://core.trac.wordpress.org/ticket/29533#comment:3).
+			$excerpt = force_balance_tags( html_entity_decode( wp_trim_words( htmlentities( $excerpt ), $excerpt_length, static::more_excerpt() ) ) );
 
 			return $excerpt;
 		};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the custom excerpt behaviour in the homepage posts block to allow a limited amount of HTML. 

This kind of replicates its original behaviour, which also allowed HTML, but balances that with a limit number of tags, and also making sure the excerpt still respects the excerpt length control. 

The custom excerpts should now allow these tags:

`<em>, <i>, <strong>, <b>, <u>, <ul>, <ol>, <li>, <h1>, <h2>, <h3>, <h4>, <h5>, <h6>, <img>, <a>, <p>`

Closes #888.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Set up a few different posts, so you have a mix of:
   * Auto-generated excerpts (no custom excerpts); for these posts add a bit of HTML to the start of the post (like `strong`, `em`, `a`). 
   * Custom excerpts of varying lengths; the custom excerpts should have a bit of HTML (`strong`, `em`, `a`), and make sure the tags span more than one word. 
3. Add a Homepage Posts block to a page and set it so it's showing your test posts. 
4. First confirm that your markup is included in the posts with custom excerpts, but not in the posts with auto-generated excerpts. The latter mimics the original block behaviour, and both are now following WordPress default behaviour (with auto-generated excerpts stripping all HTML and line breaks, and custom excerpts allowing a bit). 
5. In the editor, try adjusting the excerpt length up and down, and confirm it's respected in the editor and on the front-end.
6. Try adjusting the excerpt length to hit at least one excerpt in the middle of an HTML tag (like cutting off part of a link or strong text). Confirm that this doesn't break anything in the editor or on the front-end, and that the excerpt length count is respected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
