### PR TITLE
feat: add category filter for the categories in the blocks

### DIFF
--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -161,7 +161,7 @@ class Newspack_Blocks_API {
 
 		$linked_category = '<a href="#">' . $category->name . '</a>';
 
-		return apply_filters( 'newspack_block_categories', $linked_category );
+		return wp_kses_post( apply_filters( 'newspack_blocks_categories', $linked_category ) );
 	}
 
 	/**

--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -159,7 +159,9 @@ class Newspack_Blocks_API {
 			return '';
 		}
 
-		return $category->name;
+		$linked_category = '<a href="#">' . $category->name . '</a>';
+
+		return apply_filters( 'newspack_block_categories', $linked_category );
 	}
 
 	/**

--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -161,7 +161,7 @@ class Newspack_Blocks_API {
 
 		$linked_category = '<a href="#">' . $category->name . '</a>';
 
-		return wp_kses_post( apply_filters( 'newspack_blocks_categories', $linked_category ) );
+		return apply_filters( 'newspack_blocks_categories', $linked_category );
 	}
 
 	/**

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 import { dateI18n, __experimentalGetSettings } from '@wordpress/date';
-import { Component, createRef, Fragment } from '@wordpress/element';
+import { Component, createRef, Fragment, RawHTML } from '@wordpress/element';
 import {
 	BaseControl,
 	Button,
@@ -303,7 +303,7 @@ class Edit extends Component {
 														{ showCategory &&
 															( ! post.newspack_post_sponsors ||
 																post.newspack_sponsors_show_categories ) && (
-																<a href="#">{ decodeEntities( post.newspack_category_info ) }</a>
+																<RawHTML>{ decodeEntities( post.newspack_category_info ) }</RawHTML>
 															) }
 													</div>
 												) }

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -111,36 +111,10 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 									</span>
 									<?php
 								endif;
-								$category = false;
 
-								// Use Yoast primary category if set.
-								if ( class_exists( 'WPSEO_Primary_Term' ) ) {
-									$primary_term = new WPSEO_Primary_Term( 'category', $post_id );
-									$category_id  = $primary_term->get_primary_term();
-									if ( $category_id ) {
-										$category = get_term( $category_id );
-									}
-								}
-
-								if ( ! $category ) {
-									$categories_list = get_the_category();
-									if ( ! empty( $categories_list ) ) {
-										$category = $categories_list[0];
-									}
-								}
-
-								if ( $attributes['showCategory'] && $category && ( empty( $sponsors ) || Newspack_Blocks::newspack_display_sponsors_and_categories( $sponsors ) ) ) :
-									?>
-									<?php $category_link = get_category_link( $category->term_id ); ?>
-									<?php if ( ! empty( $category_link ) ) : ?>
-										<a href="<?php echo esc_url( get_category_link( $category->term_id ) ); ?>">
-									<?php endif; ?>
-										<?php echo esc_html( $category->name ); ?>
-									<?php if ( ! empty( $category_link ) ) : ?>
-									</a>
-										<?php
-										endif;
-									endif;
+								if ( $attributes['showCategory'] && ( empty( $sponsors ) || Newspack_Blocks::newspack_display_sponsors_and_categories( $sponsors ) ) ) :
+									newspack_blocks_categories( $post_id );
+								endif;
 								?>
 								</div>
 							<?php

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -113,7 +113,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 								endif;
 
 								if ( $attributes['showCategory'] && ( empty( $sponsors ) || Newspack_Blocks::newspack_display_sponsors_and_categories( $sponsors ) ) ) :
-									newspack_blocks_categories( $post_id );
+									echo wp_kses_post( newspack_blocks_format_categories( $post_id ) );
 								endif;
 								?>
 								</div>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -181,7 +181,7 @@ class Edit extends Component {
 							) }
 							{ showCategory &&
 								( ! post.newspack_post_sponsors || post.newspack_sponsors_show_categories ) && (
-									<a href="#">{ decodeEntities( post.newspack_category_info ) }</a>
+									<RawHTML>{ decodeEntities( post.newspack_category_info ) }</RawHTML>
 								) }
 						</div>
 					) }

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -56,21 +56,6 @@ call_user_func(
 		if ( $attributes['fetchPriority'] && in_array( $attributes['fetchPriority'], [ 'high', 'low', 'auto' ], true ) ) {
 			$thumbnail_args['fetchpriority'] = $attributes['fetchPriority'];
 		}
-		$category = false;
-		// Use Yoast primary category if set.
-		if ( class_exists( 'WPSEO_Primary_Term' ) ) {
-			$primary_term = new WPSEO_Primary_Term( 'category', $post_id );
-			$category_id  = $primary_term->get_primary_term();
-			if ( $category_id ) {
-				$category = get_term( $category_id );
-			}
-		}
-		if ( ! $category ) {
-			$categories_list = get_the_category();
-			if ( ! empty( $categories_list ) ) {
-				$category = $categories_list[0];
-			}
-		}
 
 		// Support Newspack Listings hide author/publish date options.
 		$hide_author       = apply_filters( 'newspack_listings_hide_author', false ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
@@ -105,19 +90,20 @@ call_user_func(
 		<?php endif; ?>
 
 		<div class="entry-wrapper">
-			<?php if ( ! empty( $sponsors ) || ( $attributes['showCategory'] && $category ) ) : ?>
-				<?php $category_link = get_category_link( $category->term_id ); ?>
+			<?php if ( ! empty( $sponsors ) || ( $attributes['showCategory'] ) ) : ?>
+
 				<div class="cat-links <?php if ( ! empty( $sponsors ) ) : ?>sponsor-label<?php endif; // phpcs:ignore Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace ?>">
 					<?php if ( ! empty( $sponsors ) ) : ?>
 						<span class="flag">
 							<?php echo esc_html( Newspack_Blocks::get_sponsor_label( $sponsors ) ); ?>
 						</span>
-					<?php endif; ?>
-					<?php if ( $attributes['showCategory'] && ! empty( $category_link ) && ( empty( $sponsors ) || Newspack_Blocks::newspack_display_sponsors_and_categories( $sponsors ) ) ) : ?>
-					<a href="<?php echo esc_url( $category_link ); ?>">
-						<?php echo esc_html( $category->name ); ?>
-					</a>
-					<?php endif; ?>
+						<?php
+					endif;
+
+					if ( $attributes['showCategory'] && ( empty( $sponsors ) || Newspack_Blocks::newspack_display_sponsors_and_categories( $sponsors ) ) ) :
+						newspack_blocks_categories( $post_id );
+					endif;
+					?>
 				</div>
 				<?php
 			endif;

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -101,7 +101,7 @@ call_user_func(
 					endif;
 
 					if ( $attributes['showCategory'] && ( empty( $sponsors ) || Newspack_Blocks::newspack_display_sponsors_and_categories( $sponsors ) ) ) :
-						newspack_blocks_categories( $post_id );
+						echo wp_kses_post( newspack_blocks_format_categories( $post_id ) );
 					endif;
 					?>
 				</div>

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -337,6 +337,13 @@ function newspack_blocks_format_byline( $author_info ) {
 	return implode( '', $elements );
 }
 
+/**
+ * Renders category markup plus filter.
+ *
+ * @param string $post_id Post ID.
+ *
+ * @return string Returns filtered category markup.
+ */
 function newspack_blocks_categories( $post_id ) {
 	$category = false;
 	// Use Yoast primary category if set.
@@ -354,15 +361,15 @@ function newspack_blocks_categories( $post_id ) {
 		}
 	}
 
-	$category_link = get_category_link( $category->term_id );
+	$category_link      = get_category_link( $category->term_id );
 	$category_formatted = esc_html( $category->name );
 
 	if ( ! empty( $category_link ) ) {
-		$category_formatted = "<a href='" . esc_attr( $category_link ) . "'>" . esc_html( $category->name ) . "</a>";
+		$category_formatted = '<a href="' . esc_attr( $category_link ) . '">' . esc_html( $category->name ) . '</a>';
 	}
 
 	if ( $category ) {
-		echo apply_filters( 'newspack_block_categories', $category_formatted );
+		echo apply_filters( 'newspack_blocks_categories', $category_formatted );
 	}
 }
 

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -341,10 +341,8 @@ function newspack_blocks_format_byline( $author_info ) {
  * Renders category markup plus filter.
  *
  * @param string $post_id Post ID.
- *
- * @return string Returns filtered category markup.
  */
-function newspack_blocks_categories( $post_id ) {
+function newspack_blocks_format_categories( $post_id ) {
 	$category = false;
 	// Use Yoast primary category if set.
 	if ( class_exists( 'WPSEO_Primary_Term' ) ) {
@@ -369,7 +367,7 @@ function newspack_blocks_categories( $post_id ) {
 	}
 
 	if ( $category ) {
-		echo apply_filters( 'newspack_blocks_categories', $category_formatted );
+		return apply_filters( 'newspack_blocks_categories', $category_formatted );
 	}
 }
 

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -337,6 +337,35 @@ function newspack_blocks_format_byline( $author_info ) {
 	return implode( '', $elements );
 }
 
+function newspack_blocks_categories( $post_id ) {
+	$category = false;
+	// Use Yoast primary category if set.
+	if ( class_exists( 'WPSEO_Primary_Term' ) ) {
+		$primary_term = new WPSEO_Primary_Term( 'category', $post_id );
+		$category_id  = $primary_term->get_primary_term();
+		if ( $category_id ) {
+			$category = get_term( $category_id );
+		}
+	}
+	if ( ! $category ) {
+		$categories_list = get_the_category();
+		if ( ! empty( $categories_list ) ) {
+			$category = $categories_list[0];
+		}
+	}
+
+	$category_link = get_category_link( $category->term_id );
+	$category_formatted = esc_html( $category->name );
+
+	if ( ! empty( $category_link ) ) {
+		$category_formatted = "<a href='" . esc_attr( $category_link ) . "'>" . esc_html( $category->name ) . "</a>";
+	}
+
+	if ( $category ) {
+		echo apply_filters( 'newspack_block_categories', $category_formatted );
+	}
+}
+
 /**
  * Inject amp-state containing all post IDs visible on page load.
  */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the filter `newspack_block_categories` to the post category output used by the Homepage Posts and Carousel blocks, similar to the `[newspack_theme_categories](https://github.com/Automattic/newspack-theme/blob/84319066842b0aea136b1ccab4d5c1f6c3b93592/newspack-theme/inc/template-tags.php#L257)` filter used in the themes.

This addresses a publisher specific request related to how one of our smaller plugins works on single posts but not Homepage Posts, but it could have some other uses!

See 1205368557216686-as-1205459019020490.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Add a Homepage Posts and Carousel block to the editor; set the categories to display. Confirm there are no issues. 
3. Set up something to filter `newspack_blocks_categories`, or test this plugin with: 115-gh-automattic/newspack-custom-code
4. Confirm that the filtered content is showing up after the categories for both blocks, on the front-end and in the editor. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
