### PR TITLE
fix: support account creation on modal checkout

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -198,13 +198,13 @@ final class Modal_Checkout {
 					<div class="newspack-blocks-variation-modal__selection" data-product-id="<?php echo esc_attr( $product_id ); ?>">
 						<h3><?php echo esc_html( $product->get_name() ); ?></h3>
 						<p><?php esc_html_e( 'Select an option below:', 'newspack-blocks' ); ?></p>
-					<?php
-					$variations = $product->get_available_variations( 'objects' );
-					foreach ( $variations as $variation ) {
-						$name        = $variation->get_formatted_variation_attributes( true );
-						$price       = $variation->get_price_html();
-						$description = $variation->get_variation_description();
-						?>
+						<?php
+						$variations = $product->get_available_variations( 'objects' );
+						foreach ( $variations as $variation ) {
+							$name        = $variation->get_formatted_variation_attributes( true );
+							$price       = $variation->get_price_html();
+							$description = $variation->get_variation_description();
+							?>
 							<form>
 								<input type="hidden" name="newspack_checkout" value="1" />
 								<input type="hidden" name="product_id" value="<?php echo esc_attr( $variation->get_id() ); ?>" />
@@ -219,8 +219,8 @@ final class Modal_Checkout {
 								</button>
 							</form>
 							<?php
-					}
-					?>
+						}
+						?>
 					</div>
 				</div>
 			</div>

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -213,7 +213,7 @@ final class Modal_Checkout {
 										<span class="price"><?php echo $price; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
 										<span class="variation_name"><?php echo esc_html( $name ); ?></span>
 									</span>
-								<?php if ( ! empty( $description ) ) : ?>
+									<?php if ( ! empty( $description ) ) : ?>
 										<span class="description"><?php echo esc_html( $description ); ?></span>
 									<?php endif; ?>
 								</button>
@@ -224,7 +224,7 @@ final class Modal_Checkout {
 					</div>
 				</div>
 			</div>
-				<?php
+			<?php
 		}
 	}
 

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -198,13 +198,13 @@ final class Modal_Checkout {
 					<div class="newspack-blocks-variation-modal__selection" data-product-id="<?php echo esc_attr( $product_id ); ?>">
 						<h3><?php echo esc_html( $product->get_name() ); ?></h3>
 						<p><?php esc_html_e( 'Select an option below:', 'newspack-blocks' ); ?></p>
-						<?php
-						$variations = $product->get_available_variations( 'objects' );
-						foreach ( $variations as $variation ) {
-							$name        = $variation->get_formatted_variation_attributes( true );
-							$price       = $variation->get_price_html();
-							$description = $variation->get_variation_description();
-							?>
+					<?php
+					$variations = $product->get_available_variations( 'objects' );
+					foreach ( $variations as $variation ) {
+						$name        = $variation->get_formatted_variation_attributes( true );
+						$price       = $variation->get_price_html();
+						$description = $variation->get_variation_description();
+						?>
 							<form>
 								<input type="hidden" name="newspack_checkout" value="1" />
 								<input type="hidden" name="product_id" value="<?php echo esc_attr( $variation->get_id() ); ?>" />
@@ -213,18 +213,18 @@ final class Modal_Checkout {
 										<span class="price"><?php echo $price; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
 										<span class="variation_name"><?php echo esc_html( $name ); ?></span>
 									</span>
-									<?php if ( ! empty( $description ) ) : ?>
+								<?php if ( ! empty( $description ) ) : ?>
 										<span class="description"><?php echo esc_html( $description ); ?></span>
 									<?php endif; ?>
 								</button>
 							</form>
 							<?php
-						}
-						?>
+					}
+					?>
 					</div>
 				</div>
 			</div>
-			<?php
+				<?php
 		}
 	}
 
@@ -337,9 +337,17 @@ final class Modal_Checkout {
 	 * @return string Template file.
 	 */
 	public static function wc_get_template( $located, $template_name ) {
-		if ( 'checkout/form-checkout.php' === $template_name && isset( $_REQUEST['modal_checkout'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$located = NEWSPACK_BLOCKS__PLUGIN_DIR . 'src/modal-checkout/templates/checkout-form.php';
+		$custom_templates = [
+			'checkout/form-checkout.php' => 'src/modal-checkout/templates/checkout-form.php',
+			'checkout/form-billing.php'  => 'src/modal-checkout/templates/billing-form.php',
+		];
+
+		foreach ( $custom_templates as $original_template => $custom_template ) {
+			if ( $template_name === $original_template && isset( $_REQUEST['modal_checkout'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$located = NEWSPACK_BLOCKS__PLUGIN_DIR . $custom_template;
+			}
 		}
+
 		return $located;
 	}
 
@@ -488,7 +496,7 @@ final class Modal_Checkout {
 	 *
 	 * @return bool
 	 */
-	private static function should_show_order_details() {
+	public static function should_show_order_details() {
 		$cart = \WC()->cart;
 		if ( $cart->is_empty() ) {
 			return false;

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -22,6 +22,12 @@
 			}
 		}
 	}
+	#order-details-wrapper.hidden {
+		display: none;
+	}
+	.woocommerce-NoticeGroup {
+		margin-top: 16px;
+	}
 	.woocommerce-checkout-review-order-table {
 		margin-top: 16px;
 		th,
@@ -29,6 +35,7 @@
 			font-size: 0.8rem;
 		}
 		&.empty {
+			display: none;
 			margin: 0;
 			padding: 0;
 		}
@@ -61,6 +68,17 @@
 			}
 		}
 	}
+	.woocommerce-account-fields .create-account {
+		border-bottom: 1px solid colors.$color__border;
+		padding-bottom: 32px;
+
+		.woocommerce-password-strength,
+		.woocommerce-password-hint {
+			color: colors.$color__error;
+			margin-top: 16px;
+		}
+	}
+
 	form {
 		margin: 0;
 		#wc-stripe-payment-request-button-separator {
@@ -168,6 +186,24 @@
 		list-style: none;
 		margin: 16px 0 0;
 		padding: 0;
+	}
+
+	.blockOverlay {
+		align-items: center;
+		display: flex;
+		inset: 0;
+		justify-content: center;
+		position: fixed !important;
+		&::after {
+			animation: spin 1s infinite linear;
+			border: 2px solid colors.$color__background-body;
+			border-top-color: colors.$color__text-light;
+			border-radius: 50%;
+			content: '';
+			display: block;
+			height: 25px;
+			width: 25px;
+		}
 	}
 }
 

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -57,6 +57,7 @@ domReady( () => {
 	modalCheckoutInput.name = 'modal_checkout';
 	modalCheckoutInput.value = '1';
 	const modalContent = modalCheckout.querySelector( '.newspack-blocks-checkout-modal__content' );
+	const initialHeight = modalContent.clientHeight + 'px';
 	const iframe = document.createElement( 'iframe' );
 	iframe.name = iframeName;
 	modalContent.appendChild( iframe );
@@ -69,6 +70,8 @@ domReady( () => {
 	closeButtons.forEach( button => {
 		button.addEventListener( 'click', ev => {
 			ev.preventDefault();
+			modalContent.style.height = initialHeight;
+			spinner.style.display = 'flex';
 			closeCheckout( modalCheckout );
 		} );
 	} );
@@ -129,6 +132,7 @@ domReady( () => {
 					const contentRect = entries[ 0 ].contentRect;
 					if ( contentRect ) {
 						modalContent.style.height = contentRect.top + contentRect.bottom + 'px';
+						spinner.style.display = 'none';
 					}
 				} );
 				iframe.addEventListener( 'load', () => {
@@ -144,11 +148,30 @@ domReady( () => {
 							ras.setAuthenticated( true );
 						}
 					}
-					const container = iframe.contentWindow.document.querySelector(
-						'#newspack_modal_checkout'
-					);
-					if ( container ) iframeResizeObserver.observe( container );
-					spinner.style.display = 'none';
+					const container = iframe.contentDocument.querySelector( '#newspack_modal_checkout' );
+					if ( container ) {
+						iframeResizeObserver.observe( container );
+					}
+					const innerButtons = [
+						...iframe.contentDocument.querySelectorAll( '.modal-continue, .edit-billing-link' ),
+					];
+					innerButtons.forEach( innerButton => {
+						innerButton.addEventListener( 'click', () => ( spinner.style.display = 'flex' ) );
+					} );
+					const innerForm = iframe.contentDocument.querySelector( '.checkout' );
+					if ( innerForm ) {
+						const innerBillingFields = [
+							...innerForm.querySelectorAll( '.woocommerce-billing-fields input' ),
+						];
+						innerBillingFields.forEach( innerField => {
+							innerField.addEventListener( 'keyup', e => {
+								if ( 'Enter' === e.key ) {
+									spinner.style.display = 'flex';
+									innerForm.submit();
+								}
+							} );
+						} );
+					}
 				} );
 			} );
 		} );

--- a/src/modal-checkout/modal.scss
+++ b/src/modal-checkout/modal.scss
@@ -41,24 +41,25 @@
 		}
 	}
 	&__spinner {
-		position: absolute;
-		top: 50%;
-		left: 50%;
-		transform: translate( -50%, -50% );
-		width: 100%;
-		height: 100%;
-		display: flex;
 		align-items: center;
-		justify-content: center;
 		background: #fff;
 		border-radius: 5px;
+		display: flex;
+		height: 100%;
+		justify-content: center;
+		left: 50%;
+		opacity: 0.5;
+		position: absolute;
+		top: 50%;
+		transform: translate(-50%, -50%);
+		width: 100%;
 		> span {
-			width: 25px;
-			height: 25px;
+			animation: spin 1s infinite linear;
 			border: 2px solid colors.$color__background-body;
 			border-top-color: colors.$color__text-light;
 			border-radius: 50%;
-			animation: spin 1s infinite linear;
+			height: 25px;
+			width: 25px;
 		}
 	}
 	&__close {

--- a/src/modal-checkout/templates/billing-form.php
+++ b/src/modal-checkout/templates/billing-form.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Billing Form
+ * Moves the account creation fields to our custom checkout-form.php.
+ * Original template: https://github.com/woocommerce/woocommerce/edit/trunk/plugins/woocommerce/templates/checkout/form-billing.php
+ *
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package Newspack_Blocks
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WooCommerce hooks.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template variables.
+
+?>
+<div class="woocommerce-billing-fields">
+	<?php if ( wc_ship_to_billing_address_only() && WC()->cart->needs_shipping() ) : ?>
+
+		<h3><?php esc_html_e( 'Billing &amp; Shipping', 'newspack-blocks' ); ?></h3>
+
+	<?php else : ?>
+
+		<h3><?php esc_html_e( 'Billing details', 'newspack-blocks' ); ?></h3>
+
+	<?php endif; ?>
+
+	<?php do_action( 'woocommerce_before_checkout_billing_form', $checkout ); ?>
+
+	<div class="woocommerce-billing-fields__field-wrapper">
+		<?php
+		$fields = $checkout->get_checkout_fields( 'billing' );
+
+		foreach ( $fields as $key => $field ) {
+			woocommerce_form_field( $key, $field, $checkout->get_value( $key ) );
+		}
+		?>
+	</div>
+
+	<?php do_action( 'woocommerce_after_checkout_billing_form', $checkout ); ?>
+</div>

--- a/src/modal-checkout/templates/checkout-form.php
+++ b/src/modal-checkout/templates/checkout-form.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Checkout Form
+ * Original template: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/templates/checkout/form-checkout.php
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package Newspack_Blocks
@@ -75,7 +76,7 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 	}
 	?>
 
-	<div id="order-details-wrapper">
+	<div id="order-details-wrapper" class="<?php echo esc_attr( ! \Newspack_Blocks\Modal_Checkout::should_show_order_details() ? 'hidden' : '' ); ?>">
 		<?php do_action( 'woocommerce_checkout_before_order_review_heading' ); ?>
 		<h3 id="order_review_heading" class="screen-reader-text"><?php esc_html_e( 'Order Details', 'newspack-blocks' ); ?></h3>
 		<?php do_action( 'woocommerce_checkout_before_order_review' ); ?>
@@ -108,6 +109,36 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 			<?php foreach ( $form_billing_fields as $key => $value ) : ?>
 				<input type="hidden" name="<?php echo esc_attr( 'billing_' . $key ); ?>" value="<?php echo esc_attr( $value ); ?>" />
 			<?php endforeach; ?>
+
+			<?php if ( ! is_user_logged_in() && $checkout->is_registration_enabled() ) : ?>
+				<div class="woocommerce-account-fields">
+					<?php if ( ! $checkout->is_registration_required() ) : ?>
+
+						<p class="form-row form-row-wide create-account">
+							<label class="woocommerce-form__label woocommerce-form__label-for-checkbox checkbox">
+								<input class="woocommerce-form__input woocommerce-form__input-checkbox input-checkbox" id="createaccount" <?php checked( ( true === $checkout->get_value( 'createaccount' ) || ( true === apply_filters( 'woocommerce_create_account_default_checked', false ) ) ), true ); ?> type="checkbox" name="createaccount" value="1" /> <span><?php esc_html_e( 'Create an account?', 'newspack-blocks' ); ?></span>
+							</label>
+						</p>
+
+					<?php endif; ?>
+
+					<?php do_action( 'woocommerce_before_checkout_registration_form', $checkout ); ?>
+
+					<?php if ( $checkout->get_checkout_fields( 'account' ) ) : ?>
+
+						<div class="create-account">
+							<?php foreach ( $checkout->get_checkout_fields( 'account' ) as $key => $field ) : ?>
+								<?php woocommerce_form_field( $key, $field, $checkout->get_value( $key ) ); ?>
+							<?php endforeach; ?>
+							<div class="clear"></div>
+						</div>
+
+					<?php endif; ?>
+
+					<?php do_action( 'woocommerce_after_checkout_registration_form', $checkout ); ?>
+				</div>
+			<?php endif; ?>
+
 			<div class="after-customer-details">
 				<?php do_action( 'woocommerce_checkout_after_customer_details' ); ?>
 			</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the modal checkout flow when WooCommerce settings are set to allow account creation and password setting during checkout.

Also adds a few accessibility and style improvements to the modal checkout flow:

- Allows submitting part 1 (billing details) of the form with and "enter" keypress
- Shows the spinner when submitting part 1 of the form, to provide visual feedback that the form is loading another part
- Fully hides the order review table if we're not supposed to see it (if there are no coupons or taxes to calculate), so that we don't see it flash on screen before Woo hides it via JS

Some caveats/discussion points:

- Enabling this account creation flow during checkout allows readers to bypass the RAS account verification flow, as the reader account will be generated with a password but without verifying ownership of the email address. Should we be concerned about this?
- The account creation fields will warn you about weak passwords, but this doesn't prevent you from submitting the form and creating an account with a weak password. This seems to be WooCommerce behavior, but it caught me a little off guard.

Closes `1200550061930446/1205326345667190`.

### How to test the changes in this Pull Request:

1. On `master`, in WooCommerce settings > Accounts & Privacy, enable the "Allow customers to create an account during checkout" option and disable the "When creating an account, automatically generate an account username for the customer based on their name, surname or email" and "When creating an account, send the new user a link to set their password" options. Like this:

<img width="1134" alt="Screenshot 2023-08-23 at 5 49 38 PM" src="https://github.com/Automattic/newspack-blocks/assets/2230142/a1f38e95-6491-41fc-a6e3-f18a6d51581c">

2. Start a donation with the modal checkout and observe that the "Create an account" section with username and password fields appear in the first part of the modal checkout flow.
3. Fill out all fields and click "Continue" to proceed to part 2.
4. Complete part 2 of the checkout flow and observe errors preventing you from submitting the form.
5. Check out this branch and repeat steps 2-4. This time confirm that the "Create an account" section and fields appear on part 2 of the checkout flow, and that you're able to complete the transaction.
6. After completing the transaction, start a new session and confirm you're able to log into the account using the email + password you set during step 5, and that the display name matches what you entered during checkout.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
