### PR TITLE
feat(checkout-button): support product variations

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -40,8 +40,12 @@ final class Modal_Checkout {
 	public static function process_checkout_request() {
 		$is_newspack_checkout = filter_input( INPUT_GET, 'newspack_checkout', FILTER_SANITIZE_NUMBER_INT );
 		$product_id           = filter_input( INPUT_GET, 'product_id', FILTER_SANITIZE_NUMBER_INT );
+		$variation_id         = filter_input( INPUT_GET, 'variation_id', FILTER_SANITIZE_NUMBER_INT );
 		if ( ! $is_newspack_checkout || ! $product_id ) {
 			return;
+		}
+		if ( $variation_id ) {
+			$product_id = $variation_id;
 		}
 
 		\WC()->cart->empty_cart();

--- a/src/blocks/checkout-button/block.json
+++ b/src/blocks/checkout-button/block.json
@@ -11,6 +11,9 @@
 		"product": {
 			"type": "string"
 		},
+		"variation": {
+			"type": "string"
+		},
 		"price": {
 			"type": "string"
 		},

--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -124,6 +124,7 @@ function ProductControl( props ) {
 							{ selected.name }
 						</Button>
 					</BaseControl>
+					{ props.children }
 				</>
 			) : (
 				<>
@@ -163,9 +164,6 @@ function CheckoutButtonEdit( props ) {
 		setProductData( data );
 
 		// Handle product variation data.
-		if ( product !== data.id.toString() ) {
-			setAttributes( { variation: '' } );
-		}
 		if ( data?.variations?.length ) {
 			apiFetch( { path: `/wc/v2/products/${ data.id }/variations` } )
 				.then( res => setVariations( res ) )
@@ -245,31 +243,32 @@ function CheckoutButtonEdit( props ) {
 					<ProductControl
 						value={ product }
 						price={ price }
-						onChange={ value => setAttributes( { product: value } ) }
+						onChange={ value => setAttributes( { product: value, variation: '' } ) }
 						onProduct={ handleProduct }
-					/>
-				</PanelBody>
-				{ productData?.variations?.length > 0 && (
-					<PanelBody title={ __( 'Product variations', 'newspack-blocks' ) }>
-						{ variations.length ? (
-							<SelectControl
-								label={ __( 'Variation', 'newspack-blocks' ) }
-								help={ __(
-									'Select a product variation to be added to the cart.',
-									'newspack-blocks'
+					>
+						{ productData?.variations?.length > 0 && (
+							<>
+								{ variations.length ? (
+									<SelectControl
+										label={ __( 'Variation', 'newspack-blocks' ) }
+										help={ __(
+											'Select the product variation to be added to cart.',
+											'newspack-blocks'
+										) }
+										value={ variation }
+										options={ variations.map( item => ( {
+											label: getVariationName( item ),
+											value: item.id,
+										} ) ) }
+										onChange={ value => setAttributes( { variation: value } ) }
+									/>
+								) : (
+									<Spinner />
 								) }
-								value={ variation }
-								options={ variations.map( item => ( {
-									label: getVariationName( item ),
-									value: item.id,
-								} ) ) }
-								onChange={ value => setAttributes( { variation: value } ) }
-							/>
-						) : (
-							<Spinner />
+							</>
 						) }
-					</PanelBody>
-				) }
+					</ProductControl>
+				</PanelBody>
 				{ nyp?.isNYP && (
 					<PanelBody title={ __( 'Name Your Price', 'newspack-blocks' ) }>
 						<p>

--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -166,7 +166,10 @@ function CheckoutButtonEdit( props ) {
 		// Handle product variation data.
 		if ( data?.variations?.length ) {
 			apiFetch( { path: `/wc/v2/products/${ data.id }/variations` } )
-				.then( res => setVariations( res ) )
+				.then( res => {
+					setAttributes( { variation: res[ 0 ].id } );
+					setVariations( res );
+				} )
 				.catch( () => setVariations( [] ) );
 		} else {
 			setVariations( [] );

--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -167,7 +167,9 @@ function CheckoutButtonEdit( props ) {
 		if ( data?.variations?.length ) {
 			apiFetch( { path: `/wc/v2/products/${ data.id }/variations` } )
 				.then( res => {
-					setAttributes( { variation: res[ 0 ].id } );
+					if ( ! variation && res.length ) {
+						setAttributes( { variation: res[ 0 ].id.toString() } );
+					}
 					setVariations( res );
 				} )
 				.catch( () => setVariations( [] ) );
@@ -246,7 +248,7 @@ function CheckoutButtonEdit( props ) {
 					<ProductControl
 						value={ product }
 						price={ price }
-						onChange={ value => setAttributes( { product: value, variation: '' } ) }
+						onChange={ value => setAttributes( { product: value, variation: '', price: '' } ) }
 						onProduct={ handleProduct }
 					>
 						{ productData?.variations?.length > 0 && (
@@ -263,7 +265,7 @@ function CheckoutButtonEdit( props ) {
 											label: getVariationName( item ),
 											value: item.id,
 										} ) ) }
-										onChange={ value => setAttributes( { variation: value } ) }
+										onChange={ value => setAttributes( { variation: value, price: '' } ) }
 									/>
 								) : (
 									<Spinner />

--- a/src/blocks/checkout-button/save.js
+++ b/src/blocks/checkout-button/save.js
@@ -16,7 +16,7 @@ import {
 } from '@wordpress/block-editor';
 
 export default function save( { attributes, className } ) {
-	const { textAlign, fontSize, style, text, product, price } = attributes;
+	const { textAlign, fontSize, style, text, product, price, variation } = attributes;
 
 	if ( ! text || ! product ) {
 		return null;
@@ -58,6 +58,7 @@ export default function save( { attributes, className } ) {
 				<input type="hidden" name="product_id" value={ product } />
 				<input type="hidden" name="newspack_checkout" value="1" />
 				{ price && <input type="hidden" name="price" value={ price } /> }
+				{ variation && <input type="hidden" name="variation_id" value={ variation } /> }
 			</form>
 		</div>
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements support to select a product variation in the Checkout Button.

<img width="1102" alt="image" src="https://user-images.githubusercontent.com/820752/236842878-f367bc70-7533-4c1b-9a6f-f14e268718b0.png">

### How to test the changes in this Pull Request:

1. Create a WC subscription product with 2 variations, with one variation having "Name Your Price", and a product without variations (if you don't have any)
2. Draft a page and add the Checkout Button block
3. Select the product with variations
4. Confirm you see the variation selection
5. Change the variation to the one with NYP, configure the price, and save
6. Visit the frontend, click on the button, and confirm the cart contains the product with the correct price
7. Edit the page and change the variation to the one without NYP
8. Save and repeat step 6
9. Edit the page, change the product to the one without variations
10. Save and repeat step 6

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
