### PR TITLE
Chore: update phpcs to handle PHP 8

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -33,6 +33,8 @@
 		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
 		<exclude name="Universal.Operators.DisallowStandalonePostIncrementDecrement.PostIncrementFound" />
 		<exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction" />
+		<exclude name="WordPress.PHP.YodaConditions.NotYoda" />
+		<exclude name="Generic.Formatting.MultipleStatementAlignment.NotSameWarning" />
 	</rule>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -28,8 +28,10 @@
 	<config name="minimum_supported_wp_version" value="4.6"/>
 	<rule ref="WordPress">
 	</rule>
-		<rule ref="WordPress">
+	<rule ref="WordPress">
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
+		<exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction" />
 	</rule>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -31,6 +31,7 @@
 	<rule ref="WordPress">
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
 		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
+		<exclude name="Universal.Operators.DisallowStandalonePostIncrementDecrement.PostIncrementFound" />
 		<exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction" />
 	</rule>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
 	"type": "wordpress-plugin",
 	"require-dev": {
 		"composer/installers": "~2.0",
-		"automattic/vipwpcs": "^2.0.0",
+		"automattic/vipwpcs": "^3.0",
 		"brainmaestro/composer-git-hooks": "^2.6",
-		"wp-coding-standards/wpcs": "*",
+		"wp-coding-standards/wpcs": "^3.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "*",
 		"phpcompatibility/phpcompatibility-wp": "*",
 		"sirbrillig/phpcs-variable-analysis": "^2.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,29 +4,30 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c2ae738f7d55095c0c8a1522f18b831c",
+    "content-hash": "1ac2decd4a5e66a65ff3bb0d2960c6de",
     "packages": [],
     "packages-dev": [
         {
             "name": "automattic/vipwpcs",
-            "version": "2.3.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6"
+                "reference": "1b8960ebff9ea3eb482258a906ece4d1ee1e25fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6",
-                "reference": "b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/1b8960ebff9ea3eb482258a906ece4d1ee1e25fd",
+                "reference": "1b8960ebff9ea3eb482258a906ece4d1ee1e25fd",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
+                "phpcsstandards/phpcsextra": "^1.1.0",
+                "phpcsstandards/phpcsutils": "^1.0.8",
                 "sirbrillig/phpcs-variable-analysis": "^2.11.17",
-                "squizlabs/php_codesniffer": "^3.7.1",
-                "wp-coding-standards/wpcs": "^2.3"
+                "squizlabs/php_codesniffer": "^3.7.2",
+                "wp-coding-standards/wpcs": "^3.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -58,7 +59,7 @@
                 "source": "https://github.com/Automattic/VIP-Coding-Standards",
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
-            "time": "2023-08-24T15:11:13+00:00"
+            "time": "2023-09-05T11:01:05+00:00"
         },
         {
             "name": "brainmaestro/composer-git-hooks",
@@ -825,6 +826,142 @@
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
             "time": "2022-10-24T09:00:36+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
+                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "time": "2023-09-20T22:06:18+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/69465cab9d12454e5e7767b9041af0cd8cd13be7",
+                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.7.1 || 4.0.x-dev@dev"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "time": "2023-07-16T21:39:41+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3254,30 +3391,38 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
                 "shasum": ""
             },
             "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "phpcsstandards/phpcsextra": "^1.1.0",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -3294,6 +3439,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -3301,7 +3447,13 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2020-05-13T23:57:56+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/thewpcc/contribute/wp-php-63406",
+                    "type": "custom"
+                }
+            ],
+            "time": "2023-09-14T07:06:09+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",
@@ -3374,5 +3526,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -12,19 +12,19 @@ class Newspack_Blocks_API {
 	/**
 	 * Get thumbnail featured image source for the rest field.
 	 *
-	 * @param array $object The object info.
+	 * @param array $object_info The object info.
 	 * @return array | bool Featured image if available, false if not.
 	 */
-	public static function newspack_blocks_get_image_src( $object ) {
+	public static function newspack_blocks_get_image_src( $object_info ) {
 		$featured_image_set = [];
 
-		if ( 0 === $object['featured_media'] ) {
+		if ( 0 === $object_info['featured_media'] ) {
 			return false;
 		}
 
 		// Large image.
 		$feat_img_array_large        = wp_get_attachment_image_src(
-			$object['featured_media'],
+			$object_info['featured_media'],
 			'large',
 			false
 		);
@@ -34,7 +34,7 @@ class Newspack_Blocks_API {
 		$landscape_size = Newspack_Blocks::image_size_for_orientation( 'landscape' );
 
 		$feat_img_array_landscape        = wp_get_attachment_image_src(
-			$object['featured_media'],
+			$object_info['featured_media'],
 			$landscape_size,
 			false
 		);
@@ -44,7 +44,7 @@ class Newspack_Blocks_API {
 		$portrait_size = Newspack_Blocks::image_size_for_orientation( 'portrait' );
 
 		$feat_img_array_portrait        = wp_get_attachment_image_src(
-			$object['featured_media'],
+			$object_info['featured_media'],
 			$portrait_size,
 			false
 		);
@@ -54,7 +54,7 @@ class Newspack_Blocks_API {
 		$square_size = Newspack_Blocks::image_size_for_orientation( 'square' );
 
 		$feat_img_array_square        = wp_get_attachment_image_src(
-			$object['featured_media'],
+			$object_info['featured_media'],
 			$square_size,
 			false
 		);
@@ -64,7 +64,7 @@ class Newspack_Blocks_API {
 		$uncropped_size = 'newspack-article-block-uncropped';
 
 		$feat_img_array_uncropped        = wp_get_attachment_image_src(
-			$object['featured_media'],
+			$object_info['featured_media'],
 			$uncropped_size,
 			false
 		);
@@ -76,20 +76,20 @@ class Newspack_Blocks_API {
 	/**
 	 * Get thumbnail featured image captions for the rest field.
 	 *
-	 * @param array $object The object info.
+	 * @param array $object_info The object info.
 	 * @return string|null Image caption on success, null on failure.
 	 */
-	public static function newspack_blocks_get_image_caption( $object ) {
-		return (int) $object['featured_media'] > 0 ? trim( wp_get_attachment_caption( $object['featured_media'] ) ) : null;
+	public static function newspack_blocks_get_image_caption( $object_info ) {
+		return (int) $object_info['featured_media'] > 0 ? trim( wp_get_attachment_caption( $object_info['featured_media'] ) ) : null;
 	}
 
 	/**
 	 * Get author info for the rest field.
 	 *
-	 * @param array $object The object info.
+	 * @param array $object_info The object info.
 	 * @return array Author data.
 	 */
-	public static function newspack_blocks_get_author_info( $object ) {
+	public static function newspack_blocks_get_author_info( $object_info ) {
 		$author_data = [];
 
 		if ( function_exists( 'coauthors_posts_links' ) && ! empty( get_coauthors() ) ) :
@@ -116,13 +116,13 @@ class Newspack_Blocks_API {
 		else :
 			$author_data[] = array(
 				/* Get the author name */
-				'display_name' => get_the_author_meta( 'display_name', $object['author'] ),
+				'display_name' => get_the_author_meta( 'display_name', $object_info['author'] ),
 				/* Get the author avatar */
-				'avatar'       => get_avatar( $object['author'], 48 ),
+				'avatar'       => get_avatar( $object_info['author'], 48 ),
 				/* Get the author ID */
-				'id'           => $object['author'],
+				'id'           => $object_info['author'],
 				/* Get the author Link */
-				'author_link'  => get_author_posts_url( $object['author'] ),
+				'author_link'  => get_author_posts_url( $object_info['author'] ),
 			);
 		endif;
 
@@ -133,15 +133,15 @@ class Newspack_Blocks_API {
 	/**
 	 * Get primary category for the rest field.
 	 *
-	 * @param array $object The object info.
+	 * @param array $object_info The object info.
 	 * @return string Category name.
 	 */
-	public static function newspack_blocks_get_primary_category( $object ) {
+	public static function newspack_blocks_get_primary_category( $object_info ) {
 		$category = false;
 
 		// Use Yoast primary category if set.
 		if ( class_exists( 'WPSEO_Primary_Term' ) ) {
-			$primary_term = new WPSEO_Primary_Term( 'category', $object['id'] );
+			$primary_term = new WPSEO_Primary_Term( 'category', $object_info['id'] );
 			$category_id  = $primary_term->get_primary_term();
 			if ( $category_id ) {
 				$category = get_term( $category_id );
@@ -149,7 +149,7 @@ class Newspack_Blocks_API {
 		}
 
 		if ( ! $category ) {
-			$categories_list = get_the_category( $object['id'] );
+			$categories_list = get_the_category( $object_info['id'] );
 			if ( ! empty( $categories_list ) ) {
 				$category = $categories_list[0];
 			}
@@ -167,22 +167,22 @@ class Newspack_Blocks_API {
 	/**
 	 * Get a list of category, tag classes for the rest field.
 	 *
-	 * @param array $object The object info.
+	 * @param array $object_info The object info.
 	 * @return string classes from assigned categories and tags.
 	 */
-	public static function newspack_blocks_get_cat_tag_classes( $object ) {
-		return Newspack_Blocks::get_term_classes( $object['id'] );
+	public static function newspack_blocks_get_cat_tag_classes( $object_info ) {
+		return Newspack_Blocks::get_term_classes( $object_info['id'] );
 	}
 
 	/**
 	 * Get all sponsor information for the rest field.
 	 *
-	 * @param array $object The object info.
+	 * @param array $object_info The object info.
 	 * @return array sponsor information.
 	 */
-	public static function newspack_blocks_sponsor_info( $object ) {
+	public static function newspack_blocks_sponsor_info( $object_info ) {
 		$sponsors = Newspack_Blocks::get_all_sponsors(
-			$object['id'],
+			$object_info['id'],
 			'native',
 			'post',
 			array(
@@ -217,11 +217,11 @@ class Newspack_Blocks_API {
 	/**
 	 * Pass whether there is a custom excerpt to the editor.
 	 *
-	 * @param array $object The object info.
+	 * @param array $object_info The object info.
 	 * @return boolean custom excerpt status.
 	 */
-	public static function newspack_blocks_has_custom_excerpt( $object ) {
-		$post_has_custom_excerpt = has_excerpt( $object['id'] );
+	public static function newspack_blocks_has_custom_excerpt( $object_info ) {
+		$post_has_custom_excerpt = has_excerpt( $object_info['id'] );
 		return $post_has_custom_excerpt;
 	}
 

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -201,7 +201,7 @@ class Newspack_Blocks {
 						'slug'  => $tax->name,
 						'label' => $tax->label,
 					];
-				};
+				}
 			},
 			get_taxonomies(
 				[

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -794,7 +794,7 @@ class Newspack_Blocks {
 	 * @param array  $data          Data to be passed into the template to be included.
 	 * @return string
 	 */
-	public static function template_inc( $template, $data = array() ) { //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public static function template_inc( $template, $data = array() ) { //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable, Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		if ( ! strpos( $template, '.php' ) ) {
 			$template = $template . '.php';
 		}

--- a/src/blocks/author-list/class-wp-rest-newspack-author-list-controller.php
+++ b/src/blocks/author-list/class-wp-rest-newspack-author-list-controller.php
@@ -81,12 +81,10 @@ class WP_REST_Newspack_Author_List_Controller extends WP_REST_Newspack_Authors_C
 		foreach ( $array as $value ) {
 			if ( is_array( $value ) ) {
 				$value = self::sanitize_array( $value );
-			} else {
-				if ( is_string( $value ) ) {
+			} elseif ( is_string( $value ) ) {
 					$value = sanitize_text_field( $value );
-				} else {
-					$value = floatval( $value );
-				}
+			} else {
+				$value = floatval( $value );
 			}
 		}
 

--- a/src/blocks/author-list/class-wp-rest-newspack-author-list-controller.php
+++ b/src/blocks/author-list/class-wp-rest-newspack-author-list-controller.php
@@ -74,11 +74,11 @@ class WP_REST_Newspack_Author_List_Controller extends WP_REST_Newspack_Authors_C
 	/**
 	 * Sanitize an array of text or number values.
 	 *
-	 * @param array $array Array of text or float values to be sanitized.
+	 * @param array $array_to_sanitize Array of text or float values to be sanitized.
 	 * @return array Sanitized array.
 	 */
-	public static function sanitize_array( $array ) {
-		foreach ( $array as $value ) {
+	public static function sanitize_array( $array_to_sanitize ) {
+		foreach ( $array_to_sanitize as $value ) {
 			if ( is_array( $value ) ) {
 				$value = self::sanitize_array( $value );
 			} elseif ( is_string( $value ) ) {
@@ -88,7 +88,7 @@ class WP_REST_Newspack_Author_List_Controller extends WP_REST_Newspack_Authors_C
 			}
 		}
 
-		return $array;
+		return $array_to_sanitize;
 	}
 
 	/**

--- a/src/blocks/author-list/class-wp-rest-newspack-author-list-controller.php
+++ b/src/blocks/author-list/class-wp-rest-newspack-author-list-controller.php
@@ -219,7 +219,7 @@ class WP_REST_Newspack_Author_List_Controller extends WP_REST_Newspack_Authors_C
 			// Keep querying until we have all guest authors.
 			if ( $current_page < $number_of_pages ) {
 				while ( $current_page < $number_of_pages ) {
-					$current_page               ++;
+					$current_page++;
 					$guest_author_args['paged'] = $current_page;
 					$results                    = new \WP_Query( $guest_author_args );
 					$all_guest_authors          = array_merge( $all_guest_authors, $results->posts );
@@ -276,7 +276,7 @@ class WP_REST_Newspack_Author_List_Controller extends WP_REST_Newspack_Authors_C
 			// Keep querying until we have all users.
 			if ( $current_page < $number_of_pages ) {
 				while ( $current_page < $number_of_pages ) {
-					$current_page       ++;
+					$current_page++;
 					$user_args['paged'] = $current_page;
 					$results            = new \WP_User_Query( $user_args );
 					$all_users          = array_merge( $all_users, $results->get_results() );

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -104,21 +104,19 @@ call_user_func(
 				<?php
 			endif;
 
-			if ( '' === $attributes['sectionHeader'] ) :
+			if ( '' === $attributes['sectionHeader'] ) {
 				// Don't link the title if the post lacks a valid URL.
-				if ( ! $post_link ) :
+				if ( ! $post_link ) {
 					the_title( '<h2 class="entry-title">', '</h2>' );
-				else :
+				} else {
 					the_title( '<h2 class="entry-title"><a href="' . esc_url( $post_link ) . '" rel="bookmark">', '</a></h2>' );
-				endif;
-			else :
+				}
+			} elseif ( ! $post_link ) {
 				// Don't link the title if the post lacks a valid URL.
-				if ( ! $post_link ) :
-					the_title( '<h3 class="entry-title">', '</h3>' );
-				else :
-					the_title( '<h3 class="entry-title"><a href="' . esc_url( $post_link ) . '" rel="bookmark">', '</a></h3>' );
-				endif;
-			endif;
+				the_title( '<h3 class="entry-title">', '</h3>' );
+			} else {
+				the_title( '<h3 class="entry-title"><a href="' . esc_url( $post_link ) . '" rel="bookmark">', '</a></h3>' );
+			}
 			?>
 			<?php
 			if ( $attributes['showSubtitle'] ) :

--- a/src/blocks/homepage-articles/templates/articles-list.php
+++ b/src/blocks/homepage-articles/templates/articles-list.php
@@ -12,8 +12,8 @@ call_user_func(
 		echo Newspack_Blocks::template_inc( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			__DIR__ . '/articles-loop.php',
 			array(
-				'attributes'    => $data['attributes'],
-				'article_query' => $data['article_query'],
+				'attributes'    => $data['attributes'], // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				'article_query' => $data['article_query'], // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			)
 		);
 	},

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -204,9 +204,9 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 				echo Newspack_Blocks::template_inc( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					__DIR__ . '/templates/articles-list.php',
 					[
-						'articles_rest_url' => $articles_rest_url,
-						'article_query'     => $article_query,
-						'attributes'        => $attributes,
+						'articles_rest_url' => $articles_rest_url, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						'article_query'     => $article_query, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						'attributes'        => $attributes, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					]
 				);
 				?>

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -308,7 +308,7 @@ function newspack_blocks_format_byline( $author_info ) {
 		array_reduce(
 			$author_info,
 			function ( $accumulator, $author ) use ( $author_info, &$index ) {
-				$index ++;
+				$index++;
 				$penultimate = count( $author_info ) - 2;
 
 				$get_author_posts_url = get_author_posts_url( $author->ID );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,7 +23,7 @@ require_once $newspack_blocks_tests_dir . '/includes/functions.php';
  * Manually load the plugin being tested.
  */
 function newspack_blocks_manually_load_plugin() {
-	require dirname( dirname( __FILE__ ) ) . '/newspack-blocks.php';
+	require dirname( __DIR__ ) . '/newspack-blocks.php';
 }
 tests_add_filter( 'muplugins_loaded', 'newspack_blocks_manually_load_plugin' );
 
@@ -32,4 +32,4 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 // Start up the WP testing environment.
 require $newspack_blocks_tests_dir . '/includes/bootstrap.php';
-require dirname( dirname( __FILE__ ) ) . '/tests/wp-unittestcase-blocks.php';
+require dirname( __DIR__ ) . '/tests/wp-unittestcase-blocks.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updates the lint-related Composer packages to handle PHP 8. 

After upgrading to PHP 8, running the linting commands (`./vendor/bin/phpcs`, `./vendor/bin/phpcbf`) was erroring out. This was resolved by updating these packages. Along with the updates, some code had to be refactored – some of it automatically with `phpcbf`, some manually.

### How to test the changes in this Pull Request:

1. Smoke test code changes, everything should behave as before
2. Ensure the lint-php job is passing on CI
3. For a good measure, run the linting commands locally to see if there are no issues with local development

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->