### PR TITLE
Fix WP 6.4 HPB rendering issue

### DIFF
--- a/src/blocks/author-list/edit.js
+++ b/src/blocks/author-list/edit.js
@@ -279,7 +279,6 @@ const AuthorList = ( { attributes, clientId, setAttributes } ) => {
 									const isCurrent = textSize === option.value;
 									return (
 										<Button
-											isLarge
 											isPrimary={ isCurrent }
 											aria-pressed={ isCurrent }
 											aria-label={ option.label }
@@ -326,7 +325,6 @@ const AuthorList = ( { attributes, clientId, setAttributes } ) => {
 										const isCurrent = avatarSize === option.value;
 										return (
 											<Button
-												isLarge
 												isPrimary={ isCurrent }
 												aria-pressed={ isCurrent }
 												aria-label={ option.label }

--- a/src/blocks/author-profile/edit.js
+++ b/src/blocks/author-profile/edit.js
@@ -224,7 +224,6 @@ const AuthorProfile = ( { attributes, setAttributes } ) => {
 									const isCurrent = textSize === option.value;
 									return (
 										<Button
-											isLarge
 											isPrimary={ isCurrent }
 											aria-pressed={ isCurrent }
 											aria-label={ option.label }
@@ -271,7 +270,6 @@ const AuthorProfile = ( { attributes, setAttributes } ) => {
 										const isCurrent = avatarSize === option.value;
 										return (
 											<Button
-												isLarge
 												isPrimary={ isCurrent }
 												aria-pressed={ isCurrent }
 												aria-label={ option.label }

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -396,7 +396,6 @@ class Edit extends Component {
 											const isCurrent = colGap === option.value;
 											return (
 												<Button
-													isLarge
 													isPrimary={ isCurrent }
 													aria-pressed={ isCurrent }
 													aria-label={ option.label }
@@ -487,7 +486,6 @@ class Edit extends Component {
 											const isCurrent = imageScale === option.value;
 											return (
 												<Button
-													isLarge
 													isPrimary={ isCurrent }
 													aria-pressed={ isCurrent }
 													aria-label={ option.label }

--- a/src/blocks/homepage-articles/utils.ts
+++ b/src/blocks/homepage-articles/utils.ts
@@ -211,7 +211,7 @@ type Select = ( namespace: string ) => {
 	// core/blocks-editor
 	getBlocks: () => Block[];
 	// core/editor
-	getEditorBlocks: () => Block[];
+	getEditedPostAttribute: ( attribute: string ) => Block[];
 	// core
 	getPostTypes: ( query: object ) => null | PostType[];
 	// STORE_NAMESPACE - TODO: move these to src/blocks/homepage-articles/store.js once it's TS
@@ -230,19 +230,22 @@ export const postsBlockSelector = (
 		attributes,
 	}: { clientId: Block[ 'clientId' ]; attributes: HomepageArticlesAttributes }
 ): Omit< HomepageArticlesProps, 'attributes' > => {
-	const { getEditorBlocks } = select( 'core/editor' );
+	const { getEditedPostAttribute } = select( 'core/editor' );
+	const editorBlocks = getEditedPostAttribute( 'blocks' ) || [];
 	const { getBlocks } = select( 'core/block-editor' );
-	const editorBlocksIds = getEditorBlocksIds( getEditorBlocks() );
+	const editorBlocksIds = getEditorBlocksIds( editorBlocks );
+	const blocks = getBlocks();
+	const isWidgetEditor = blocks.some( block => block.name === 'core/widget-area' );
 	// The block might be rendered in the block styles preview, not in the editor.
-	const isWidgetEditor = getBlocks().some( block => block.name === 'core/widget-area' );
-	const isEditorBlock = editorBlocksIds.indexOf( clientId ) >= 0 || isWidgetEditor;
+	const isEditorBlock =
+		editorBlocksIds.length === 0 || editorBlocksIds.indexOf( clientId ) >= 0 || isWidgetEditor;
 
 	const { getPosts, getError, isUIDisabled } = select( STORE_NAMESPACE );
 	const props = {
 		isEditorBlock,
 		isUIDisabled: isUIDisabled(),
 		error: getError( { clientId } ),
-		topBlocksClientIdsInOrder: getBlocks().map( block => block.clientId ),
+		topBlocksClientIdsInOrder: blocks.map( block => block.clientId ),
 		latestPosts: isEditorBlock
 			? getPosts( { clientId } )
 			: // For block preview, display static content.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue occurring on WP 6.4, where the Homepage Articles Blocks renders placeholder content in the editor. As it turns out, we were relying on an initial-rendering bug fixed in https://github.com/WordPress/gutenberg/pull/52417. This PR tweaks the check for in-editor (as opposed to in-preview) block rendering so that it renders correctly in the editor and in the previews.  

Should fix https://github.com/Automattic/wp-calypso/issues/80069 once Calypso is updated after these changes are released.

Also removes `isLarge` prop on some buttons, which is not used. React was complaining in the console. 

### How to test the changes in this Pull Request:

1. Install WP 6.4 (`wp core update --version=6.4-beta2`)
2. While on the `master` branch, create a post or page with the Homepage Posts Block. Save and reload the editor, observe that the block renders placeholder content. 
3. Switch to this branch, observe that the block renders the actual site content 
4. By clicking the plus icon in the editor's block inserter (a new paragraph), open up the block patterns (Browse All -> Patterns)
5. Click on "Newspack Homepage Posts", observe that the block pattern previews display placeholder content

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->