### PR TITLE
fix(post-carousel): set aspect ratio on init

### DIFF
--- a/src/blocks/carousel/create-swiper.js
+++ b/src/blocks/carousel/create-swiper.js
@@ -130,6 +130,7 @@ export default function createSwiper( els, config = {} ) {
 					deactivateSlide( slide )
 				);
 
+				setAspectRatio.call( this ); // Set the aspect ratio on init.
 				activateSlide( this.slides[ this.activeIndex ] ); // Set-up our active slide.
 			},
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When using lazy load for images, the block aspect ratio is only applied when the last slide loads. Being a fixed aspect ratio, there's no need to wait for all the images to load in order to set the height.

This PR sets the aspect ratio on the swiper init function.

### How to test the changes in this Pull Request:

1. While on the `release` branch, make sure you have Jetpack with the site accelerator and lazy load (Performance section)
2. Add a Post Carousel to a page and set the aspect ratio to 16:9
3. Visit the page and confirm it renders at 1:1 and switches to 16:9 when reaching the last slide (all images loaded)
4. Check out this branch, build, and confirm the carousel renders at 16:9 on load

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
