### PR TITLE
Exclude non-dist files from the release archive

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,15 +1,23 @@
 # A set of files you probably don't want in your WordPress.org distribution
+__mocks__/
 .distignore
 .editorconfig
+.eslintrc.js
 .git
 .gitignore
 .gitlab-ci.yml
+.npmignore
+.npmrc
+.nvmrc
+.prettierrc
 .travis.yml
 .DS_Store
 Thumbs.db
+babel.config.js
 behat.yml
 bitbucket-pipelines.yml
 .circleci/config.yml
+commitlint.config.js
 composer.json
 composer.lock
 package-lock.json
@@ -21,6 +29,8 @@ multisite.xml.dist
 phpcs.xml
 .phpcs.xml.dist
 phpcs.xml.dist
+tsconfig.json
+webpack.config.js
 wp-cli.local.yml
 yarn.lock
 node_modules


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The following files/folders are currently included in the release archive, which is not ideal:

* `__mocks__/`
* .eslintrc.js
* .npmignore
* .npmrc
* .nvmrc
* .prettierrc
* babel.config.js
* commitlint.config.js
* package.json
* tsconfig.json
* webpack.config.js

This change adds them to `.distignore` so that they don't make it into the release archive.

### How to test the changes in this Pull Request:

1. Run `npm run release:archive`
2. Open the resulting newspack-blocks.zip archive
3. Confirm the files/folders listed above are not present

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
