### PR TITLE
feat: adding link to the author bio avatar

### DIFF
--- a/src/templates/author-profile-card.php
+++ b/src/templates/author-profile-card.php
@@ -53,25 +53,33 @@ call_user_func(
 			<?php if ( $attributes['showAvatar'] && isset( $author['avatar'] ) ) : ?>
 				<div class="wp-block-newspack-blocks-author-profile__avatar">
 					<figure style="border-radius: <?php echo esc_attr( $attributes['avatarBorderRadius'] ); ?>; height: <?php echo esc_attr( $attributes['avatarSize'] ); ?>px; width: <?php echo esc_attr( $attributes['avatarSize'] ); ?>px;">
+					<?php if ( $show_archive_link ) : ?>
+						<a href="<?php echo esc_url( $author['url'] ); ?>">
 						<?php
-						echo wp_kses(
-							$author['avatar'],
-							[
-								'img' => [
-									'alt'      => true,
-									'class'    => true,
-									'data-*'   => true,
-									'decoding' => true,
-									'height'   => true,
-									'loading'  => true,
-									'sizes'    => true,
-									'src'      => true,
-									'srcset'   => true,
-									'width'    => true,
-								],
-							]
-						);
-						?>
+					endif;
+
+					echo wp_kses(
+						$author['avatar'],
+						[
+							'img' => [
+								'alt'      => true,
+								'class'    => true,
+								'data-*'   => true,
+								'decoding' => true,
+								'height'   => true,
+								'loading'  => true,
+								'sizes'    => true,
+								'src'      => true,
+								'srcset'   => true,
+								'width'    => true,
+							],
+						]
+					);
+
+				if ( $show_archive_link ) :
+					?>
+						</a>
+					<?php endif; ?>
 					</figure>
 				</div>
 			<?php endif; ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a link to the author avatar in the Author Profile and Author List blocks, to line up with the links that are added to the theme in https://github.com/Automattic/newspack-theme/pull/2114. 

In the blocks, these links should be disable-able by turning off the "Link to author archive", just like the link in the author name and at the end of the bio.

See 1200550061930446-as-1204508674733864

### How to test the changes in this Pull Request:

1. Apply this PR.
2. Add a couple Author Bio blocks (one with a regular author and one with a guest author), and an Author List block (that's showing at least one regular and one guest author).
3. View the blocks on the front-end, and confirm that the avatars are linked to each author's archive. 
4. Turn off the "Link to author archive" toggle for all blocks, and confirm there are no adverse effects. 
5. Disable the Co-Authors Plus plugin.
6. Revisit the blocks and confirm that things work as expected, with and without the "Link to author archive" toggle turned on.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
