### PR TITLE
fix: allow order details wrapper to render

### DIFF
--- a/src/modal-checkout/templates/checkout-form.php
+++ b/src/modal-checkout/templates/checkout-form.php
@@ -76,7 +76,7 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 	}
 	?>
 
-	<div id="order-details-wrapper" class="<?php echo esc_attr( ! \Newspack_Blocks\Modal_Checkout::should_show_order_details() ? 'hidden' : '' ); ?>">
+	<div id="order-details-wrapper">
 		<?php do_action( 'woocommerce_checkout_before_order_review_heading' ); ?>
 		<h3 id="order_review_heading" class="screen-reader-text"><?php esc_html_e( 'Order Details', 'newspack-blocks' ); ?></h3>
 		<?php do_action( 'woocommerce_checkout_before_order_review' ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

#1516 introduced a regression by hiding the order details wrapper in the template. Since #1485 this has been [handled dynamically](https://github.com/Automattic/newspack-blocks/blob/d1dfb2ae700dd8ceea001d2c0c71690b405b99f3/includes/class-modal-checkout.php#L516-L535), due to the dynamic nature of WC cart template fragments. Adding or removing coupons changes whether the order details should be rendered or not.

This PR removes the "hidden" class from the template so the fragment hook can determine whether to render details.

### How to test the changes in this Pull Request:

1. While on the release branch, checkout a product with the checkout button block and apply a coupon
2. Confirm the coupon doesn't seem applied
3. Check out this branch, try again, and confirm the UI updates and the coupon is applied

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
