### PR TITLE
fix: attribute types for custom author fields

### DIFF
--- a/src/blocks/author-list/block.json
+++ b/src/blocks/author-list/block.json
@@ -28,7 +28,12 @@
 		},
 		"authorRoles": {
 			"type": "array",
-			"default": [ "Administrator", "Editor", "Author", "Contributor" ]
+			"default": [
+				"Administrator",
+				"Editor",
+				"Author",
+				"Contributor"
+			]
 		},
 		"authorType": {
 			"type": "string",

--- a/src/blocks/author-list/view.php
+++ b/src/blocks/author-list/view.php
@@ -18,7 +18,7 @@ function newspack_blocks_register_author_list() {
 		$author_custom_fields = \Newspack\Authors_Custom_Fields::get_custom_fields();
 		foreach ( $author_custom_fields as $field ) {
 			$block_json['attributes'][ 'show' . $field['name'] ] = [
-				'type'    => 'string',
+				'type'    => 'boolean',
 				'default' => true,
 			];
 		}

--- a/src/blocks/author-profile/view.php
+++ b/src/blocks/author-profile/view.php
@@ -18,7 +18,7 @@ function newspack_blocks_register_author_profile() {
 		$author_custom_fields = \Newspack\Authors_Custom_Fields::get_custom_fields();
 		foreach ( $author_custom_fields as $field ) {
 			$block_json['attributes'][ 'show' . $field['name'] ] = [
-				'type'    => 'string',
+				'type'    => 'boolean',
 				'default' => true,
 			];
 		}

--- a/src/blocks/shared/author.js
+++ b/src/blocks/shared/author.js
@@ -32,13 +32,13 @@ export const AuthorDisplaySettings = ( { attributes, setAttributes } ) => {
 		<>
 			<p>{ __( 'Display the following fields:', 'newspack-blocks' ) }</p>
 			{ fields.map( field => {
-				const attrbuteName = `show${ field.name }`;
+				const attributeName = `show${ field.name }`;
 				return (
 					<ToggleControl
 						key={ field.name }
 						label={ field.label }
-						checked={ Boolean( attributes[ attrbuteName ] ) }
-						onChange={ () => setAttributes( { [ attrbuteName ]: ! attributes[ attrbuteName ] } ) }
+						checked={ Boolean( attributes[ attributeName ] ) }
+						onChange={ () => setAttributes( { [ attributeName ]: ! attributes[ attributeName ] } ) }
 					/>
 				);
 			} ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a type issue that causes custom Author Profile and Author List fields to be displayed on the front-end even if those fields are disabled in the editor. The `string` type of the attribute forces the rendered value to always be truthy.

Closes 1203695565716937/1203810977425531.

### How to test the changes in this Pull Request:

1. Add an Author Profile and Author List block to a post. Add guest authors who have custom fields filled out (Job Title, Role, Employer, Phone Number)
2. Uncheck some of the fields and observe that they're hidden in the editor, but not on the front-end.
3. Check out this branch and confirm that only the checked fields are shown in both the editor and the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
