### PR TITLE
Inline HPB styles in a style tag

### DIFF
--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -404,7 +404,12 @@ class Newspack_Blocks_API {
 	 * @return WP_REST_Response.
 	 */
 	public static function css_endpoint() {
-		return newspack_blocks_get_homepage_articles_css_string( [ 'typeScale' => range( 1, 10 ) ] );
+		return newspack_blocks_get_homepage_articles_css_string(
+			[
+				'typeScale'    => range( 1, 10 ),
+				'showSubtitle' => [ 1 ],
+			]
+		);
 	}
 }
 

--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -397,6 +397,15 @@ class Newspack_Blocks_API {
 		$where .= ' AND post_title LIKE "%' . $search . '%" ';
 		return $where;
 	}
+
+	/**
+	 * Return CSS for the Homepage Articles block, when rendered in the editor.
+	 *
+	 * @return WP_REST_Response.
+	 */
+	public static function css_endpoint() {
+		return newspack_blocks_get_homepage_articles_css_string( [ 'typeScale' => range( 1, 10 ) ] );
+	}
 }
 
 add_action( 'rest_api_init', array( 'Newspack_Blocks_API', 'register_video_playlist_endpoint' ) );

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -107,6 +107,19 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 				},
 			]
 		);
+
+		// Endpoint to get styles in the editor.
+		register_rest_route(
+			$this->namespace,
+			'/homepage-articles-css',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ 'Newspack_Blocks_API', 'css_endpoint' ],
+				'permission_callback' => function() {
+					return current_user_can( 'edit_posts' );
+				},
+			]
+		);
 	}
 
 	/**

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -195,10 +195,7 @@ class Edit extends Component {
 						</h3>
 					) }
 					{ IS_SUBTITLE_SUPPORTED_IN_THEME && showSubtitle && (
-						<RawHTML
-							key="subtitle"
-							className="newspack-post-subtitle newspack-post-subtitle--in-homepage-block"
-						>
+						<RawHTML key="subtitle" className="newspack-post-subtitle">
 							{ post.meta.newspack_post_subtitle || '' }
 						</RawHTML>
 					) }

--- a/src/blocks/homepage-articles/editor.js
+++ b/src/blocks/homepage-articles/editor.js
@@ -1,13 +1,27 @@
 /**
- * Internal dependencies
+ * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
 import { settings, name } from '.';
 import { name as carouselBlockName } from '../carousel';
-
 import { registerQueryStore } from './store';
 
 const BLOCK_NAME = `newspack-blocks/${ name }`;
 
 registerBlockType( BLOCK_NAME, settings );
 registerQueryStore( [ BLOCK_NAME, `newspack-blocks/${ carouselBlockName }` ] );
+
+// Fetch CSS and insert it in a style tag.
+apiFetch( {
+	path: '/newspack-blocks/v1/homepage-articles-css',
+} ).then( css => {
+	const style = document.createElement( 'style' );
+	style.innerHTML = css;
+	style.id = 'newspack-blocks-homepage-articles-styles';
+	document.head.appendChild( style );
+} );

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -6,65 +6,6 @@
 	article {
 		.entry-title {
 			margin: 0 0 0.25em;
-			font-size: 1.2em;
-		}
-	}
-
-	p {
-		margin: 0.5em 0;
-	}
-
-	&.ts-10 article {
-		.entry-title {
-			font-size: 2.6em;
-		}
-	}
-	&.ts-9 article {
-		.entry-title {
-			font-size: 2.4em;
-		}
-	}
-	&.ts-8 article {
-		.entry-title {
-			font-size: 2.2em;
-		}
-	}
-	&.ts-7 article {
-		.entry-title {
-			font-size: 2em;
-		}
-	}
-	&.ts-6 article {
-		.entry-title {
-			font-size: 1.7em;
-		}
-	}
-	&.ts-5 article {
-		.entry-title {
-			font-size: 1.4em;
-		}
-	}
-	&.ts-3 article {
-		.entry-title {
-			font-size: 1em;
-		}
-	}
-	&.ts-1 article,
-	&.ts-2 article {
-		.entry-title {
-			font-size: 0.9em;
-		}
-	}
-
-	.post-thumbnail {
-		margin: 0;
-		margin-bottom: 0.25em;
-		img {
-			height: auto;
-			width: 100%;
-		}
-		figcaption {
-			margin-bottom: 0.5em;
 		}
 	}
 

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -6,6 +6,49 @@
 	article {
 		.entry-title {
 			margin: 0 0 0.25em;
+			font-size: 1.2em;
+		}
+	}
+
+	&.ts-10 article {
+		.entry-title {
+			font-size: 2.6em;
+		}
+	}
+	&.ts-9 article {
+		.entry-title {
+			font-size: 2.4em;
+		}
+	}
+	&.ts-8 article {
+		.entry-title {
+			font-size: 2.2em;
+		}
+	}
+	&.ts-7 article {
+		.entry-title {
+			font-size: 2em;
+		}
+	}
+	&.ts-6 article {
+		.entry-title {
+			font-size: 1.7em;
+		}
+	}
+	&.ts-5 article {
+		.entry-title {
+			font-size: 1.4em;
+		}
+	}
+	&.ts-3 article {
+		.entry-title {
+			font-size: 1em;
+		}
+	}
+	&.ts-1 article,
+	&.ts-2 article {
+		.entry-title {
+			font-size: 0.9em;
 		}
 	}
 

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -10,6 +10,10 @@
 		}
 	}
 
+	p {
+		margin: 0.5em 0;
+	}
+
 	&.ts-10 article {
 		.entry-title {
 			font-size: 2.6em;
@@ -49,6 +53,18 @@
 	&.ts-2 article {
 		.entry-title {
 			font-size: 0.9em;
+		}
+	}
+
+	.post-thumbnail {
+		margin: 0;
+		margin-bottom: 0.25em;
+		img {
+			height: auto;
+			width: 100%;
+		}
+		figcaption {
+			margin-bottom: 0.5em;
 		}
 	}
 

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -125,7 +125,7 @@ call_user_func(
 				$subtitle = get_post_meta( $post_id, 'newspack_post_subtitle', true );
 
 				?>
-				<div class="newspack-post-subtitle newspack-post-subtitle--in-homepage-block">
+				<div class="newspack-post-subtitle">
 					<?php
 					$allowed_tags = array(
 						'b'      => true,

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -231,6 +231,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	// Gather all Homepage Articles blocks on the page and output only the needed CSS.
 	// This CSS will be printed right after .entry-content.
 	global $newspack_blocks_hpb_all_blocks;
+	$inline_style_html = '';
 	if ( ! is_array( $newspack_blocks_hpb_all_blocks ) ) {
 		$newspack_blocks_hpb_all_blocks = newspack_blocks_retrieve_homepage_articles_blocks(
 			parse_blocks( get_the_content() ),
@@ -238,9 +239,11 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 		);
 		$all_used_attrs                 = newspack_blocks_collect_all_attribute_values( array_column( $newspack_blocks_hpb_all_blocks, 'attrs' ) );
 		$css_string                     = newspack_blocks_get_homepage_articles_css_string( $all_used_attrs );
+		ob_start();
 		?>
 			<style id="newspack-blocks-inline-css" type="text/css"><?php echo esc_html( $css_string ); ?></style>
 		<?php
+		$inline_style_html = ob_get_clean();
 	}
 
 	// This will let the FSE plugin know we need CSS/JS now.
@@ -401,7 +404,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	$content = ob_get_clean();
 	Newspack_Blocks::enqueue_view_assets( 'homepage-articles' );
 
-	return $content;
+	return $inline_style_html . $content;
 }
 
 /**

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -137,6 +137,19 @@ function newspack_blocks_get_homepage_articles_css_string( $attrs ) {
 		.wpnbha .entry-title {
 			font-size: 1.2em;
 		}
+		.wpnbha .entry-meta {
+			display: flex;
+			flex-wrap: wrap;
+			align-items: center;
+			margin-top: 0.5em;
+		}
+		.wpnbha article .entry-meta {
+			font-size: 0.8em;
+		}
+		.wpnbha article .avatar {
+			height: 25px;
+			width: 25px;
+		}
 		.wpnbha .post-thumbnail{
 			margin: 0;
 			margin-bottom: 0.25em;

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -198,7 +198,7 @@ function newspack_blocks_get_homepage_articles_css_string( $attrs ) {
 				}
 			}
 		}
-		if ( isset( $attrs['showSubtitle'] ) && in_array( 1, $attrs['showSubtitle'], false ) ) {
+		if ( isset( $attrs['showSubtitle'] ) && in_array( 1, $attrs['showSubtitle'], false ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.FoundNonStrictFalse
 			echo esc_html(
 				'.newspack-post-subtitle {
 					margin-top: 0.3em;

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -185,6 +185,16 @@ function newspack_blocks_get_homepage_articles_css_string( $attrs ) {
 				}
 			}
 		}
+		if ( isset( $attrs['showSubtitle'] ) && in_array( 1, $attrs['showSubtitle'], false ) ) {
+			echo esc_html(
+				'.newspack-post-subtitle {
+					margin-top: 0.3em;
+					margin-bottom: 0;
+					line-height: 1.4;
+					font-style: italic;
+				}'
+			);
+		}
 		?>
 	<?php
 	return ob_get_clean();

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -155,7 +155,34 @@ function newspack_blocks_get_homepage_articles_css_string( $attrs ) {
 		<?php
 		if ( isset( $attrs['typeScale'] ) ) {
 			foreach ( $attrs['typeScale'] as $scale ) {
-				echo esc_html( ".wpnbha.ts-$scale .entry-title{font-size: {$entry_title_type_scale[$scale - 1]}}" );
+				echo esc_html(
+					".wpnbha.ts-$scale .entry-title{font-size: {$entry_title_type_scale[$scale - 1]}}"
+				);
+				if ( in_array( $scale, [ 8, 9, 10 ], true ) ) {
+					echo esc_html(
+						".wpnbha.ts-$scale .entry-title {line-height: 1.1;}"
+					);
+				}
+				if ( in_array( $scale, [ 7, 8, 9, 10 ], true ) ) {
+					echo esc_html(
+						".wpnbha.ts-$scale .newspack-post-subtitle {font-size: 1.4em;}"
+					);
+				}
+				if ( in_array( $scale, [ 6 ], true ) ) {
+					echo esc_html(
+						".wpnbha.ts-$scale article .newspack-post-subtitle {font-size: 1.4em;}"
+					);
+				}
+				if ( in_array( $scale, [ 5 ], true ) ) {
+					echo esc_html(
+						".wpnbha.ts-$scale article .newspack-post-subtitle {font-size: 1.2em;}"
+					);
+				}
+				if ( in_array( $scale, [ 1, 2, 3 ], true ) ) {
+					echo esc_html(
+						".wpnbha.ts-$scale article .newspack-post-subtitle,.entry-wrapper p,.entry-wrapper .more-link,.entry-meta {font-size: 0.8em;}"
+					);
+				}
 			}
 		}
 		?>

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -113,6 +113,8 @@ function newspack_blocks_collect_all_attribute_values( $blocks ) {
 
 /**
  * Output a CSS string based on attributes used in a set of blocks.
+ * This is to mitigate CLS. Any CSS that might cause CLS should be output here,
+ * inline and before the blocks are printed.
  *
  * @param array $attrs The attributes used in the blocks.
  */
@@ -135,6 +137,21 @@ function newspack_blocks_get_homepage_articles_css_string( $attrs ) {
 		.wpnbha .entry-title {
 			font-size: 1.2em;
 		}
+		.wpnbha .post-thumbnail{
+			margin: 0;
+			margin-bottom: 0.25em;
+		}
+		.wpnbha .post-thumbnail img {
+			height: auto;
+			width: 100%;
+		}
+		.wpnbha .post-thumbnail figcaption {
+			margin-bottom: 0.5em;
+		}
+		.wpnbha p {
+			margin: 0.5em 0;
+		}
+
 		<?php
 		if ( isset( $attrs['typeScale'] ) ) {
 			foreach ( $attrs['typeScale'] as $scale ) {

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -511,9 +511,6 @@
 .wpnbha {
 	/* 'Normal' size */
 	article {
-		.entry-title {
-			font-size: 1.2em;
-		}
 		.entry-meta {
 			font-size: 0.8em;
 		}
@@ -559,9 +556,6 @@
 	}
 
 	&.ts-10 article {
-		.entry-title {
-			font-size: 2.6em;
-		}
 		@include mixins.media( tablet ) {
 			.entry-title {
 				font-size: 3.6em;
@@ -575,9 +569,6 @@
 	}
 
 	&.ts-9 article {
-		.entry-title {
-			font-size: 2.4em;
-		}
 		@include mixins.media( tablet ) {
 			.entry-title {
 				font-size: 3.4em;
@@ -591,9 +582,6 @@
 	}
 
 	&.ts-8 article {
-		.entry-title {
-			font-size: 2.2em;
-		}
 		@include mixins.media( tablet ) {
 			.entry-title {
 				font-size: 3em;
@@ -607,9 +595,6 @@
 	}
 
 	&.ts-7 article {
-		.entry-title {
-			font-size: 2em;
-		}
 		@include mixins.media( tablet ) {
 			.entry-title {
 				font-size: 2.4em;
@@ -627,9 +612,6 @@
 	}
 
 	&.ts-6 article {
-		.entry-title {
-			font-size: 1.7em;
-		}
 		.newspack-post-subtitle {
 			font-size: 1.4em;
 		}
@@ -650,9 +632,6 @@
 	}
 
 	&.ts-5 article {
-		.entry-title {
-			font-size: 1.4em;
-		}
 		.newspack-post-subtitle {
 			font-size: 1.2em;
 		}
@@ -675,9 +654,6 @@
 	/* Type Scale 4: default */
 
 	&.ts-3 article {
-		.entry-title {
-			font-size: 1em;
-		}
 		.newspack-post-subtitle,
 		.entry-wrapper p,
 		.entry-wrapper .more-link,
@@ -702,9 +678,6 @@
 
 	&.ts-2 article,
 	&.ts-1 article {
-		.entry-title {
-			font-size: 0.9em;
-		}
 		.newspack-post-subtitle,
 		.entry-wrapper p,
 		.entry-wrapper .more-link,

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -485,6 +485,13 @@
 		gap: 0.5em;
 		line-height: 1;
 	}
+
+	.newspack-post-subtitle {
+		margin-top: 0.3em;
+		margin-bottom: 0;
+		line-height: 1.4;
+		font-style: italic;
+	}
 }
 
 /*
@@ -738,15 +745,5 @@
 			border: 0;
 			padding-right: 0;
 		}
-	}
-}
-
-/* Styles for the Subtitle, as part of the the Block */
-.newspack-post-subtitle {
-	&--in-homepage-block {
-		margin-top: 0.3em;
-		margin-bottom: 0;
-		line-height: 1.4;
-		font-style: italic;
 	}
 }

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -239,11 +239,6 @@
 	}
 
 	.entry-meta {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: center;
-		margin-top: 0.5em;
-
 		.byline:not( :last-child ) {
 			margin-right: 1.5em;
 		}
@@ -492,22 +487,11 @@
  */
 /* stylelint-disable no-duplicate-selectors  */
 .wpnbha {
-	/* 'Normal' size */
 	article {
-		.entry-meta {
-			font-size: 0.8em;
-		}
-
-		.avatar {
-			height: 25px;
-			width: 25px;
-		}
-
 		@include mixins.media( tablet ) {
 			.entry-title {
 				font-size: 1.6em;
 			}
-
 			.avatar {
 				height: 40px;
 				width: 40px;

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -518,23 +518,11 @@
 	&.ts-10,
 	&.ts-9,
 	&.ts-8 {
-		.entry-title {
-			line-height: 1.1;
-		}
 		@include mixins.media( tablet ) {
 			article .avatar {
 				height: 2.4em;
 				width: 2.4em;
 			}
-		}
-	}
-
-	&.ts-10,
-	&.ts-9,
-	&.ts-8,
-	&.ts-7 {
-		.newspack-post-subtitle {
-			font-size: 1.4em;
 		}
 	}
 
@@ -595,9 +583,6 @@
 	}
 
 	&.ts-6 article {
-		.newspack-post-subtitle {
-			font-size: 1.4em;
-		}
 		@include mixins.media( tablet ) {
 			.entry-title {
 				font-size: 2em;
@@ -615,9 +600,6 @@
 	}
 
 	&.ts-5 article {
-		.newspack-post-subtitle {
-			font-size: 1.2em;
-		}
 		@include mixins.media( tablet ) {
 			.entry-title {
 				font-size: 1.8em;
@@ -637,12 +619,6 @@
 	/* Type Scale 4: default */
 
 	&.ts-3 article {
-		.newspack-post-subtitle,
-		.entry-wrapper p,
-		.entry-wrapper .more-link,
-		.entry-meta {
-			font-size: 0.8em;
-		}
 		@include mixins.media( tablet ) {
 			.entry-title {
 				font-size: 1.2em;
@@ -661,13 +637,6 @@
 
 	&.ts-2 article,
 	&.ts-1 article {
-		.newspack-post-subtitle,
-		.entry-wrapper p,
-		.entry-wrapper .more-link,
-		.entry-meta {
-			font-size: 0.8em;
-		}
-
 		@include mixins.media( tablet ) {
 			.newspack-post-subtitle,
 			.entry-wrapper p,

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -485,13 +485,6 @@
 		gap: 0.5em;
 		line-height: 1;
 	}
-
-	.newspack-post-subtitle {
-		margin-top: 0.3em;
-		margin-bottom: 0;
-		line-height: 1.4;
-		font-style: italic;
-	}
 }
 
 /*
@@ -645,7 +638,6 @@
 	&.ts-2 article,
 	&.ts-1 article {
 		@include mixins.media( tablet ) {
-			.newspack-post-subtitle,
 			.entry-wrapper p,
 			.entry-wrapper .more-link,
 			.entry-meta,

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -136,19 +136,6 @@
 	}
 
 	/* Image styles */
-	.post-thumbnail {
-		margin: 0;
-		margin-bottom: 0.25em;
-
-		img {
-			height: auto;
-			width: 100%;
-		}
-
-		figcaption {
-			margin-bottom: 0.5em;
-		}
-	}
 
 	figcaption {
 		font-size: variables.$font__size-xxs;
@@ -274,10 +261,6 @@
 		border-radius: 100%;
 		display: block;
 		margin-right: 0.5em;
-	}
-
-	p {
-		margin: 0.5em 0;
 	}
 
 	&.has-text-color {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Inlines the critical parts of CSS needed by the Homepage Posts Block, in order to get rid of [layout shift](https://web.dev/cls/) happening when the file-based CSS stylesheet is loaded. 

To demonstrate, here's a recording of a (throttled) page load on `master`:

<img src="https://github.com/Automattic/newspack-blocks/assets/7383192/49a0645e-cbec-488a-8887-c1c751d1231e" width="300px">

And here's how it looks like on this branch:

<img src="https://github.com/Automattic/newspack-blocks/assets/7383192/d16eebde-75b5-4bc9-88f3-083c74113e5c" width="300px">

If this strategy proves effective in production environment, it can be enhanced by moving more of the static styles from `view.css` to the dynamically created inline stylesheet. 

### How to test the changes in this Pull Request:

1. Create a page with some instances of the Homepage Posts Block, with different type scale settings and images shown
2. Load the front-end, observe the styles are applied just like on `master`, only faster*

\* use DevTools' Network speed throttling to observe it better

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->