### PR TITLE
fix(checkout-button): handle 10+ product variations

### DIFF
--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -167,7 +167,7 @@ function CheckoutButtonEdit( props ) {
 		// Handle product variation data.
 		if ( data?.variations?.length ) {
 			setAttributes( { is_variable: true } );
-			apiFetch( { path: `/wc/v2/products/${ data.id }/variations` } )
+			apiFetch( { path: `/wc/v2/products/${ data.id }/variations?per_page=100` } )
 				.then( res => setVariations( res ) )
 				.catch( () => setVariations( [] ) );
 		} else {

--- a/src/modal-checkout/modal.scss
+++ b/src/modal-checkout/modal.scss
@@ -51,7 +51,7 @@
 		opacity: 0.5;
 		position: absolute;
 		top: 50%;
-		transform: translate(-50%, -50%);
+		transform: translate( -50%, -50% );
 		width: 100%;
 		> span {
 			animation: spin 1s infinite linear;
@@ -84,6 +84,8 @@
 .newspack-blocks-variation-modal {
 	&__content {
 		padding: 32px;
+		overflow: auto;
+		border-radius: 5px;
 		h3 {
 			margin: 0 0 1em;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Increase the pagination limit while fetching product variations in the Checkout Button block and the overflow for the variation modal when users are allowed to select a variation before checkout.

### How to test the changes in this Pull Request:

1. While on the `release` branch, create a product with 20 variations
2. Draft a new page and add a "Checkout Button" block
3. Select the new product, uncheck the "Allow the reader to select the variation before checkout." option, and confirm the dropdown below only renders 10 variations
4. Check the option again, save, visit the page, click the button, and confirm the variation list exceeds the container bounds
5. Check out this branch, refresh the page, click the button, and confirm the variation modal renders a scrollbar
6. Edit the page, uncheck the "Allow the reader to select the variation before checkout." option and confirm all variations render in the dropdown

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
