### PR TITLE
fix: update WC's variation methods

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -209,9 +209,9 @@ final class Modal_Checkout {
 						<?php
 						$variations = $product->get_available_variations( 'objects' );
 						foreach ( $variations as $variation ) {
-							$name        = $variation->get_formatted_variation_attributes( true );
+							$name        = wc_get_formatted_variation( $variation, true );
 							$price       = $variation->get_price_html();
-							$description = $variation->get_variation_description();
+							$description = $variation->get_description();
 							?>
 							<form>
 								<input type="hidden" name="newspack_checkout" value="1" />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updates WC's variation-related methods.

### How to test the changes in this Pull Request:

1. Create a product with variations
2. Add a Checkout Button block to a page and select the product
3. Load the page with the button, observe warnings about deprecated methods used being logged
4. Switch to this branch, observe no warnings

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->