### PR TITLE
fix(modal-checkout): support utm params

### DIFF
--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -105,6 +105,17 @@ domReady( () => {
 		forms.forEach( form => {
 			form.appendChild( modalCheckoutInput.cloneNode() );
 			form.target = iframeName;
+			// Append UTM parameters if any.
+			const utmParams = new URLSearchParams( window.location.search );
+			utmParams.forEach( ( value, key ) => {
+				if ( key.indexOf( 'utm_' ) === 0 ) {
+					const input = document.createElement( 'input' );
+					input.type = 'hidden';
+					input.name = key;
+					input.value = value;
+					form.appendChild( input );
+				}
+			} );
 			form.addEventListener( 'submit', ev => {
 				const formData = new FormData( form );
 				// Clear any open variation modal.

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -106,8 +106,8 @@ domReady( () => {
 			form.appendChild( modalCheckoutInput.cloneNode() );
 			form.target = iframeName;
 			// Append UTM parameters if any.
-			const utmParams = new URLSearchParams( window.location.search );
-			utmParams.forEach( ( value, key ) => {
+			const urlParams = new URLSearchParams( window.location.search );
+			urlParams.forEach( ( value, key ) => {
 				if ( key.indexOf( 'utm_' ) === 0 ) {
 					const input = document.createElement( 'input' );
 					input.type = 'hidden';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ensures UTM parameters are passed as form inputs to the checkout modal.

### How to test the changes in this Pull Request:

Further details and instructions at https://github.com/Automattic/newspack-plugin/pull/2665

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
