### PR TITLE
fix: only show Additional Fields panel when using Stripe platform

### DIFF
--- a/src/blocks/donate/edit/index.tsx
+++ b/src/blocks/donate/edit/index.tsx
@@ -383,12 +383,14 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 						label={ __( 'Button Color', 'newspack-blocks' ) }
 					/>
 				</PanelBody>
-				<PanelBody
-					title={ __( 'Additional data fields', 'newspack-blocks' ) }
-					initialOpen={ false }
-				>
-					<AdditionalFields attributes={ attributes } setAttributes={ setAttributes } />
-				</PanelBody>
+				{ 'stripe' === settings.platform && (
+					<PanelBody
+						title={ __( 'Additional data fields', 'newspack-blocks' ) }
+						initialOpen={ false }
+					>
+						<AdditionalFields attributes={ attributes } setAttributes={ setAttributes } />
+					</PanelBody>
+				) }
 				<PanelBody title={ __( 'Campaign', 'newspack-blocks' ) } initialOpen={ false }>
 					<TextControl
 						label={ __( 'Campaign ID', 'newspack-blocks' ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The "Additional Fields" panel applies only to the Simplified Donate block, but it's always shown in the block's sidebar in the editor. This fix only shows it if the Reader Revenue platform is Stripe. This condition will have to be changed once we allow the SDB to be used with WooCommerce as well.

### How to test the changes in this Pull Request:

1. On `master` or `release`, set your Reader Revenue platform to "Newspack" or anything other than "Stripe".
2. Add a Donate block to a post or page and observe that the Additional Fields panel is available, but that it won't do anything to the front-end render of the block.
3. Check out this branch and confirm the Additional Fields panel is now hidden.
4. Set your Reader Revenue platform to "Stripe", reload the editor, and confirm the Additional Fields panel is available again and lets you add additional fields that are rendered on the front-end, as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
