### PR TITLE
fix: modal checkout outside of ras

### DIFF
--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer.php
@@ -26,15 +26,13 @@ class Newspack_Blocks_Donate_Renderer {
 	 */
 	public function __construct() {
 		add_filter( 'woocommerce_checkout_fields', [ __CLASS__, 'woocommerce_checkout_fields' ] );
-		if ( defined( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION' ) && NEWSPACK_EXPERIMENTAL_READER_ACTIVATION ) {
-			add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_modal_checkout_scripts' ] );
-			add_action( 'wp_footer', [ __CLASS__, 'render_modal_checkout_markup' ] );
-			add_action( 'template_include', [ __CLASS__, 'get_modal_checkout_template' ] );
-			add_filter( 'wc_get_template', [ __CLASS__, 'wc_get_template' ], 10, 2 );
-			add_filter( 'show_admin_bar', [ __CLASS__, 'show_admin_bar' ] );
-			add_filter( 'woocommerce_checkout_get_value', [ __CLASS__, 'woocommerce_checkout_get_value' ], 10, 2 );
-			add_filter( 'woocommerce_get_return_url', [ __CLASS__, 'woocommerce_get_return_url' ], 10, 2 );
-		}
+		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_modal_checkout_scripts' ] );
+		add_action( 'wp_footer', [ __CLASS__, 'render_modal_checkout_markup' ] );
+		add_action( 'template_include', [ __CLASS__, 'get_modal_checkout_template' ] );
+		add_filter( 'wc_get_template', [ __CLASS__, 'wc_get_template' ], 10, 2 );
+		add_filter( 'show_admin_bar', [ __CLASS__, 'show_admin_bar' ] );
+		add_filter( 'woocommerce_checkout_get_value', [ __CLASS__, 'woocommerce_checkout_get_value' ], 10, 2 );
+		add_filter( 'woocommerce_get_return_url', [ __CLASS__, 'woocommerce_get_return_url' ], 10, 2 );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Remove the modal checkout feature for the Donate Block from behind the RAS flag. Allows every publisher to use the feature if their RR platform is Newspack (WooCommerce).

### How to test the changes in this Pull Request:

1. Check out this branch and confirm your instance doesn't have the RAS flag
2. Make sure your RR platform is Newspack
3. Render a Donate Block and confirm the modal checkout flow works as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
