### PR TITLE
feat: changes required for Campaigns rearchitecture

### DIFF
--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
@@ -312,25 +312,6 @@ abstract class Newspack_Blocks_Donate_Renderer_Base {
 	}
 
 	/**
-	 * Render Client ID hidden form input.
-	 */
-	protected static function render_client_id_form_input() {
-		if ( class_exists( 'Newspack_Popups_Segmentation' ) ) {
-			$client_id = Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME;
-			ob_start();
-			?>
-				<input
-					name="cid"
-					type="hidden"
-					value="CLIENT_ID(<?php echo esc_attr( $client_id ); ?>)"
-					data-amp-replace="CLIENT_ID"
-				/>
-			<?php
-			return ob_get_clean();
-		}
-	}
-
-	/**
 	 * Render the block HTML.
 	 *
 	 * @param array $attributes Block attributes.

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-frequency-based.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-frequency-based.php
@@ -76,7 +76,6 @@ class Newspack_Blocks_Donate_Renderer_Frequency_Based extends Newspack_Blocks_Do
 		<?php if ( $campaign ) : ?>
 			<input type='hidden' name='campaign' value='<?php echo esc_attr( $campaign ); ?>' />
 		<?php endif; ?>
-		<?php echo self::render_client_id_form_input(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 
 		<?php
 		return ob_get_clean();

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-tiers-based.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-tiers-based.php
@@ -203,7 +203,6 @@ class Newspack_Blocks_Donate_Renderer_Tiers_Based extends Newspack_Blocks_Donate
 					<?php echo self::render_streamlined_payment_ui( $attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					<input data-is-streamlined-input-amount type="hidden" name="" value="0">
 					<input type="hidden" name="<?php echo esc_attr( self::FREQUENCY_PARAM ); ?>" value="<?php echo esc_attr( $intial_selected_frequency ); ?>">
-					<?php echo self::render_client_id_form_input(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				</div>
 				</form>
 			<?php endif; ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

All changes required for the Campaigns Rearchitecture initiative. Also requires https://github.com/Automattic/newspack-plugin/pull/2558 and https://github.com/Automattic/newspack-popups/pull/1192.

### How to test the changes in this Pull Request:

There should be no functional changes as a result of this changeset, but it does remove the hidden AMP client ID field which was previously a requirement for the Campaigns Lightweight API, since client ID is no longer needed for Campaigns segmentation APIs.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
