### PR TITLE
fix: add thankyou hook to custom form-login template

### DIFF
--- a/src/modal-checkout/templates/form-login.php
+++ b/src/modal-checkout/templates/form-login.php
@@ -69,6 +69,7 @@ function newspack_blocks_replace_login_with_order_summary() {
 			</li>
 
 		</ul>
+			<?php do_action( 'newspack_woocommerce_thankyou', $order->get_id() ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound ?>
 		<?php else : ?>
 		<h4><?php esc_html_e( 'Summary', 'newspack-blocks' ); ?></h4>
 		<p>
@@ -83,6 +84,7 @@ function newspack_blocks_replace_login_with_order_summary() {
 			);
 			?>
 		</p>
+
 		<?php endif; ?>
 	</div>
 	<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1550 implemented a custom form-login template that shows the regular "thank you" template order summary even when completing a transaction with an already-registered email address. #1521 added an optional redirect button to the regular thank you template. This PR adds the custom hook required to show the redirect button on the custom form-login template.

### How to test the changes in this Pull Request:

1. Follow instructions in #1521 to add a redirect button to a Checkout Button block.
2. Complete a transaction using the Checkout Button, using an email address that's already registered with your test site.
3. On `master`, observe that the redirect button is not shown.
4. On this PR, confirm it is shown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
