### PR TITLE
chore: newspack.pub > newspack.com

### DIFF
--- a/languages/newspack-blocks-de_DE.po
+++ b/languages/newspack-blocks-de_DE.po
@@ -30,7 +30,7 @@ msgstr ""
 
 #. Plugin URI of the plugin
 #. Author URI of the plugin
-msgid "https://newspack.blog/"
+msgid "https://newspack.com/"
 msgstr ""
 
 #. Description of the plugin

--- a/languages/newspack-blocks-es_ES.po
+++ b/languages/newspack-blocks-es_ES.po
@@ -22,7 +22,7 @@ msgstr ""
 
 #. Plugin URI of the plugin
 #. Author URI of the plugin
-msgid "https://newspack.blog/"
+msgid "https://newspack.com/"
 msgstr ""
 
 #. Description of the plugin

--- a/languages/newspack-blocks-fr_BE.po
+++ b/languages/newspack-blocks-fr_BE.po
@@ -20,8 +20,8 @@ msgstr "Newspack Blocks"
 
 #. Plugin URI of the plugin
 #. Author URI of the plugin
-msgid "https://newspack.blog/"
-msgstr "https://newspack.blog/"
+msgid "https://newspack.com/"
+msgstr "https://newspack.com/"
 
 #. Description of the plugin
 msgid "A collection of blocks for news publishers."

--- a/languages/newspack-blocks-pt_PT.po
+++ b/languages/newspack-blocks-pt_PT.po
@@ -22,7 +22,7 @@ msgstr ""
 
 #. Plugin URI of the plugin
 #. Author URI of the plugin
-msgid "https://newspack.blog/"
+msgid "https://newspack.com/"
 msgstr ""
 
 #. Description of the plugin

--- a/languages/newspack-blocks.pot
+++ b/languages/newspack-blocks.pot
@@ -20,7 +20,7 @@ msgstr ""
 
 #. Plugin URI of the plugin
 #. Author URI of the plugin
-msgid "https://newspack.blog/"
+msgid "https://newspack.com/"
 msgstr ""
 
 #. Description of the plugin

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * Plugin Name:     Newspack Blocks
- * Plugin URI:      https://newspack.blog/
+ * Plugin URI:      https://newspack.com/
  * Description:     A collection of blocks for news publishers.
  * Author:          Automattic
- * Author URI:      https://newspack.blog/
+ * Author URI:      https://newspack.com/
  * Text Domain:     newspack-blocks
  * Domain Path:     /languages
  * Version:         1.75.4


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updates some lingering legacy URLs throughout the code. All instances of newspack.pub or newspack.blog should be newspack.com

### How to test the changes in this Pull Request:

No functional changes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
