### PR TITLE
Add filter when building WP_Query arguments

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -716,7 +716,7 @@ class Newspack_Blocks {
 		/**
 		 * Customize the WP_Query arguments to fetch post articles before the actual query is executed.
 		 *
-		 * The filter is called after the build_articles_query() function is called by a newspack block to 
+		 * The filter is called after the build_articles_query() function is called by a Newspack block to 
 		 * build the WP_Query arguments based on the given attributes and block requesting the query.
 		 *
 		 * @param array 	$args 		WP_Query arguments as created by build_articles_query()

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -719,8 +719,6 @@ class Newspack_Blocks {
 		 * The filter is called after the build_articles_query() function is called by a newspack block to 
 		 * build the WP_Query arguments based on the given attributes and block requesting the query.
 		 *
-		 * @since 1.66.0
-		 *
 		 * @param array 	$args 		WP_Query arguments as created by build_articles_query()
 		 * @param array 	$attributes The attributes initial passed to build_articles_query()
 		 * @param string 	$block_name The name of the requesting block to create the query args for

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -713,6 +713,18 @@ class Newspack_Blocks {
 			}
 		}
 
+		/**
+		 * Customize the WP_Query arguments to fetch post articles before the actual query is executed.
+		 *
+		 * The filter is called after the build_articles_query() function is called by a newspack block to 
+		 * build the WP_Query arguments based on the given attributes and block requesting the query.
+		 *
+		 * @since 1.66.0
+		 *
+		 * @param array 	$args 		WP_Query arguments as created by build_articles_query()
+		 * @param array 	$attributes The attributes initial passed to build_articles_query()
+		 * @param string 	$block_name The name of the requesting block to create the query args for
+		 */
 		return apply_filters( 'newspack_blocks_build_articles_query', $args, $attributes, $block_name ); 
 	}
 

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -713,7 +713,7 @@ class Newspack_Blocks {
 			}
 		}
 
-		return $args;
+		return apply_filters( 'newspack_blocks_build_articles_query', $args, $attributes, $block_name ); 
 	}
 
 	/**


### PR DESCRIPTION
Allow to customize the arguments for WP_Query created by build_articles_query using the new filter 'newspack_blocks_build_articles_query'.

### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Our websites make heavy use of the Homepage Articles block on the Homepage and related type of pages. This results in a significant amount of slow WP_Query calls by the Homepage Articles blocks in case of a cache invalidation caused by new post publications or content changes to these pages. The underlying reason for the slow queries is the default usage of SQL_CALC_FOUND_ROWS by Wordpress. As this seems not to be necessary for a Homepage Articles block, it would be usefull to set the argument 'no_found_rows' for WP_Query in such situations. 

But as such a change might break other existing code in the plugin or third party usage, the best way seems to add a filter to build_articles_query() to allow users to add such an argument in a filter when usefull.

I our case we were a able to reduce the time to generate the Homepage from 24 seconds down to 13 seconds by adding the filter and add the 'no_found_rows' argument in the custom filter. 

Closes # .

### How to test the changes in this Pull Request:

1. Add a filter such as
```
add_filter( 'newspack_blocks_build_articles_query', function( $args, $attributes, $block_name) {
	if ( 'newspack-blocks/homepage-articles' === $block_name ) {
		$args['no_found_rows'] = true;
	}
	return $args;
}, 10, 3 );
```
2. The resulting SQL should not contain the SQL_CALC_FOUND_ROWS keyword.
3. Execution time for the SQL statement should improve.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
