### PR TITLE
feat(homepage-posts): support deduplication toggling

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -671,8 +671,14 @@ class Newspack_Blocks {
 		} else {
 			$args['posts_per_page'] = $posts_to_show;
 
-			$show_rendered_posts = apply_filters( 'newspack_blocks_homepage_shown_rendered_posts', false );
-			if ( $show_rendered_posts ) {
+			/**
+			 * Filters whether to use deduplication while rendering this block.
+			 *
+			 * @param bool   $deduplicate Whether to deduplicate.
+			 * @param array  $attributes  The block attributes.
+			 */
+			$deduplicate = apply_filters( 'newspack_blocks_should_deduplicate', $attributes['deduplicate'], $attributes );
+			if ( ! $deduplicate ) {
 				$args['post__not_in'] = [ get_the_ID() ];
 			} else {
 				if ( count( $newspack_blocks_all_specific_posts_ids ) ) {

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -605,6 +605,7 @@ class Newspack_Blocks {
 			}
 			if (
 				$block_name === $block['blockName'] &&
+				! empty( $block['attrs']['deduplicate'] ) &&
 				! empty( $block['attrs']['specificMode'] ) &&
 				! empty( $block['attrs']['specificPosts'] )
 			) {

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -677,7 +677,7 @@ class Newspack_Blocks {
 			 * @param bool   $deduplicate Whether to deduplicate.
 			 * @param array  $attributes  The block attributes.
 			 */
-			$deduplicate = apply_filters( 'newspack_blocks_should_deduplicate', $attributes['deduplicate'], $attributes );
+			$deduplicate = apply_filters( 'newspack_blocks_should_deduplicate', $attributes['deduplicate'] ?? true, $attributes );
 			if ( ! $deduplicate ) {
 				$args['post__not_in'] = [ get_the_ID() ];
 			} else {

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -586,6 +586,23 @@ class Newspack_Blocks {
 	}
 
 	/**
+	 * Whether the block should be included in the deduplication logic.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return bool
+	 */
+	public static function should_deduplicate_block( $attributes ) {
+		/**
+		 * Filters whether to use deduplication while rendering the given block.
+		 *
+		 * @param bool   $deduplicate Whether to deduplicate.
+		 * @param array  $attributes  The block attributes.
+		 */
+		return apply_filters( 'newspack_blocks_should_deduplicate', $attributes['deduplicate'] ?? true, $attributes );
+	}
+
+	/**
 	 * Get all "specificPosts" ids from given blocks.
 	 *
 	 * @param array  $blocks     An array of blocks.
@@ -605,7 +622,7 @@ class Newspack_Blocks {
 			}
 			if (
 				$block_name === $block['blockName'] &&
-				! empty( $block['attrs']['deduplicate'] ) &&
+				self::should_deduplicate_block( $block['attrs'] ) &&
 				! empty( $block['attrs']['specificMode'] ) &&
 				! empty( $block['attrs']['specificPosts'] )
 			) {
@@ -671,15 +688,7 @@ class Newspack_Blocks {
 			$args['orderby']  = 'post__in';
 		} else {
 			$args['posts_per_page'] = $posts_to_show;
-
-			/**
-			 * Filters whether to use deduplication while rendering this block.
-			 *
-			 * @param bool   $deduplicate Whether to deduplicate.
-			 * @param array  $attributes  The block attributes.
-			 */
-			$deduplicate = apply_filters( 'newspack_blocks_should_deduplicate', $attributes['deduplicate'] ?? true, $attributes );
-			if ( ! $deduplicate ) {
+			if ( ! self::should_deduplicate_block( $attributes ) ) {
 				$args['post__not_in'] = [ get_the_ID() ];
 			} else {
 				if ( count( $newspack_blocks_all_specific_posts_ids ) ) {

--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -191,6 +191,10 @@
 			"type": "array",
 			"default": [ "publish" ],
 			"items": { "type": "string" }
+		},
+		"deduplicate": {
+			"type": "boolean",
+			"default": true
 		}
 	}
 }

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -435,6 +435,15 @@ class Edit extends Component {
 							/>
 						)
 					) }
+					<ToggleControl
+						label={ __( 'Use deduplication logic', 'newspack-blocks' ) }
+						help={ __(
+							'If checked, the block will not show posts that have already been displayed in the page. Unchecking this option may result in duplicate posts being displayed.',
+							'newspack-blocks'
+						) }
+						checked={ attributes.deduplicate }
+						onChange={ () => setAttributes( { deduplicate: ! attributes.deduplicate } ) }
+					/>
 				</PanelBody>
 				<PanelBody title={ __( 'Featured Image Settings', 'newspack-blocks' ) }>
 					<PanelRow>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -443,6 +443,7 @@ class Edit extends Component {
 						) }
 						checked={ attributes.deduplicate }
 						onChange={ () => setAttributes( { deduplicate: ! attributes.deduplicate } ) }
+						className="newspack-blocks-deduplication-toggle"
 					/>
 				</PanelBody>
 				<PanelBody title={ __( 'Featured Image Settings', 'newspack-blocks' ) }>

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -438,7 +438,7 @@ class Edit extends Component {
 					<ToggleControl
 						label={ __( 'Use deduplication logic', 'newspack-blocks' ) }
 						help={ __(
-							'If checked, the block will not show posts that have already been displayed in the page. Unchecking this option may result in duplicate posts being displayed.',
+							'If unchecked, this block will be excluded from the deduplication logic and may show duplicate posts.',
 							'newspack-blocks'
 						) }
 						checked={ attributes.deduplicate }

--- a/src/blocks/homepage-articles/store.js
+++ b/src/blocks/homepage-articles/store.js
@@ -110,6 +110,19 @@ function* getPostsForBlock( block ) {
 	return postsIds;
 }
 
+/**
+ * Whether a block uses deduplication.
+ *
+ * @param {string} clientId
+ *
+ * @return {Boolean} whether the block uses deduplication
+ */
+function shouldDeduplicate( clientId ) {
+	const { getBlock } = select( 'core/block-editor' );
+	const block = getBlock( clientId );
+	return block?.attributes?.deduplicate;
+}
+
 const createFetchPostsSaga = blockNames => {
 	/**
 	 * "worker" Saga: will be fired on REFLOW actions
@@ -148,14 +161,19 @@ const createFetchPostsSaga = blockNames => {
 		let exclude = sanitizePostList( [ ...specificPostsId, getCurrentPostId() ] );
 		while ( blockQueries.length ) {
 			const nextBlock = blockQueries.shift();
-			nextBlock.postsQuery.exclude = exclude;
+			const deduplicate = shouldDeduplicate( nextBlock.clientId );
+			if ( deduplicate ) {
+				nextBlock.postsQuery.exclude = exclude;
+			}
 			let fetchedPostIds = [];
 			try {
 				fetchedPostIds = yield call( getPostsForBlock, nextBlock );
 			} catch ( e ) {
 				yield put( { type: 'UPDATE_BLOCK_ERROR', clientId: nextBlock.clientId, error: e.message } );
 			}
-			exclude = [ ...exclude, ...fetchedPostIds ];
+			if ( deduplicate ) {
+				exclude = [ ...exclude, ...fetchedPostIds ];
+			}
 		}
 
 		yield put( { type: 'ENABLE_UI' } );

--- a/src/blocks/homepage-articles/store.js
+++ b/src/blocks/homepage-articles/store.js
@@ -115,7 +115,7 @@ function* getPostsForBlock( block ) {
  *
  * @param {string} clientId
  *
- * @return {Boolean} whether the block uses deduplication
+ * @return {boolean} whether the block uses deduplication
  */
 function shouldDeduplicate( clientId ) {
 	const { getBlock } = select( 'core/block-editor' );
@@ -151,8 +151,8 @@ const createFetchPostsSaga = blockNames => {
 		const blockQueries = getBlockQueries( blocks, blockNames );
 
 		// Use requested specific posts ids as the starting state of exclusion list.
-		const specificPostsId = blockQueries.reduce( ( acc, { postsQuery } ) => {
-			if ( postsQuery.include ) {
+		const specificPostsId = blockQueries.reduce( ( acc, { clientId, postsQuery } ) => {
+			if ( shouldDeduplicate( clientId ) && postsQuery.include ) {
 				acc = [ ...acc, ...postsQuery.include ];
 			}
 			return acc;

--- a/src/blocks/homepage-articles/templates/articles-loop.php
+++ b/src/blocks/homepage-articles/templates/articles-loop.php
@@ -18,10 +18,11 @@ call_user_func(
 
 		Newspack_Blocks::filter_excerpt( $attributes );
 
-		$enable_post_duplication = apply_filters( 'newspack_blocks_homepage_enable_duplication', false );
+		$deduplicate = apply_filters( 'newspack_blocks_use_deduplication', $attributes['deduplicate'], $attributes );
+
 		while ( $article_query->have_posts() ) {
 			$article_query->the_post();
-			if ( ! $enable_post_duplication ) {
+			if ( $deduplicate ) {
 				$newspack_blocks_post_id[ get_the_ID() ] = true;
 			}
 			echo Newspack_Blocks::template_inc( __DIR__ . '/article.php', array( 'attributes' => $attributes ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/src/blocks/homepage-articles/templates/articles-loop.php
+++ b/src/blocks/homepage-articles/templates/articles-loop.php
@@ -18,11 +18,9 @@ call_user_func(
 
 		Newspack_Blocks::filter_excerpt( $attributes );
 
-		$deduplicate = apply_filters( 'newspack_blocks_use_deduplication', $attributes['deduplicate'], $attributes );
-
 		while ( $article_query->have_posts() ) {
 			$article_query->the_post();
-			if ( $deduplicate ) {
+			if ( Newspack_Blocks::should_deduplicate_block( $attributes ) ) {
 				$newspack_blocks_post_id[ get_the_ID() ] = true;
 			}
 			echo Newspack_Blocks::template_inc( __DIR__ . '/article.php', array( 'attributes' => $attributes ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/src/blocks/homepage-articles/utils.ts
+++ b/src/blocks/homepage-articles/utils.ts
@@ -38,6 +38,7 @@ const POST_QUERY_ATTRIBUTES = [
 	'categoryExclusions',
 	'postType',
 	'includedPostStatuses',
+	'deduplicate',
 ];
 
 type HomepageArticlesAttributes = {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1205451924709229-as-1205631504130139

Implements a toggle to allow a Homepage Posts block to be excluded to deduplication logic.

**Without deduplication, the block will not account for previously queried posts and will also not have their queried posts as part of the exclusion for the following blocks.**

<img width="279" alt="image" src="https://github.com/Automattic/newspack-blocks/assets/820752/6f1de5c3-05ab-40bc-9971-9e22ef248bda">

---

| Default deduplication | With "Block 2" opted-out |
| --- | --- |
| <img width="851" alt="image" src="https://github.com/Automattic/newspack-blocks/assets/820752/29508c67-7361-4b2a-8f15-6e4423fa4cc2"> | <img width="846" alt="image" src="https://github.com/Automattic/newspack-blocks/assets/820752/4b58a3d9-88b2-412d-974a-e2fbf01d38b3"> |

Closes #258.

### How to test the changes in this Pull Request:

1. Check out this branch and draft a new page with 3 Homepage Posts block, similar to the image above
2. Toggle the "Use deduplication logic" off in the second block and confirm the content is duplicate from the previous block and the third block renders the content that was previously being rendered in the edited block (same as the image above)
3. Save, visit the page, and confirm the same behavior persists
4. Edit the page and change the second block to "Choose Specific Posts"
5. Select a post from the first block and confirm the post renders without interfering with the previous block
6. Save, visit the page, and confirm the same behavior persists

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
