### PR TITLE
fix(modal-checkout): add id attributes to hidden inputs; add select

### DIFF
--- a/src/modal-checkout/templates/checkout-form.php
+++ b/src/modal-checkout/templates/checkout-form.php
@@ -115,7 +115,17 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 				</p>
 			</div>
 			<?php foreach ( $form_billing_fields as $key => $value ) : ?>
-				<input type="hidden" name="<?php echo esc_attr( 'billing_' . $key ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+				<?php if ( 'state' === $key ) : ?>
+					<?php $wc_states = WC()->countries->get_states( $form_billing_fields['country'] ); ?>
+					<select style="display:none;" id="<?php echo esc_attr( 'billing_' . $key ); ?>" name="<?php echo esc_attr( 'billing_' . $key ); ?>" value="<?php echo esc_attr( $value ); ?>" >
+						<?php foreach ( $wc_states as $key => $value ) { ?>
+							<option <?php echo $key === $form_billing_fields['state'] ? 'selected' : ''; ?> value="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $value ); ?></option>
+						<?php } ?>
+					</select>
+					<span id="select2-billing_state-container" style="display:none;"></span>
+				<?php else : ?>
+					<input type="hidden" id="<?php echo esc_attr( 'billing_' . $key ); ?>" name="<?php echo esc_attr( 'billing_' . $key ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+				<?php endif; ?>
 			<?php endforeach; ?>
 
 			<?php if ( ! is_user_logged_in() && $checkout->is_registration_enabled() ) : ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

There's an address validation plugin out there, which relies on checkout `inputs` having `id` attributes and on the `state` input being a `select`, as on the native WC checkout page. This PR updates the code so the hidden inputs are more in line with the native checkout.  

### How to test the changes in this Pull Request:

1. In Newspack -> Reader Revenue wizard -> Donations tab, check all the address fields in "Billing Fields" settings
2. Use the modal checkout and input a full address on checkout
3. Use the checkout again, this time the "Billing details" section should present the address, instead of the edit form
4. Inspect the source, observe a series of hidden inputs below the address, verify the values match the address

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->