### PR TITLE
fix(donate-block): allow spaces in button label

### DIFF
--- a/src/blocks/donate/edit/FrequencyBasedLayout.tsx
+++ b/src/blocks/donate/edit/FrequencyBasedLayout.tsx
@@ -186,8 +186,8 @@ const FrequencyBasedLayout = ( props: { isTiered: boolean } & ComponentProps ) =
 	);
 
 	const renderButton = () => (
-		<button
-			type="submit"
+		<div
+			className="button wpbnbd__button"
 			onClick={ evt => evt.preventDefault() }
 			style={ {
 				backgroundColor: attributes.buttonColor,
@@ -209,7 +209,7 @@ const FrequencyBasedLayout = ( props: { isTiered: boolean } & ComponentProps ) =
 					tagName="span"
 				/>
 			) }
-		</button>
+		</div>
 	);
 
 	const selectedPaymentRequestTypeOption = PAYMENT_REQUEST_BUTTON_TYPE_OPTIONS.find(

--- a/src/blocks/donate/edit/FrequencyBasedLayout.tsx
+++ b/src/blocks/donate/edit/FrequencyBasedLayout.tsx
@@ -188,7 +188,6 @@ const FrequencyBasedLayout = ( props: { isTiered: boolean } & ComponentProps ) =
 	const renderButton = () => (
 		<div
 			className="button wpbnbd__button"
-			onClick={ evt => evt.preventDefault() }
 			style={ {
 				backgroundColor: attributes.buttonColor,
 				color: getColorForContrast( attributes.buttonColor ),

--- a/src/blocks/donate/edit/FrequencyBasedLayout.tsx
+++ b/src/blocks/donate/edit/FrequencyBasedLayout.tsx
@@ -187,7 +187,7 @@ const FrequencyBasedLayout = ( props: { isTiered: boolean } & ComponentProps ) =
 
 	const renderButton = () => (
 		<div
-			className="button wpbnbd__button"
+			className="submit-button"
 			style={ {
 				backgroundColor: attributes.buttonColor,
 				color: getColorForContrast( attributes.buttonColor ),

--- a/src/blocks/donate/edit/TierBasedLayout.tsx
+++ b/src/blocks/donate/edit/TierBasedLayout.tsx
@@ -117,9 +117,10 @@ const TierBasedLayout = ( props: ComponentProps ) => {
 									{ getFrequencyLabel( currentFrequency ) }
 								</span>
 							</div>
-							<button
-								type="submit"
+							<div
+								className="button wpbnbd__button"
 								style={ {
+									appearance: 'button',
 									borderColor: attributes.buttonColor,
 									...( isAnyRecommended && ! recommendLabel
 										? {
@@ -138,7 +139,7 @@ const TierBasedLayout = ( props: ComponentProps ) => {
 									value={ attributes.tiersBasedOptions[ index ].buttonText }
 									tagName="span"
 								/>
-							</button>
+							</div>
 							<div className="wpbnbd__tiers__description">
 								<RichText
 									onChange={ handleTierOptionChange( index, 'description' ) }

--- a/src/blocks/donate/edit/TierBasedLayout.tsx
+++ b/src/blocks/donate/edit/TierBasedLayout.tsx
@@ -118,7 +118,7 @@ const TierBasedLayout = ( props: ComponentProps ) => {
 								</span>
 							</div>
 							<div
-								className="button wpbnbd__button"
+								className="submit-button"
 								style={ {
 									appearance: 'button',
 									borderColor: attributes.buttonColor,

--- a/src/blocks/donate/frequency-based/style.scss
+++ b/src/blocks/donate/frequency-based/style.scss
@@ -35,14 +35,15 @@
 		z-index: 1;
 	}
 
-	button {
+	button,
+	.button {
 		margin: 0 0.76rem 0.76rem;
 
 		@include mixins.media( tablet ) {
 			margin: 0 1.5rem 1.5rem;
 		}
 	}
-	.wpbnbd {
+	label.wpbnbd {
 		&__button {
 			text-transform: uppercase;
 		}

--- a/src/blocks/donate/frequency-based/style.scss
+++ b/src/blocks/donate/frequency-based/style.scss
@@ -36,7 +36,7 @@
 	}
 
 	button,
-	.button {
+	.submit-button {
 		margin: 0 0.76rem 0.76rem;
 
 		@include mixins.media( tablet ) {

--- a/src/blocks/donate/streamlined/style.scss
+++ b/src/blocks/donate/streamlined/style.scss
@@ -52,7 +52,7 @@
 		input[type='email'],
 		&__checkbox,
 		button,
-		.button {
+		.submit-button {
 			font-size: 0.7em;
 		}
 		input[type='text'],
@@ -200,7 +200,7 @@
 				width: auto;
 			}
 			button,
-			.button {
+			.submit-button {
 				margin-left: 0;
 				margin-right: 0;
 				margin-bottom: 0;
@@ -268,7 +268,7 @@
 			}
 
 			button,
-			.button {
+			.submit-button {
 				border-top-left-radius: 5px;
 				border-top-right-radius: 5px;
 				margin: 0;

--- a/src/blocks/donate/streamlined/style.scss
+++ b/src/blocks/donate/streamlined/style.scss
@@ -51,7 +51,8 @@
 		input[type='text'],
 		input[type='email'],
 		&__checkbox,
-		button {
+		button,
+		.button {
 			font-size: 0.7em;
 		}
 		input[type='text'],
@@ -198,7 +199,8 @@
 			@include mixins.media( mobile ) {
 				width: auto;
 			}
-			button {
+			button,
+			.button {
 				margin-left: 0;
 				margin-right: 0;
 				margin-bottom: 0;
@@ -265,7 +267,8 @@
 				padding: 0;
 			}
 
-			button {
+			button,
+			.button {
 				border-top-left-radius: 5px;
 				border-top-right-radius: 5px;
 				margin: 0;

--- a/src/blocks/donate/styles/editor.scss
+++ b/src/blocks/donate/styles/editor.scss
@@ -30,16 +30,20 @@
 		}
 	}
 
-	button {
+	button,
+	.button {
+		font-family: var( --newspack-theme-font-heading );
 		font-size: variables.$font__size-sm;
 		font-weight: bold;
 		outline: none;
+
+		&:not( .wpbnbd__button ),
+		&[type="submit"] {
+			border: none;
+		}
 	}
-	button:not( .wpbnbd__button ),
-	button[type='submit'] {
-		border: none;
-	}
-	button[type='submit'] {
+	button[type='submit'],
+	.button {
 		border-radius: 5px;
 		box-sizing: border-box;
 		color: colors.$color__background-body;
@@ -90,11 +94,11 @@
 }
 
 .block-editor-block-list__layout
-	.block-editor-block-list__block
-	.wp-block-newspack-blocks-donate.tiered.is-style-minimal
-	.wp-block-newspack-blocks-donate__tiers
-	input[type='radio']:checked
-	+ .tier-select-label {
+.block-editor-block-list__block
+.wp-block-newspack-blocks-donate.tiered.is-style-minimal
+.wp-block-newspack-blocks-donate__tiers
+input[type='radio']:checked
++ .tier-select-label {
 	background: transparent;
 	color: colors.$color__text-main;
 }

--- a/src/blocks/donate/styles/editor.scss
+++ b/src/blocks/donate/styles/editor.scss
@@ -30,20 +30,23 @@
 		}
 	}
 
+	.submit-button {
+		display: inline-block;
+	}
+
 	button,
-	.button {
+	.submit-button {
 		font-family: var( --newspack-theme-font-heading );
 		font-size: variables.$font__size-sm;
 		font-weight: bold;
 		outline: none;
 
-		&:not( .wpbnbd__button ),
 		&[type="submit"] {
 			border: none;
 		}
 	}
 	button[type='submit'],
-	.button {
+	.submit-button {
 		border-radius: 5px;
 		box-sizing: border-box;
 		color: colors.$color__background-body;

--- a/src/blocks/donate/tiers-based/style.scss
+++ b/src/blocks/donate/tiers-based/style.scss
@@ -26,7 +26,8 @@
 				display: flex;
 				justify-content: center;
 				margin-bottom: 14px;
-				button {
+				button,
+				.button {
 					font-size: 13px;
 					white-space: nowrap;
 				}
@@ -109,7 +110,8 @@
 					font-size: 13px;
 				}
 			}
-			button[type='submit'] {
+			button[type='submit'],
+			.button {
 				border-radius: 3px;
 				border: 2px solid;
 				font-size: 14px;

--- a/src/blocks/donate/tiers-based/style.scss
+++ b/src/blocks/donate/tiers-based/style.scss
@@ -3,7 +3,8 @@
 
 .wpbnbd--tiers-based {
 	.wpbnbd {
-		&__button {
+		&__button,
+		.submit-button {
 			border-width: 1px;
 			border-color: transparent;
 			border-radius: 0;
@@ -27,7 +28,7 @@
 				justify-content: center;
 				margin-bottom: 14px;
 				button,
-				.button {
+				.submit-button {
 					font-size: 13px;
 					white-space: nowrap;
 				}
@@ -111,7 +112,7 @@
 				}
 			}
 			button[type='submit'],
-			.button {
+			.submit-button {
 				border-radius: 3px;
 				border: 2px solid;
 				font-size: 14px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a minor but annoying bug in which the `RichText` component for the submit button in the editor for Donate blocks doesn't allow spaces if it's nested inside a `button` element. This fix changes the `button` element to a `div` with the same styles, in the editor only. See also https://github.com/Automattic/newspack-newsletters/pull/1202
  
  Closes `1204751246381643/1204483195828260`.

### How to test the changes in this Pull Request:

1. On `master`, add a Donate block to a post or page.
2. In both Frequency and Tiers layout options, observe that you can edit the submit button labels but can't add spaces in either case.
3. Check out this branch, repeat step 2 and confirm that you can now add spaces, and that both editor and front-end styles and behavior are otherwise unchanged.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
