### PR TITLE
feat: add option for a button after checkout

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -553,22 +553,24 @@ final class Modal_Checkout {
 	 */
 	public static function woocommerce_thankyou() {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( ! isset( $_REQUEST['modal_checkout'] ) ||
+		if (
+			empty( $_REQUEST['modal_checkout'] ) ||
 			empty( $_REQUEST['after_success_behavior'] ) ||
-			empty( $_REQUEST['after_success_button_label'] ) ||
 			empty( $_REQUEST['after_success_url'] )
 		) {
 			return;
 		}
+
+		$button_label = ! empty( $_REQUEST['after_success_button_label'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['after_success_button_label'] ) ) : __( 'Continue browsing', 'newspack-blocks' );
 
 		?>
 			<a
 				class="button"
 				href="<?php echo esc_url( sanitize_text_field( wp_unslash( $_REQUEST['after_success_url'] ) ) ); ?>"
 				target="_top"
-				style="display:block;"
+				style="display:block;margin:16px 0;"
 			>
-				<?php echo esc_html( sanitize_text_field( wp_unslash( $_REQUEST['after_success_button_label'] ) ) ); ?>
+				<?php echo esc_html( $button_label ); ?>
 			</a>
 		<?php
 		// phpcs:enable

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -562,7 +562,11 @@ final class Modal_Checkout {
 		}
 
 		?>
-			<a class="button" href="<?php echo esc_url( sanitize_text_field( wp_unslash( $_REQUEST['after_success_url'] ) ) ); ?>">
+			<a
+				class="button"
+				href="<?php echo esc_url( sanitize_text_field( wp_unslash( $_REQUEST['after_success_url'] ) ) ); ?>"
+				target="_top"
+			>
 				<?php echo esc_html( sanitize_text_field( wp_unslash( $_REQUEST['after_success_button_label'] ) ) ); ?>
 			</a>
 		<?php

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -43,15 +43,21 @@ final class Modal_Checkout {
 		add_filter( 'woocommerce_checkout_get_value', [ __CLASS__, 'woocommerce_checkout_get_value' ], 10, 2 );
 		add_filter( 'woocommerce_checkout_fields', [ __CLASS__, 'woocommerce_checkout_fields' ] );
 		add_filter( 'woocommerce_update_order_review_fragments', [ __CLASS__, 'order_review_fragments' ] );
+		add_action( 'woocommerce_thankyou', [ __CLASS__, 'woocommerce_thankyou' ] ); // Core Woo, not present in Newspack theme custom template.
+		add_action( 'newspack_woocommerce_thankyou', [ __CLASS__, 'woocommerce_thankyou' ] ); // Newspack Theme.
 	}
 
 	/**
 	 * Process checkout request for modal.
 	 */
 	public static function process_checkout_request() {
-		$is_newspack_checkout = filter_input( INPUT_GET, 'newspack_checkout', FILTER_SANITIZE_NUMBER_INT );
-		$product_id           = filter_input( INPUT_GET, 'product_id', FILTER_SANITIZE_NUMBER_INT );
-		$variation_id         = filter_input( INPUT_GET, 'variation_id', FILTER_SANITIZE_NUMBER_INT );
+		$is_newspack_checkout       = filter_input( INPUT_GET, 'newspack_checkout', FILTER_SANITIZE_NUMBER_INT );
+		$product_id                 = filter_input( INPUT_GET, 'product_id', FILTER_SANITIZE_NUMBER_INT );
+		$variation_id               = filter_input( INPUT_GET, 'variation_id', FILTER_SANITIZE_NUMBER_INT );
+		$after_success_behavior     = filter_input( INPUT_GET, 'after_success_behavior', FILTER_SANITIZE_STRING );
+		$after_success_url          = filter_input( INPUT_GET, 'after_success_url', FILTER_SANITIZE_STRING );
+		$after_success_button_label = filter_input( INPUT_GET, 'after_success_button_label', FILTER_SANITIZE_STRING );
+
 		if ( ! $is_newspack_checkout || ! $product_id ) {
 			return;
 		}
@@ -69,6 +75,8 @@ final class Modal_Checkout {
 		if ( ! empty( $parsed_url['query'] ) ) {
 			wp_parse_str( $parsed_url['query'], $params );
 		}
+
+		$params = array_merge( $params, compact( 'after_success_behavior', 'after_success_url', 'after_success_button_label' ) );
 
 		if ( function_exists( 'wpcom_vip_url_to_postid' ) ) {
 			$referer_post_id = wpcom_vip_url_to_postid( $referer );
@@ -134,9 +142,9 @@ final class Modal_Checkout {
 		}
 		$query_args['modal_checkout'] = 1;
 
-		// Pass through UTM params so they can be forwarded to the WooCommerce checkout flow.
+		// Pass through UTM and after_success params so they can be forwarded to the WooCommerce checkout flow.
 		foreach ( $params as $param => $value ) {
-			if ( 'utm' === substr( $param, 0, 3 ) ) {
+			if ( 'utm' === substr( $param, 0, 3 ) || 'after_success' === substr( $param, 0, 13 ) ) {
 				$param                = sanitize_text_field( $param );
 				$query_args[ $param ] = sanitize_text_field( $value );
 			}
@@ -319,10 +327,14 @@ final class Modal_Checkout {
 		if ( ! isset( $_REQUEST['modal_checkout'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return $url;
 		}
+
 		return add_query_arg(
 			[
-				'modal_checkout' => '1',
-				'email'          => isset( $_REQUEST['billing_email'] ) ? rawurlencode( sanitize_email( wp_unslash( $_REQUEST['billing_email'] ) ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				'modal_checkout'             => '1',
+				'email'                      => isset( $_REQUEST['billing_email'] ) ? rawurlencode( sanitize_email( wp_unslash( $_REQUEST['billing_email'] ) ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				'after_success_behavior'     => isset( $_REQUEST['after_success_behavior'] ) ? rawurlencode( sanitize_text_field( wp_unslash( $_REQUEST['after_success_behavior'] ) ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				'after_success_url'          => isset( $_REQUEST['after_success_url'] ) ? rawurlencode( sanitize_text_field( wp_unslash( $_REQUEST['after_success_url'] ) ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				'after_success_button_label' => isset( $_REQUEST['after_success_button_label'] ) ? rawurlencode( sanitize_text_field( wp_unslash( $_REQUEST['after_success_button_label'] ) ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			],
 			$url
 		);
@@ -532,6 +544,29 @@ final class Modal_Checkout {
 			$fragments['.woocommerce-checkout-review-order-table'] = '<table class="shop_table woocommerce-checkout-review-order-table empty"></table>';
 		}
 		return $fragments;
+	}
+
+	/**
+	 * Adds an additional button to the Thank you page
+	 *
+	 * @return void
+	 */
+	public static function woocommerce_thankyou() {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_REQUEST['modal_checkout'] ) ||
+			empty( $_REQUEST['after_success_behavior'] ) ||
+			empty( $_REQUEST['after_success_button_label'] ) ||
+			empty( $_REQUEST['after_success_url'] )
+		) {
+			return;
+		}
+
+		?>
+			<a class="button" href="<?php echo esc_url( sanitize_text_field( wp_unslash( $_REQUEST['after_success_url'] ) ) ); ?>">
+				<?php echo esc_html( sanitize_text_field( wp_unslash( $_REQUEST['after_success_button_label'] ) ) ); ?>
+			</a>
+		<?php
+		// phpcs:enable
 	}
 }
 Modal_Checkout::init();

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -566,6 +566,7 @@ final class Modal_Checkout {
 				class="button"
 				href="<?php echo esc_url( sanitize_text_field( wp_unslash( $_REQUEST['after_success_url'] ) ) ); ?>"
 				target="_top"
+				style="display:block;"
 			>
 				<?php echo esc_html( sanitize_text_field( wp_unslash( $_REQUEST['after_success_button_label'] ) ) ); ?>
 			</a>

--- a/src/blocks/checkout-button/block.json
+++ b/src/blocks/checkout-button/block.json
@@ -35,6 +35,15 @@
 		},
 		"gradient": {
 			"type": "string"
+		},
+		"afterSuccessBehavior": {
+			"type": "string"
+		},
+		"afterSuccessButtonLabel": {
+			"type": "string"
+		},
+		"afterSuccessURL": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -158,7 +158,7 @@ function RedirectAfterSuccess( props ) {
 	return (
 		<>
 			<SelectControl
-				label={ __( 'Redirect after success', 'newspack-blocks' ) }
+				label={ __( 'Post-Checkout Button', 'newspack-blocks' ) }
 				help={ __(
 					'Select whether the user should be presented with a button to navigate after a successful purchase.',
 					'newspack-blocks'

--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -160,7 +160,7 @@ function RedirectAfterSuccess( props ) {
 			<SelectControl
 				label={ __( 'Redirect after success', 'newspack-blocks' ) }
 				help={ __(
-					'Select whether the user should be presented with a button to navigate after a successfull purchase.',
+					'Select whether the user should be presented with a button to navigate after a successful purchase.',
 					'newspack-blocks'
 				) }
 				value={ attributes.afterSuccessBehavior }

--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -167,7 +167,7 @@ function RedirectAfterSuccess( props ) {
 				options={ [
 					{ label: __( 'Do not show a button', 'newspack-blocks' ), value: '' },
 					{ label: __( 'Go to a custom URL', 'newspack-blocks' ), value: 'custom' },
-					{ label: __( 'Go to the referrer page', 'newspack-blocks' ), value: 'referrer' },
+					{ label: __( 'Go to the previous page', 'newspack-blocks' ), value: 'referrer' },
 				] }
 				onChange={ value => {
 					setAttributes( { afterSuccessBehavior: value.toString() } );

--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -153,6 +153,48 @@ function ProductControl( props ) {
 	);
 }
 
+function RedirectAfterSuccess( props ) {
+	const { attributes, setAttributes } = props;
+	return (
+		<>
+			<SelectControl
+				label={ __( 'Redirect after success', 'newspack-blocks' ) }
+				help={ __(
+					'Select whether the user should be presented with a button to navigate after a successfull purchase.',
+					'newspack-blocks'
+				) }
+				value={ attributes.afterSuccessBehavior }
+				options={ [
+					{ label: __( 'Do not show a button', 'newspack-blocks' ), value: '' },
+					{ label: __( 'Go to a custom URL', 'newspack-blocks' ), value: 'custom' },
+					{ label: __( 'Go to the referrer page', 'newspack-blocks' ), value: 'referrer' },
+				] }
+				onChange={ value => {
+					setAttributes( { afterSuccessBehavior: value.toString() } );
+				} }
+			/>
+			{ attributes.afterSuccessBehavior !== '' && (
+				<>
+					<TextControl
+						label={ __( 'Button Label', 'newspack-blocks' ) }
+						placeholder={ __( 'Continue browsing', 'newspack-blocks' ) }
+						value={ attributes.afterSuccessButtonLabel || '' }
+						onChange={ value => setAttributes( { afterSuccessButtonLabel: value } ) }
+					/>
+					{ attributes.afterSuccessBehavior === 'custom' && (
+						<TextControl
+							label={ __( 'Custom URL', 'newspack-blocks' ) }
+							placeholder={ __( 'https://example.com', 'newspack-blocks' ) }
+							value={ attributes.afterSuccessURL || '' }
+							onChange={ value => setAttributes( { afterSuccessURL: value } ) }
+						/>
+					) }
+				</>
+			) }
+		</>
+	);
+}
+
 function CheckoutButtonEdit( props ) {
 	const { attributes, setAttributes, className } = props;
 	const { placeholder, style, text, product, price, variation } = attributes;
@@ -290,6 +332,9 @@ function CheckoutButtonEdit( props ) {
 							</>
 						) }
 					</ProductControl>
+				</PanelBody>
+				<PanelBody title={ __( 'After purchase', 'newspack-blocks' ) }>
+					<RedirectAfterSuccess setAttributes={ setAttributes } attributes={ attributes } />
 				</PanelBody>
 				{ nyp?.isNYP && (
 					<PanelBody title={ __( 'Name Your Price', 'newspack-blocks' ) }>

--- a/src/blocks/checkout-button/save.js
+++ b/src/blocks/checkout-button/save.js
@@ -57,6 +57,18 @@ export default function save( { attributes, className } ) {
 				/>
 				<input type="hidden" name="product_id" value={ product } />
 				<input type="hidden" name="newspack_checkout" value="1" />
+				<input
+					type="hidden"
+					name="after_success_behavior"
+					value={ attributes.afterSuccessBehavior }
+				/>
+				<input
+					type="hidden"
+					name="after_success_button_label"
+					value={ attributes.afterSuccessButtonLabel }
+				/>
+				<input type="hidden" name="after_success_url" value={ attributes.afterSuccessURL } />
+
 				{ price && <input type="hidden" name="price" value={ price } /> }
 				{ variation && <input type="hidden" name="variation_id" value={ variation } /> }
 				{ is_variable && <input type="hidden" name="is_variable" value="1" /> }

--- a/src/blocks/checkout-button/save.js
+++ b/src/blocks/checkout-button/save.js
@@ -76,8 +76,12 @@ export default function save( { attributes, className } ) {
 						value={ attributes.afterSuccessButtonLabel }
 					/>
 				) }
-				{ attributes.afterSuccessURL && (
-					<input type="hidden" name="after_success_url" value={ attributes.afterSuccessURL } />
+				{ attributes.afterSuccessBehavior && (
+					<input
+						type="hidden"
+						name="after_success_url"
+						value={ attributes.afterSuccessURL || '' }
+					/>
 				) }
 			</form>
 		</div>

--- a/src/blocks/checkout-button/save.js
+++ b/src/blocks/checkout-button/save.js
@@ -57,21 +57,28 @@ export default function save( { attributes, className } ) {
 				/>
 				<input type="hidden" name="product_id" value={ product } />
 				<input type="hidden" name="newspack_checkout" value="1" />
-				<input
-					type="hidden"
-					name="after_success_behavior"
-					value={ attributes.afterSuccessBehavior }
-				/>
-				<input
-					type="hidden"
-					name="after_success_button_label"
-					value={ attributes.afterSuccessButtonLabel }
-				/>
-				<input type="hidden" name="after_success_url" value={ attributes.afterSuccessURL } />
 
 				{ price && <input type="hidden" name="price" value={ price } /> }
 				{ variation && <input type="hidden" name="variation_id" value={ variation } /> }
 				{ is_variable && <input type="hidden" name="is_variable" value="1" /> }
+
+				{ attributes.afterSuccessBehavior && (
+					<input
+						type="hidden"
+						name="after_success_behavior"
+						value={ attributes.afterSuccessBehavior }
+					/>
+				) }
+				{ attributes.afterSuccessButtonlabel && (
+					<input
+						type="hidden"
+						name="after_success_button_label"
+						value={ attributes.afterSuccessButtonLabel }
+					/>
+				) }
+				{ attributes.afterSuccessURL && (
+					<input type="hidden" name="after_success_url" value={ attributes.afterSuccessURL } />
+				) }
 			</form>
 		</div>
 	);

--- a/src/blocks/checkout-button/save.js
+++ b/src/blocks/checkout-button/save.js
@@ -69,7 +69,7 @@ export default function save( { attributes, className } ) {
 						value={ attributes.afterSuccessBehavior }
 					/>
 				) }
-				{ attributes.afterSuccessButtonlabel && (
+				{ attributes.afterSuccessButtonLabel && (
 					<input
 						type="hidden"
 						name="after_success_button_label"

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -105,6 +105,20 @@ domReady( () => {
 		forms.forEach( form => {
 			form.appendChild( modalCheckoutInput.cloneNode() );
 			form.target = iframeName;
+
+			// Fill in the referrer field.
+			const afterSuccessUrlInput = form.querySelector( 'input[name="after_success_url"]' );
+			const afterSuccessBehaviorInput = form.querySelector(
+				'input[name="after_success_behavior"]'
+			);
+			if (
+				afterSuccessBehaviorInput &&
+				afterSuccessUrlInput &&
+				'referrer' === afterSuccessBehaviorInput.getAttribute( 'value' )
+			) {
+				afterSuccessUrlInput.setAttribute( 'value', document.referrer );
+			}
+
 			form.addEventListener( 'submit', ev => {
 				const formData = new FormData( form );
 				// Clear any open variation modal.

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -116,7 +116,7 @@ domReady( () => {
 				afterSuccessUrlInput &&
 				'referrer' === afterSuccessBehaviorInput.getAttribute( 'value' )
 			) {
-				afterSuccessUrlInput.setAttribute( 'value', document.referrer );
+				afterSuccessUrlInput.setAttribute( 'value', document.referrer || window.location.href );
 			}
 
 			form.addEventListener( 'submit', ev => {

--- a/src/modal-checkout/templates/checkout-form.php
+++ b/src/modal-checkout/templates/checkout-form.php
@@ -24,6 +24,10 @@ $form_class          = 'checkout woocommerce-checkout';
 $form_method         = $edit_billing ? 'get' : 'post';
 $form_billing_fields = \Newspack_Blocks\Modal_Checkout::get_prefilled_fields();
 
+$after_success_behavior     = filter_input( INPUT_GET, 'after_success_behavior', FILTER_SANITIZE_STRING );
+$after_success_url          = filter_input( INPUT_GET, 'after_success_url', FILTER_SANITIZE_STRING );
+$after_success_button_label = filter_input( INPUT_GET, 'after_success_button_label', FILTER_SANITIZE_STRING );
+
 if ( $edit_billing ) {
 	$form_class .= ' edit-billing';
 }
@@ -70,6 +74,10 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 <form name="checkout" method="<?php echo esc_attr( $form_method ); ?>" class="<?php echo esc_attr( $form_class ); ?>" action="<?php echo esc_url( $form_action ); ?>" enctype="multipart/form-data">
 
 	<input type="hidden" name="modal_checkout" value="1" />
+	<input type="hidden" name="after_success_behavior" value="<?php echo esc_attr( $after_success_behavior ); ?>" />
+	<input type="hidden" name="after_success_url" value="<?php echo esc_attr( $after_success_url ); ?>" />
+	<input type="hidden" name="after_success_button_label" value="<?php echo esc_attr( $after_success_button_label ); ?>" />
+
 	<?php
 	if ( $edit_billing ) {
 		wp_nonce_field( 'newspack_blocks_edit_billing', 'newspack_blocks_edit_billing_nonce' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements an optional link to click after the transaction is complete on the modal checkout.

The button supports linking to the page referrer (which falls back to the current page URL if the referrer is empty) or a custom URL.

![image](https://github.com/Automattic/newspack-blocks/assets/971483/d91ce97a-af7f-47eb-bd8c-5738da373ba7)


### How to test the changes in this Pull Request:

1. Checkout this branch and https://github.com/Automattic/newspack-theme/pull/2180
2. Add a checkout button to a page
3. Select the option to go to the Referrer after purchase and add a button label
4. Add a link to this page in the site menu
5. Visit an article
6. Go to the page via the menu link
7. Click the button and buy the product
8. Confirm the button shows up in the thank you message and link back to the article you were seeing
9. In a new tab, copy and paste the page URL directly into the browser so you get no referrer
10. Make the purchase again and confirm the button links to the current page
11. Edit the button and choose to go to a custom URL
12. Repeat the purchase and confirm the button now takes you to that URL
13. Edit the button again and choose not to show the button
14. Purchase again and confirm there is no button in the thank you message

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
