### PR TITLE
fix(donate): tiers based layout support check

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -285,12 +285,12 @@ class Newspack_Blocks {
 	 * Can the tiers-based layout of the Donate block be rendered?
 	 */
 	public static function can_render_tiers_based_layout() {
-		if ( method_exists( '\Newspack\AMP_Enhancements', 'is_amp_plus_configured' ) ) {
+		if ( ! is_plugin_active( 'amp/amp.php' ) ) {
+			return true;
+		} elseif ( method_exists( '\Newspack\AMP_Enhancements', 'is_amp_plus_configured' ) ) {
 			return \Newspack\AMP_Enhancements::is_amp_plus_configured();
-		} else {
-			return ! is_plugin_active( 'amp/amp.php' );
 		}
-		return true;
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes the check for supporting tiers-based layout on the Donate Block. The current method will return false if AMP and AMP Plus are both off, it should be true if AMP is not installed.

### How to test the changes in this Pull Request:

1. While on the master branch make sure you don't have either AMP or AMP Plus
2. Add a Donate Block to a page and toggle on  the "Tiered" option in the "Suggested Donations" panel
3. Confirm that you are still unable to select the "Tiers" layout
4. Check out this branch, refresh, and confirm you are able to select the "Tiers" layout
5. Save and visit the page, confirm the block renders and behaves as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
