### PR TITLE
fix(homepage-posts): check existing "specific posts" recursively for deduplication

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -596,7 +596,6 @@ class Newspack_Blocks {
 	private static function get_specific_posts_from_blocks( $blocks, $block_name ) {
 		$specific_posts = [];
 		foreach ( $blocks as $block ) {
-			error_log( print_r( array_keys($block ), true));
 			if ( ! empty( $block['innerBlocks'] ) ) {
 				$specific_posts = array_merge(
 					$specific_posts,

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -586,6 +586,39 @@ class Newspack_Blocks {
 	}
 
 	/**
+	 * Get all "specificPosts" ids from given blocks.
+	 *
+	 * @param array  $blocks     An array of blocks.
+	 * @param string $block_name Name of the block requesting the query.
+	 *
+	 * @return array All "specificPosts" ids from all eligible blocks.
+	 */
+	private static function get_specific_posts_from_blocks( $blocks, $block_name ) {
+		$specific_posts = [];
+		foreach ( $blocks as $block ) {
+			error_log( print_r( array_keys($block ), true));
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$specific_posts = array_merge(
+					$specific_posts,
+					self::get_specific_posts_from_blocks( $block['innerBlocks'], $block_name )
+				);
+				continue;
+			}
+			if (
+				$block_name === $block['blockName'] &&
+				! empty( $block['attrs']['specificMode'] ) &&
+				! empty( $block['attrs']['specificPosts'] )
+			) {
+				$specific_posts = array_merge(
+					$specific_posts,
+					$block['attrs']['specificPosts']
+				);
+			}
+		}
+		return $specific_posts;
+	}
+
+	/**
 	 * Builds and returns query args based on block attributes.
 	 *
 	 * @param array $attributes An array of block attributes.
@@ -606,23 +639,7 @@ class Newspack_Blocks {
 		global $newspack_blocks_all_specific_posts_ids;
 		if ( ! is_array( $newspack_blocks_all_specific_posts_ids ) ) {
 			$blocks                                 = parse_blocks( get_the_content() );
-			$newspack_blocks_all_specific_posts_ids = array_reduce(
-				$blocks,
-				function ( $acc, $block ) use ( $block_name ) {
-					if (
-						$block_name === $block['blockName'] &&
-						isset( $block['attrs']['specificMode'], $block['attrs']['specificPosts'] ) &&
-						count( $block['attrs']['specificPosts'] )
-					) {
-						return array_merge(
-							$block['attrs']['specificPosts'],
-							$acc
-						);
-					}
-					return $acc;
-				},
-				[]
-			);
+			$newspack_blocks_all_specific_posts_ids = self::get_specific_posts_from_blocks( $blocks, $block_name );
 		}
 
 		$post_type              = isset( $attributes['postType'] ) ? $attributes['postType'] : [ 'post' ];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1200550061930446-as-1204938638613364

Implements a recursive check on existing "specificPosts" to apply deduplication logic. The existing approach only loops through top-level blocks, not considering blocks inside columns or groups.

### How to test the changes in this Pull Request:

1. While on the master branch, add a 3-column block
2. For each column, add a Homepage Posts block rendering 1 post
3. For the second block, set it to a specific post and select the post that is being rendered on the first column
4. Save and visit the post
5. Confirm you get the first post duplicated
6. Check out this branch, refresh, and confirm the deduplication rule is correctly applied

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
