### PR TITLE
fix(donate): allow "once" in tiers-based layout

### DIFF
--- a/src/blocks/donate/edit/index.tsx
+++ b/src/blocks/donate/edit/index.tsx
@@ -153,9 +153,6 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 		attributes.manual
 			? ! attributes.disabledFrequencies[ slug ]
 			: ! settings.disabledFrequencies[ slug ]
-	).filter( slug => ( isTierBasedLayoutEnabled ? slug !== 'once' : true ) );
-	const displayedFrequencies = FREQUENCY_SLUGS.filter( slug =>
-		isTierBasedLayoutEnabled ? slug !== 'once' : true
 	);
 
 	// Editor bug – initially, the default style is selected, but the class not applied.
@@ -278,13 +275,13 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 							{ attributes.tiered ? (
 								<>
 									<div className="components-frequency-donations">
-										{ displayedFrequencies.map( ( frequency: DonationFrequencySlug ) => {
+										{ FREQUENCY_SLUGS.map( ( frequency: DonationFrequencySlug ) => {
 											const isFrequencyDisabled = attributes.disabledFrequencies[ frequency ];
 											const disabledDisplayedFrequencyCount = Object.values(
-												pick( attributes.disabledFrequencies, displayedFrequencies )
+												pick( attributes.disabledFrequencies, FREQUENCY_SLUGS )
 											).filter( Boolean ).length;
 											const isOnlyOneFrequencyActive =
-												displayedFrequencies.length - disabledDisplayedFrequencyCount === 1;
+												FREQUENCY_SLUGS.length - disabledDisplayedFrequencyCount === 1;
 											return (
 												<Fragment key={ frequency }>
 													<CheckboxControl

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
@@ -105,9 +105,6 @@ abstract class Newspack_Blocks_Donate_Renderer_Base {
 			if ( $configuration['disabledFrequencies'][ $frequency_slug ] ) {
 				unset( $frequencies[ $frequency_slug ] );
 			}
-			if ( $is_tiers_based && 'once' === $frequency_slug ) {
-				unset( $frequencies[ $frequency_slug ] );
-			}
 		}
 		$configuration['frequencies'] = $frequencies;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds support of "once" frequency to tiers-based layout.

Closes 1200550061930446-as-1205559648883658/f

### How to test the changes in this Pull Request:

1. On `master`, insert a Donate block and set it to Layout of "Tiers"
2. In Reader Revenue wizard, Donations tab, Suggested Donations section, disable monthly and annual donation tiers, while having "Tiered" donations option selected
3. Visit the page with the Donate block, observe it not rendering
4. Switch to this branch, observe the block is rendering (with only the "once" tier)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->