### PR TITLE
Modal checkout – post-checkout newsletter signup

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -656,7 +656,7 @@ final class Modal_Checkout {
 								value="<?php echo \esc_attr( $list['id'] ); ?>"
 								id="<?php echo \esc_attr( $checkbox_id ); ?>"
 								<?php
-								if ( $list['checked'] ) {
+								if ( isset( $list['checked'] ) && $list['checked'] ) {
 									echo 'checked';
 								}
 								?>

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -43,8 +43,6 @@ final class Modal_Checkout {
 		add_filter( 'woocommerce_checkout_get_value', [ __CLASS__, 'woocommerce_checkout_get_value' ], 10, 2 );
 		add_filter( 'woocommerce_checkout_fields', [ __CLASS__, 'woocommerce_checkout_fields' ] );
 		add_filter( 'woocommerce_update_order_review_fragments', [ __CLASS__, 'order_review_fragments' ] );
-		add_action( 'woocommerce_thankyou', [ __CLASS__, 'woocommerce_thankyou' ] ); // Core Woo, not present in Newspack theme custom template.
-		add_action( 'newspack_woocommerce_thankyou', [ __CLASS__, 'woocommerce_thankyou' ] ); // Newspack Theme.
 	}
 
 	/**
@@ -568,7 +566,7 @@ final class Modal_Checkout {
 	 *
 	 * @return void
 	 */
-	public static function woocommerce_thankyou() {
+	public static function render_checkout_after_success_markup() {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if (
 			empty( $_REQUEST['modal_checkout'] ) ||

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -706,13 +706,7 @@ final class Modal_Checkout {
 			if ( \is_wp_error( $result ) ) {
 				return $result;
 			}
-			if ( 'subscribed' === $result['status'] ) {
-				return true;
-			}
-			if ( isset( $result['detail'] ) ) {
-				return new \WP_Error( 'newspack_blocks_newsletter_confirmation', $result['detail'] );
-			}
-			return new \WP_Error( 'newspack_blocks_newsletter_confirmation', __( 'Something went wrong while processing the newsletter signup request. Please try again later.', 'newspack-blocks' ) );
+			return true;
 		}
 		return false;
 	}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -365,7 +365,10 @@ final class Modal_Checkout {
 		$custom_templates = [
 			'checkout/form-checkout.php' => 'src/modal-checkout/templates/checkout-form.php',
 			'checkout/form-billing.php'  => 'src/modal-checkout/templates/billing-form.php',
-			'global/form-login.php'      => 'src/modal-checkout/templates/form-login.php',
+			'checkout/thankyou.php'      => 'src/modal-checkout/templates/thankyou.php',
+			// Replace the login form with the order summary if using the modal checkout. This is
+			// for the case where the reader used an existing email address.
+			'global/form-login.php'      => 'src/modal-checkout/templates/thankyou.php',
 		];
 
 		foreach ( $custom_templates as $original_template => $custom_template ) {

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -604,11 +604,11 @@ final class Modal_Checkout {
 		if ( ! $email_address ) {
 			return;
 		}
-		if ( ! method_exists( '\Newspack_Newsletters_Subscription', 'get_lists' ) ) {
+		if ( ! method_exists( '\Newspack\Reader_Activation', 'get_registration_newsletter_lists' ) ) {
 			return;
 		}
 		$newsletters_lists = array_filter(
-			\Newspack_Newsletters_Subscription::get_lists(),
+			\Newspack\Reader_Activation::get_registration_newsletter_lists(),
 			function( $item ) {
 				return $item['active'];
 			}
@@ -655,6 +655,11 @@ final class Modal_Checkout {
 								name="lists[]"
 								value="<?php echo \esc_attr( $list['id'] ); ?>"
 								id="<?php echo \esc_attr( $checkbox_id ); ?>"
+								<?php
+								if ( $list['checked'] ) {
+									echo 'checked';
+								}
+								?>
 							>
 							<label for="<?php echo \esc_attr( $checkbox_id ); ?>">
 								<b><?php echo \esc_html( $list['title'] ); ?></b>

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -166,15 +166,15 @@ final class Modal_Checkout {
 			return;
 		}
 		?>
-		<div class="newspack-blocks-checkout-modal" style="display: none;">
-			<div class="newspack-blocks-checkout-modal__content">
-				<a href="#" class="newspack-blocks-checkout-modal__close">
+		<div class="newspack-blocks-checkout-modal newspack-blocks-modal" style="display: none;">
+			<div class="newspack-blocks-modal__content">
+				<a href="#" class="newspack-blocks-modal__close">
 					<span class="screen-reader-text"><?php esc_html_e( 'Close', 'newspack-blocks' ); ?></span>
 					<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
 						<path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/>
 					</svg>
 				</a>
-				<div class="newspack-blocks-checkout-modal__spinner">
+				<div class="newspack-blocks-modal__spinner">
 					<span></span>
 				</div>
 			</div>
@@ -193,9 +193,9 @@ final class Modal_Checkout {
 				continue;
 			}
 			?>
-			<div class="newspack-blocks-variation-modal" data-product-id="<?php echo esc_attr( $product_id ); ?>" style="display:none;">
-				<div class="newspack-blocks-variation-modal__content">
-					<a href="#" class="newspack-blocks-variation-modal__close">
+			<div class="newspack-blocks-variation-modal newspack-blocks-modal" data-product-id="<?php echo esc_attr( $product_id ); ?>" style="display:none;">
+				<div class="newspack-blocks-modal__content">
+					<a href="#" class="newspack-blocks-modal__close">
 						<span class="screen-reader-text"><?php esc_html_e( 'Close', 'newspack-blocks' ); ?></span>
 						<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
 							<path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/>

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -676,7 +676,7 @@ final class Modal_Checkout {
 	 * Should post-chcekout newsletter signup be available?
 	 */
 	private static function is_newsletter_signup_available() {
-		return ! ( defined( 'NEWSPACK_DISABLE_POST_CHECKOUT_NEWSLETTER_SIGNUP' ) && NEWSPACK_DISABLE_POST_CHECKOUT_NEWSLETTER_SIGNUP );
+		return defined( 'NEWSPACK_ENABLE_POST_CHECKOUT_NEWSLETTER_SIGNUP' ) && NEWSPACK_ENABLE_POST_CHECKOUT_NEWSLETTER_SIGNUP;
 	}
 
 	/**

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -210,6 +210,47 @@
 	}
 }
 
+.newspack-modal-newsletters {
+	margin-top: 20px;
+	padding-top: 22px;
+	border-top: 1px solid colors.$color__border;
+	&__info {
+		margin-bottom: 35px;
+		span {
+			color: colors.$color__text-light;
+		}
+	}
+	&__list-item {
+		display: flex;
+		margin-bottom: 18px;
+		border: 1px solid colors.$color__border;
+		border-radius: 6px;
+		b {
+			display: block;
+			margin-bottom: 2px;
+		}
+	}
+	label {
+		flex: 1;
+		padding: 12px;
+		cursor: pointer;
+	}
+	input[type='checkbox'] {
+		padding: 10px;
+		margin-top: 18px;
+		margin-right: 19px;
+		margin-left: 20px;
+		border-radius: 5px;
+	}
+	input[type='submit'],
+	&__button {
+		margin-top: 25px;
+		width: 100%;
+		padding: 22px;
+		font-size: 1em;
+	}
+}
+
 @keyframes bounce {
 	0% {
 		transform: scale( 0 );

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -39,12 +39,12 @@ function closeCheckout() {
 	if ( iframeResizeObserver ) {
 		iframeResizeObserver.disconnect();
 	}
-	Array.from( document.querySelectorAll( '.newspack-blocks-modal' ) ).forEach(
-		el => ( el.style.display = 'none' )
-	);
-	if ( element.overlayId && window.newspackReaderActivation?.overlays ) {
-		window.newspackReaderActivation?.overlays.remove( element.overlayId );
-	}
+	Array.from( document.querySelectorAll( '.newspack-blocks-modal' ) ).forEach( el => {
+		el.style.display = 'none';
+		if ( el.overlayId && window.newspackReaderActivation?.overlays ) {
+			window.newspackReaderActivation?.overlays.remove( el.overlayId );
+		}
+	} );
 }
 
 window.newspackCloseModalCheckout = closeCheckout;

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -30,8 +30,8 @@ const triggers =
 
 let iframeResizeObserver;
 
-function closeCheckout( element ) {
-	const iframe = element.querySelector( 'iframe' );
+function closeCheckout() {
+	const iframe = document.querySelector( 'iframe[name="newspack_modal_checkout"]' );
 	if ( iframe ) {
 		iframe.src = 'about:blank';
 	}
@@ -39,8 +39,14 @@ function closeCheckout( element ) {
 	if ( iframeResizeObserver ) {
 		iframeResizeObserver.disconnect();
 	}
-	element.style.display = 'none';
+	Array.from( document.querySelectorAll( '.newspack-blocks-modal' ) ).forEach(
+		el => ( el.style.display = 'none' )
+	);
 }
+
+window.newspackCloseModalCheckout = closeCheckout;
+
+const MODAL_CLASSNAME_BASE = '.newspack-blocks-modal';
 
 domReady( () => {
 	/**
@@ -50,29 +56,29 @@ domReady( () => {
 	if ( ! modalCheckout ) {
 		return;
 	}
-	const spinner = document.querySelector( '.newspack-blocks-checkout-modal__spinner' );
+	const spinner = document.querySelector( `${ MODAL_CLASSNAME_BASE }__spinner` );
 	const iframeName = 'newspack_modal_checkout';
 	const modalCheckoutInput = document.createElement( 'input' );
 	modalCheckoutInput.type = 'hidden';
 	modalCheckoutInput.name = 'modal_checkout';
 	modalCheckoutInput.value = '1';
-	const modalContent = modalCheckout.querySelector( '.newspack-blocks-checkout-modal__content' );
+	const modalContent = modalCheckout.querySelector( `${ MODAL_CLASSNAME_BASE }__content` );
 	const initialHeight = modalContent.clientHeight + 'px';
 	const iframe = document.createElement( 'iframe' );
 	iframe.name = iframeName;
 	modalContent.appendChild( iframe );
 	modalCheckout.addEventListener( 'click', ev => {
 		if ( ev.target === modalCheckout ) {
-			closeCheckout( modalCheckout );
+			closeCheckout();
 		}
 	} );
-	const closeButtons = modalCheckout.querySelectorAll( '.newspack-blocks-checkout-modal__close' );
+	const closeButtons = modalCheckout.querySelectorAll( `${ MODAL_CLASSNAME_BASE }__close` );
 	closeButtons.forEach( button => {
 		button.addEventListener( 'click', ev => {
 			ev.preventDefault();
 			modalContent.style.height = initialHeight;
 			spinner.style.display = 'flex';
-			closeCheckout( modalCheckout );
+			closeCheckout();
 		} );
 	} );
 
@@ -83,17 +89,15 @@ domReady( () => {
 	variationModals.forEach( variationModal => {
 		variationModal.addEventListener( 'click', ev => {
 			if ( ev.target === variationModal ) {
-				closeCheckout( variationModal );
+				closeCheckout();
 			}
 		} );
-		variationModal
-			.querySelectorAll( '.newspack-blocks-variation-modal__close' )
-			.forEach( button => {
-				button.addEventListener( 'click', ev => {
-					ev.preventDefault();
-					closeCheckout( variationModal );
-				} );
+		variationModal.querySelectorAll( '.newspack-blocks-modal__close' ).forEach( button => {
+			button.addEventListener( 'click', ev => {
+				ev.preventDefault();
+				closeCheckout();
 			} );
+		} );
 	} );
 
 	/**

--- a/src/modal-checkout/modal.scss
+++ b/src/modal-checkout/modal.scss
@@ -13,8 +13,7 @@
 	}
 }
 
-.newspack-blocks-checkout-modal,
-.newspack-blocks-variation-modal {
+.newspack-blocks-modal {
 	position: fixed;
 	top: 0;
 	left: 0;
@@ -33,7 +32,7 @@
 		max-height: calc( 100vh - 32px );
 		background: colors.$color__background-body;
 		border-radius: 5px;
-		> *:not( .newspack-blocks-checkout-modal__close, .newspack-blocks-variation-modal__close ) {
+		> *:not( .newspack-blocks-modal__close ) {
 			width: 100%;
 			height: 100%;
 			border: 0;
@@ -145,8 +144,7 @@
 }
 
 @media ( max-width: 600px ) {
-	.newspack-blocks-checkout-modal,
-	.newspack-blocks-variation-modal {
+	.newspack-blocks-modal {
 		&__content {
 			max-width: 100%;
 			width: 100%;
@@ -155,7 +153,7 @@
 			bottom: 0;
 			left: 0;
 			transform: none;
-			> *:not( .newspack-blocks-variation-modal__close, .newspack-blocks-checkout-modal__close ) {
+			> *:not( .newspack-blocks-modal__close ) {
 				border-radius: 0;
 			}
 		}

--- a/src/modal-checkout/modal.scss
+++ b/src/modal-checkout/modal.scss
@@ -81,62 +81,64 @@
 }
 
 .newspack-blocks-variation-modal {
-	&__content {
-		padding: 32px;
-		overflow: auto;
-		border-radius: 5px;
-		h3 {
-			margin: 0 0 1em;
-		}
-		p {
-			font-size: 0.8em;
-		}
-		form {
-			margin: 0 0 0.5em;
-			&:last-child {
-				margin: 0;
+	.newspack-blocks-modal {
+		&__content {
+			padding: 32px;
+			overflow: auto;
+			border-radius: 5px;
+			h3 {
+				margin: 0 0 1em;
 			}
-			button {
-				display: block;
-				width: 100%;
-				padding: 16px;
-				margin: 0;
-				border: 1px solid colors.$color__border;
-				background: transparent;
-				color: colors.$color__text-main;
-				text-align: inherit;
-				font-weight: inherit;
-				> span {
-					display: block;
+			p {
+				font-size: 0.8em;
+			}
+			form {
+				margin: 0 0 0.5em;
+				&:last-child {
+					margin: 0;
 				}
-				.summary {
+				button {
+					display: block;
 					width: 100%;
-					display: flex;
-					justify-content: space-between;
-					align-items: flex-end;
-					.subscription-details {
-						bdi {
-							font-size: inherit;
+					padding: 16px;
+					margin: 0;
+					border: 1px solid colors.$color__border;
+					background: transparent;
+					color: colors.$color__text-main;
+					text-align: inherit;
+					font-weight: inherit;
+					> span {
+						display: block;
+					}
+					.summary {
+						width: 100%;
+						display: flex;
+						justify-content: space-between;
+						align-items: flex-end;
+						.subscription-details {
+							bdi {
+								font-size: inherit;
+							}
 						}
 					}
-				}
-				.price {
-					max-width: 65%;
-				}
-				.variation_name {
-					font-weight: 600;
-					font-size: 0.9em;
-					margin-left: 0.5em;
-				}
-				.description {
-					padding-top: 1em;
-					margin-top: 1em;
-					font-size: 0.9em;
-					border-top: 1px solid colors.$color__border;
-				}
-				bdi {
-					font-weight: 600;
-					font-size: 1.8em;
+					.price {
+						max-width: 65%;
+					}
+					.variation_name {
+						font-weight: 600;
+						font-size: 0.9em;
+						margin-left: 0.5em;
+					}
+					.description {
+						padding-top: 1em;
+						margin-top: 1em;
+						font-size: 0.9em;
+						border-top: 1px solid colors.$color__border;
+					}
+					bdi {
+						font-weight: 600;
+						font-size: 1.8em;
+					}
 				}
 			}
 		}

--- a/src/modal-checkout/templates/form-login.php
+++ b/src/modal-checkout/templates/form-login.php
@@ -25,6 +25,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * order-received.php template with an order details summary so the experience
  * matches whether or not the email address used is already associated with an
  * existing customer account.
+ *
+ * This template will be rendered when an existing user completes a transaction
+ * through the modal checkout. Instead of showing the login form, we'll show the
+ * order details summary.
  */
 function newspack_blocks_replace_login_with_order_summary() {
 	$order    = isset( $_GET['order_id'] ) ? \wc_get_order( \absint( \wp_unslash( $_GET['order_id'] ) ) ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -33,12 +37,9 @@ function newspack_blocks_replace_login_with_order_summary() {
 	?>
 
 	<div class="woocommerce-order">
-		<?php if ( $is_valid ) : ?>
-
 		<h4><?php esc_html_e( 'Summary', 'newspack-blocks' ); ?></h4>
-
+		<?php if ( $is_valid ) : ?>
 		<ul class="woocommerce-order-overview woocommerce-thankyou-order-details order_details">
-
 			<li class="woocommerce-order-overview__date date">
 				<?php esc_html_e( 'Date:', 'newspack-blocks' ); ?>
 				<strong><?php echo wc_format_datetime( $order->get_date_created() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
@@ -67,10 +68,8 @@ function newspack_blocks_replace_login_with_order_summary() {
 				<?php esc_html_e( 'Transaction:', 'newspack-blocks' ); ?>
 				<strong><?php echo $order->get_order_number(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
 			</li>
-
 		</ul>
 		<?php else : ?>
-		<h4><?php esc_html_e( 'Summary', 'newspack-blocks' ); ?></h4>
 		<p>
 			<?php
 			echo wp_kses_post(

--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -34,6 +34,10 @@ function newspack_blocks_replace_login_with_order_summary() {
 	?>
 
 	<div class="woocommerce-order">
+		<p class="woocommerce-notice woocommerce-notice--success woocommerce-thankyou-order-received">
+			<?php echo esc_html_e( 'Thank you for your donation!', 'newspack-blocks' ); ?>
+		</p>
+
 		<h4><?php esc_html_e( 'Summary', 'newspack-blocks' ); ?></h4>
 		<?php if ( $is_valid ) : ?>
 		<ul class="woocommerce-order-overview woocommerce-thankyou-order-details order_details">

--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -31,14 +31,20 @@ function newspack_blocks_replace_login_with_order_summary() {
 	$key      = isset( $_GET['key'] ) ? \wc_clean( \sanitize_text_field( \wp_unslash( $_GET['key'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	$is_valid = $order && is_a( $order, 'WC_Order' ) && hash_equals( $order->get_order_key(), $key ); // Validate order key to prevent CSRF.
 
+	// Handle the newsletter signup form.
+	$newsletter_confirmation = \Newspack_Blocks\Modal_Checkout::confirm_newsletter_signup();
+	if ( true === $newsletter_confirmation ) {
+		echo \Newspack_Blocks\Modal_Checkout::render_newsletter_confirmation(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		return;
+	} elseif ( \is_wp_error( $newsletter_confirmation ) ) {
+		echo esc_html( $newsletter_confirmation->get_error_message() );
+		return;
+	}
+
 	?>
 
 	<div class="woocommerce-order">
-		<p class="woocommerce-notice woocommerce-notice--success woocommerce-thankyou-order-received">
-			<?php echo esc_html_e( 'Thank you for your donation!', 'newspack-blocks' ); ?>
-		</p>
-
-		<h4><?php esc_html_e( 'Summary', 'newspack-blocks' ); ?></h4>
+		<h4><?php esc_html_e( 'Transaction Successful', 'newspack-blocks' ); ?></h4>
 		<?php if ( $is_valid ) : ?>
 		<ul class="woocommerce-order-overview woocommerce-thankyou-order-details order_details">
 			<li class="woocommerce-order-overview__date date">
@@ -87,6 +93,12 @@ function newspack_blocks_replace_login_with_order_summary() {
 	</div>
 
 	<?php echo \Newspack_Blocks\Modal_Checkout::render_checkout_after_success_markup(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+
+	<?php
+	if ( $order ) {
+		echo \Newspack_Blocks\Modal_Checkout::render_newsletter_signup_form( $order ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+	?>
 
 	<?php
 }

--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -86,7 +86,7 @@ function newspack_blocks_replace_login_with_order_summary() {
 		<?php endif; ?>
 	</div>
 
-	<?php do_action( 'newspack_woocommerce_thankyou', $order->get_id() ); ?>
+	<?php echo \Newspack_Blocks\Modal_Checkout::render_checkout_after_success_markup(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 
 	<?php
 }

--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -31,10 +31,6 @@ function newspack_blocks_replace_login_with_order_summary() {
 	$key      = isset( $_GET['key'] ) ? \wc_clean( \sanitize_text_field( \wp_unslash( $_GET['key'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	$is_valid = $order && is_a( $order, 'WC_Order' ) && hash_equals( $order->get_order_key(), $key ); // Validate order key to prevent CSRF.
 
-	if ( ! $is_valid ) {
-		return;
-	}
-
 	// Handle the newsletter signup form.
 	$newsletter_confirmation = \Newspack_Blocks\Modal_Checkout::confirm_newsletter_signup();
 	if ( true === $newsletter_confirmation ) {
@@ -42,6 +38,10 @@ function newspack_blocks_replace_login_with_order_summary() {
 		return;
 	} elseif ( \is_wp_error( $newsletter_confirmation ) ) {
 		echo esc_html( $newsletter_confirmation->get_error_message() );
+		return;
+	}
+
+	if ( ! $is_valid ) {
 		return;
 	}
 

--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -25,15 +25,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  * order-received.php template with an order details summary so the experience
  * matches whether or not the email address used is already associated with an
  * existing customer account.
- *
- * This template will be rendered when an existing user completes a transaction
- * through the modal checkout. Instead of showing the login form, we'll show the
- * order details summary.
  */
 function newspack_blocks_replace_login_with_order_summary() {
 	$order    = isset( $_GET['order_id'] ) ? \wc_get_order( \absint( \wp_unslash( $_GET['order_id'] ) ) ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	$key      = isset( $_GET['key'] ) ? \wc_clean( \sanitize_text_field( \wp_unslash( $_GET['key'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	$is_valid = $order && is_a( $order, 'WC_Order' ) && hash_equals( $order->get_order_key(), $key ); // Validate order key to prevent CSRF.
+
 	?>
 
 	<div class="woocommerce-order">
@@ -84,6 +81,9 @@ function newspack_blocks_replace_login_with_order_summary() {
 		</p>
 		<?php endif; ?>
 	</div>
+
+	<?php do_action( 'newspack_woocommerce_thankyou', $order->get_id() ); ?>
+
 	<?php
 }
 

--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -31,6 +31,10 @@ function newspack_blocks_replace_login_with_order_summary() {
 	$key      = isset( $_GET['key'] ) ? \wc_clean( \sanitize_text_field( \wp_unslash( $_GET['key'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	$is_valid = $order && is_a( $order, 'WC_Order' ) && hash_equals( $order->get_order_key(), $key ); // Validate order key to prevent CSRF.
 
+	if ( ! $is_valid ) {
+		return;
+	}
+
 	// Handle the newsletter signup form.
 	$newsletter_confirmation = \Newspack_Blocks\Modal_Checkout::confirm_newsletter_signup();
 	if ( true === $newsletter_confirmation ) {
@@ -45,7 +49,6 @@ function newspack_blocks_replace_login_with_order_summary() {
 
 	<div class="woocommerce-order">
 		<h4><?php esc_html_e( 'Transaction Successful', 'newspack-blocks' ); ?></h4>
-		<?php if ( $is_valid ) : ?>
 		<ul class="woocommerce-order-overview woocommerce-thankyou-order-details order_details">
 			<li class="woocommerce-order-overview__date date">
 				<?php esc_html_e( 'Date:', 'newspack-blocks' ); ?>
@@ -76,20 +79,6 @@ function newspack_blocks_replace_login_with_order_summary() {
 				<strong><?php echo $order->get_order_number(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
 			</li>
 		</ul>
-		<?php else : ?>
-		<p>
-			<?php
-			echo wp_kses_post(
-				sprintf(
-					// Translators: URL to My Account.
-					__( 'Please log in to <a href="%s">My Account</a> to see order details.', 'newspack-blocks' ),
-					\wc_get_account_endpoint_url( 'dashboard' )
-				),
-				'newspack-blocks'
-			);
-			?>
-		</p>
-		<?php endif; ?>
 	</div>
 
 	<?php echo \Newspack_Blocks\Modal_Checkout::render_checkout_after_success_markup(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds post-checkout newsletter signup options:

<img width="618" alt="image" src="https://github.com/Automattic/newspack-blocks/assets/7383192/18f0534c-d275-4b27-a2ba-6cfa6a4306c0">

<img width="617" alt="image" src="https://github.com/Automattic/newspack-blocks/assets/7383192/de21738b-f3f4-476a-8965-cbf19219a77b">

### How to test the changes in this Pull Request:

1. Switch `newspack-plugin` to branch from https://github.com/Automattic/newspack-plugin/pull/2707
1. Switch `newspack-theme` to branch from https://github.com/Automattic/newspack-theme/pull/2188 
1. Ensure that the Newsletters provider is configured and some lists are active in Engagement wizard -> Newsletters
1. With "Newspack" set as the Reader Revenue platform, make a donation using the checkout modal
3. Observe that after the checkout is successful, the chosen newsletter lists are presented
4. Select some of them and click "Continue", observe a success message
5. Verify that the email used has been added to the list(s)
6. Set a `NEWSPACK_DISABLE_POST_CHECKOUT_NEWSLETTER_SIGNUP` environment variable to `true` and observe that now the signup lists are not displayed after the checkout 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->