### PR TITLE
Add brand query support to the blocks

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -587,11 +587,13 @@ class Newspack_Blocks {
 		$authors             = isset( $attributes['authors'] ) ? $attributes['authors'] : array();
 		$categories          = isset( $attributes['categories'] ) ? $attributes['categories'] : array();
 		$tags                = isset( $attributes['tags'] ) ? $attributes['tags'] : array();
+		$brands              = isset( $attributes['brands'] ) ? $attributes['brands'] : array();
 		$tag_exclusions      = isset( $attributes['tagExclusions'] ) ? $attributes['tagExclusions'] : array();
 		$category_exclusions = isset( $attributes['categoryExclusions'] ) ? $attributes['categoryExclusions'] : array();
 		$specific_posts      = isset( $attributes['specificPosts'] ) ? $attributes['specificPosts'] : array();
 		$posts_to_show       = intval( $attributes['postsToShow'] );
 		$specific_mode       = isset( $attributes['specificMode'] ) ? intval( $attributes['specificMode'] ) : false;
+
 		$args                = array(
 			'post_type'           => $post_type,
 			'post_status'         => $included_post_statuses,
@@ -624,14 +626,30 @@ class Newspack_Blocks {
 			if ( $categories && count( $categories ) ) {
 				$args['category__in'] = $categories;
 			}
+
 			if ( $tags && count( $tags ) ) {
 				$args['tag__in'] = $tags;
 			}
+
 			if ( $tag_exclusions && count( $tag_exclusions ) ) {
 				$args['tag__not_in'] = $tag_exclusions;
 			}
+
 			if ( $category_exclusions && count( $category_exclusions ) ) {
 				$args['category__not_in'] = $category_exclusions;
+			}
+
+			if ( class_exists( 'Newspack_Multibranded_Site\Customizations\Theme_Colors' ) ) {
+				if ( $brands && count( $brands ) ) {
+					$args['tax_query'] = array(
+						array(
+							'taxonomy'         => 'brand',
+							'field'            => 'term_id',
+							'terms'            => $brands,
+							'include_children' => false
+						),
+					);
+				}
 			}
 
 			$is_co_authors_plus_active = class_exists( 'CoAuthors_Guest_Authors' );
@@ -786,6 +804,15 @@ class Newspack_Blocks {
 		if ( ! empty( $categories ) ) {
 			foreach ( $categories as $cat ) {
 				$classes[] = 'category-' . $cat->slug;
+			}
+		}
+
+		if ( class_exists( 'Newspack_Multibranded_Site\Customizations\Theme_Colors' ) ) {
+			$brands = get_the_terms( $post_id, 'brand' );
+			if ( ! empty( $brands ) ) {
+				foreach ( $brands as $brand ) {
+					$classes[] = 'brands-' . $brand->slug;
+				}
 			}
 		}
 

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -593,7 +593,6 @@ class Newspack_Blocks {
 		$specific_posts      = isset( $attributes['specificPosts'] ) ? $attributes['specificPosts'] : array();
 		$posts_to_show       = intval( $attributes['postsToShow'] );
 		$specific_mode       = isset( $attributes['specificMode'] ) ? intval( $attributes['specificMode'] ) : false;
-
 		$args                = array(
 			'post_type'           => $post_type,
 			'post_status'         => $included_post_statuses,
@@ -641,14 +640,14 @@ class Newspack_Blocks {
 
 			if ( class_exists( 'Newspack_Multibranded_Site\Customizations\Theme_Colors' ) ) {
 				if ( $brands && count( $brands ) ) {
-					$args['tax_query'] = array(
-						array(
+					$args['tax_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+						[
 							'taxonomy'         => 'brand',
 							'field'            => 'term_id',
 							'terms'            => $brands,
-							'include_children' => false
-						),
-					);
+							'include_children' => false,
+						],
+					];
 				}
 			}
 

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -242,6 +242,10 @@ class Newspack_Blocks {
 				$localized_data['author_custom_fields'] = \Newspack\Authors_Custom_Fields::get_custom_fields();
 			}
 
+			if ( class_exists( 'Newspack_Multibranded_Site\Customizations\Theme_Colors' ) ) {
+				$localized_data['multibranded_sites_enabled'] = true;
+			}
+
 			wp_localize_script(
 				'newspack-blocks-editor',
 				'newspack_blocks_data',
@@ -593,15 +597,6 @@ class Newspack_Blocks {
 		$specific_posts      = isset( $attributes['specificPosts'] ) ? $attributes['specificPosts'] : array();
 		$posts_to_show       = intval( $attributes['postsToShow'] );
 		$specific_mode       = isset( $attributes['specificMode'] ) ? intval( $attributes['specificMode'] ) : false;
-
-		/*
-		TODO: Work out how to abstract the supported custom taxonomies
-		$supported_custom_taxonomies = apply_filters( 'newspack_block_supported_custom_taxonomies', [] );
-		foreach ( $supported_custom_taxonomies as $custom_tax ) {
-			$custom_tax = isset( $attributes[$custom_tax] ) ? $attributes[$custom_tax] : array();
-		}
-		*/
-
 		$args                = array(
 			'post_type'           => $post_type,
 			'post_status'         => $included_post_statuses,

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -593,6 +593,15 @@ class Newspack_Blocks {
 		$specific_posts      = isset( $attributes['specificPosts'] ) ? $attributes['specificPosts'] : array();
 		$posts_to_show       = intval( $attributes['postsToShow'] );
 		$specific_mode       = isset( $attributes['specificMode'] ) ? intval( $attributes['specificMode'] ) : false;
+
+		/*
+		TODO: Work out how to abstract the supported custom taxonomies
+		$supported_custom_taxonomies = apply_filters( 'newspack_block_supported_custom_taxonomies', [] );
+		foreach ( $supported_custom_taxonomies as $custom_tax ) {
+			$custom_tax = isset( $attributes[$custom_tax] ) ? $attributes[$custom_tax] : array();
+		}
+		*/
+
 		$args                = array(
 			'post_type'           => $post_type,
 			'post_status'         => $included_post_statuses,
@@ -621,23 +630,18 @@ class Newspack_Blocks {
 					get_the_ID() ? [ get_the_ID() ] : []
 				);
 			}
-
 			if ( $categories && count( $categories ) ) {
 				$args['category__in'] = $categories;
 			}
-
 			if ( $tags && count( $tags ) ) {
 				$args['tag__in'] = $tags;
 			}
-
 			if ( $tag_exclusions && count( $tag_exclusions ) ) {
 				$args['tag__not_in'] = $tag_exclusions;
 			}
-
 			if ( $category_exclusions && count( $category_exclusions ) ) {
 				$args['category__not_in'] = $category_exclusions;
 			}
-
 			if ( class_exists( 'Newspack_Multibranded_Site\Customizations\Theme_Colors' ) ) {
 				if ( $brands && count( $brands ) ) {
 					$args['tax_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
@@ -650,7 +654,6 @@ class Newspack_Blocks {
 					];
 				}
 			}
-
 			$is_co_authors_plus_active = class_exists( 'CoAuthors_Guest_Authors' );
 
 			if ( $authors && count( $authors ) ) {

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -150,6 +150,7 @@ class Edit extends Component {
 			authors,
 			autoplay,
 			categories,
+			brands,
 			delay,
 			hideControls,
 			imageFit,
@@ -373,6 +374,8 @@ class Edit extends Component {
 								onCategoriesChange={ value => setAttributes( { categories: value } ) }
 								tags={ tags }
 								onTagsChange={ value => setAttributes( { tags: value } ) }
+								brands={ brands }
+								onBrandsChange={ value => setAttributes( { brands: value } ) }
 								specificMode={ specificMode }
 								onSpecificModeChange={ _specificMode =>
 									setAttributes( { specificMode: _specificMode } )

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -48,6 +48,16 @@ import { postsBlockSelector, postsBlockDispatch, shouldReflow } from '../homepag
 // Max number of slides that can be shown at once.
 const MAX_NUMBER_OF_SLIDES = 6;
 
+// Check if multi-branded site
+let IS_MULTIBRANDED_SITE;
+if (
+	typeof window === 'object' &&
+	window.newspack_blocks_data &&
+	window.newspack_blocks_data.multibranded_sites_enabled
+) {
+	IS_MULTIBRANDED_SITE = true;
+}
+
 class Edit extends Component {
 	constructor( props ) {
 		super( props );
@@ -233,6 +243,15 @@ class Edit extends Component {
 				),
 			},
 		];
+
+		let brandProps = '';
+		{ IS_MULTIBRANDED_SITE && (
+			brandProps = {
+				brands: brands,
+				onBrandsChange: value => setAttributes( { brands: value } )
+			}
+		) }
+
 		return (
 			<Fragment>
 				<div className={ classes } ref={ this.carouselRef }>
@@ -360,6 +379,7 @@ class Edit extends Component {
 						</Fragment>
 					) }
 				</div>
+
 				<InspectorControls>
 					<PanelBody title={ __( 'Display Settings' ) } initialOpen={ true }>
 						{ postsToShow && (
@@ -374,8 +394,7 @@ class Edit extends Component {
 								onCategoriesChange={ value => setAttributes( { categories: value } ) }
 								tags={ tags }
 								onTagsChange={ value => setAttributes( { tags: value } ) }
-								brands={ brands }
-								onBrandsChange={ value => setAttributes( { brands: value } ) }
+								{ ...brandProps }
 								specificMode={ specificMode }
 								onSpecificModeChange={ _specificMode =>
 									setAttributes( { specificMode: _specificMode } )

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -244,13 +244,12 @@ class Edit extends Component {
 			},
 		];
 
-		let brandProps = '';
-		{ IS_MULTIBRANDED_SITE && (
-			brandProps = {
-				brands: brands,
-				onBrandsChange: value => setAttributes( { brands: value } )
-			}
-		) }
+		const brandProps = IS_MULTIBRANDED_SITE
+			? {
+					brands,
+					onBrandsChange: value => setAttributes( { brands: value } ),
+			  }
+			: '';
 
 		return (
 			<Fragment>

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -67,6 +67,9 @@ export const settings = {
 		tags: {
 			type: 'array',
 		},
+		brands: {
+			type: 'array',
+		},
 		showDate: {
 			type: 'boolean',
 			default: true,

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -410,7 +410,7 @@ function newspack_blocks_register_carousel() {
 							'type' => 'integer',
 						),
 					),
-					'brands'          => array(
+					'brands'        => array(
 						'type'    => 'array',
 						'default' => array(),
 						'items'   => array(

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -410,6 +410,13 @@ function newspack_blocks_register_carousel() {
 							'type' => 'integer',
 						),
 					),
+					'brands'          => array(
+						'type'    => 'array',
+						'default' => array(),
+						'items'   => array(
+							'type' => 'integer',
+						),
+					),
 					'autoplay'      => array(
 						'type'    => 'boolean',
 						'default' => false,

--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -100,12 +100,12 @@
 			"default": [],
 			"items": { "type": "integer" }
 		},
-		"brands": {
+		"tags": {
 			"type": "array",
 			"default": [],
 			"items": { "type": "integer" }
 		},
-		"tags": {
+		"brands": {
 			"type": "array",
 			"default": [],
 			"items": { "type": "integer" }

--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -100,6 +100,11 @@
 			"default": [],
 			"items": { "type": "integer" }
 		},
+		"brands": {
+			"type": "array",
+			"default": [],
+			"items": { "type": "integer" }
+		},
 		"tags": {
 			"type": "array",
 			"default": [],

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -266,6 +266,7 @@ class Edit extends Component {
 			specificPosts,
 			postsToShow,
 			categories,
+			brands,
 			columns,
 			colGap,
 			postType,
@@ -358,6 +359,8 @@ class Edit extends Component {
 						onAuthorsChange={ handleAttributeChange( 'authors' ) }
 						categories={ categories }
 						onCategoriesChange={ handleAttributeChange( 'categories' ) }
+						brands={ brands }
+						onBrandsChange={ handleAttributeChange( 'brands' ) }
 						tags={ tags }
 						onTagsChange={ handleAttributeChange( 'tags' ) }
 						tagExclusions={ tagExclusions }

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -352,13 +352,12 @@ class Edit extends Component {
 
 		const handleAttributeChange = key => value => setAttributes( { [ key ]: value } );
 
-		let brandProps = '';
-		{ IS_MULTIBRANDED_SITE && (
-			brandProps = {
-				brands: brands,
-				onBrandsChange: handleAttributeChange( 'brands' )
-			}
-		) }
+		const brandProps = IS_MULTIBRANDED_SITE
+			? {
+					brands,
+					onBrandsChange: handleAttributeChange( 'brands' ),
+			  }
+			: '';
 
 		return (
 			<Fragment>
@@ -384,9 +383,6 @@ class Edit extends Component {
 						categoryExclusions={ categoryExclusions }
 						onCategoryExclusionsChange={ handleAttributeChange( 'categoryExclusions' ) }
 						postType={ postType }
-
-
-
 					/>
 					{ postLayout === 'grid' && (
 						<Fragment>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -72,6 +72,15 @@ if (
 	IS_SUBTITLE_SUPPORTED_IN_THEME = true;
 }
 
+let IS_MULTIBRANDED_SITE;
+if (
+	typeof window === 'object' &&
+	window.newspack_blocks_data &&
+	window.newspack_blocks_data.multibranded_sites_enabled
+) {
+	IS_MULTIBRANDED_SITE = true;
+}
+
 const landscapeIcon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 		<Path
@@ -343,6 +352,14 @@ class Edit extends Component {
 
 		const handleAttributeChange = key => value => setAttributes( { [ key ]: value } );
 
+		let brandProps = '';
+		{ IS_MULTIBRANDED_SITE && (
+			brandProps = {
+				brands: brands,
+				onBrandsChange: handleAttributeChange( 'brands' )
+			}
+		) }
+
 		return (
 			<Fragment>
 				<PanelBody title={ __( 'Display Settings', 'newspack-blocks' ) } initialOpen={ true }>
@@ -359,15 +376,17 @@ class Edit extends Component {
 						onAuthorsChange={ handleAttributeChange( 'authors' ) }
 						categories={ categories }
 						onCategoriesChange={ handleAttributeChange( 'categories' ) }
-						brands={ brands }
-						onBrandsChange={ handleAttributeChange( 'brands' ) }
 						tags={ tags }
 						onTagsChange={ handleAttributeChange( 'tags' ) }
+						{ ...brandProps }
 						tagExclusions={ tagExclusions }
 						onTagExclusionsChange={ handleAttributeChange( 'tagExclusions' ) }
 						categoryExclusions={ categoryExclusions }
 						onCategoryExclusionsChange={ handleAttributeChange( 'categoryExclusions' ) }
 						postType={ postType }
+
+
+
 					/>
 					{ postLayout === 'grid' && (
 						<Fragment>

--- a/src/blocks/homepage-articles/utils.ts
+++ b/src/blocks/homepage-articles/utils.ts
@@ -29,6 +29,7 @@ const POST_QUERY_ATTRIBUTES = [
 	'categories',
 	'excerptLength',
 	'tags',
+	'brands',
 	'showExcerpt',
 	'specificPosts',
 	'specificMode',
@@ -46,6 +47,7 @@ type HomepageArticlesAttributes = {
 	postType: PostType[];
 	showExcerpt: boolean;
 	tags: TagId[];
+	brands: BrandId[];
 	specificPosts: string[];
 	specificMode: boolean;
 	tagExclusions: TagId[];
@@ -89,6 +91,7 @@ export const queryCriteriaFromAttributes = ( attributes: Block[ 'attributes' ] )
 		postType,
 		showExcerpt,
 		tags,
+		brands,
 		specificPosts = [],
 		specificMode,
 		tagExclusions,
@@ -112,6 +115,7 @@ export const queryCriteriaFromAttributes = ( attributes: Block[ 'attributes' ] )
 					tags,
 					tagExclusions,
 					categoryExclusions,
+					brands,
 					postType,
 					includedPostStatuses,
 			  },

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -138,6 +138,37 @@ class QueryControls extends Component {
 		} );
 	};
 
+	fetchTagSuggestions = search => {
+		return apiFetch( {
+			path: addQueryArgs( '/wp/v2/tags', {
+				search,
+				per_page: 20,
+				_fields: 'id,name',
+				orderby: 'count',
+				order: 'desc',
+			} ),
+		} ).then( function ( tags ) {
+			return tags.map( tag => ( {
+				value: tag.id,
+				label: decodeEntities( tag.name ) || __( '(no title)', 'newspack-blocks' ),
+			} ) );
+		} );
+	};
+	fetchSavedTags = tagIDs => {
+		return apiFetch( {
+			path: addQueryArgs( '/wp/v2/tags', {
+				per_page: 100,
+				_fields: 'id,name',
+				include: tagIDs.join( ',' ),
+			} ),
+		} ).then( function ( tags ) {
+			return tags.map( tag => ( {
+				value: tag.id,
+				label: decodeEntities( tag.name ) || __( '(no title)', 'newspack-blocks' ),
+			} ) );
+		} );
+	};
+
 	fetchBrandSuggestions = search => {
 		return apiFetch( {
 			path: addQueryArgs( '/wp/v2/brand', {
@@ -183,37 +214,6 @@ class QueryControls extends Component {
 		} );
 	};
 
-	fetchTagSuggestions = search => {
-		return apiFetch( {
-			path: addQueryArgs( '/wp/v2/tags', {
-				search,
-				per_page: 20,
-				_fields: 'id,name',
-				orderby: 'count',
-				order: 'desc',
-			} ),
-		} ).then( function ( tags ) {
-			return tags.map( tag => ( {
-				value: tag.id,
-				label: decodeEntities( tag.name ) || __( '(no title)', 'newspack-blocks' ),
-			} ) );
-		} );
-	};
-	fetchSavedTags = tagIDs => {
-		return apiFetch( {
-			path: addQueryArgs( '/wp/v2/tags', {
-				per_page: 100,
-				_fields: 'id,name',
-				include: tagIDs.join( ',' ),
-			} ),
-		} ).then( function ( tags ) {
-			return tags.map( tag => ( {
-				value: tag.id,
-				label: decodeEntities( tag.name ) || __( '(no title)', 'newspack-blocks' ),
-			} ) );
-		} );
-	};
-
 	render = () => {
 		const {
 			specificMode,
@@ -224,10 +224,10 @@ class QueryControls extends Component {
 			onAuthorsChange,
 			categories,
 			onCategoriesChange,
-			brands,
-			onBrandsChange,
 			tags,
 			onTagsChange,
+			brands,
+			onBrandsChange,
 			tagExclusions,
 			onTagExclusionsChange,
 			categoryExclusions,
@@ -278,15 +278,6 @@ class QueryControls extends Component {
 								label={ __( 'Categories', 'newspack-blocks' ) }
 							/>
 						) }
-						{ onBrandsChange && (
-							<AutocompleteTokenField
-								tokens={ brands || [] }
-								onChange={ onBrandsChange }
-								fetchSuggestions={ this.fetchBrandSuggestions }
-								fetchSavedInfo={ this.fetchSavedBrands }
-								label={ __( 'Brands', 'newspack-blocks' ) }
-							/>
-						) }
 						{ onTagsChange && (
 							<AutocompleteTokenField
 								tokens={ tags || [] }
@@ -294,6 +285,15 @@ class QueryControls extends Component {
 								fetchSuggestions={ this.fetchTagSuggestions }
 								fetchSavedInfo={ this.fetchSavedTags }
 								label={ __( 'Tags', 'newspack-blocks' ) }
+							/>
+						) }
+						{ onBrandsChange && (
+							<AutocompleteTokenField
+								tokens={ brands || [] }
+								onChange={ onBrandsChange }
+								fetchSuggestions={ this.fetchBrandSuggestions }
+								fetchSavedInfo={ this.fetchSavedBrands }
+								label={ __( 'Brands', 'newspack-blocks' ) }
 							/>
 						) }
 						{ onTagExclusionsChange && (

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -28,6 +28,7 @@ declare global {
 	type PostId = number;
 	type CategoryId = number;
 	type TagId = number;
+	type BrandId = number;
 	type AuthorId = number;
 
 	type PostType = { name: string; slug: string; supports: { newspack_blocks: boolean } };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

[Edited to add all of this after @leogermani's review! Basically copied over some comments about this PR from Slack 🙂 ]

This PR adds the 'Brands' taxonomy as an option for querying to the Homepage Posts and Post Carousel blocks. 

See 1204179187018802-as-1204179187293071

This is a pretty literal set up, just adding the grabbing the Brands taxonomy. We do have an existing issue for allowing more [general custom taxonomy support](https://github.com/Automattic/newspack-blocks/issues/858); this could be a good opportunity to add that by abstracting these changes.  

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Confirm there are no issues/errors on the front-end or in the editor when you add a homepage posts block.
3. Install and activate the [Multi-Branded Site](https://github.com/automattic/newspack-multibranded-site) plugin
4. Set up some brands and apply them to stories
5. Add a homepage posts block to a page; confirm you now have a 'Brands' field in with the Category and Tags query options.
6. Use it to pick one of your brands.
7. Confirm that the block is showing the expect stories in the editor and on the front-end. 
8. Repeat the same steps for the Post Carousel block.
9. Deactivate the Multi-Branded Site plugin, and confirm there are no issues with the blocks in the editor and the front-end, that they no longer query the Brands or throw errors.
10. Confirm that the Brands code is loading when it should be - I did leave some const definitions in place even when the plugin isn't active; I wasn't sure if they should always be wrapped in a check for the plugin or if it was ok to leave them as is! 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
