### PR TITLE
Fix/checkout login prompt

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -184,6 +184,9 @@
 			display: none; // Hide the "Please log in to view this order" message on the thank you page.
 		}
 	}
+	.woocommerce-form-login-toggle {
+		display: none; // Hide the "Returning customer?	Click here to login" message.
+	}
 	.woocommerce-order-overview {
 		color: colors.$color__text-light;
 		list-style: none;

--- a/src/modal-checkout/templates/form-login.php
+++ b/src/modal-checkout/templates/form-login.php
@@ -30,15 +30,16 @@ function newspack_blocks_replace_login_with_order_summary() {
 	$order    = isset( $_GET['order_id'] ) ? \wc_get_order( \absint( \wp_unslash( $_GET['order_id'] ) ) ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	$key      = isset( $_GET['key'] ) ? \wc_clean( \sanitize_text_field( \wp_unslash( $_GET['key'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	$is_valid = $order && is_a( $order, 'WC_Order' ) && hash_equals( $order->get_order_key(), $key ); // Validate order key to prevent CSRF.
+
+	if ( ! $is_valid ) {
+		return;
+	}
 	?>
 
 	<div class="woocommerce-order">
-		<?php if ( $is_valid ) : ?>
-
 		<h4><?php esc_html_e( 'Summary', 'newspack-blocks' ); ?></h4>
 
 		<ul class="woocommerce-order-overview woocommerce-thankyou-order-details order_details">
-
 			<li class="woocommerce-order-overview__date date">
 				<?php esc_html_e( 'Date:', 'newspack-blocks' ); ?>
 				<strong><?php echo wc_format_datetime( $order->get_date_created() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
@@ -67,23 +68,7 @@ function newspack_blocks_replace_login_with_order_summary() {
 				<?php esc_html_e( 'Transaction:', 'newspack-blocks' ); ?>
 				<strong><?php echo $order->get_order_number(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
 			</li>
-
 		</ul>
-		<?php else : ?>
-		<h4><?php esc_html_e( 'Summary', 'newspack-blocks' ); ?></h4>
-		<p>
-			<?php
-			echo wp_kses_post(
-				sprintf(
-					// Translators: URL to My Account.
-					__( 'Please log in to <a href="%s">My Account</a> to see order details.', 'newspack-blocks' ),
-					\wc_get_account_endpoint_url( 'dashboard' )
-				),
-				'newspack-blocks'
-			);
-			?>
-		</p>
-		<?php endif; ?>
 	</div>
 	<?php
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The login prompt was introduced here (https://github.com/Automattic/newspack-blocks/pull/1550#issuecomment-1755996086), but if the key and order are not valid, this template will not be rendered at all.

Also, there's a WC login prompt. This does not work, some necessary JS seems not to be enqueued in the modal checkout. Until that's resolved, the prompt will be hidden.

### How to test the changes in this Pull Request:

1. On branch `release`, initiate a modal checkout flow in a fresh session. Observe two login prompts at the top of the modal:

<img width="620" alt="image" src="https://github.com/Automattic/newspack-blocks/assets/7383192/be00a1fe-f9b8-4597-a84f-e192ce1b7341">

2. Switch to this branch, repeat, observe no login prompts

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->