### PR TITLE
fix: make sure carousels without images aren't collapsed

### DIFF
--- a/src/blocks/carousel/editor.scss
+++ b/src/blocks/carousel/editor.scss
@@ -1,6 +1,6 @@
 @use '../../shared/sass/placeholder';
 
-.wpnbpc {
+.wp-block-newspack-blocks-carousel {
 	.swiper-wrapper {
 		height: auto;
 		pointer-events: none;
@@ -19,6 +19,9 @@
 	}
 	.post-thumbnail img {
 		display: block;
+	}
+	&__placeholder {
+		height: 100%;
 	}
 	.swiper-pagination-bullet.swiper-pagination-bullet-active {
 		opacity: 1;

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -3,7 +3,7 @@
 @use '../../shared/sass/colors';
 @use '../../shared/sass/preview';
 
-.wpnbpc {
+.wp-block-newspack-blocks-carousel {
 	position: relative;
 	margin-top: 0;
 
@@ -99,6 +99,9 @@
 	&__placeholder {
 		height: 420px;
 		background: colors.$color__background-screen;
+	}
+	.swiper-initialized .wp-block-newspack-blocks-carousel__placeholder {
+		height: 100%;
 	}
 	p {
 		white-space: normal;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue where the Post Carousel slider would be collapsed on the front-end if none of the posts had featured images.

See 1200550061930446-as-1204845439898529

### How to test the changes in this Pull Request:

1. Add a post carousel to the editor and change the setting so none of the posts have featured images (this could be adjusting the query, or quickly spinning up 3+ posts without featured images.
2. View on the front-end; note you have the little pagination at the bottom, and nothing more:

![image](https://github.com/Automattic/newspack-blocks/assets/177561/4af96c20-7cdf-47e9-b474-a32eef4ea65a)

3. Apply the PR and run `npm run build`.
4. Confirm your carousel now shows on the front-end.

![image](https://github.com/Automattic/newspack-blocks/assets/177561/4180deb0-980c-4e13-9ea8-9eaf8e32bdc5)

5. Test a couple different aspect ratio options and confirm the placeholders fill the space on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
