### PR TITLE
Change default behavior of Homepage Posts and Carousel blocks to include posts in subcategories 

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -628,17 +628,17 @@ class Newspack_Blocks {
 		if ( current_user_can( 'edit_others_posts' ) && isset( $attributes['includedPostStatuses'] ) ) {
 			$included_post_statuses = $attributes['includedPostStatuses'];
 		}
-		$authors                = isset( $attributes['authors'] ) ? $attributes['authors'] : array();
-		$categories             = isset( $attributes['categories'] ) ? $attributes['categories'] : array();
-		$include_subcategories  = isset( $attributes['includeSubcategories'] ) ? intval( $attributes['includeSubcategories'] ) : false;
-		$tags                   = isset( $attributes['tags'] ) ? $attributes['tags'] : array();
-		$custom_taxonomies      = isset( $attributes['customTaxonomies'] ) ? $attributes['customTaxonomies'] : array();
-		$tag_exclusions         = isset( $attributes['tagExclusions'] ) ? $attributes['tagExclusions'] : array();
-		$category_exclusions    = isset( $attributes['categoryExclusions'] ) ? $attributes['categoryExclusions'] : array();
-		$specific_posts         = isset( $attributes['specificPosts'] ) ? $attributes['specificPosts'] : array();
-		$posts_to_show          = intval( $attributes['postsToShow'] );
-		$specific_mode          = isset( $attributes['specificMode'] ) ? intval( $attributes['specificMode'] ) : false;
-		$args                   = array(
+		$authors               = isset( $attributes['authors'] ) ? $attributes['authors'] : array();
+		$categories            = isset( $attributes['categories'] ) ? $attributes['categories'] : array();
+		$include_subcategories = isset( $attributes['includeSubcategories'] ) ? intval( $attributes['includeSubcategories'] ) : false;
+		$tags                  = isset( $attributes['tags'] ) ? $attributes['tags'] : array();
+		$custom_taxonomies     = isset( $attributes['customTaxonomies'] ) ? $attributes['customTaxonomies'] : array();
+		$tag_exclusions        = isset( $attributes['tagExclusions'] ) ? $attributes['tagExclusions'] : array();
+		$category_exclusions   = isset( $attributes['categoryExclusions'] ) ? $attributes['categoryExclusions'] : array();
+		$specific_posts        = isset( $attributes['specificPosts'] ) ? $attributes['specificPosts'] : array();
+		$posts_to_show         = intval( $attributes['postsToShow'] );
+		$specific_mode         = isset( $attributes['specificMode'] ) ? intval( $attributes['specificMode'] ) : false;
+		$args                  = array(
 			'post_type'           => $post_type,
 			'post_status'         => $included_post_statuses,
 			'suppress_filters'    => false,
@@ -671,7 +671,7 @@ class Newspack_Blocks {
 					foreach  ( $categories as $parent ) {
 						$children[] = get_categories(array('child_of'=> $parent));
 						foreach ( $children[0] as $child ) {
-						$categories[] = $child->term_id;
+							$categories[] = $child->term_id;
 						}
 					}
 				}

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -668,7 +668,7 @@ class Newspack_Blocks {
 			}
 			if ( $categories && count( $categories ) ) {
 				if ( $include_subcategories === 1 ){
-					foreach  ( $categories as $parent ) {
+					foreach ( $categories as $parent ) {
 						$children[] = get_categories( array( 'child_of' => $parent ) );
 						foreach ( $children[0] as $child ) {
 							$categories[] = $child->term_id;

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -628,17 +628,17 @@ class Newspack_Blocks {
 		if ( current_user_can( 'edit_others_posts' ) && isset( $attributes['includedPostStatuses'] ) ) {
 			$included_post_statuses = $attributes['includedPostStatuses'];
 		}
-		$authors             	= isset( $attributes['authors'] ) ? $attributes['authors'] : array();
-		$categories          	= isset( $attributes['categories'] ) ? $attributes['categories'] : array();
-		$include_subcategories	= isset( $attributes['includeSubcategories'] ) ? intval($attributes['includeSubcategories']) : false;
-		$tags                	= isset( $attributes['tags'] ) ? $attributes['tags'] : array();
-		$custom_taxonomies   	= isset( $attributes['customTaxonomies'] ) ? $attributes['customTaxonomies'] : array();
-		$tag_exclusions      	= isset( $attributes['tagExclusions'] ) ? $attributes['tagExclusions'] : array();
-		$category_exclusions 	= isset( $attributes['categoryExclusions'] ) ? $attributes['categoryExclusions'] : array();
-		$specific_posts      	= isset( $attributes['specificPosts'] ) ? $attributes['specificPosts'] : array();
-		$posts_to_show       	= intval( $attributes['postsToShow'] );
-		$specific_mode       	= isset( $attributes['specificMode'] ) ? intval( $attributes['specificMode'] ) : false;
-		$args                	= array(
+		$authors                = isset( $attributes['authors'] ) ? $attributes['authors'] : array();
+		$categories             = isset( $attributes['categories'] ) ? $attributes['categories'] : array();
+		$include_subcategories  = isset( $attributes['includeSubcategories'] ) ? intval($attributes['includeSubcategories']) : false;
+		$tags                   = isset( $attributes['tags'] ) ? $attributes['tags'] : array();
+		$custom_taxonomies      = isset( $attributes['customTaxonomies'] ) ? $attributes['customTaxonomies'] : array();
+		$tag_exclusions         = isset( $attributes['tagExclusions'] ) ? $attributes['tagExclusions'] : array();
+		$category_exclusions    = isset( $attributes['categoryExclusions'] ) ? $attributes['categoryExclusions'] : array();
+		$specific_posts         = isset( $attributes['specificPosts'] ) ? $attributes['specificPosts'] : array();
+		$posts_to_show          = intval( $attributes['postsToShow'] );
+		$specific_mode          = isset( $attributes['specificMode'] ) ? intval( $attributes['specificMode'] ) : false;
+		$args                   = array(
 			'post_type'           => $post_type,
 			'post_status'         => $included_post_statuses,
 			'suppress_filters'    => false,

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -628,16 +628,17 @@ class Newspack_Blocks {
 		if ( current_user_can( 'edit_others_posts' ) && isset( $attributes['includedPostStatuses'] ) ) {
 			$included_post_statuses = $attributes['includedPostStatuses'];
 		}
-		$authors             = isset( $attributes['authors'] ) ? $attributes['authors'] : array();
-		$categories          = isset( $attributes['categories'] ) ? $attributes['categories'] : array();
-		$tags                = isset( $attributes['tags'] ) ? $attributes['tags'] : array();
-		$custom_taxonomies   = isset( $attributes['customTaxonomies'] ) ? $attributes['customTaxonomies'] : array();
-		$tag_exclusions      = isset( $attributes['tagExclusions'] ) ? $attributes['tagExclusions'] : array();
-		$category_exclusions = isset( $attributes['categoryExclusions'] ) ? $attributes['categoryExclusions'] : array();
-		$specific_posts      = isset( $attributes['specificPosts'] ) ? $attributes['specificPosts'] : array();
-		$posts_to_show       = intval( $attributes['postsToShow'] );
-		$specific_mode       = isset( $attributes['specificMode'] ) ? intval( $attributes['specificMode'] ) : false;
-		$args                = array(
+		$authors             	= isset( $attributes['authors'] ) ? $attributes['authors'] : array();
+		$categories          	= isset( $attributes['categories'] ) ? $attributes['categories'] : array();
+		$include_subcategories	= isset( $attributes['includeSubcategories'] ) ? intval($attributes['includeSubcategories']) : false;
+		$tags                	= isset( $attributes['tags'] ) ? $attributes['tags'] : array();
+		$custom_taxonomies   	= isset( $attributes['customTaxonomies'] ) ? $attributes['customTaxonomies'] : array();
+		$tag_exclusions      	= isset( $attributes['tagExclusions'] ) ? $attributes['tagExclusions'] : array();
+		$category_exclusions 	= isset( $attributes['categoryExclusions'] ) ? $attributes['categoryExclusions'] : array();
+		$specific_posts      	= isset( $attributes['specificPosts'] ) ? $attributes['specificPosts'] : array();
+		$posts_to_show       	= intval( $attributes['postsToShow'] );
+		$specific_mode       	= isset( $attributes['specificMode'] ) ? intval( $attributes['specificMode'] ) : false;
+		$args                	= array(
 			'post_type'           => $post_type,
 			'post_status'         => $included_post_statuses,
 			'suppress_filters'    => false,
@@ -666,6 +667,14 @@ class Newspack_Blocks {
 				);
 			}
 			if ( $categories && count( $categories ) ) {
+				if ($include_subcategories === 1){
+					foreach ($categories as $parent) {
+						$children[] = get_categories(array('child_of'=> $parent));
+						foreach ($children[0] as $child) {
+						$categories[] = $child->term_id;
+						}
+					}
+				}
 				$args['category__in'] = $categories;
 			}
 			if ( $tags && count( $tags ) ) {

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -630,7 +630,7 @@ class Newspack_Blocks {
 		}
 		$authors                = isset( $attributes['authors'] ) ? $attributes['authors'] : array();
 		$categories             = isset( $attributes['categories'] ) ? $attributes['categories'] : array();
-		$include_subcategories  = isset( $attributes['includeSubcategories'] ) ? intval($attributes['includeSubcategories']) : false;
+		$include_subcategories  = isset( $attributes['includeSubcategories'] ) ? intval( $attributes['includeSubcategories'] ) : false;
 		$tags                   = isset( $attributes['tags'] ) ? $attributes['tags'] : array();
 		$custom_taxonomies      = isset( $attributes['customTaxonomies'] ) ? $attributes['customTaxonomies'] : array();
 		$tag_exclusions         = isset( $attributes['tagExclusions'] ) ? $attributes['tagExclusions'] : array();
@@ -667,10 +667,10 @@ class Newspack_Blocks {
 				);
 			}
 			if ( $categories && count( $categories ) ) {
-				if ($include_subcategories === 1){
-					foreach ($categories as $parent) {
+				if ( $include_subcategories === 1 ){
+					foreach  ( $categories as $parent ) {
 						$children[] = get_categories(array('child_of'=> $parent));
-						foreach ($children[0] as $child) {
+						foreach ( $children[0] as $child ) {
 						$categories[] = $child->term_id;
 						}
 					}

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -150,6 +150,7 @@ class Edit extends Component {
 			authors,
 			autoplay,
 			categories,
+			includeSubcategories,
 			customTaxonomies,
 			delay,
 			hideControls,
@@ -374,6 +375,8 @@ class Edit extends Component {
 								onAuthorsChange={ value => setAttributes( { authors: value } ) }
 								categories={ categories }
 								onCategoriesChange={ value => setAttributes( { categories: value } ) }
+								includeSubcategories={ includeSubcategories }
+								onIncludeSubcategoriesChange={ _includeSubcategories => setAttributes( { includeSubcategories: _includeSubcategories } ) }
 								tags={ tags }
 								onTagsChange={ value => setAttributes( { tags: value } ) }
 								onCustomTaxonomiesChange={ value => setAttributes( { customTaxonomies: value } ) }

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -64,6 +64,10 @@ export const settings = {
 		categories: {
 			type: 'array',
 		},
+		includeSubcategories: {
+			type: 'boolean',
+			default: true
+		},
 		tags: {
 			type: 'array',
 		},

--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -100,6 +100,10 @@
 			"default": [],
 			"items": { "type": "integer" }
 		},
+		"includeSubcategories": {
+			"type": "boolean",
+			"default": true
+		},
 		"tags": {
 			"type": "array",
 			"default": [],

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -266,6 +266,7 @@ class Edit extends Component {
 			specificPosts,
 			postsToShow,
 			categories,
+			includeSubcategories,
 			customTaxonomies,
 			columns,
 			colGap,
@@ -359,6 +360,8 @@ class Edit extends Component {
 						onAuthorsChange={ handleAttributeChange( 'authors' ) }
 						categories={ categories }
 						onCategoriesChange={ handleAttributeChange( 'categories' ) }
+						includeSubcategories={ includeSubcategories }
+						onIncludeSubcategoriesChange={ handleAttributeChange( 'includeSubcategories' ) }
 						tags={ tags }
 						onTagsChange={ handleAttributeChange( 'tags' ) }
 						onCustomTaxonomiesChange={ handleAttributeChange( 'customTaxonomies' ) }

--- a/src/blocks/homepage-articles/utils.ts
+++ b/src/blocks/homepage-articles/utils.ts
@@ -27,6 +27,7 @@ const POST_QUERY_ATTRIBUTES = [
 	'postsToShow',
 	'authors',
 	'categories',
+	'includeSubcategories',
 	'excerptLength',
 	'tags',
 	'customTaxonomies',
@@ -43,6 +44,7 @@ type HomepageArticlesAttributes = {
 	postsToShow: number;
 	authors: AuthorId[];
 	categories: CategoryId[];
+	includeSubcategories: boolean;
 	excerptLength: number;
 	postType: PostType[];
 	showExcerpt: boolean;
@@ -87,6 +89,7 @@ export const queryCriteriaFromAttributes = ( attributes: Block[ 'attributes' ] )
 		postsToShow,
 		authors,
 		categories,
+		includeSubcategories,
 		excerptLength,
 		postType,
 		showExcerpt,
@@ -111,6 +114,7 @@ export const queryCriteriaFromAttributes = ( attributes: Block[ 'attributes' ] )
 			: {
 					postsToShow,
 					categories,
+					includeSubcategories,
 					authors,
 					tags,
 					tagExclusions,

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -223,6 +223,8 @@ class QueryControls extends Component {
 			onAuthorsChange,
 			categories,
 			onCategoriesChange,
+			includeSubcategories,
+			onIncludeSubcategoriesChange,
 			tags,
 			onTagsChange,
 			customTaxonomies,
@@ -288,6 +290,15 @@ class QueryControls extends Component {
 								fetchSuggestions={ this.fetchCategorySuggestions }
 								fetchSavedInfo={ this.fetchSavedCategories }
 								label={ __( 'Categories', 'newspack-blocks' ) }
+							/>
+						) }
+						{ onIncludeSubcategoriesChange && (
+							<ToggleControl
+								checked={ includeSubcategories }
+								onChange={ onIncludeSubcategoriesChange }
+								fetchSuggestions={ this.fetchCategorySuggestions }
+								fetchSavedInfo={ this.fetchSavedCategories }
+								label={ __( 'Include subcategories ' + includeSubcategories, 'newspack-blocks' ) }
 							/>
 						) }
 						{ onTagsChange && (

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -296,9 +296,7 @@ class QueryControls extends Component {
 							<ToggleControl
 								checked={ includeSubcategories }
 								onChange={ onIncludeSubcategoriesChange }
-								fetchSuggestions={ this.fetchCategorySuggestions }
-								fetchSavedInfo={ this.fetchSavedCategories }
-								label={ __( 'Include subcategories ' + includeSubcategories, 'newspack-blocks' ) }
+								label={ __( 'Include subcategories ', 'newspack-blocks' ) }
 							/>
 						) }
 						{ onTagsChange && (


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Change the default behavior of the Homepage Posts and Carousel blocks to include posts in subcategories of the selected categories. Added a toggle under the category picker to switch this behavior off. 

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Generally speaking, this is more in line with how Wordpress treats parent/child categories, where a query for the parent category is inclusive of posts in the child categories, and seems more intuitive. 

Closes #207

### How to test the changes in this Pull Request:

1. Create a category with one or more child categories (i.e. Food > Tacos)
2. Categorize some posts into the parent category (i.e. Food)
3. Categorize some posts into the child category, but do not explicitly categorize them into the parent category (i.e. Tacos, but not Food)
4. Create a new page and add a Homepage Posts block
5. Under Display Settings, filter by the parent category (i.e. Food)
6. Observe that posts from the child category are also included 
7. Toggle "Include subcategories" off, observe that now only posts from the parent category are displayed
8. Do the same with the Carousel block

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
