### PR TITLE
Add custom taxonomies support 

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -209,16 +209,22 @@ class Newspack_Blocks {
 	 */
 	public static function get_custom_taxonomies() {
 		$custom_taxonomies = array_map(
-			function( $tax_slug ) {
-				$tax = get_taxonomy( $tax_slug );
-				if ( ! empty( array_intersect( [ 'post', 'page' ], $tax->object_type ) ) && ! $tax->_builtin && $tax->show_in_rest ) {
+			function( $tax ) {
+				if ( ! empty( array_intersect( [ 'post', 'page' ], $tax->object_type ) ) ) {
 					return [
-						'slug'  => $tax_slug,
+						'slug'  => $tax->name,
 						'label' => $tax->label,
 					];
 				};
 			},
-			get_taxonomies( [ 'public' => true ] )
+			get_taxonomies(
+				[
+					'public'       => true,
+					'_builtin'     => false,
+					'show_in_rest' => true,
+				],
+				'objects'
+			)
 		);
 		$custom_taxonomies = array_values(
 			array_filter(
@@ -234,7 +240,7 @@ class Newspack_Blocks {
 		 *
 		 * By default, on the top of category and tags, will display any public taxonomy applied to post or pages
 		 *
-		 * @param $custom_taxonomies array Array of custom taxonomies where each taxonomy is an array with slug and label keys.
+		 * @param array $custom_taxonomies Array of custom taxonomies where each taxonomy is an array with slug and label keys.
 		 */
 		return apply_filters( 'newspack_blocks_home_page_block_custom_taxonomies', $custom_taxonomies );
 	}

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -48,16 +48,6 @@ import { postsBlockSelector, postsBlockDispatch, shouldReflow } from '../homepag
 // Max number of slides that can be shown at once.
 const MAX_NUMBER_OF_SLIDES = 6;
 
-// Check if multi-branded site
-let IS_MULTIBRANDED_SITE;
-if (
-	typeof window === 'object' &&
-	window.newspack_blocks_data &&
-	window.newspack_blocks_data.multibranded_sites_enabled
-) {
-	IS_MULTIBRANDED_SITE = true;
-}
-
 class Edit extends Component {
 	constructor( props ) {
 		super( props );
@@ -160,7 +150,7 @@ class Edit extends Component {
 			authors,
 			autoplay,
 			categories,
-			brands,
+			customTaxonomies,
 			delay,
 			hideControls,
 			imageFit,
@@ -243,13 +233,6 @@ class Edit extends Component {
 				),
 			},
 		];
-
-		const brandProps = IS_MULTIBRANDED_SITE
-			? {
-					brands,
-					onBrandsChange: value => setAttributes( { brands: value } ),
-			  }
-			: '';
 
 		return (
 			<Fragment>
@@ -393,7 +376,8 @@ class Edit extends Component {
 								onCategoriesChange={ value => setAttributes( { categories: value } ) }
 								tags={ tags }
 								onTagsChange={ value => setAttributes( { tags: value } ) }
-								{ ...brandProps }
+								onCustomTaxonomiesChange={ value => setAttributes( { customTaxonomies: value } ) }
+								customTaxonomies={ customTaxonomies }
 								specificMode={ specificMode }
 								onSpecificModeChange={ _specificMode =>
 									setAttributes( { specificMode: _specificMode } )

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -67,7 +67,7 @@ export const settings = {
 		tags: {
 			type: 'array',
 		},
-		brands: {
+		customTaxonomies: {
 			type: 'array',
 		},
 		showDate: {

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -382,82 +382,93 @@ function newspack_blocks_register_carousel() {
 			'newspack_blocks_block_args',
 			array(
 				'attributes'      => array(
-					'className'     => array(
+					'className'        => array(
 						'type' => 'string',
 					),
-					'postsToShow'   => array(
+					'postsToShow'      => array(
 						'type'    => 'integer',
 						'default' => 3,
 					),
-					'authors'       => array(
+					'authors'          => array(
 						'type'    => 'array',
 						'default' => array(),
 						'items'   => array(
 							'type' => 'integer',
 						),
 					),
-					'categories'    => array(
+					'categories'       => array(
 						'type'    => 'array',
 						'default' => array(),
 						'items'   => array(
 							'type' => 'integer',
 						),
 					),
-					'tags'          => array(
+					'tags'             => array(
 						'type'    => 'array',
 						'default' => array(),
 						'items'   => array(
 							'type' => 'integer',
 						),
 					),
-					'brands'        => array(
+					'customTaxonomies' => array(
 						'type'    => 'array',
 						'default' => array(),
 						'items'   => array(
-							'type' => 'integer',
+							'type'       => 'object',
+							'properties' => array(
+								'slug'  => array(
+									'type' => 'string',
+								),
+								'terms' => array(
+									'type'  => 'array',
+									'items' => array(
+										'type' => 'integer',
+									),
+								),
+							),
 						),
 					),
-					'autoplay'      => array(
+					'autoplay'         => array(
 						'type'    => 'boolean',
 						'default' => false,
 					),
-					'delay'         => array(
+					'delay'            => array(
 						'type'    => 'integer',
 						'default' => 5,
 					),
-					'showAuthor'    => array(
+					'showAuthor'       => array(
 						'type'    => 'boolean',
 						'default' => true,
 					),
-					'showAvatar'    => array(
+					'showAvatar'       => array(
 						'type'    => 'boolean',
 						'default' => true,
 					),
-					'showCategory'  => array(
+					'showCategory'     => array(
 						'type'    => 'boolean',
 						'default' => false,
 					),
-					'showDate'      => array(
+					'showDate'         => array(
 						'type'    => 'boolean',
 						'default' => true,
 					),
-					'imageFit'      => array(
+					'imageFit'         => array(
 						'type'    => 'string',
 						'default' => 'cover',
 					),
-					'showTitle'     => array(
+					'showTitle'        => array(
 						'type'    => 'boolean',
 						'default' => true,
 					),
-					'slidesPerView' => array(
+					'slidesPerView'    => array(
 						'type'    => 'number',
 						'default' => 1,
 					),
-					'hideControls'  => array(
+					'hideControls'     => array(
 						'type'    => 'boolean',
 						'default' => false,
 					),
-					'aspectRatio'   => array(
+					'aspectRatio'      => array(
 						'type'    => 'number',
 						'default' => 0.75,
 					),

--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -105,10 +105,23 @@
 			"default": [],
 			"items": { "type": "integer" }
 		},
-		"brands": {
+		"customTaxonomies": {
 			"type": "array",
 			"default": [],
-			"items": { "type": "integer" }
+			"items": {
+				"type": "object",
+				"properties": {
+					"slug": {
+						"type": "string"
+					},
+					"terms": {
+						"type": "array",
+						"items": {
+							"type": "integer"
+						}
+					}
+				}
+			}
 		},
 		"tagExclusions": {
 			"type": "array",

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -72,15 +72,6 @@ if (
 	IS_SUBTITLE_SUPPORTED_IN_THEME = true;
 }
 
-let IS_MULTIBRANDED_SITE;
-if (
-	typeof window === 'object' &&
-	window.newspack_blocks_data &&
-	window.newspack_blocks_data.multibranded_sites_enabled
-) {
-	IS_MULTIBRANDED_SITE = true;
-}
-
 const landscapeIcon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 		<Path
@@ -370,9 +361,7 @@ class Edit extends Component {
 						onCategoriesChange={ handleAttributeChange( 'categories' ) }
 						tags={ tags }
 						onTagsChange={ handleAttributeChange( 'tags' ) }
-						onCustomTaxonomiesChange={ value => {
-							setAttributes( { customTaxonomies: value } );
-						} }
+						onCustomTaxonomiesChange={ handleAttributeChange( 'customTaxonomies' ) }
 						customTaxonomies={ customTaxonomies }
 						tagExclusions={ tagExclusions }
 						onTagExclusionsChange={ handleAttributeChange( 'tagExclusions' ) }

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -275,7 +275,7 @@ class Edit extends Component {
 			specificPosts,
 			postsToShow,
 			categories,
-			brands,
+			customTaxonomies,
 			columns,
 			colGap,
 			postType,
@@ -352,13 +352,6 @@ class Edit extends Component {
 
 		const handleAttributeChange = key => value => setAttributes( { [ key ]: value } );
 
-		const brandProps = IS_MULTIBRANDED_SITE
-			? {
-					brands,
-					onBrandsChange: handleAttributeChange( 'brands' ),
-			  }
-			: '';
-
 		return (
 			<Fragment>
 				<PanelBody title={ __( 'Display Settings', 'newspack-blocks' ) } initialOpen={ true }>
@@ -377,7 +370,10 @@ class Edit extends Component {
 						onCategoriesChange={ handleAttributeChange( 'categories' ) }
 						tags={ tags }
 						onTagsChange={ handleAttributeChange( 'tags' ) }
-						{ ...brandProps }
+						onCustomTaxonomiesChange={ value => {
+							setAttributes( { customTaxonomies: value } );
+						} }
+						customTaxonomies={ customTaxonomies }
 						tagExclusions={ tagExclusions }
 						onTagExclusionsChange={ handleAttributeChange( 'tagExclusions' ) }
 						categoryExclusions={ categoryExclusions }

--- a/src/blocks/homepage-articles/utils.ts
+++ b/src/blocks/homepage-articles/utils.ts
@@ -29,7 +29,7 @@ const POST_QUERY_ATTRIBUTES = [
 	'categories',
 	'excerptLength',
 	'tags',
-	'brands',
+	'customTaxonomies',
 	'showExcerpt',
 	'specificPosts',
 	'specificMode',
@@ -47,7 +47,7 @@ type HomepageArticlesAttributes = {
 	postType: PostType[];
 	showExcerpt: boolean;
 	tags: TagId[];
-	brands: BrandId[];
+	customTaxonomies: Taxonomy[];
 	specificPosts: string[];
 	specificMode: boolean;
 	tagExclusions: TagId[];
@@ -91,7 +91,7 @@ export const queryCriteriaFromAttributes = ( attributes: Block[ 'attributes' ] )
 		postType,
 		showExcerpt,
 		tags,
-		brands,
+		customTaxonomies,
 		specificPosts = [],
 		specificMode,
 		tagExclusions,
@@ -115,7 +115,7 @@ export const queryCriteriaFromAttributes = ( attributes: Block[ 'attributes' ] )
 					tags,
 					tagExclusions,
 					categoryExclusions,
-					brands,
+					customTaxonomies,
 					postType,
 					includedPostStatuses,
 			  },

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -139,6 +139,20 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	if ( '' !== $attributes['customTextColor'] ) {
 		$styles = 'color: ' . $attributes['customTextColor'] . ';';
 	}
+
+	// Handle custom taxonomies.
+	if ( isset( $attributes['customTaxonomies'] ) ) {
+		$custom_taxes = $attributes['customTaxonomies'];
+		unset( $attributes['customTaxonomies'] );
+		if ( is_array( $custom_taxes ) && ! empty( $custom_taxes ) ) {
+			foreach ( $custom_taxes as $tax ) {
+				if ( ! empty( $tax['slug'] ) && ! empty( $tax['terms'] ) ) {
+					$attributes[ $tax['slug'] ] = $tax['terms'];
+				}
+			}
+		}
+	}
+
 	$articles_rest_url = add_query_arg(
 		array_merge(
 			array_map(

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -16,8 +16,7 @@ import AutocompleteTokenField from './autocomplete-tokenfield';
 const getCategoryTitle = category =>
 	decodeEntities( category.name ) || __( '(no title)', 'newspack-blocks' );
 
-const getBrandTitle = brand =>
-	decodeEntities( brand.name ) || __( '(no title)', 'newspack-blocks' );
+const getTermTitle = term => decodeEntities( term.name ) || __( '(no title)', 'newspack-blocks' );
 
 class QueryControls extends Component {
 	state = {
@@ -169,47 +168,47 @@ class QueryControls extends Component {
 		} );
 	};
 
-	fetchBrandSuggestions = search => {
+	fetchCustomTaxonomiesSuggestions = ( taxSlug, search ) => {
 		return apiFetch( {
-			path: addQueryArgs( '/wp/v2/brand', {
+			path: addQueryArgs( `/wp/v2/${ taxSlug }`, {
 				search,
 				per_page: 20,
 				_fields: 'id,name,parent',
 				orderby: 'count',
 				order: 'desc',
 			} ),
-		} ).then( brands =>
+		} ).then( terms =>
 			Promise.all(
-				brands.map( brand => {
-					if ( brand.parent > 0 ) {
+				terms.map( term => {
+					if ( term.parent > 0 ) {
 						return apiFetch( {
-							path: addQueryArgs( `/wp/v2/brand/${ brand.parent }`, {
+							path: addQueryArgs( `/wp/v2/${ taxSlug }/${ term.parent }`, {
 								_fields: 'name',
 							} ),
-						} ).then( parentBrand => ( {
-							value: brand.id,
-							label: `${ getBrandTitle( brand ) } – ${ getBrandTitle( parentBrand ) }`,
+						} ).then( parentTerm => ( {
+							value: term.id,
+							label: `${ getTermTitle( term ) } – ${ getTermTitle( parentTerm ) }`,
 						} ) );
 					}
 					return Promise.resolve( {
-						value: brand.id,
-						label: getBrandTitle( brand ),
+						value: term.id,
+						label: getTermTitle( term ),
 					} );
 				} )
 			)
 		);
 	};
-	fetchSavedBrands = brandIDs => {
+	fetchSavedCustomTaxonomies = ( taxSlug, termIDs ) => {
 		return apiFetch( {
-			path: addQueryArgs( '/wp/v2/brand', {
+			path: addQueryArgs( `/wp/v2/${ taxSlug }`, {
 				per_page: 100,
 				_fields: 'id,name',
-				include: brandIDs.join( ',' ),
+				include: termIDs.join( ',' ),
 			} ),
-		} ).then( function ( brands ) {
-			return brands.map( brand => ( {
-				value: brand.id,
-				label: decodeEntities( brand.name ) || __( '(no title)', 'newspack-blocks' ),
+		} ).then( function ( terms ) {
+			return terms.map( term => ( {
+				value: term.id,
+				label: decodeEntities( term.name ) || __( '(no title)', 'newspack-blocks' ),
 			} ) );
 		} );
 	};
@@ -226,8 +225,8 @@ class QueryControls extends Component {
 			onCategoriesChange,
 			tags,
 			onTagsChange,
-			brands,
-			onBrandsChange,
+			customTaxonomies,
+			onCustomTaxonomiesChange,
 			tagExclusions,
 			onTagExclusionsChange,
 			categoryExclusions,
@@ -235,6 +234,32 @@ class QueryControls extends Component {
 			enableSpecific,
 		} = this.props;
 		const { showAdvancedFilters } = this.state;
+
+		const registeredCustomTaxonomies = window.newspack_blocks_data?.custom_taxonomies;
+
+		const customTaxonomiesPrepareChange = ( taxSlug, value ) => {
+			const existingTers = getTermsOfCustomTaxonomy( taxSlug );
+			let newValue;
+			if ( existingTers.length ) {
+				newValue = customTaxonomies.map( tax => {
+					if ( tax.slug !== taxSlug ) {
+						return value;
+					}
+					return {
+						slug: taxSlug,
+						terms: value,
+					};
+				} );
+			} else {
+				newValue = [ ...customTaxonomies, { slug: taxSlug, terms: value } ];
+			}
+			onCustomTaxonomiesChange( newValue );
+		};
+
+		const getTermsOfCustomTaxonomy = taxSlug => {
+			const tax = customTaxonomies.find( tax => tax.slug === taxSlug );
+			return tax ? tax.terms : [];
+		};
 
 		return (
 			<>
@@ -287,15 +312,22 @@ class QueryControls extends Component {
 								label={ __( 'Tags', 'newspack-blocks' ) }
 							/>
 						) }
-						{ onBrandsChange && (
-							<AutocompleteTokenField
-								tokens={ brands || [] }
-								onChange={ onBrandsChange }
-								fetchSuggestions={ this.fetchBrandSuggestions }
-								fetchSavedInfo={ this.fetchSavedBrands }
-								label={ __( 'Brands', 'newspack-blocks' ) }
-							/>
-						) }
+						{ onCustomTaxonomiesChange &&
+							registeredCustomTaxonomies.map( tax => (
+								<AutocompleteTokenField
+									key={ `${ customTaxonomies[ tax.slug ] }-selector` }
+									tokens={ getTermsOfCustomTaxonomy( tax.slug ) }
+									onChange={ value => {
+										console.log( value );
+										customTaxonomiesPrepareChange( tax.slug, value );
+									} }
+									fetchSuggestions={ search =>
+										this.fetchCustomTaxonomiesSuggestions( tax.slug, search )
+									}
+									fetchSavedInfo={ termIds => this.fetchSavedCustomTaxonomies( tax.slug, termIds ) }
+									label={ tax.label }
+								/>
+							) ) }
 						{ onTagExclusionsChange && (
 							<p>
 								<Button
@@ -343,7 +375,7 @@ QueryControls.defaultProps = {
 	authors: [],
 	categories: [],
 	tags: [],
-	brands: [],
+	customTaxonomies: [],
 	tagExclusions: [],
 };
 

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -238,26 +238,13 @@ class QueryControls extends Component {
 		const registeredCustomTaxonomies = window.newspack_blocks_data?.custom_taxonomies;
 
 		const customTaxonomiesPrepareChange = ( taxSlug, value ) => {
-			const existingTers = getTermsOfCustomTaxonomy( taxSlug );
-			let newValue;
-			if ( existingTers.length ) {
-				newValue = customTaxonomies.map( tax => {
-					if ( tax.slug !== taxSlug ) {
-						return value;
-					}
-					return {
-						slug: taxSlug,
-						terms: value,
-					};
-				} );
-			} else {
-				newValue = [ ...customTaxonomies, { slug: taxSlug, terms: value } ];
-			}
+			let newValue = customTaxonomies.filter( tax => tax.slug !== taxSlug );
+			newValue = [ ...newValue, { slug: taxSlug, terms: value } ];
 			onCustomTaxonomiesChange( newValue );
 		};
 
 		const getTermsOfCustomTaxonomy = taxSlug => {
-			const tax = customTaxonomies.find( tax => tax.slug === taxSlug );
+			const tax = customTaxonomies.find( taxObj => taxObj.slug === taxSlug );
 			return tax ? tax.terms : [];
 		};
 
@@ -318,7 +305,6 @@ class QueryControls extends Component {
 									key={ `${ customTaxonomies[ tax.slug ] }-selector` }
 									tokens={ getTermsOfCustomTaxonomy( tax.slug ) }
 									onChange={ value => {
-										console.log( value );
 										customTaxonomiesPrepareChange( tax.slug, value );
 									} }
 									fetchSuggestions={ search =>

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -28,7 +28,7 @@ declare global {
 	type PostId = number;
 	type CategoryId = number;
 	type TagId = number;
-	type BrandId = number;
+	type Taxonomy = { slug: string, terms: number[] }[];
 	type AuthorId = number;
 
 	type PostType = { name: string; slug: string; supports: { newspack_blocks: boolean } };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Replaces the hard-coded support to the `brands` taxonomy with a generic support to any registered custom taxonomy.

### How to test the changes in this Pull Request:

1. On a site without multi-branded plugin, confirm the homepage block and the carousel block still work as expected
2. Activate the multi-branded plugin
3. Confirm you now see the option to filter by brands in both blocks
4. Confirm the filtering works as expected
5. Confirm that the post shows the correct posts in the front end
6. Confirm the articles have a corresponding `$taxonomy-$term-slug` class in the HTML element
7. Confirm the content of the block is updated on the fly when you make changes
8. Register another custom taxonomy and make sure it works as expected:
7; Also confirm that if the custom taxonomy is not public or if `show_in_rest` is set to `false` it won't show up.

```PHP
add_action( 'init', '__register_custom_tax' );
function __register_custom_tax() {
register_taxonomy( 'genre', 'book', array(
       'public' => true,
       'show_in_rest' => true,
    ) );
}

```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
