### PR TITLE
fix(homepage-posts): change copy for deduplication block option

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -435,13 +435,13 @@ class Edit extends Component {
 						)
 					) }
 					<ToggleControl
-						label={ __( 'Use deduplication logic', 'newspack-blocks' ) }
+						label={ __( 'Allow duplicate stories', 'newspack-blocks' ) }
 						help={ __(
-							'If unchecked, this block will be excluded from the deduplication logic and may show duplicate posts.',
+							"If checked, this block will be excluded from the page's de-duplication logic. Duplicate stories may appear.",
 							'newspack-blocks'
 						) }
-						checked={ attributes.deduplicate }
-						onChange={ () => setAttributes( { deduplicate: ! attributes.deduplicate } ) }
+						checked={ ! attributes.deduplicate }
+						onChange={ value => setAttributes( { deduplicate: ! value } ) }
 						className="newspack-blocks-deduplication-toggle"
 					/>
 				</PanelBody>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Changes the copy and reverse the toggle for the deduplication logic toggle on the Homepage Posts block (first introduced in https://github.com/Automattic/newspack-blocks/pull/1543):

| Before | After |
| --- | --- |
| <img width="278" alt="image" src="https://github.com/Automattic/newspack-blocks/assets/820752/a4bd8d62-2d03-4617-992b-a50bb9d01d57"> | <img width="279" alt="image" src="https://github.com/Automattic/newspack-blocks/assets/820752/8375c88c-a291-4cbd-bba6-d00ed4f8dc62"> |

### How to test the changes in this Pull Request:

1. Draft a new page and add 3 Homepage Posts block
2. On the 2nd block, toggle "Allow duplicate posts" on and confirm it renders the contents from the first block and the 3rd block renders the content that was previously being rendered in the 2nd block
3. Save, visit the page and confirm the same posts also render in the frontend

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
