### PR TITLE
feat: display purchase details in checkout modal when taxes are enabled

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -22,6 +22,13 @@
 			}
 		}
 	}
+	.woocommerce-checkout-review-order-table {
+		margin-top: 16px;
+		th,
+		td {
+			font-size: 0.8rem;
+		}
+	}
 	.woocommerce-billing-fields {
 		margin-bottom: 16px;
 	}

--- a/src/modal-checkout/templates/checkout-form.php
+++ b/src/modal-checkout/templates/checkout-form.php
@@ -13,8 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WooCommerce hooks.
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template variables.
 
-$order_details_display = get_theme_mod( 'collapse_order_details', 'hide' );
-
 $has_filled_billing = \Newspack_Blocks\Modal_Checkout::has_filled_required_fields( 'billing' );
 $edit_billing       = ! $has_filled_billing || isset( $_REQUEST['edit_billing'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 

--- a/src/modal-checkout/templates/checkout-form.php
+++ b/src/modal-checkout/templates/checkout-form.php
@@ -40,17 +40,6 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 		wp_nonce_field( 'newspack_blocks_edit_billing', 'newspack_blocks_edit_billing_nonce' );
 	}
 	?>
-	<?php if ( 'toggle' === $order_details_display ) : ?>
-	<div class="cart-summary-header">
-		<h3><?php esc_html_e( 'Summary', 'newspack-blocks' ); ?></h3>
-		<button id="toggle-order-details" class="order-details-hidden" on="tap:AMP.setState( { orderVisible: !orderVisible } )" [class]="orderVisible ? '' : 'order-details-hidden'" aria-controls="full-order-details" [aria-expanded]="orderVisible ? 'true' : 'false'" aria-expanded="false">
-		<?php echo wp_kses( newspack_get_icon_svg( 'chevron_left', 24 ), newspack_sanitize_svgs() ); ?>
-		<span [text]="orderVisible ? '<?php esc_html_e( 'Hide details', 'newspack-blocks' ); ?>' : '<?php esc_html_e( 'Show details', 'newspack-blocks' ); ?>'"><?php esc_html_e( 'Show details', 'newspack-blocks' ); ?></span>
-		</button>
-	</div>
-	<?php endif; ?>
-
-	<?php if ( 'display' !== $order_details_display ) : ?>
 	<div class="order-details-summary">
 		<?php
 		// Simplified output of order.
@@ -78,6 +67,11 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 		}
 		?>
 	</div><!-- .order-details-summary -->
+
+	<?php if ( wc_tax_enabled() && ! WC()->cart->display_prices_including_tax() && ! $edit_billing ) : ?>
+		<div id="order_review" class="woocommerce-checkout-review-order">
+			<?php do_action( 'woocommerce_checkout_order_review' ); ?>
+		</div>
 	<?php endif; ?>
 
 	<?php if ( $checkout->get_checkout_fields() ) : ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the tax/order details table on the second screen of the modal checkout, if you have taxes enabled. 

It also removes some cruft that came over from the theme's version of this template; the theme had options to hide this information outright, display it with a toggle, or show it all the time. We could also go that route; I was just leery of duplicating the setting, or tying it to something in the current theme if we can avoid it 😬 

I also didn't do much with the styling; I tried to keep with the simplified appearance for this information, but it just felt more cluttered. The table's a straight copy of how this information displays in the theme. 

See 1200550061930446-as-1204773493453836

### How to test the changes in this Pull Request:

First enable and set up taxes. 
1. Enable taxes in WooCommerce by following [these steps](https://woocommerce.com/document/setting-up-taxes-in-woocommerce/#enabling-taxes). You want your prices to be exclusive of tax (so they're added at checkout).
2. When you get to [Shipping Tax Class](https://woocommerce.com/document/setting-up-taxes-in-woocommerce/#shipping-tax-class), you only need the 'Standard Rate'. 
3. Add some Tax Rates by clicking WooCommerce > Settings > Tax > Standard Rate; you can import [this CSV](https://github.com/Automattic/newspack-blocks/files/11820147/tax_rates.csv) for the tax rates for the different Canadian provinces/territories, or add your own.
4. Under WooCommerce > Settings > Taxes, set taxes to be applied from the Shop location, and make sure your shop address matches a location you've set some taxes for. 

![image](https://github.com/Automattic/newspack-blocks/assets/177561/8b28e912-4dca-4aef-beb8-9f5eadddb2e9)

Next, test the PR:
1. Apply the PR and run `npm run build`.
2. Set up a page with a checkout button linked to a product. 
3. Click the button, and fill in your billing details; click Continue.
4. On the next screen, you should get a table of billing details under the simplified total that includes your taxes (my shop is set in BC, so it's charging both GST and PST):

![image](https://github.com/Automattic/newspack-blocks/assets/177561/2fb288e6-00d6-43c8-b7fd-6f142d6a3b37)

5. Disable taxes under WooCommerce > Settings > Genera.
6. Repeat steps 3-4, and confirm the table no longer displays. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
