### PR TITLE
fix(modal-checkout): z-index when used w/ Campaigns

### DIFF
--- a/src/blocks/donate/styles/view.scss
+++ b/src/blocks/donate/styles/view.scss
@@ -42,7 +42,7 @@
 	width: 100%;
 	height: 100%;
 	background: rgba( 0, 0, 0, 0.5 );
-	z-index: 9999;
+	z-index: 99999;
 	&__content {
 		position: absolute;
 		top: 50%;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Because of z-index order, a Donate block inside a Campaign will be rendered behind it:

<img width="854" alt="image" src="https://user-images.githubusercontent.com/7383192/223680108-83fb98c2-c155-4fdb-b407-df2b70ff4bc8.png">

This PR fixes that. Note that the **alpha release should be updated with this change**, since it already went out.

### How to test the changes in this Pull Request:

1. On `master`, with Newspack set as the RR platform, place a Donate block in an overlay prompt
2. Click "Donate", observe the modal checkout renders behind the prompt
3. Switch to this branch, repeat, observe the checkout modal is rendered in front of the prompt

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->