### PR TITLE
fix: query for CAP terms

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -707,6 +707,7 @@ class Newspack_Blocks {
 			if ( $authors && count( $authors ) ) {
 				$co_authors_names = [];
 				$author_names     = [];
+				$author_emails    = [];
 
 				if ( $is_co_authors_plus_active ) {
 					$co_authors_guest_authors = new CoAuthors_Guest_Authors();
@@ -736,7 +737,8 @@ class Newspack_Blocks {
 										unset( $authors[ $index ] );
 									}
 								} else {
-									$author_names[] = $author_data->user_login;
+									$author_names[]  = $author_data->user_login;
+									$author_emails[] = $author_data->user_email;
 								}
 							}
 						}
@@ -770,6 +772,11 @@ class Newspack_Blocks {
 									'field'    => 'name',
 									'taxonomy' => 'author',
 									'terms'    => $author_names,
+								],
+								[
+									'field'    => 'name',
+									'taxonomy' => 'author',
+									'terms'    => $author_emails,
 								],
 							],
 						];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Co-Authors Plus author terms for WP users match the WP user's `user_login` at the time of the WP user's creation. The `user_login` can't be updated in WP once the user is created, so it assumes that these values will always match. But in production environments, we've seen cases where this is not the case: specifically, the `user_login` and `user_email` differ, but the CAP term name matches the `user_email` instead of the `user_login. This seems to be possible only through direct DB manipulation, so I suspect this is happening from data migration. I haven't been able to recreate this scenario in a test site using WP admin, so the risk of it happening seems low for sites that haven't run into it, but it can be a serious issue with no workaround for sites that are affected.

### How to test the changes in this Pull Request:

1. On `release`, using a test site with Co-Authors Plus active, create a new WP "author" user. Make sure the `user_login` is something different from the `user_email`.
2. Assign the user to one or more posts. This will also assign an `author` taxonomy term to the posts, as is standard CAP behavior. By default, the CAP term name will match the WP user's `user_login`, which you can verify by running `wp term get author <user_login>` and verifying that term exists. You can also run `wp post term list author <post_id>` on any of the posts assigned to the user to verify that this term is assigned to those posts.
3. Using WP CLI, change the name of the author term to the `user_email`: `wp term update author <term_id> --name=<user_email>`
4. In a page or post, add a new Homepage Posts block and set the Authors field to the WP user. Observe that the block finds 0 posts because it assumes the term's name will match the user's `user_login`.
5. Check out this branch and refresh. Confirm that the block now shows the posts assigned to the user in step 2, in the editor and the front-end.
6. Create another a new WP user and assign to different posts, but this time don't change anything about the term. Confirm that the user's posts still get fetched properly in the Homepage Posts block when setting the Author to this user.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
