### PR TITLE
fix: bump up font size on smallest blocks

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -737,7 +737,7 @@ amp-script .wpnbha {
 	&.ts-2 article {
 		@include mixins.media( tablet ) {
 			.entry-title {
-				font-size: 0.85em;
+				font-size: 0.9em;
 			}
 
 			.avatar {

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -691,15 +691,17 @@ amp-script .wpnbha {
 		}
 		.newspack-post-subtitle,
 		.entry-wrapper p,
-		.entry-wrapper .more-link {
-			font-size: 0.8em;
-		}
+		.entry-wrapper .more-link,
 		.entry-meta {
-			font-size: 0.7em;
+			font-size: 0.8em;
 		}
 		@include mixins.media( tablet ) {
 			.entry-title {
 				font-size: 1.2em;
+			}
+
+			.entry-meta {
+				font-size: 0.7em;
 			}
 
 			.avatar {
@@ -709,22 +711,33 @@ amp-script .wpnbha {
 		}
 	}
 
-	&.ts-2 article {
+	&.ts-2 article,
+	&.ts-1 article {
 		.entry-title {
-			font-size: 0.8em;
+			font-size: 0.9em;
 		}
-		.newspack-post-subtitle {
-			font-size: 0.7em;
-		}
+		.newspack-post-subtitle,
 		.entry-wrapper p,
 		.entry-wrapper .more-link,
 		.entry-meta {
-			font-size: 0.7em;
+			font-size: 0.8em;
 		}
 
 		@include mixins.media( tablet ) {
+			.newspack-post-subtitle,
+			.entry-wrapper p,
+			.entry-wrapper .more-link,
+			.entry-meta,
+			.newspack-post-subtitle {
+				font-size: 0.7em;
+			}
+		}
+	}
+
+	&.ts-2 article {
+		@include mixins.media( tablet ) {
 			.entry-title {
-				font-size: 0.9em;
+				font-size: 0.85em;
 			}
 
 			.avatar {
@@ -735,18 +748,11 @@ amp-script .wpnbha {
 	}
 
 	&.ts-1 article {
-		.entry-title,
-		.entry-wrapper p,
-		.entry-wrapper .more-link {
-			font-size: 0.7em;
-		}
-		.newspack-post-subtitle {
-			font-size: 0.7em;
-		}
-		.entry-meta {
-			font-size: 0.6em;
-		}
 		@include mixins.media( tablet ) {
+			.entry-title {
+				font-size: 0.7em;
+			}
+
 			.avatar {
 				height: 24px;
 				width: 24px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The smaller homepage post blocks sizes (1 and 2) get really small on mobile; this PR bumps them up a bit, makes the sizing a wee more standard on desktop (by also tweaking them a bit).


The specific size changes are bolded below:

### TS 3

| DESKTOP     | Before | After | MOBILE     | Before | After |
| ----------- | ------  | ----- | ----------- | ------  | ----- |
|  **Category**   | 12px | 12px  | **Category**   | 10.8px | 10.8px  |
| **Title** | 24px |  24px  | **Title** | 18px |  18px  |
| **Subtitle** | 16px | 16px | **Subtitle** | 14.4px | 14.4px |
| **Paragraph** | 16px | 16px | **Paragraph** | 14.4px | 14.4px |
| **More Link** | 16px | 16px | **More Link** | 14.4px | 14.4px |
| **Post Meta** | 14px | 14px | **Post Meta** | 12.6px | **14.4px** 

### TS 2

| DESKTOP     | Before | After | MOBILE     | Before | After |
| ----------- | ------  | ----- | ----------- | ------  | ----- |
|  **Category**   | 12px | 12px  | **Category**   | 10.8px | 10.8px  |
| **Title** | 18px |  18px  | **Title** | 14.4px |  **16.2px**  |
| **Subtitle** | 14px | 14px | **Subtitle** | 12.6px | **14.4px** |
| **Paragraph** | 14px | 14px | **Paragraph** | 12.6px | **14.4px** |
| **More Link** | 14px | 14px | **More Link** | 12.6px | **14.4px** |
| **Post Meta** | 14px | 14px | **Post Meta** | 12.6px | **14.4px** |


### TS 1

| DESKTOP     | Before | After | MOBILE     | Before | After |
| ----------- | ------  | ----- | ----------- | ------  | ----- |
|  **Category**   | 12px | 12px  | **Category**   | 10.8px | 10.8px  |
| **Title** | 14px |  14px  | **Title** | 12.6px |  **16.2px**  |
| **Subtitle** | 14px | 14px | **Subtitle** | 12.6px | **14.4px** |
| **Paragraph** | 14px | 14px | **Paragraph** | 12.6px | **14.4px** |
| **More Link** | 14px | 14px | **More Link** | 12.6px | **14.4px** |
| **Post Meta** | 12px | **14px** | **Post Meta** | 10.8px | **14.4px** |


### How to test the changes in this Pull Request:

1. Set up a post with three homepage post blocks, with three different type scales: 1, 2 and 3.
2. Review how they look on mobile and desktop.
3. Apply the PR and run `npm run build`.
4. Review how they look on mobile and desktop; confirm they still have a mobile hierarchy, and that the calculated font sizes listed in the after column above.

Mobile styles before: 

![image](https://user-images.githubusercontent.com/177561/236575133-cdc171ec-d60c-4ade-afc5-cba23f6e7206.png)

Mobile styles after:

![image](https://user-images.githubusercontent.com/177561/236575080-b928ac3e-4308-4d0f-b0c1-000aa505a8fd.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
