### PR TITLE
fix: match thankyou template when using existing customer email

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -311,19 +311,27 @@ final class Modal_Checkout {
 	/**
 	 * Return URL for modal checkout "thank you" page.
 	 *
-	 * @param string $url The URL to redirect to.
+	 * @param string   $url The URL to redirect to.
+	 * @param WC_Order $order The order related to the transaction.
 	 *
 	 * @return string
 	 */
-	public static function woocommerce_get_return_url( $url ) {
+	public static function woocommerce_get_return_url( $url, $order ) {
 		if ( ! isset( $_REQUEST['modal_checkout'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return $url;
 		}
+		$args = [
+			'modal_checkout' => '1',
+			'email'          => isset( $_REQUEST['billing_email'] ) ? rawurlencode( sanitize_email( wp_unslash( $_REQUEST['billing_email'] ) ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		];
+
+		// Pass order ID for modal checkout templates.
+		if ( $order && is_a( $order, 'WC_Order' ) ) {
+			$args['order_id'] = $order->get_id();
+		}
+
 		return add_query_arg(
-			[
-				'modal_checkout' => '1',
-				'email'          => isset( $_REQUEST['billing_email'] ) ? rawurlencode( sanitize_email( wp_unslash( $_REQUEST['billing_email'] ) ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			],
+			$args,
 			$url
 		);
 	}
@@ -337,13 +345,18 @@ final class Modal_Checkout {
 	 * @return string Template file.
 	 */
 	public static function wc_get_template( $located, $template_name ) {
+		if ( ! isset( $_REQUEST['modal_checkout'] ) || ! boolval( $_REQUEST['modal_checkout'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return $located;
+		}
+
 		$custom_templates = [
 			'checkout/form-checkout.php' => 'src/modal-checkout/templates/checkout-form.php',
 			'checkout/form-billing.php'  => 'src/modal-checkout/templates/billing-form.php',
+			'global/form-login.php'      => 'src/modal-checkout/templates/form-login.php',
 		];
 
 		foreach ( $custom_templates as $original_template => $custom_template ) {
-			if ( $template_name === $original_template && isset( $_REQUEST['modal_checkout'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( $template_name === $original_template ) {
 				$located = NEWSPACK_BLOCKS__PLUGIN_DIR . $custom_template;
 			}
 		}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -322,12 +322,13 @@ final class Modal_Checkout {
 		}
 		$args = [
 			'modal_checkout' => '1',
-			'email'          => isset( $_REQUEST['billing_email'] ) ? rawurlencode( sanitize_email( wp_unslash( $_REQUEST['billing_email'] ) ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			'email'          => isset( $_REQUEST['billing_email'] ) ? rawurlencode( \sanitize_email( \wp_unslash( $_REQUEST['billing_email'] ) ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		];
 
 		// Pass order ID for modal checkout templates.
 		if ( $order && is_a( $order, 'WC_Order' ) ) {
 			$args['order_id'] = $order->get_id();
+			$args['key']      = isset( $_GET['key'] ) ? \wc_clean( \sanitize_text_field( \wp_unslash( $_GET['key'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
 
 		return add_query_arg(

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -328,7 +328,7 @@ final class Modal_Checkout {
 		// Pass order ID for modal checkout templates.
 		if ( $order && is_a( $order, 'WC_Order' ) ) {
 			$args['order_id'] = $order->get_id();
-			$args['key']      = isset( $_GET['key'] ) ? \wc_clean( \sanitize_text_field( \wp_unslash( $_GET['key'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$args['key']      = $order->get_order_key();
 		}
 
 		return add_query_arg(

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -180,6 +180,9 @@
 			transform: scale( 0 );
 			width: 40px;
 		}
+		+ .woocommerce-info {
+			display: none; // Hide the "Please log in to view this order" message on the thank you page.
+		}
 	}
 	.woocommerce-order-overview {
 		color: colors.$color__text-light;

--- a/src/modal-checkout/templates/form-login.php
+++ b/src/modal-checkout/templates/form-login.php
@@ -1,16 +1,6 @@
 <?php
 /**
- * Login form. WooCommerce by default doesn't allow order details to be shown
- * if the order is completed using a customer email address that doesn't match
- * the currently logged in user.
- *
- * Details: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php#L302-L321
- *
- * For Newspack sites, we don't want to emphasize user account flows outside of
- * RAS. This custom login template replaces the login form that appears on the
- * order-received.php template with an order details summary so the experience
- * matches whether or not the email address used is already associated with an
- * existing customer account.
+ * Login form.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
@@ -23,45 +13,63 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$order = isset( $_GET['order_id'] ) ? \wc_get_order( \absint( \wp_unslash( $_GET['order_id'] ) ) ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.WP.GlobalVariablesOverride.Prohibited
-?>
+/**
+ * WooCommerce by default doesn't allow order details to be shown
+ * if the order is completed using a customer email address that doesn't match
+ * the currently logged in user.
+ *
+ * Details: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php#L302-L321
+ *
+ * For Newspack sites, we don't want to emphasize user account flows outside of
+ * RAS. This custom login template replaces the login form that appears on the
+ * order-received.php template with an order details summary so the experience
+ * matches whether or not the email address used is already associated with an
+ * existing customer account.
+ */
+function newspack_blocks_replace_login_with_order_summary() {
+	$order = isset( $_GET['order_id'] ) ? \wc_get_order( \absint( \wp_unslash( $_GET['order_id'] ) ) ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	?>
 
-<div class="woocommerce-order">
-	<?php if ( $order ) : ?>
+	<div class="woocommerce-order">
+		<?php if ( $order ) : ?>
 
-	<h4><?php esc_html_e( 'Summary', 'newspack-blocks' ); ?></h4>
+		<h4><?php esc_html_e( 'Summary', 'newspack-blocks' ); ?></h4>
 
-	<ul class="woocommerce-order-overview woocommerce-thankyou-order-details order_details">
+		<ul class="woocommerce-order-overview woocommerce-thankyou-order-details order_details">
 
-		<li class="woocommerce-order-overview__date date">
-			<?php esc_html_e( 'Date:', 'newspack-blocks' ); ?>
-			<strong><?php echo wc_format_datetime( $order->get_date_created() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
-		</li>
-
-		<?php if ( is_user_logged_in() && $order->get_user_id() === get_current_user_id() && $order->get_billing_email() ) : ?>
-			<li class="woocommerce-order-overview__email email">
-				<?php esc_html_e( 'Email:', 'newspack-blocks' ); ?>
-				<strong><?php echo $order->get_billing_email(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
+			<li class="woocommerce-order-overview__date date">
+				<?php esc_html_e( 'Date:', 'newspack-blocks' ); ?>
+				<strong><?php echo wc_format_datetime( $order->get_date_created() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
 			</li>
-		<?php endif; ?>
 
-		<li class="woocommerce-order-overview__total total">
-			<?php esc_html_e( 'Total:', 'newspack-blocks' ); ?>
-			<strong><?php echo $order->get_formatted_order_total(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
-		</li>
+			<?php if ( is_user_logged_in() && $order->get_user_id() === get_current_user_id() && $order->get_billing_email() ) : ?>
+				<li class="woocommerce-order-overview__email email">
+					<?php esc_html_e( 'Email:', 'newspack-blocks' ); ?>
+					<strong><?php echo $order->get_billing_email(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
+				</li>
+			<?php endif; ?>
 
-		<?php if ( $order->get_payment_method_title() ) : ?>
-			<li class="woocommerce-order-overview__payment-method method">
-				<?php esc_html_e( 'Payment method:', 'newspack-blocks' ); ?>
-				<strong><?php echo wp_kses_post( $order->get_payment_method_title() ); ?></strong>
+			<li class="woocommerce-order-overview__total total">
+				<?php esc_html_e( 'Total:', 'newspack-blocks' ); ?>
+				<strong><?php echo $order->get_formatted_order_total(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
 			</li>
+
+			<?php if ( $order->get_payment_method_title() ) : ?>
+				<li class="woocommerce-order-overview__payment-method method">
+					<?php esc_html_e( 'Payment method:', 'newspack-blocks' ); ?>
+					<strong><?php echo wp_kses_post( $order->get_payment_method_title() ); ?></strong>
+				</li>
+			<?php endif; ?>
+
+			<li class="woocommerce-order-overview__order order">
+				<?php esc_html_e( 'Transaction:', 'newspack-blocks' ); ?>
+				<strong><?php echo $order->get_order_number(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
+			</li>
+
+		</ul>
 		<?php endif; ?>
+	</div>
+	<?php
+}
 
-		<li class="woocommerce-order-overview__order order">
-			<?php esc_html_e( 'Transaction:', 'newspack-blocks' ); ?>
-			<strong><?php echo $order->get_order_number(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
-		</li>
-
-	</ul>
-	<?php endif; ?>
-</div>
+newspack_blocks_replace_login_with_order_summary();

--- a/src/modal-checkout/templates/form-login.php
+++ b/src/modal-checkout/templates/form-login.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Login form. WooCommerce by default doesn't allow order details to be shown
+ * if the order is completed using a customer email address that doesn't match
+ * the currently logged in user.
+ *
+ * Details: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php#L302-L321
+ *
+ * For Newspack sites, we don't want to emphasize user account flows outside of
+ * RAS. This custom login template replaces the login form that appears on the
+ * order-received.php template with an order details summary so the experience
+ * matches whether or not the email address used is already associated with an
+ * existing customer account.
+ *
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates
+ * @version 8.1.0
+ *
+ * @var WC_Order $order
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$order = isset( $_GET['order_id'] ) ? \wc_get_order( \absint( \wp_unslash( $_GET['order_id'] ) ) ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.WP.GlobalVariablesOverride.Prohibited
+?>
+
+<div class="woocommerce-order">
+	<?php if ( $order ) : ?>
+
+	<h4><?php esc_html_e( 'Summary', 'newspack-blocks' ); ?></h4>
+
+	<ul class="woocommerce-order-overview woocommerce-thankyou-order-details order_details">
+
+		<li class="woocommerce-order-overview__date date">
+			<?php esc_html_e( 'Date:', 'newspack-blocks' ); ?>
+			<strong><?php echo wc_format_datetime( $order->get_date_created() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
+		</li>
+
+		<?php if ( is_user_logged_in() && $order->get_user_id() === get_current_user_id() && $order->get_billing_email() ) : ?>
+			<li class="woocommerce-order-overview__email email">
+				<?php esc_html_e( 'Email:', 'newspack-blocks' ); ?>
+				<strong><?php echo $order->get_billing_email(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
+			</li>
+		<?php endif; ?>
+
+		<li class="woocommerce-order-overview__total total">
+			<?php esc_html_e( 'Total:', 'newspack-blocks' ); ?>
+			<strong><?php echo $order->get_formatted_order_total(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
+		</li>
+
+		<?php if ( $order->get_payment_method_title() ) : ?>
+			<li class="woocommerce-order-overview__payment-method method">
+				<?php esc_html_e( 'Payment method:', 'newspack-blocks' ); ?>
+				<strong><?php echo wp_kses_post( $order->get_payment_method_title() ); ?></strong>
+			</li>
+		<?php endif; ?>
+
+		<li class="woocommerce-order-overview__order order">
+			<?php esc_html_e( 'Transaction:', 'newspack-blocks' ); ?>
+			<strong><?php echo $order->get_order_number(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
+		</li>
+
+	</ul>
+	<?php endif; ?>
+</div>

--- a/src/modal-checkout/templates/form-login.php
+++ b/src/modal-checkout/templates/form-login.php
@@ -27,11 +27,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * existing customer account.
  */
 function newspack_blocks_replace_login_with_order_summary() {
-	$order = isset( $_GET['order_id'] ) ? \wc_get_order( \absint( \wp_unslash( $_GET['order_id'] ) ) ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$order    = isset( $_GET['order_id'] ) ? \wc_get_order( \absint( \wp_unslash( $_GET['order_id'] ) ) ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$key      = isset( $_GET['key'] ) ? \wc_clean( \sanitize_text_field( \wp_unslash( $_GET['key'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$is_valid = $order && is_a( $order, 'WC_Order' ) && hash_equals( $order->get_order_key(), $key ); // Validate order key to prevent CSRF.
 	?>
 
 	<div class="woocommerce-order">
-		<?php if ( $order ) : ?>
+		<?php if ( $is_valid ) : ?>
 
 		<h4><?php esc_html_e( 'Summary', 'newspack-blocks' ); ?></h4>
 
@@ -67,6 +69,20 @@ function newspack_blocks_replace_login_with_order_summary() {
 			</li>
 
 		</ul>
+		<?php else : ?>
+		<h4><?php esc_html_e( 'Summary', 'newspack-blocks' ); ?></h4>
+		<p>
+			<?php
+			echo wp_kses_post(
+				sprintf(
+					// Translators: URL to My Account.
+					__( 'Please log in to <a href="%s">My Account</a> to see order details.', 'newspack-blocks' ),
+					\wc_get_account_endpoint_url( 'dashboard' )
+				),
+				'newspack-blocks'
+			);
+			?>
+		</p>
 		<?php endif; ?>
 	</div>
 	<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adjusts some logic in the WooCommerce checkout flow when using the modal checkout. In the scenario where a donation is made while logged out but using an email address that's already associated with a custom account, we don't want to show the login prompt on the thank you step—instead, we want to show the order summary like we do for new email addresses or when already logged in.

### How to test the changes in this Pull Request:

1. On `release`, while not logged in, make a donation using an email address that's already associated with an existing reader account.
2. On the thank you step after the successful transaction, observe that instead of an order summary, there's a message to "Please log in to your account to view this order" and a login form.
3. Check out this branch, repeat with a new donation and the same email address. This time confirm that the thank you page shows an order summary and no message or login form, similarly to what's shown when donating using a new email address.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
