### PR TITLE
Fix Homepage Posts Block to support primary category theme mod setting

### DIFF
--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -140,7 +140,7 @@ class Newspack_Blocks_API {
 		$category = false;
 
 		// Use Yoast primary category if set.
-		if ( class_exists( 'WPSEO_Primary_Term' ) ) {
+		if ( class_exists( 'WPSEO_Primary_Term' ) && get_theme_mod( 'post_primary_category', true ) ) {
 			$primary_term = new WPSEO_Primary_Term( 'category', $object['id'] );
 			$category_id  = $primary_term->get_primary_term();
 			if ( $category_id ) {

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -345,7 +345,7 @@ function newspack_blocks_format_byline( $author_info ) {
 function newspack_blocks_format_categories( $post_id ) {
 	$category = false;
 	// Use Yoast primary category if set.
-	if ( class_exists( 'WPSEO_Primary_Term' ) ) {
+	if ( class_exists( 'WPSEO_Primary_Term' ) && get_theme_mod( 'post_primary_category', true ) ) {
 		$primary_term = new WPSEO_Primary_Term( 'category', $post_id );
 		$category_id  = $primary_term->get_primary_term();
 		if ( $category_id ) {


### PR DESCRIPTION
Fixed Homepage Posts Block to adhere to the existing Customizer Theme Mod boolean 'post_primary_category'. This customizer boolean is used by the Newspack Theme to show either the WPSEO/Yoast primary category or all categories in archive and post templates.

Now that this same boolean is checked in the Homepage Posts Block, the block output will better match the theme category output.

Newspack Theme > Customizer > Template Settings > Post Settings:

![image](https://github.com/Automattic/newspack-blocks/assets/116242607/fb6d9ec9-9038-40be-a074-5530993a292d)

Homepage Posts Block will now check this setting.

This pull request essentially copies 2 lines of code from Newspack Theme (condensed into 1): [get_theme_mod](https://github.com/Automattic/newspack-theme/blob/89df5c7d446698b314ba9493e64d1eab7af045fa/newspack-theme/inc/template-tags.php#L233) and [if check](https://github.com/Automattic/newspack-theme/blob/89df5c7d446698b314ba9493e64d1eab7af045fa/newspack-theme/inc/template-tags.php#L236)


