### PR TITLE
fix: always show email address for order summaries

### DIFF
--- a/src/modal-checkout/templates/form-login.php
+++ b/src/modal-checkout/templates/form-login.php
@@ -44,7 +44,7 @@ function newspack_blocks_replace_login_with_order_summary() {
 				<strong><?php echo wc_format_datetime( $order->get_date_created() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
 			</li>
 
-			<?php if ( is_user_logged_in() && $order->get_user_id() === get_current_user_id() && $order->get_billing_email() ) : ?>
+			<?php if ( $order->get_billing_email() ) : ?>
 				<li class="woocommerce-order-overview__email email">
 					<?php esc_html_e( 'Email:', 'newspack-blocks' ); ?>
 					<strong><?php echo $order->get_billing_email(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1550 introduced a custom template to force the "order summary" to appear in the thank-you template when completing a transaction using an email address that's already registered on the site. However, this custom template inherited some logic which only exposed the order's email address if it matches the currently logged-in user. Since this template is only shown in scenarios where a non-logged-in user is completing a transaction using an existing account's email, that condition will never be satisfied, so this PR removes the logic and always shows the email address in the order summary. This should be safe because we're checking the order key before showing order summary details to ensure that the order details are only shown during the course of a checkout flow involving that exact order.

### How to test the changes in this Pull Request:

1. Complete testing steps for #1550.
2. On `release`, observe that no email address is shown on the thank you screen.
3. On this branch, confirm that the email address is shown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
