### PR TITLE
fix: prevent enqueuing non-existent stylesheet

### DIFF
--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer.php
@@ -110,6 +110,7 @@ class Newspack_Blocks_Donate_Renderer {
 			}
 		}
 
+		$has_css = true;
 		switch ( $handle_slug ) {
 			case 'streamlined':
 				$filename = 'donateStreamlined';
@@ -125,6 +126,7 @@ class Newspack_Blocks_Donate_Renderer {
 				break;
 			case 'modal-checkout-block':
 				$filename = 'donateCheckoutBlock';
+				$has_css  = false;
 				break;
 			default:
 				$filename = false;
@@ -146,13 +148,15 @@ class Newspack_Blocks_Donate_Renderer {
 		);
 		wp_script_add_data( $handle, 'async', true );
 
-		$style_path = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $filename . ( is_rtl() ? '.rtl' : '' ) . '.css';
-		wp_enqueue_style(
-			$handle,
-			plugins_url( $style_path, NEWSPACK_BLOCKS__PLUGIN_FILE ),
-			[],
-			NEWSPACK_BLOCKS__VERSION
-		);
+		if ( $has_css ) {
+			$style_path = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $filename . ( is_rtl() ? '.rtl' : '' ) . '.css';
+			wp_enqueue_style(
+				$handle,
+				plugins_url( $style_path, NEWSPACK_BLOCKS__PLUGIN_FILE ),
+				[],
+				NEWSPACK_BLOCKS__VERSION
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Small tweak. 

### How to test the changes in this Pull Request:

1. On `master`, with Newspack set as the RR platform and RAS activated (in order to get the modal checkout experience), load a page with a Donate block
2. Inspect network requests, observe that there's a failed request for a `donateCheckoutBlock.css` file (there's no such file)
3. Switch to this branch, reload, observe no such failed request

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->