### PR TITLE
Changes to button-after-success feature 

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -610,9 +610,8 @@ final class Modal_Checkout {
 			return;
 		}
 
-		$button_label = ! empty( $_REQUEST['after_success_button_label'] ) ? sanitize_text_field( urldecode( wp_unslash( $_REQUEST['after_success_button_label'] ) ) ) : __( 'Continue browsing', 'newspack-blocks' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$url          = ! empty( $_REQUEST['after_success_url'] ) ? sanitize_text_field( urldecode( wp_unslash( $_REQUEST['after_success_url'] ) ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-
+		$button_label = ! empty( $_REQUEST['after_success_button_label'] ) ? urldecode( wp_unslash( $_REQUEST['after_success_button_label'] ) ) : __( 'Continue browsing', 'newspack-blocks' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$url          = ! empty( $_REQUEST['after_success_url'] ) ? urldecode( wp_unslash( $_REQUEST['after_success_url'] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		?>
 			<a
 				<?php if ( empty( $url ) ) : ?>

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -729,7 +729,7 @@ final class Modal_Checkout {
 		$signup_data = self::get_newsletter_signup_data();
 		if ( false !== $signup_data ) {
 			if ( empty( $signup_data['lists'] ) ) {
-				return new \WP_Error( 'no-lists', __( 'No lists selected.', 'newspack-blocks' ) );
+				return new \WP_Error( 'newspack_no_lists_selected', __( 'No lists selected.', 'newspack-blocks' ) );
 			} else {
 				$result = \Newspack_Newsletters_Subscription::add_contact(
 					[
@@ -771,10 +771,14 @@ final class Modal_Checkout {
 
 	/**
 	 * Renders newsletter signup confirmation.
+	 *
+	 * @param bool $no_lists_selected Whether no lists were selected.
 	 */
-	public static function render_newsletter_confirmation() {
+	public static function render_newsletter_confirmation( $no_lists_selected = false ) {
 		?>
-			<h4><?php esc_html_e( 'Signup successful!', 'newspack-blocks' ); ?></h4>
+			<?php if ( ! $no_lists_selected ) : ?>
+				<h4><?php esc_html_e( 'Signup successful!', 'newspack-blocks' ); ?></h4>
+			<?php endif; ?>
 			<p>
 				<?php
 				echo esc_html(

--- a/src/blocks/checkout-button/block.json
+++ b/src/blocks/checkout-button/block.json
@@ -40,7 +40,8 @@
 			"type": "string"
 		},
 		"afterSuccessButtonLabel": {
-			"type": "string"
+			"type": "string",
+			"default": "Continue browsing"
 		},
 		"afterSuccessURL": {
 			"type": "string"

--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -34,6 +34,7 @@ import apiFetch from '@wordpress/api-fetch';
  * Internal dependencies
  */
 import './edit.scss';
+import RedirectAfterSuccess from '../../components/redirect-after-success';
 
 function getVariationName( variation ) {
 	const attributes = [];
@@ -150,48 +151,6 @@ function ProductControl( props ) {
 				</>
 			) }
 		</div>
-	);
-}
-
-function RedirectAfterSuccess( props ) {
-	const { attributes, setAttributes } = props;
-	return (
-		<>
-			<SelectControl
-				label={ __( 'Post-Checkout Button', 'newspack-blocks' ) }
-				help={ __(
-					'Select whether the user should be presented with a button to navigate after a successful purchase.',
-					'newspack-blocks'
-				) }
-				value={ attributes.afterSuccessBehavior }
-				options={ [
-					{ label: __( 'Do not show a button', 'newspack-blocks' ), value: '' },
-					{ label: __( 'Go to a custom URL', 'newspack-blocks' ), value: 'custom' },
-					{ label: __( 'Go to the previous page', 'newspack-blocks' ), value: 'referrer' },
-				] }
-				onChange={ value => {
-					setAttributes( { afterSuccessBehavior: value.toString() } );
-				} }
-			/>
-			{ attributes.afterSuccessBehavior !== '' && (
-				<>
-					<TextControl
-						label={ __( 'Button Label', 'newspack-blocks' ) }
-						placeholder={ __( 'Continue browsing', 'newspack-blocks' ) }
-						value={ attributes.afterSuccessButtonLabel || '' }
-						onChange={ value => setAttributes( { afterSuccessButtonLabel: value } ) }
-					/>
-					{ attributes.afterSuccessBehavior === 'custom' && (
-						<TextControl
-							label={ __( 'Custom URL', 'newspack-blocks' ) }
-							placeholder={ __( 'https://example.com', 'newspack-blocks' ) }
-							value={ attributes.afterSuccessURL || '' }
-							onChange={ value => setAttributes( { afterSuccessURL: value } ) }
-						/>
-					) }
-				</>
-			) }
-		</>
 	);
 }
 

--- a/src/blocks/donate/block.json
+++ b/src/blocks/donate/block.json
@@ -90,6 +90,15 @@
 		"additionalFields": {
 			"type": "array",
 			"default": []
+		},
+		"afterSuccessBehavior": {
+			"type": "string"
+		},
+		"afterSuccessButtonLabel": {
+			"type": "string"
+		},
+		"afterSuccessURL": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/src/blocks/donate/block.json
+++ b/src/blocks/donate/block.json
@@ -95,7 +95,8 @@
 			"type": "string"
 		},
 		"afterSuccessButtonLabel": {
-			"type": "string"
+			"type": "string",
+			"default": "Continue browsing"
 		},
 		"afterSuccessURL": {
 			"type": "string"

--- a/src/blocks/donate/edit/index.tsx
+++ b/src/blocks/donate/edit/index.tsx
@@ -45,6 +45,7 @@ import {
 	LAYOUT_OPTIONS,
 	DISABLED_IN_TIERS_BASED_LAYOUT_TIER_INDEX,
 } from '../consts';
+import RedirectAfterSuccess from '../../../components/redirect-after-success';
 
 const TIER_LABELS = [
 	__( 'Low-tier', 'newspack-blocks' ),
@@ -421,6 +422,9 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 						</p>
 					</PanelBody>
 				) }
+				<PanelBody title={ __( 'After purchase', 'newspack-blocks' ) }>
+					<RedirectAfterSuccess setAttributes={ setAttributes } attributes={ attributes } />
+				</PanelBody>
 			</InspectorControls>
 		</>
 	);

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
@@ -290,9 +290,11 @@ abstract class Newspack_Blocks_Donate_Renderer_Base {
 	}
 
 	/**
-	 * Render hidden form input indentifying a donate form submission.
+	 * Render hidden form inputs.
+	 *
+	 * @param array $attributes The block attributes.
 	 */
-	protected static function render_donate_form_input() {
+	protected static function render_hidden_form_inputs( $attributes ) {
 		ob_start();
 		/**
 		 * Action to add custom fields before the form fields of the donation block.
@@ -302,6 +304,17 @@ abstract class Newspack_Blocks_Donate_Renderer_Base {
 		?>
 			<input type='hidden' name='newspack_donate' value='1' />
 		<?php
+
+		foreach ( [ [ 'afterSuccessBehavior', 'after_success_behavior' ], [ 'afterSuccessButtonLabel', 'after_success_button_label' ], [ 'afterSuccessURL', 'after_success_url' ] ] as $attribute ) {
+			$attribute_name = $attribute[0];
+			$param_name     = $attribute[1];
+			if ( isset( $attributes[ $attribute_name ] ) ) {
+				?>
+					<input type='hidden' name='<?php echo esc_attr( $param_name ); ?>' value='<?php echo esc_attr( $attributes[ $attribute_name ] ); ?>' />
+				<?php
+			}
+		}
+
 		return ob_get_clean();
 	}
 

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
@@ -308,11 +308,10 @@ abstract class Newspack_Blocks_Donate_Renderer_Base {
 		foreach ( [ [ 'afterSuccessBehavior', 'after_success_behavior' ], [ 'afterSuccessButtonLabel', 'after_success_button_label' ], [ 'afterSuccessURL', 'after_success_url' ] ] as $attribute ) {
 			$attribute_name = $attribute[0];
 			$param_name     = $attribute[1];
-			if ( isset( $attributes[ $attribute_name ] ) ) {
-				?>
-					<input type='hidden' name='<?php echo esc_attr( $param_name ); ?>' value='<?php echo esc_attr( $attributes[ $attribute_name ] ); ?>' />
-				<?php
-			}
+			$value          = isset( $attributes[ $attribute_name ] ) ? $attributes[ $attribute_name ] : '';
+			?>
+				<input type='hidden' name='<?php echo esc_attr( $param_name ); ?>' value='<?php echo esc_attr( $value ); ?>' />
+			<?php
 		}
 
 		return ob_get_clean();

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-frequency-based.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-frequency-based.php
@@ -105,7 +105,7 @@ class Newspack_Blocks_Donate_Renderer_Frequency_Based extends Newspack_Blocks_Do
 			id="<?php echo esc_html( $configuration['uid'] ); ?>"
 		>
 			<form data-streamlined-config="<?php echo esc_html( htmlspecialchars( wp_json_encode( $configuration['configuration_for_streamlined'] ), ENT_QUOTES, 'UTF-8' ) ); ?>">
-				<?php echo self::render_donate_form_input(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<?php echo self::render_hidden_form_inputs( $attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<div class='wp-block-newspack-blocks-donate__options'>
 					<div class='wp-block-newspack-blocks-donate__frequencies frequencies'>
 						<?php foreach ( $configuration['frequencies'] as $frequency_slug => $frequency_name ) : ?>
@@ -154,7 +154,7 @@ class Newspack_Blocks_Donate_Renderer_Frequency_Based extends Newspack_Blocks_Do
 			id="<?php echo esc_html( $configuration['uid'] ); ?>"
 		>
 			<form data-streamlined-config="<?php echo esc_html( htmlspecialchars( wp_json_encode( $configuration['configuration_for_streamlined'] ), ENT_QUOTES, 'UTF-8' ) ); ?>">
-				<?php echo self::render_donate_form_input(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<?php echo self::render_hidden_form_inputs( $attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<div class='wp-block-newspack-blocks-donate__options'>
 					<div class='wp-block-newspack-blocks-donate__frequencies frequencies'>
 						<?php foreach ( $configuration['frequencies'] as $frequency_slug => $frequency_name ) : ?>

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-tiers-based.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-tiers-based.php
@@ -150,7 +150,7 @@ class Newspack_Blocks_Donate_Renderer_Tiers_Based extends Newspack_Blocks_Donate
 		>
 			<form data-is-init-form <?php echo 'stripe' === $configuration['platform'] ? 'onsubmit="return false;"' : ''; ?>>
 				<div class="wpbnbd__tiers__view">
-					<?php echo self::render_donate_form_input(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					<?php echo self::render_hidden_form_inputs( $attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					<input type="hidden" name="<?php echo esc_attr( self::FREQUENCY_PARAM ); ?>" value="<?php echo esc_attr( $intial_selected_frequency ); ?>">
 					<div class="wpbnbd__tiers">
 						<div class="wpbnbd__tiers__selection">

--- a/src/blocks/donate/types.ts
+++ b/src/blocks/donate/types.ts
@@ -96,6 +96,10 @@ export type DonateBlockAttributes = OverridableConfiguration & {
 	tiersBasedOptions: [ TierBasedOptionValue, TierBasedOptionValue, TierBasedOptionValue ];
 	// Manual mode enables block-level overrides of the global Donate settings.
 	manual: boolean;
+	// Post-checkout button option.
+	afterSuccessBehavior: string;
+	afterSuccessButtonLabel: string;
+	afterSuccessURL: string;
 	// Legacy attributes.
 	suggestedAmounts?: [ number, number, number ];
 	suggestedAmountUntiered?: number;

--- a/src/components/redirect-after-success.tsx
+++ b/src/components/redirect-after-success.tsx
@@ -18,12 +18,12 @@ const RedirectAfterSuccess = ( { attributes, setAttributes }: Props ) => (
 		<SelectControl
 			label={ __( 'Post-Checkout Button', 'newspack-blocks' ) }
 			help={ __(
-				'Select whether the user should be presented with a button to navigate after a successful purchase.',
+				'After a successful purchase, a button will be presented to finish the process.',
 				'newspack-blocks'
 			) }
 			value={ attributes.afterSuccessBehavior }
 			options={ [
-				{ label: __( 'Do not show a button', 'newspack-blocks' ), value: '' },
+				{ label: __( 'Close the modal', 'newspack-blocks' ), value: '' },
 				{ label: __( 'Go to a custom URL', 'newspack-blocks' ), value: 'custom' },
 				{ label: __( 'Go to the previous page', 'newspack-blocks' ), value: 'referrer' },
 			] }
@@ -31,23 +31,18 @@ const RedirectAfterSuccess = ( { attributes, setAttributes }: Props ) => (
 				setAttributes( { afterSuccessBehavior: value.toString() } );
 			} }
 		/>
-		{ attributes.afterSuccessBehavior !== '' && (
-			<>
-				<TextControl
-					label={ __( 'Button Label', 'newspack-blocks' ) }
-					placeholder={ __( 'Continue browsing', 'newspack-blocks' ) }
-					value={ attributes.afterSuccessButtonLabel || '' }
-					onChange={ ( value: string ) => setAttributes( { afterSuccessButtonLabel: value } ) }
-				/>
-				{ attributes.afterSuccessBehavior === 'custom' && (
-					<TextControl
-						label={ __( 'Custom URL', 'newspack-blocks' ) }
-						placeholder={ __( 'https://example.com', 'newspack-blocks' ) }
-						value={ attributes.afterSuccessURL || '' }
-						onChange={ ( value: string ) => setAttributes( { afterSuccessURL: value } ) }
-					/>
-				) }
-			</>
+		<TextControl
+			label={ __( 'Button Label', 'newspack-blocks' ) }
+			value={ attributes.afterSuccessButtonLabel || '' }
+			onChange={ ( value: string ) => setAttributes( { afterSuccessButtonLabel: value } ) }
+		/>
+		{ attributes.afterSuccessBehavior === 'custom' && (
+			<TextControl
+				label={ __( 'Custom URL', 'newspack-blocks' ) }
+				placeholder={ __( 'https://example.com', 'newspack-blocks' ) }
+				value={ attributes.afterSuccessURL || '' }
+				onChange={ ( value: string ) => setAttributes( { afterSuccessURL: value } ) }
+			/>
 		) }
 	</>
 );

--- a/src/components/redirect-after-success.tsx
+++ b/src/components/redirect-after-success.tsx
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { TextControl, SelectControl } from '@wordpress/components';
+
+type Props = {
+	attributes: {
+		afterSuccessBehavior: string;
+		afterSuccessButtonLabel: string;
+		afterSuccessURL: string;
+	};
+	setAttributes: ( attributes: Partial< Props[ 'attributes' ] > ) => void;
+};
+
+const RedirectAfterSuccess = ( { attributes, setAttributes }: Props ) => (
+	<>
+		<SelectControl
+			label={ __( 'Post-Checkout Button', 'newspack-blocks' ) }
+			help={ __(
+				'Select whether the user should be presented with a button to navigate after a successful purchase.',
+				'newspack-blocks'
+			) }
+			value={ attributes.afterSuccessBehavior }
+			options={ [
+				{ label: __( 'Do not show a button', 'newspack-blocks' ), value: '' },
+				{ label: __( 'Go to a custom URL', 'newspack-blocks' ), value: 'custom' },
+				{ label: __( 'Go to the previous page', 'newspack-blocks' ), value: 'referrer' },
+			] }
+			onChange={ ( value: string ) => {
+				setAttributes( { afterSuccessBehavior: value.toString() } );
+			} }
+		/>
+		{ attributes.afterSuccessBehavior !== '' && (
+			<>
+				<TextControl
+					label={ __( 'Button Label', 'newspack-blocks' ) }
+					placeholder={ __( 'Continue browsing', 'newspack-blocks' ) }
+					value={ attributes.afterSuccessButtonLabel || '' }
+					onChange={ ( value: string ) => setAttributes( { afterSuccessButtonLabel: value } ) }
+				/>
+				{ attributes.afterSuccessBehavior === 'custom' && (
+					<TextControl
+						label={ __( 'Custom URL', 'newspack-blocks' ) }
+						placeholder={ __( 'https://example.com', 'newspack-blocks' ) }
+						value={ attributes.afterSuccessURL || '' }
+						onChange={ ( value: string ) => setAttributes( { afterSuccessURL: value } ) }
+					/>
+				) }
+			</>
+		) }
+	</>
+);
+
+export default RedirectAfterSuccess;

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -249,8 +249,8 @@
 	&__button {
 		margin-top: 25px;
 		width: 100%;
-		padding: 22px;
-		font-size: 1em;
+		padding: 22px !important;
+		font-size: 1em !important;
 	}
 }
 

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -136,6 +136,23 @@ domReady( () => {
 						modal => modal.dataset.productId === formData.get( 'product_id' )
 					);
 					if ( variationModal ) {
+						// Fill in the after success variables in the variation modal.
+						variationModal
+							.querySelectorAll( 'form[target="newspack_modal_checkout"]' )
+							.forEach( singleVariationForm => {
+								[
+									'after_success_behavior',
+									'after_success_url',
+									'after_success_button_label',
+								].forEach( afterSuccessParam => {
+									const input = document.createElement( 'input' );
+									input.type = 'hidden';
+									input.name = afterSuccessParam;
+									input.value = formData.get( afterSuccessParam );
+									singleVariationForm.appendChild( input );
+								} );
+							} );
+						// Open the variations modal.
 						ev.preventDefault();
 						document.body.classList.add( 'newspack-modal-checkout-open' );
 						variationModal.style.display = 'block';

--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -33,10 +33,12 @@ function newspack_blocks_replace_login_with_order_summary() {
 
 	// Handle the newsletter signup form.
 	$newsletter_confirmation = \Newspack_Blocks\Modal_Checkout::confirm_newsletter_signup();
-	if ( true === $newsletter_confirmation ) {
-		echo \Newspack_Blocks\Modal_Checkout::render_newsletter_confirmation(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	$is_error                = \is_wp_error( $newsletter_confirmation );
+	$no_selected_lists       = $is_error && 'newspack_no_lists_selected' === $newsletter_confirmation->get_error_code();
+	if ( true === $newsletter_confirmation || $no_selected_lists ) {
+		echo \Newspack_Blocks\Modal_Checkout::render_newsletter_confirmation( $no_selected_lists ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		return;
-	} elseif ( \is_wp_error( $newsletter_confirmation ) ) {
+	} elseif ( $is_error ) {
 		echo esc_html( $newsletter_confirmation->get_error_message() );
 		return;
 	}

--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -45,49 +45,61 @@ function newspack_blocks_replace_login_with_order_summary() {
 		return;
 	}
 
+	$is_success = ! $order->has_status( 'failed' );
+
 	?>
 
 	<div class="woocommerce-order">
-		<h4><?php esc_html_e( 'Transaction Successful', 'newspack-blocks' ); ?></h4>
-		<ul class="woocommerce-order-overview woocommerce-thankyou-order-details order_details">
-			<li class="woocommerce-order-overview__date date">
-				<?php esc_html_e( 'Date:', 'newspack-blocks' ); ?>
-				<strong><?php echo wc_format_datetime( $order->get_date_created() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
-			</li>
-
-			<?php if ( $order->get_billing_email() ) : ?>
-				<li class="woocommerce-order-overview__email email">
-					<?php esc_html_e( 'Email:', 'newspack-blocks' ); ?>
-					<strong><?php echo $order->get_billing_email(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
+		<?php if ( $is_success ) : ?>
+			<h4><?php esc_html_e( 'Transaction Successful', 'newspack-blocks' ); ?></h4>
+			<ul class="woocommerce-order-overview woocommerce-thankyou-order-details order_details">
+				<li class="woocommerce-order-overview__date date">
+					<?php esc_html_e( 'Date:', 'newspack-blocks' ); ?>
+					<strong><?php echo wc_format_datetime( $order->get_date_created() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
 				</li>
-			<?php endif; ?>
 
-			<li class="woocommerce-order-overview__total total">
-				<?php esc_html_e( 'Total:', 'newspack-blocks' ); ?>
-				<strong><?php echo $order->get_formatted_order_total(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
-			</li>
+				<?php if ( $order->get_billing_email() ) : ?>
+					<li class="woocommerce-order-overview__email email">
+						<?php esc_html_e( 'Email:', 'newspack-blocks' ); ?>
+						<strong><?php echo $order->get_billing_email(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
+					</li>
+				<?php endif; ?>
 
-			<?php if ( $order->get_payment_method_title() ) : ?>
-				<li class="woocommerce-order-overview__payment-method method">
-					<?php esc_html_e( 'Payment method:', 'newspack-blocks' ); ?>
-					<strong><?php echo wp_kses_post( $order->get_payment_method_title() ); ?></strong>
+				<li class="woocommerce-order-overview__total total">
+					<?php esc_html_e( 'Total:', 'newspack-blocks' ); ?>
+					<strong><?php echo $order->get_formatted_order_total(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
 				</li>
-			<?php endif; ?>
 
-			<li class="woocommerce-order-overview__order order">
-				<?php esc_html_e( 'Transaction:', 'newspack-blocks' ); ?>
-				<strong><?php echo $order->get_order_number(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
-			</li>
-		</ul>
+				<?php if ( $order->get_payment_method_title() ) : ?>
+					<li class="woocommerce-order-overview__payment-method method">
+						<?php esc_html_e( 'Payment method:', 'newspack-blocks' ); ?>
+						<strong><?php echo wp_kses_post( $order->get_payment_method_title() ); ?></strong>
+					</li>
+				<?php endif; ?>
+
+				<li class="woocommerce-order-overview__order order">
+					<?php esc_html_e( 'Transaction:', 'newspack-blocks' ); ?>
+					<strong><?php echo $order->get_order_number(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
+				</li>
+			</ul>
+		<?php else : ?>
+			<p class="woocommerce-notice woocommerce-notice--error woocommerce-thankyou-order-failed">
+				<?php esc_html_e( 'Unfortunately your order cannot be processed. Please attempt your purchase again.', 'newspack-blocks' ); ?>
+			</p>
+
+			<p class="woocommerce-notice woocommerce-notice--error woocommerce-thankyou-order-failed-actions">
+				<a href="<?php echo esc_url( $order->get_checkout_payment_url() ); ?>" class="button pay"><?php esc_html_e( 'Pay', 'newspack-blocks' ); ?></a>
+				<?php if ( is_user_logged_in() ) : ?>
+					<a href="<?php echo esc_url( wc_get_page_permalink( 'myaccount' ) ); ?>" class="button pay"><?php esc_html_e( 'My account', 'newspack-blocks' ); ?></a>
+				<?php endif; ?>
+			</p>
+		<?php endif; ?>
 	</div>
 
-	<?php echo \Newspack_Blocks\Modal_Checkout::render_checkout_after_success_markup(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-
-	<?php
-	if ( $order ) {
-		echo \Newspack_Blocks\Modal_Checkout::render_newsletter_signup_form( $order ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	}
-	?>
+	<?php if ( $is_success ) : ?>
+		<?php echo \Newspack_Blocks\Modal_Checkout::render_checkout_after_success_markup(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+		<?php echo \Newspack_Blocks\Modal_Checkout::render_newsletter_signup_form( $order ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+	<?php endif; ?>
 
 	<?php
 }

--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -97,8 +97,7 @@ function newspack_blocks_replace_login_with_order_summary() {
 	</div>
 
 	<?php if ( $is_success ) : ?>
-		<?php echo \Newspack_Blocks\Modal_Checkout::render_checkout_after_success_markup(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-		<?php echo \Newspack_Blocks\Modal_Checkout::render_newsletter_signup_form( $order ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+		<?php echo \Newspack_Blocks\Modal_Checkout::render_checkout_after_success_markup( $order ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	<?php endif; ?>
 
 	<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1. Implements the post-checkout button (https://github.com/Automattic/newspack-blocks/pull/1521) for the Donate block. 
2. Changes how the post-checkout button works:
    1. It will be displayed at all times, instead of optionally
    2. By default, the post-checkout button will say "Continue browsing" and close the checkout modal on clicking
    3. Two other options are, as before, to go to previous page (the `referrer`) or go to custom URL

### How to test the changes in this Pull Request:

1. Switch `newspack-plugin` to `feat/donate-post-checkout-button` (https://github.com/Automattic/newspack-plugin/pull/2719)
4. Add a Donate block to a page, configure it to display a button in the "After Purchase" sidebar settings panel
5. Complete a transaction, observe the button is displayed (as in https://github.com/Automattic/newspack-blocks/pull/1521/)
6. Test the post-checkout button flow in various configurations:
    1. With and without the newsletters (`NEWSPACK_ENABLE_POST_CHECKOUT_NEWSLETTER_SIGNUP`, see https://github.com/Automattic/newspack-blocks/pull/1561)
    2. Initiated from a Checkout Button block
    3. Initiated from a Checkout Button block, with a variable product

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->