### PR TITLE
fix: add checks for Newspack plugin

### DIFF
--- a/src/templates/author-profile-card.php
+++ b/src/templates/author-profile-card.php
@@ -23,16 +23,20 @@ call_user_func(
 		if ( $attributes['showEmail'] && ! empty( $author['email'] ) ) {
 			$social_links['email'] = $author['email'];
 		}
-		if ( $attributes['shownewspack_phone_number'] && ! empty( $author['newspack_phone_number'] ) ) {
-			$social_links['newspack_phone_number'] = $author['newspack_phone_number'];
+		if ( is_plugin_active( 'newspack-plugin' ) ) {
+			if ( $attributes['shownewspack_phone_number'] && ! empty( $author['newspack_phone_number'] ) ) {
+				$social_links['newspack_phone_number'] = $author['newspack_phone_number'];
+			}
 		}
 
 		$employment_values = [];
-		if ( $attributes['shownewspack_role'] && ! empty( $author['newspack_role'] ) ) {
-			$employment_values[] = $author['newspack_role'];
-		}
-		if ( $attributes['shownewspack_employer'] && ! empty( $author['newspack_employer'] ) ) {
-			$employment_values[] = $author['newspack_employer'];
+		if ( is_plugin_active( 'newspack-plugin' ) ) {
+			if ( $attributes['shownewspack_role'] && ! empty( $author['newspack_role'] ) ) {
+				$employment_values[] = $author['newspack_role'];
+			}
+			if ( $attributes['shownewspack_employer'] && ! empty( $author['newspack_employer'] ) ) {
+				$employment_values[] = $author['newspack_employer'];
+			}
 		}
 		$employment = implode( ', ', $employment_values );
 
@@ -81,11 +85,17 @@ call_user_func(
 					<?php endif; ?>
 				</h3>
 
-				<?php if ( $attributes['shownewspack_job_title'] && ! empty( $author['newspack_job_title'] ) ) : ?>
-					<p class="wp-block-newspack-blocks-author-profile__job-title">
-						<?php echo esc_html( $author['newspack_job_title'] ); ?>
-					</p>
-				<?php endif; ?>
+				<?php
+				if ( is_plugin_active( 'newspack-plugin' ) ) :
+					if ( $attributes['shownewspack_job_title'] && ! empty( $author['newspack_job_title'] ) ) :
+						?>
+						<p class="wp-block-newspack-blocks-author-profile__job-title">
+							<?php echo esc_html( $author['newspack_job_title'] ); ?>
+						</p>
+						<?php
+					endif;
+				endif;
+				?>
 				<?php if ( ! empty( $employment ) ) : ?>
 					<p class="wp-block-newspack-blocks-author-profile__employment">
 						<?php echo esc_html( $employment ); ?>

--- a/src/templates/author-profile-card.php
+++ b/src/templates/author-profile-card.php
@@ -23,14 +23,14 @@ call_user_func(
 		if ( $attributes['showEmail'] && ! empty( $author['email'] ) ) {
 			$social_links['email'] = $author['email'];
 		}
-		if ( is_plugin_active( 'newspack-plugin' ) ) {
+		if ( class_exists( '\Newspack\Authors_Custom_Fields' ) ) {
 			if ( $attributes['shownewspack_phone_number'] && ! empty( $author['newspack_phone_number'] ) ) {
 				$social_links['newspack_phone_number'] = $author['newspack_phone_number'];
 			}
 		}
 
 		$employment_values = [];
-		if ( is_plugin_active( 'newspack-plugin' ) ) {
+		if ( class_exists( '\Newspack\Authors_Custom_Fields' ) ) {
 			if ( $attributes['shownewspack_role'] && ! empty( $author['newspack_role'] ) ) {
 				$employment_values[] = $author['newspack_role'];
 			}
@@ -86,7 +86,7 @@ call_user_func(
 				</h3>
 
 				<?php
-				if ( is_plugin_active( 'newspack-plugin' ) ) :
+				if ( class_exists( '\Newspack\Authors_Custom_Fields' ) ) :
 					if ( $attributes['shownewspack_job_title'] && ! empty( $author['newspack_job_title'] ) ) :
 						?>
 						<p class="wp-block-newspack-blocks-author-profile__job-title">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds some checks to the Author Profile and Author List block output, so it doesn't display warnings when the Newspack Plugin is deactivated. 

See: 1200550061930446-as-1205176822910070

### How to test the changes in this Pull Request:

1. Add an Author Profile and Author List block to a page; publish.
2. Navigate to WP Admin > Plugins, and deactivate the Newspack Plugin.
3. View your page on the frontend, and note the warnings (example: `Warning: Undefined array key “shownewspack_role” in /srv/users/user8bdc4063/apps/user8bdc4063/public/wp-content/plugins/newspack-blocks/src/templates/author-profile-card.php on line 31`).
4. Apply the PR.
5. Confirm the warnings are gone.
6. Reactivate the Newspack Plugin.
7. Edit one of the authors the block displays and populate one of the Newspack fields (Employeer, Job Title...).
8. View the block on the front-end and confirm that the fields still display.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
