### PR TITLE
fix(donate): reset "other" value when switching tiers

### DIFF
--- a/src/blocks/donate/frequency-based/index.ts
+++ b/src/blocks/donate/frequency-based/index.ts
@@ -2,3 +2,59 @@
  * Internal dependencies
  */
 import './style.scss';
+
+/**
+ * Specify a function to execute when the DOM is fully loaded.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/packages/dom-ready/
+ *
+ * @param {Function} callback A function to execute after the DOM is ready.
+ * @return {void}
+ */
+function domReady( callback: () => void ): void {
+	if ( typeof document === 'undefined' ) {
+		return;
+	}
+	if (
+		document.readyState === 'complete' || // DOMContentLoaded + Images/Styles/etc loaded, so we call directly.
+		document.readyState === 'interactive' // DOMContentLoaded fires at this point, so we call directly.
+	) {
+		return void callback();
+	}
+	// DOMContentLoaded has not fired yet, delay callback until then.
+	document.addEventListener( 'DOMContentLoaded', callback );
+}
+
+const resetOtherValue = ( container: HTMLElement ) => {
+	const frequencies = container.querySelectorAll( '.tiers' );
+	if ( ! frequencies?.length ) {
+		return;
+	}
+	frequencies.forEach( frequency => {
+		const tiers = frequency.querySelectorAll( 'input[type="radio"]' );
+		const input = <HTMLInputElement>frequency.querySelector( '.money-input input' );
+		if ( ! tiers?.length || ! input ) {
+			return;
+		}
+		const originalValue = input.getAttribute( 'value' );
+		const reset = () => {
+			input.value = originalValue || '';
+		};
+		tiers.forEach( tierInput => {
+			tierInput.addEventListener( 'change', reset );
+		} );
+	} );
+};
+
+export const processFrequencyBasedElements = ( parentEl = document ) => {
+	const elements = parentEl.querySelectorAll(
+		'.wpbnbd--frequency-based'
+	) as NodeListOf< HTMLElement >;
+	elements.forEach( container => {
+		resetOtherValue( container );
+	} );
+};
+
+if ( typeof window !== 'undefined' ) {
+	domReady( () => processFrequencyBasedElements() );
+}

--- a/src/blocks/donate/frequency-based/index.ts
+++ b/src/blocks/donate/frequency-based/index.ts
@@ -30,6 +30,7 @@ const resetOtherValue = ( container: HTMLElement ) => {
 	if ( ! frequencies?.length ) {
 		return;
 	}
+	const frequencyInputs = container.querySelectorAll( 'input[name="donation_frequency"]' );
 	frequencies.forEach( frequency => {
 		const tiers = frequency.querySelectorAll( 'input[type="radio"]' );
 		const input = <HTMLInputElement>frequency.querySelector( '.money-input input' );
@@ -42,6 +43,9 @@ const resetOtherValue = ( container: HTMLElement ) => {
 		};
 		tiers.forEach( tierInput => {
 			tierInput.addEventListener( 'change', reset );
+		} );
+		frequencyInputs.forEach( frequencyInput => {
+			frequencyInput.addEventListener( 'change', reset );
 		} );
 	} );
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Suppose a reader inputs an invalid value to the "Other" tier option and selects any other tier. In that case, the form will fail to submit due to the browser's native validation for the number input.

This PR implements a reset to the input whenever the tier selection changes, preventing the value from failing form validation.

### How to test the changes in this Pull Request:

1. While in the release branch confirm the issue by visiting a page with a frequency-based donate block
2. Input a value lower than the allowed minimum (default is $5)
3. Switch to a suggested value tier and confirm you're not able to continue donating
4. Switch back to "Other", place a valid number, switch back to the suggested option and confirm you're able to continue
5. Switch to this branch, repeat steps 2 and 3, and confirm you are able to continue
6. Close the modal, switch back to "Other" and confirm the value is the default suggestion

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
