### PR TITLE
fix(checkout-button): overlay class for modal stacking

### DIFF
--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -36,7 +36,9 @@ function closeCheckout( element ) {
 		iframe.src = 'about:blank';
 	}
 	document.body.classList.remove( 'newspack-modal-checkout-open' );
-	iframeResizeObserver.disconnect();
+	if ( iframeResizeObserver ) {
+		iframeResizeObserver.disconnect();
+	}
 	element.style.display = 'none';
 }
 
@@ -78,7 +80,7 @@ domReady( () => {
 	variationModals.forEach( variationModal => {
 		variationModal.addEventListener( 'click', ev => {
 			if ( ev.target === variationModal ) {
-				variationModal.style.display = 'none';
+				closeCheckout( variationModal );
 			}
 		} );
 		variationModal
@@ -86,7 +88,7 @@ domReady( () => {
 			.forEach( button => {
 				button.addEventListener( 'click', ev => {
 					ev.preventDefault();
-					variationModal.style.display = 'none';
+					closeCheckout( variationModal );
 				} );
 			} );
 	} );
@@ -111,6 +113,7 @@ domReady( () => {
 					);
 					if ( variationModal ) {
 						ev.preventDefault();
+						document.body.classList.add( 'newspack-modal-checkout-open' );
 						variationModal.style.display = 'block';
 						return;
 					}

--- a/src/modal-checkout/modal.scss
+++ b/src/modal-checkout/modal.scss
@@ -111,10 +111,20 @@
 					width: 100%;
 					display: flex;
 					justify-content: space-between;
-					align-items: baseline;
+					align-items: flex-end;
+					.subscription-details {
+						bdi {
+							font-size: inherit;
+						}
+					}
+				}
+				.price {
+					max-width: 65%;
 				}
 				.variation_name {
 					font-weight: 600;
+					font-size: 0.9em;
+					margin-left: 0.5em;
 				}
 				.description {
 					padding-top: 1em;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes the behavior of the pre-checkout modal for variation selection so it can work with other overlays.

### How to test the changes in this Pull Request:

1. While on master, create a content gate with the "Overlay" style and add a Checkout Button block with a variable product for user selection
2. Visit a gated content and confirm that clicking the button renders the modal behind the gate overlay
3. Checkout this branch, refresh the page and confirm the pre-checkout modal replaces the gate modal
4. Close the modal and confirm the gate renders
5. Click again, select a variation, and confirm the checkout modal also renders as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
