### PR TITLE
feat(modal-checkout): render order details under different conditions

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -3,6 +3,16 @@
 #newspack_modal_checkout { /* stylelint-disable-line */
 	padding: 32px;
 	font-size: 1rem;
+	.cart-summary-header {
+		align-items: center;
+		display: flex;
+		justify-content: space-between;
+		margin: 0 0 0.5rem;
+		h3 {
+			margin: 0;
+			font-size: 1em;
+		}
+	}
 	.order-details-summary {
 		border: 2px solid;
 		border-radius: 3px;
@@ -78,7 +88,7 @@
 		#payment button#place_order { /* stylelint-disable-line */
 			margin-bottom: 0;
 		}
-		button {
+		.checkout-billing button[type='submit'] {
 			display: block;
 			width: 100%;
 		}

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -3,16 +3,6 @@
 #newspack_modal_checkout { /* stylelint-disable-line */
 	padding: 32px;
 	font-size: 1rem;
-	.cart-summary-header {
-		align-items: center;
-		display: flex;
-		justify-content: space-between;
-		margin: 0 0 0.5rem;
-		h3 {
-			margin: 0;
-			font-size: 1em;
-		}
-	}
 	.order-details-summary {
 		border: 2px solid;
 		border-radius: 3px;

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -38,6 +38,10 @@
 		td {
 			font-size: 0.8rem;
 		}
+		&.empty {
+			margin: 0;
+			padding: 0;
+		}
 	}
 	.woocommerce-billing-fields {
 		margin-bottom: 16px;
@@ -88,7 +92,8 @@
 		#payment button#place_order { /* stylelint-disable-line */
 			margin-bottom: 0;
 		}
-		.checkout-billing button[type='submit'] {
+		.checkout-billing button[type='submit'],
+		button.modal-continue {
 			display: block;
 			width: 100%;
 		}

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -2,3 +2,35 @@
  * Style dependencies
  */
 import './checkout.scss';
+
+/**
+ * Specify a function to execute when the DOM is fully loaded.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/packages/dom-ready/
+ *
+ * @param {Function} callback A function to execute after the DOM is ready.
+ * @return {void}
+ */
+function domReady( callback ) {
+	if ( typeof document === 'undefined' ) {
+		return;
+	}
+	if (
+		document.readyState === 'complete' || // DOMContentLoaded + Images/Styles/etc loaded, so we call directly.
+		document.readyState === 'interactive' // DOMContentLoaded fires at this point, so we call directly.
+	) {
+		return void callback();
+	}
+	// DOMContentLoaded has not fired yet, delay callback until then.
+	document.addEventListener( 'DOMContentLoaded', callback );
+}
+
+domReady( () => {
+	const continueButton = document.querySelector( '.modal-continue' );
+	if ( continueButton ) {
+		continueButton.addEventListener( 'click', () => {
+			const form = document.querySelector( '.checkout' );
+			form.submit();
+		} );
+	}
+} );

--- a/src/modal-checkout/templates/checkout-form.php
+++ b/src/modal-checkout/templates/checkout-form.php
@@ -13,6 +13,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WooCommerce hooks.
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template variables.
 
+$cart = WC()->cart;
+
 $has_filled_billing = \Newspack_Blocks\Modal_Checkout::has_filled_required_fields( 'billing' );
 $edit_billing       = ! $has_filled_billing || isset( $_REQUEST['edit_billing'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
@@ -25,8 +27,6 @@ if ( $edit_billing ) {
 	$form_class .= ' edit-billing';
 }
 
-$order_details_display = get_theme_mod( 'collapse_order_details', 'hide' );
-
 do_action( 'woocommerce_before_checkout_form', $checkout );
 
 // If checkout registration is disabled and not logged in, the user cannot checkout.
@@ -36,21 +36,11 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 }
 ?>
 
-<?php if ( 'toggle' === $order_details_display ) : ?>
-	<div class="cart-summary-header">
-		<h3><?php esc_html_e( 'Summary', 'newspack-blocks' ); ?></h3>
-		<button id="toggle-order-details" type="button" class="order-details-hidden" on="tap:AMP.setState( { orderVisible: !orderVisible } )" [class]="orderVisible ? '' : 'order-details-hidden'" aria-controls="full-order-details" [aria-expanded]="orderVisible ? 'true' : 'false'" aria-expanded="false">
-			<?php echo wp_kses( newspack_get_icon_svg( 'chevron_left', 24 ), newspack_sanitize_svgs() ); ?>
-			<span [text]="orderVisible ? '<?php esc_html_e( 'Hide details', 'newspack-blocks' ); ?>' : '<?php esc_html_e( 'Show details', 'newspack-blocks' ); ?>'"><?php esc_html_e( 'Show details', 'newspack-blocks' ); ?></span>
-		</button>
-	</div>
-<?php endif; ?>
-
-<?php if ( 'display' !== $order_details_display ) : ?>
+<?php if ( 1 === $cart->get_cart_contents_count() ) : ?>
 	<div class="order-details-summary">
 		<?php
 		// Simplified output of order.
-		foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+		foreach ( $cart->get_cart() as $cart_item_key => $cart_item ) {
 			$_product = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
 
 			if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_checkout_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
@@ -65,7 +55,7 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 			</strong>
 			<span>
 				<?php
-				echo apply_filters( 'woocommerce_cart_item_subtotal', WC()->cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo apply_filters( 'woocommerce_cart_item_subtotal', $cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				?>
 			</span>
 		</h4>
@@ -85,23 +75,14 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 	}
 	?>
 
-	<?php if ( 'display' === $order_details_display ) : ?>
-		<div id="order-details-wrapper">
-	<?php else : ?>
-		<div id="order-details-wrapper" class="order-details-hidden" [class]="orderVisible ? '' : 'order-details-hidden'">
-	<?php endif; ?>
+	<div id="order-details-wrapper">
 		<?php do_action( 'woocommerce_checkout_before_order_review_heading' ); ?>
-
 		<h3 id="order_review_heading" class="screen-reader-text"><?php esc_html_e( 'Order Details', 'newspack-blocks' ); ?></h3>
-
 		<?php do_action( 'woocommerce_checkout_before_order_review' ); ?>
-
 		<div id="order_review" class="woocommerce-checkout-review-order">
 			<?php do_action( 'woocommerce_checkout_order_review' ); ?>
 		</div>
-
 		<?php do_action( 'woocommerce_checkout_after_order_review' ); ?>
-
 	</div><!-- .full-order-details -->
 
 	<?php if ( $checkout->get_checkout_fields() ) : ?>
@@ -111,7 +92,7 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 		<?php if ( $edit_billing ) : ?>
 			<div class="checkout-billing">
 				<?php do_action( 'woocommerce_checkout_billing' ); ?>
-				<button type="submit" class="button alt wp-element-button"><?php esc_html_e( 'Continue', 'newspack-blocks' ); ?></button>
+				<button type="button" class="button alt wp-element-button modal-continue"><?php esc_html_e( 'Continue', 'newspack-blocks' ); ?></button>
 			</div>
 		<?php else : ?>
 			<div class="checkout-billing checkout-billing-summary">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements a dynamic check on whether to render the order details for a modal checkout cart.

The following should render the order details table:
 - Cart has an applied coupon
 - Taxes are enabled and set to display prices excluding taxes (#1480)
 - Cart has more than one item

### How to test the changes in this Pull Request:

1. Repeat steps from #1480
2. Disable tax rates and calculations on WC settings (or switch the "display prices" in the "tax" tab to "including taxes")
3. Enable coupons and create a coupon
4. Click on the checkout button and confirm the order details do not render
5. Apply the coupon and confirm the order details rendered with coupon details as the coupon is applied
6. Go through the entire checkout process and confirm the order is placed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
