### PR TITLE
feat(donate): add body class for modal checkout

### DIFF
--- a/src/blocks/donate/checkout-modal/block.js
+++ b/src/blocks/donate/checkout-modal/block.js
@@ -27,6 +27,7 @@ function closeCheckout( element ) {
 	if ( iframe ) {
 		iframe.src = 'about:blank';
 	}
+	document.body.classList.remove( 'newspack-modal-checkout-open' );
 	iframeResizeObserver.disconnect();
 	element.style.display = 'none';
 }
@@ -57,6 +58,7 @@ domReady( () => {
 			form.addEventListener( 'submit', () => {
 				spinner.style.display = 'flex';
 				modalCheckout.style.display = 'block';
+				document.body.classList.add( 'newspack-modal-checkout-open' );
 				iframeResizeObserver = new ResizeObserver( entries => {
 					if ( ! entries || ! entries.length ) {
 						return;

--- a/src/blocks/donate/styles/view.scss
+++ b/src/blocks/donate/styles/view.scss
@@ -41,7 +41,7 @@
 	left: 0;
 	width: 100%;
 	height: 100%;
-	background: rgba( 0, 0, 0, 0.5 );
+	background: rgba( 0, 0, 0, 0.75 );
 	z-index: 99999;
 	&__content {
 		position: absolute;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a body class when the modal checkout is open. This allows for other overlays to hide and allow the checkout to be prioritized in the UI.

### How to test the changes in this Pull Request:

1. Checkout this branch and https://github.com/Automattic/newspack-popups/pull/1077
2. Make sure you have reader revenue platform set to Newspack
3. Create an overlay campaign prompt with a donate block
4. Visit a page that renders the prompt, click to donate and confirm the prompt is not visible when the checkout opens
5. Close the checkout and confirm the prompt is now visible again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
