### PR TITLE
fix: reduce post carousel font size for 5-6 slides

### DIFF
--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -318,7 +318,7 @@
 		}
 	}
 
-	&[data-slides-per-view='2'] article {
+	&.slides-per-view-2 article {
 		.entry-title {
 			@include mixins.media( tablet ) {
 				font-size: 1.4em;
@@ -334,6 +334,32 @@
 			}
 			@include mixins.media( desktop ) {
 				font-size: 1em;
+			}
+		}
+		.entry-meta {
+			@include mixins.media( tablet ) {
+				font-size: 0.7em;
+			}
+		}
+	}
+
+	&.slides-per-view-5 article,
+	&.slides-per-view-6 article {
+		.entry-wrapper {
+			@include mixins.media( desktop ) {
+				padding: 1em;
+			}
+		}
+		.entry-title {
+			@include mixins.media( tablet ) {
+				font-size: 1.2em;
+			}
+			@include mixins.media( desktop ) {
+				font-size: 0.9em;
+
+				a {
+					-webkit-line-clamp: 2;
+				}
 			}
 		}
 		.entry-meta {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR reduces the font size of the post title and meta when your slideshow is showing 5-6 slides at once.

It was [previously done for 3-4 slides](https://github.com/Automattic/newspack-blocks/pull/946), and honestly, I have no idea why I didn't do it for these slide counts as well at this time 😐 

See 1200550061930446-1204989622181280

### How to test the changes in this Pull Request:

1. Add three post carousels, one with 4 slides at once, one with 5 slides and one with 6.
2. View in the editor and on the front-end - note you can barely see the titles on the 5 and 6 slide blocks:

![image](https://github.com/Automattic/newspack-blocks/assets/177561/65b06b8e-9ab6-4d21-a2c5-e180e29dc12d)

3. Apply this PR and run `npm run build`.
4. Confirm that the titles are now logically sized for the 5 and 6 slide blocks, and that they truncate to two lines.

![image](https://github.com/Automattic/newspack-blocks/assets/177561/65b06b8e-9ab6-4d21-a2c5-e180e29dc12d)

5. Scale down your browser window and confirm that the 5 and 6 slide blocks drop to 2 and then 1 slide at a time, and confirm they match the appearance of the 4-slides-at-once block at each breakpoint. 

![image](https://github.com/Automattic/newspack-blocks/assets/177561/11959775-5d62-4058-b723-2768034d35e5)

![image](https://github.com/Automattic/newspack-blocks/assets/177561/b0111a6a-78b3-4608-93dc-6e5ed0b3c71d)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
