### PR TITLE
fix: undefined variable error

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -670,9 +670,10 @@ class Newspack_Blocks {
 			}
 			if ( $categories && count( $categories ) ) {
 				if ( 1 === $include_subcategories ) {
+					$children = [];
 					foreach ( $categories as $parent ) {
-						$children[] = get_categories( array( 'child_of' => $parent ) );
-						foreach ( $children[0] as $child ) {
+						$children = array_merge( $children, get_categories( [ 'child_of' => $parent ] ) );
+						foreach ( $children as $child ) {
 							$categories[] = $child->term_id;
 						}
 					}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a well-hidden PHP error due to an undefined variable. It looks like PHP in some cases is silently casting this undefined `$children` variable to an array, suppressing the warning unless you invoke the variable before the first `$children[] =` definition.

### How to test the changes in this Pull Request:

1. On `release`, create two categories that are children of another category and assign to some posts. Add `error_log( print_r( $children, true ) );` to right before [this line](https://github.com/Automattic/newspack-blocks/blob/master/includes/class-newspack-blocks.php#L674).
2. On another post, add a Homepage Posts block with the "include subcategories" option on and assign it to the parent category. Observe a PHP warning: `PHP Warning:  Undefined variable $children in /newspack-repos/newspack-blocks/includes/class-newspack-blocks.php on line 673`
3. Check out this branch, make sure the `error_log` is still the first line inside the `foreach ( $categories as $parent ) {
` block, and confirm that the PHP warning doesn't happen, and that the block still shows all posts in both parent and child categories (but only if the "include subcategories" option is on). Confirm on the front-end as well.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
