### PR TITLE
fix: bugs for Post Carousel

### DIFF
--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -99,6 +99,7 @@ class Edit extends Component {
 				if ( latestPosts && this.swiperInstance.realIndex < latestPosts.length ) {
 					initialSlide = this.swiperInstance.realIndex;
 				}
+				this.setState( { swiperInitialized: false } );
 				this.swiperInstance.destroy( true, true );
 			}
 
@@ -115,7 +116,6 @@ class Edit extends Component {
 
 		if ( latestPosts && latestPosts.length ) {
 			const { aspectRatio, autoplay, delay, slidesPerView } = this.props.attributes;
-
 			const swiperInstance = createSwiper(
 				{
 					block: this.carouselRef.current, // Editor uses the same wrapper for block and swiper container.
@@ -240,7 +240,7 @@ class Edit extends Component {
 							<div style={ { margin: 'auto' } }>{ __( 'Sorry, no posts were found.' ) }</div>
 						</Placeholder>
 					) }
-					{ ! latestPosts && (
+					{ ( ! this.state.swiperInitialized || ! latestPosts ) && (
 						<Placeholder icon={ <Spinner /> } className="component-placeholder__align-center" />
 					) }
 					{ latestPosts && (

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -15,26 +15,37 @@ if ( typeof window !== 'undefined' ) {
 			document.querySelectorAll( '.wp-block-newspack-blocks-carousel' )
 		);
 		blocksArray.forEach( block => {
-			const slidesPerView = parseInt( block.dataset.slidesPerView );
-			const slideCount = parseInt( block.dataset.slideCount );
-			createSwiper(
-				{
-					block,
-					container: block.querySelector( '.swiper' ),
-					prev: block.querySelector( '.swiper-button-prev' ),
-					next: block.querySelector( '.swiper-button-next' ),
-					pagination: block.querySelector( '.swiper-pagination-bullets' ),
-					pause: block.querySelector( '.swiper-button-pause' ),
-					play: block.querySelector( '.swiper-button-play' ),
+			// Initialize Swiper only when the carousel becomes visible.
+			const observer = new IntersectionObserver(
+				entries => {
+					entries.forEach( entry => {
+						if ( entry.isIntersecting ) {
+							const slidesPerView = parseInt( block.dataset.slidesPerView );
+							const slideCount = parseInt( block.dataset.slideCount );
+							createSwiper(
+								{
+									block,
+									container: block.querySelector( '.swiper' ),
+									prev: block.querySelector( '.swiper-button-prev' ),
+									next: block.querySelector( '.swiper-button-next' ),
+									pagination: block.querySelector( '.swiper-pagination-bullets' ),
+									pause: block.querySelector( '.swiper-button-pause' ),
+									play: block.querySelector( '.swiper-button-play' ),
+								},
+								{
+									aspectRatio: parseFloat( block.dataset.aspectRatio ),
+									autoplay: !! parseInt( block.dataset.autoplay ),
+									delay: parseInt( block.dataset.autoplay_delay ) * 1000,
+									slidesPerView: slidesPerView <= slideCount ? slidesPerView : slideCount,
+									spaceBetween: 16,
+								}
+							);
+						}
+					} );
 				},
-				{
-					aspectRatio: parseFloat( block.dataset.aspectRatio ),
-					autoplay: !! parseInt( block.dataset.autoplay ),
-					delay: parseInt( block.dataset.autoplay_delay ) * 1000,
-					slidesPerView: slidesPerView <= slideCount ? slidesPerView : slideCount,
-					spaceBetween: 16,
-				}
+				{ threshold: 0.25 }
 			);
+			observer.observe( block );
 		} );
 	} );
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an editor bug and a front-end bug.

Closes `1204166503564710/1204293714861357`.

### How to test the changes in this Pull Request:

Editor bug:

1. Add a Post Carousel to a post in the editor. Change the aspect ratio and/or slides per view options from the defaults.
2. Update the query params for the carousel block—e.g. add a category or tag. On `master`, observe that the block preview updates with the new posts, but the carousel itself becomes non-functional and doesn't show your aspect ratio or slides per view settings until you change another attribute. This is because the Swiper library operates outside of React and doesn't trigger a component re-render by itself.
3. Check out this branch, repeat, confirm that the carousel remains interactive after updating the post query. The fix ties the initialization of a Swiper instance to state data so that it triggers a re-render every time Swiper initializes a new instance.

Front-end bug:

1. Add a Post Carousel to a Campaigns prompt. Change the aspect ratio and/or slides per view options from the defaults. (Not required, but makes it easier to see when the carousel is initialized.)
2. View the prompt on the front-end on `master`. Observe that the carousel never becomes interactive and your aspect ratio/slides per view options are never reflected. This is because Swiper executes immediately on `domReady` but won't init elements that aren't visible in the DOM, and the prompts are hidden on `domReady` until the segmentation logic completes asynchronously.
3. Check out this branch and repeat step 2. This time confirm that the carousel initializes as soon as the prompt becomes visible. The fix ties the Swiper init method to an `IntersectionObserver` for each block instance so that the carousel isn't initialized until/unless it becomes at least 25% visible.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
