### PR TITLE
fix: harden usage and output of attribute values

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -1496,5 +1496,32 @@ class Newspack_Blocks {
 			return 'white';
 		}
 	}
+
+	/**
+	 * Get an array of allowed HTML attributes for sanitizing image markup.
+	 * For use with wp_kses: https://developer.wordpress.org/reference/functions/wp_kses/
+	 *
+	 * @return array
+	 */
+	public static function get_sanitized_image_attributes() {
+		return [
+			'img'      => [
+				'alt'      => true,
+				'class'    => true,
+				'data-*'   => true,
+				'decoding' => true,
+				'height'   => true,
+				'loading'  => true,
+				'sizes'    => true,
+				'src'      => true,
+				'srcset'   => true,
+				'width'    => true,
+			],
+			'noscript' => [],
+			'a'        => [
+				'href' => true,
+			],
+		];
+	}
 }
 Newspack_Blocks::init();

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -543,13 +543,15 @@ class Newspack_Blocks {
 			),
 		);
 
-		foreach ( $sizes[ $orientation ] as $key => $dimensions ) {
-			$attachment = wp_get_attachment_image_src(
-				get_post_thumbnail_id( get_the_ID() ),
-				'newspack-article-block-' . $orientation . '-' . $key
-			);
-			if ( ! empty( $attachment ) && $dimensions[0] === $attachment[1] && $dimensions[1] === $attachment[2] ) {
-				return 'newspack-article-block-' . $orientation . '-' . $key;
+		if ( isset( $sizes[ $orientation ] ) ) {
+			foreach ( $sizes[ $orientation ] as $key => $dimensions ) {
+				$attachment = wp_get_attachment_image_src(
+					get_post_thumbnail_id( get_the_ID() ),
+					'newspack-article-block-' . $orientation . '-' . $key
+				);
+				if ( ! empty( $attachment ) && $dimensions[0] === $attachment[1] && $dimensions[1] === $attachment[2] ) {
+					return 'newspack-article-block-' . $orientation . '-' . $key;
+				}
 			}
 		}
 

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -73,6 +73,10 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 			$hide_publish_date = apply_filters( 'newspack_listings_hide_publish_date', false ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 			$show_author       = $attributes['showAuthor'] && ! $hide_author;
 			$show_date         = $attributes['showDate'] && ! $hide_publish_date;
+
+			// Validate the value of the "image fit" attribute.
+			$image_fits = [ 'cover', 'contain' ];
+			$image_fit  = in_array( $attributes['imageFit'], $image_fits, true ) ? $attributes['imageFit'] : $image_fits[0];
 			?>
 
 			<article data-post-id="<?php echo esc_attr( $post_id ); ?>" class="<?php echo esc_attr( implode( ' ', $article_classes ) . ' ' . $post_type ); ?>">
@@ -86,9 +90,9 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 								the_post_thumbnail(
 									'large',
 									array(
-										'object-fit' => $attributes['imageFit'],
+										'object-fit' => $image_fit,
 										'layout'     => 'fill',
-										'class'      => 'contain' === $attributes['imageFit'] ? 'image-fit-contain' : 'image-fit-cover',
+										'class'      => 'contain' === $image_fit ? 'image-fit-contain' : 'image-fit-cover',
 										'alt'        => trim( wp_strip_all_tags( get_the_title( $post_id ) ) ),
 									)
 								);

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -249,9 +249,9 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 		);
 	}
 
-	$slides_per_view = absint( $attributes['slidesPerView'] ) ?? 1;
+	$slides_per_view = absint( $attributes['slidesPerView'] ?? 1 );
 	$slides_to_show  = $slides_per_view <= $counter ? $slides_per_view : $counter;
-	$aspect_ratio    = floatval( $attributes['aspectRatio'] ) ?? 0.75;
+	$aspect_ratio    = floatval( $attributes['aspectRatio'] ?? 0.75 ) ;
 
 	if ( $is_amp ) {
 		$selector = sprintf(

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -259,8 +259,9 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 		);
 	}
 
-	$slides_per_view = absint( ! empty( $attributes['slidesPerView'] ) ? $attributes['slidesPerView'] : 1 );
+	$slides_per_view = absint( $attributes['slidesPerView'] ) ?? 1;
 	$slides_to_show  = $slides_per_view <= $counter ? $slides_per_view : $counter;
+	$aspect_ratio    = floatval( $attributes['aspectRatio'] ) ?? 0.75;
 
 	if ( $is_amp ) {
 		$selector = sprintf(
@@ -272,15 +273,15 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 
 		$carousel    = sprintf(
 			'<amp-base-carousel class="wp-block-newspack-carousel__amp-carousel" width="%1$s" height="%2$s" heights="%3$s" layout="responsive" snap="true" data-next-button-aria-label="%4$s" data-prev-button-aria-label="%5$s" controls="auto" loop="true" %6$s id="wp-block-newspack-carousel__amp-carousel__%7$s" on="slideChange:wp-block-newspack-carousel__amp-pagination__%7$s.toggle(index=event.index, value=true)" advance-count="1" visible-count="%8$s">%9$s</amp-base-carousel>',
-			$attributes['slidesPerView'] * 1,
-			$attributes['aspectRatio'],
-			'(min-width: 1168px) ' . ( $attributes['aspectRatio'] / $slides_to_show * 100 ) . '% !important, (min-width: 782px) ' . ( $slides_to_show > 1 ? ( $attributes['aspectRatio'] / 2 * 100 ) . '% !important' : ( $attributes['aspectRatio'] * 100 ) . '% !important' ) . ', ' . ( $attributes['aspectRatio'] * 100 ) . '% !important',
+			esc_attr( $slides_per_view * 1 ),
+			esc_attr( $aspect_ratio ),
+			esc_attr( '(min-width: 1168px) ' . ( $aspect_ratio / $slides_to_show * 100 ) . '% !important, (min-width: 782px) ' . ( $slides_to_show > 1 ? ( $aspect_ratio / 2 * 100 ) . '% !important' : ( $aspect_ratio * 100 ) . '% !important' ) . ', ' . ( $aspect_ratio * 100 ) . '% !important' ),
 			esc_attr__( 'Next Slide', 'newspack-blocks' ),
 			esc_attr__( 'Previous Slide', 'newspack-blocks' ),
 			$autoplay ? 'auto-advance="true" auto-advance-interval=' . esc_attr( $delay * 1000 ) : '',
 			absint( $newspack_blocks_carousel_id ),
-			'(min-width: 1168px) ' . $slides_to_show . ', (min-width: 782px) ' . ( $slides_to_show > 1 ? 2 : 1 ) . ', ' . 1,
-			$slides
+			esc_attr( '(min-width: 1168px) ' . $slides_to_show . ', (min-width: 782px) ' . ( $slides_to_show > 1 ? 2 : 1 ) . ', ' . 1 ),
+			wp_kses_post( $slides )
 		);
 		$autoplay_ui = $autoplay ? newspack_blocks_carousel_block_autoplay_ui_amp( $newspack_blocks_carousel_id ) : '';
 	} else {
@@ -297,16 +298,16 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 		);
 		$carousel    = sprintf(
 			'<div class="swiper"><div class="swiper-wrapper">%s</div>%s</div>',
-			$slides,
+			wp_kses_post( $slides ),
 			$navigation
 		);
 		$autoplay_ui = $autoplay ? newspack_blocks_carousel_block_autoplay_ui( $newspack_blocks_carousel_id ) : '';
 	}
 	$data_attributes = [
 		'data-current-post-id=' . $post_id,
-		'data-slides-per-view=' . $attributes['slidesPerView'],
+		'data-slides-per-view=' . esc_attr( $slides_per_view ),
 		'data-slide-count=' . $counter,
-		'data-aspect-ratio=' . $attributes['aspectRatio'],
+		'data-aspect-ratio=' . esc_attr( $aspect_ratio ),
 	];
 
 	if ( $autoplay && ! $is_amp ) {

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -251,7 +251,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 
 	$slides_per_view = absint( $attributes['slidesPerView'] ?? 1 );
 	$slides_to_show  = $slides_per_view <= $counter ? $slides_per_view : $counter;
-	$aspect_ratio    = floatval( $attributes['aspectRatio'] ?? 0.75 ) ;
+	$aspect_ratio    = floatval( $attributes['aspectRatio'] ?? 0.75 );
 
 	if ( $is_amp ) {
 		$selector = sprintf(

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -208,21 +208,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 								if ( $attributes['showAvatar'] ) :
 									echo wp_kses(
 										newspack_blocks_format_avatars( $authors ),
-										array(
-											'img'      => array(
-												'class'  => true,
-												'src'    => true,
-												'alt'    => true,
-												'width'  => true,
-												'height' => true,
-												'data-*' => true,
-												'srcset' => true,
-											),
-											'noscript' => array(),
-											'a'        => array(
-												'href' => true,
-											),
-										)
+										Newspack_Blocks::get_sanitized_image_attributes()
 									);
 								endif;
 								?>
@@ -285,7 +271,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 			$autoplay ? 'auto-advance="true" auto-advance-interval=' . esc_attr( $delay * 1000 ) : '',
 			absint( $newspack_blocks_carousel_id ),
 			esc_attr( '(min-width: 1168px) ' . $slides_to_show . ', (min-width: 782px) ' . ( $slides_to_show > 1 ? 2 : 1 ) . ', ' . 1 ),
-			wp_kses_post( $slides )
+			$slides
 		);
 		$autoplay_ui = $autoplay ? newspack_blocks_carousel_block_autoplay_ui_amp( $newspack_blocks_carousel_id ) : '';
 	} else {
@@ -302,7 +288,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 		);
 		$carousel    = sprintf(
 			'<div class="swiper"><div class="swiper-wrapper">%s</div>%s</div>',
-			wp_kses_post( $slides ),
+			$slides,
 			$navigation
 		);
 		$autoplay_ui = $autoplay ? newspack_blocks_carousel_block_autoplay_ui( $newspack_blocks_carousel_id ) : '';

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -231,21 +231,7 @@ call_user_func(
 						if ( $attributes['showAvatar'] ) :
 							echo wp_kses(
 								newspack_blocks_format_avatars( $authors ),
-								array(
-									'img'      => array(
-										'class'  => true,
-										'src'    => true,
-										'alt'    => true,
-										'width'  => true,
-										'height' => true,
-										'data-*' => true,
-										'srcset' => true,
-									),
-									'noscript' => array(),
-									'a'        => array(
-										'href' => true,
-									),
-								)
+								Newspack_Blocks::get_sanitized_image_attributes()
 							);
 						endif;
 						?>

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -29,7 +29,7 @@ call_user_func(
 		$post_link = Newspack_Blocks::get_post_link( $post_id );
 
 		if ( 'behind' === $attributes['mediaPosition'] && $attributes['showImage'] && has_post_thumbnail() ) {
-			$styles = 'min-height: ' . $attributes['minHeight'] . 'vh; padding-top: ' . ( $attributes['minHeight'] / 5 ) . 'vh;';
+			$styles = 'min-height: ' . absint( $attributes['minHeight'] ) . 'vh; padding-top: ' . ( absint( $attributes['minHeight'] ) / 5 ) . 'vh;';
 		}
 		$image_size = 'newspack-article-block-uncropped';
 		if ( has_post_thumbnail() && 'uncropped' !== $attributes['imageShape'] ) {

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -284,7 +284,14 @@ add_action( 'init', 'newspack_blocks_register_homepage_articles' );
 function newspack_blocks_format_avatars( $author_info ) {
 	$elements = array_map(
 		function ( $author ) {
-			return sprintf( '<a href="%s">%s</a>', esc_url( $author->url ), wp_kses_post( $author->avatar ) );
+			return sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( $author->url ),
+				wp_kses(
+					$author->avatar,
+					Newspack_Blocks::get_sanitized_image_attributes()
+				)
+			);
 		},
 		$author_info
 	);

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -25,7 +25,7 @@ function newspack_blocks_hpb_maximum_image_width() {
 		$site_content_width  = 1200;
 		$is_image_half_width = in_array( $attributes['mediaPosition'], [ 'left', 'right' ], true );
 		if ( 'grid' === $attributes['postLayout'] ) {
-			$columns = $attributes['columns'];
+			$columns = absint( $attributes['columns'] );
 			if ( $is_image_half_width ) {
 				// If the media position is on left or right, the image is 50% of the column width.
 				$columns = $columns * 2;
@@ -284,7 +284,7 @@ add_action( 'init', 'newspack_blocks_register_homepage_articles' );
 function newspack_blocks_format_avatars( $author_info ) {
 	$elements = array_map(
 		function ( $author ) {
-			return sprintf( '<a href="%s">%s</a>', $author->url, $author->avatar );
+			return sprintf( '<a href="%s">%s</a>', esc_url( $author->url ), wp_kses_post( $author->avatar ) );
 		},
 		$author_info
 	);

--- a/src/blocks/video-playlist/view.php
+++ b/src/blocks/video-playlist/view.php
@@ -119,7 +119,9 @@ function newspack_blocks_get_video_playlist_videos( $args ) {
 			}
 		);
 		foreach ( $youtube_blocks as $youtube_block ) {
-			$videos[] = $youtube_block['attrs']['url'];
+			if ( isset( $youtube_block['attrs']['url'] ) ) {
+				$videos[] = esc_url( $youtube_block['attrs']['url'] );
+			}
 		}
 	}
 

--- a/src/templates/author-profile-card.php
+++ b/src/templates/author-profile-card.php
@@ -60,20 +60,7 @@ call_user_func(
 
 					echo wp_kses(
 						$author['avatar'],
-						[
-							'img' => [
-								'alt'      => true,
-								'class'    => true,
-								'data-*'   => true,
-								'decoding' => true,
-								'height'   => true,
-								'loading'  => true,
-								'sizes'    => true,
-								'src'      => true,
-								'srcset'   => true,
-								'width'    => true,
-							],
-						]
+						Newspack_Blocks::get_sanitized_image_attributes()
 					);
 
 				if ( $show_archive_link ) :


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Hardens the use of block attribute values across blocks. There should be no unescaped values, and we shouldn't assume that values will be of the expected type.

### How to test the changes in this Pull Request:

1. On `release`, add a Posts Carousel, Homepage Posts, and YouTube Video Playlist block to a post or page. Note that for the YouTube Video Playlist block, you'll need to add some YouTube embed blocks to _other_ posts with valid YouTube URLs.
2. On the Posts Carousel block, ensure that you change the aspect ratio, number of slides to show, and the image fit options. In the Homepage Posts block, ensure that the author + avatars are shown.
3. Save the posts with your modified blocks. 
4. Check out this branch.
5. View the blocks in both the editor and the front-end, and ensure that all function as expected in both contexts with no changes in behavior.
6. Test with both AMP and non-AMP—this repo technically still supports AMP, but we will likely remove this support in a future release.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
