### PR TITLE
feat(modal-checkout): always use donation billing fields

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -41,6 +41,7 @@ final class Modal_Checkout {
 		add_filter( 'woocommerce_get_checkout_order_received_url', [ __CLASS__, 'woocommerce_get_return_url' ], 10, 2 );
 		add_filter( 'wc_get_template', [ __CLASS__, 'wc_get_template' ], 10, 2 );
 		add_filter( 'woocommerce_checkout_get_value', [ __CLASS__, 'woocommerce_checkout_get_value' ], 10, 2 );
+		add_filter( 'woocommerce_checkout_fields', [ __CLASS__, 'woocommerce_checkout_fields' ] );
 	}
 
 	/**
@@ -390,6 +391,37 @@ final class Modal_Checkout {
 			$value = sanitize_text_field( wp_unslash( $_REQUEST[ $input ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
 		return $value;
+	}
+
+	/**
+	 * Modify fields for modal checkout.
+	 *
+	 * @param array $fields Checkout fields.
+	 *
+	 * @return array
+	 */
+	public static function woocommerce_checkout_fields( $fields ) {
+		if ( ! isset( $_REQUEST['modal_checkout'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return $fields;
+		}
+		/**
+		 * Temporarily use the same fields as the donation checkout.
+		 *
+		 * This should soon be replaced with a logic that allows the customization
+		 * at the Checkout Button Block level.
+		 */
+		$billing_fields = apply_filters( 'newspack_blocks_donate_billing_fields_keys', [] );
+		if ( empty( $billing_fields ) ) {
+			return $fields;
+		}
+		$billing_keys = array_keys( $fields['billing'] );
+		foreach ( $billing_keys as $key ) {
+			if ( in_array( $key, $billing_fields, true ) ) {
+				continue;
+			}
+			unset( $fields['billing'][ $key ] );
+		}
+		return $fields;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements the selection of donation billing fields as default for the modal checkout.

This temporary solution should soon be replaced with a logic that also allows customization at the Checkout Button Block level.

### How to test the changes in this Pull Request:

1. In your dashboard, visit Newspack -> Reader Revenue, in the "Donations" tab, select only "First Name", "Last Name" and "Email" and save
2. Add a Checkout Button block attached to a custom subscription product
3. Visit the page and confirm the checkout form is only rendering the selected billing fields
4. Visit the regular checkout page (`/checkout`) and confirm all fields are rendered

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
