### PR TITLE
feat: expose is_modal_checkout method

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -897,7 +897,7 @@ final class Modal_Checkout {
 	/**
 	 * Is this request using the modal checkout?
 	 */
-	private static function is_modal_checkout() {
+	public static function is_modal_checkout() {
 		return isset( $_REQUEST['modal_checkout'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	}
 }


### PR DESCRIPTION
Expose `\Newspack_Blocks\Modal_Checkout::is_modal_checkout` method, so it can be used by other code, https://github.com/Automattic/newspack-plugin/pull/2695#discussion_r1379086313.