### PR TITLE
feat(modal-checkout): support shipping

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -634,7 +634,7 @@ final class Modal_Checkout {
 	public static function has_filled_required_fields() {
 		$checkout        = \WC()->checkout();
 		$cart            = \WC()->cart;
-		$checkout_fields = [ 'billing' => $checkout->get_checkout_fields( $type ) ];
+		$checkout_fields = [ 'billing' => $checkout->get_checkout_fields( 'billing' ) ];
 		$required        = [];
 
 		// If the customer has selected the option to use a different shipping address, add those as required fields.

--- a/src/modal-checkout/templates/checkout-form.php
+++ b/src/modal-checkout/templates/checkout-form.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $cart = WC()->cart;
 
-$has_filled_billing = \Newspack_Blocks\Modal_Checkout::has_filled_required_fields( 'billing' );
+$has_filled_billing = \Newspack_Blocks\Modal_Checkout::has_filled_required_fields();
 $edit_billing       = ! $has_filled_billing || isset( $_REQUEST['edit_billing'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 $form_action                = $edit_billing ? '#checkout' : wc_get_checkout_url();
@@ -25,7 +25,7 @@ $form_method                = $edit_billing ? 'get' : 'post';
 $form_fields                = \Newspack_Blocks\Modal_Checkout::get_prefilled_fields();
 $form_billing_fields        = [];
 $form_shipping_fields       = [];
-$different_shipping_address = isset( $_REQUEST['ship_to_different_address'] ) ? boolval( $_REQUEST['ship_to_different_address'] ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$different_shipping_address = boolval( filter_input( INPUT_GET, 'ship_to_different_address', FILTER_SANITIZE_NUMBER_INT ) );
 foreach ( $form_fields['billing'] as $key => $value ) {
 	$form_billing_fields[ str_replace( 'billing_', '', $key ) ] = $value;
 }

--- a/src/modal-checkout/templates/checkout-form.php
+++ b/src/modal-checkout/templates/checkout-form.php
@@ -38,7 +38,6 @@ if ( $different_shipping_address && ! empty( $form_fields['shipping'] ) ) {
 $after_success_behavior     = filter_input( INPUT_GET, 'after_success_behavior', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 $after_success_url          = filter_input( INPUT_GET, 'after_success_url', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 $after_success_button_label = filter_input( INPUT_GET, 'after_success_button_label', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
-$order_comments             = filter_input( INPUT_GET, 'order_comments', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 if ( $edit_billing ) {
 	$form_class .= ' edit-billing';
@@ -106,108 +105,75 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 		<?php do_action( 'woocommerce_checkout_after_order_review' ); ?>
 	</div><!-- .full-order-details -->
 
-	<?php
-	if ( $checkout->get_checkout_fields() ) :
-		?>
-
+	<?php if ( $checkout->get_checkout_fields() ) : ?>
 		<?php do_action( 'woocommerce_checkout_before_customer_details' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound ?>
-
 		<?php if ( $edit_billing ) : ?>
 			<div class="checkout-billing">
 				<?php do_action( 'woocommerce_checkout_billing' ); ?>
-				<?php
-				if ( $cart->needs_shipping_address() ) {
-					do_action( 'woocommerce_checkout_shipping' );
-				}
-				?>
+				<?php do_action( 'woocommerce_checkout_shipping' ); ?>
 				<button type="button" class="button alt wp-element-button modal-continue"><?php esc_html_e( 'Continue', 'newspack-blocks' ); ?></button>
 			</div>
-					<?php else : ?>
+		<?php else : ?>
 			<div class="checkout-billing checkout-billing-summary">
 				<div class="checkout-billing-summary__grid">
 					<h3><?php esc_html_e( 'Billing details', 'newspack-blocks' ); ?></h3>
 					<a href="<?php echo esc_url( add_query_arg( 'edit_billing', 1 ) ); ?>" class="edit-billing-link"><?php esc_html_e( 'Edit', 'newspack-blocks' ); ?></a>
 				</div>
 				<p>
-						<?php echo esc_html( $form_billing_fields['email'] ); ?><br/>
-						<?php echo WC()->countries->get_formatted_address( $form_billing_fields ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					<?php echo esc_html( $form_billing_fields['email'] ); ?><br/>
+					<?php echo WC()->countries->get_formatted_address( $form_billing_fields ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				</p>
-			</div>
-						<?php foreach ( $form_billing_fields as $key => $value ) : ?>
-							<?php if ( 'state' === $key ) : ?>
-								<?php $wc_states = WC()->countries->get_states( $form_billing_fields['country'] ); ?>
-					<select style="display:none;" id="<?php echo esc_attr( 'billing_' . $key ); ?>" name="<?php echo esc_attr( 'billing_' . $key ); ?>" value="<?php echo esc_attr( $value ); ?>" >
-								<?php foreach ( $wc_states as $key => $value ) { ?>
-							<option <?php echo $key === $form_billing_fields['state'] ? 'selected' : ''; ?> value="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $value ); ?></option>
-						<?php } ?>
-					</select>
-					<span id="select2-billing_state-container" style="display:none;"></span>
-				<?php else : ?>
-					<input type="hidden" id="<?php echo esc_attr( 'billing_' . $key ); ?>" name="<?php echo esc_attr( 'billing_' . $key ); ?>" value="<?php echo esc_attr( $value ); ?>" />
-				<?php endif; ?>
-			<?php endforeach; ?>
-						<?php if ( $different_shipping_address && ! empty( $form_shipping_fields ) ) : ?>
-				<div class="checkout-billing checkout-billing-summary">
+				<?php if ( $different_shipping_address && ! empty( $form_shipping_fields ) ) : ?>
+					<input type="hidden" id="ship_to_different_address" name="ship_to_different_address" value="1" />
 					<h5><?php esc_html_e( 'Shipping address', 'newspack-blocks' ); ?></h5>
 					<p>
-							<?php echo WC()->countries->get_formatted_address( $form_shipping_fields ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<?php echo WC()->countries->get_formatted_address( $form_shipping_fields ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</p>
-				</div>
-							<?php foreach ( $form_shipping_fields as $key => $value ) : ?>
-								<?php if ( 'state' === $key ) : ?>
-									<?php $wc_states = WC()->countries->get_states( $form_shipping_fields['country'] ); ?>
-						<select style="display:none;" id="<?php echo esc_attr( 'shipping_' . $key ); ?>" name="<?php echo esc_attr( 'shipping_' . $key ); ?>" value="<?php echo esc_attr( $value ); ?>" >
-									<?php foreach ( $wc_states as $key => $value ) { ?>
-					<option <?php echo $key === $form_shipping_fields['state'] ? 'selected' : ''; ?> value="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $value ); ?></option>
-				<?php } ?>
-						</select>
-						<span id="select2-shipping_state-container" style="display:none;"></span>
-					<?php else : ?>
-						<input type="hidden" id="<?php echo esc_attr( 'shipping_' . $key ); ?>" name="<?php echo esc_attr( 'shipping_' . $key ); ?>" value="<?php echo esc_attr( $value ); ?>" />
-					<?php endif; ?>
-				<?php endforeach; ?>
-				<input type="hidden" id="ship_to_different_address" name="ship_to_different_address" value="1" />
-							<?php if ( ! empty( $order_comments ) ) : ?>
-					<input type="hidden" id="order_comments" name="order_comments" value="<?php echo esc_attr( $order_comments ); ?>" />
 				<?php endif; ?>
+				<?php foreach ( $form_fields as $field_type => $fields ) : ?>
+					<?php foreach ( $fields as $key => $value ) : ?>
+						<?php if ( '_state' === substr( $key, -6 ) ) : ?>
+							<?php $wc_states = WC()->countries->get_states( $form_fields[ $field_type ][ $field_type . '_country' ] ); ?>
+								<select style="display:none;" id="<?php echo esc_attr( $key ); ?>" name="<?php echo esc_attr( $key ); ?>" value="<?php echo esc_attr( $value ); ?>" >
+									<?php foreach ( $wc_states as $key => $value ) : ?>
+										<option <?php echo $key === $form_fields[ $field_type ][ $field_type . '_state' ] ? 'selected' : ''; ?> value="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $value ); ?></option>
+									<?php endforeach; ?>
+								</select>
+								<span id="select2-billing_state-container" style="display:none;"></span>
+						<?php else : ?>
+							<input type="hidden" id="<?php echo esc_attr( $key ); ?>" name="<?php echo esc_attr( $key ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+						<?php endif; ?>
+					<?php endforeach; ?>
+				<?php endforeach; ?>
+			</div>
 
-			<?php endif; ?>
-
-						<?php if ( ! is_user_logged_in() && $checkout->is_registration_enabled() ) : ?>
+			<?php if ( ! is_user_logged_in() && $checkout->is_registration_enabled() ) : ?>
 				<div class="woocommerce-account-fields">
-							<?php if ( ! $checkout->is_registration_required() ) : ?>
-
+					<?php if ( ! $checkout->is_registration_required() ) : ?>
 						<p class="form-row form-row-wide create-account">
 							<label class="woocommerce-form__label woocommerce-form__label-for-checkbox checkbox">
 								<input class="woocommerce-form__input woocommerce-form__input-checkbox input-checkbox" id="createaccount" <?php checked( ( true === $checkout->get_value( 'createaccount' ) || ( true === apply_filters( 'woocommerce_create_account_default_checked', false ) ) ), true ); ?> type="checkbox" name="createaccount" value="1" /> <span><?php esc_html_e( 'Create an account?', 'newspack-blocks' ); ?></span>
 							</label>
 						</p>
-
 					<?php endif; ?>
-
-							<?php do_action( 'woocommerce_before_checkout_registration_form', $checkout ); ?>
-
-							<?php if ( $checkout->get_checkout_fields( 'account' ) ) : ?>
-
+					<?php do_action( 'woocommerce_before_checkout_registration_form', $checkout ); ?>
+					<?php if ( $checkout->get_checkout_fields( 'account' ) ) : ?>
 						<div class="create-account">
 								<?php foreach ( $checkout->get_checkout_fields( 'account' ) as $key => $field ) : ?>
 									<?php woocommerce_form_field( $key, $field, $checkout->get_value( $key ) ); ?>
 							<?php endforeach; ?>
 							<div class="clear"></div>
 						</div>
-
 					<?php endif; ?>
-
-							<?php do_action( 'woocommerce_after_checkout_registration_form', $checkout ); ?>
+					<?php do_action( 'woocommerce_after_checkout_registration_form', $checkout ); ?>
 				</div>
 			<?php endif; ?>
 
 			<div class="after-customer-details">
-						<?php do_action( 'woocommerce_checkout_after_customer_details' ); ?>
+				<?php do_action( 'woocommerce_checkout_after_customer_details' ); ?>
 			</div>
 		<?php endif; ?>
-
-			<?php endif; ?>
+	<?php endif; ?>
 
 </form>
 

--- a/src/modal-checkout/templates/checkout-form.php
+++ b/src/modal-checkout/templates/checkout-form.php
@@ -108,7 +108,6 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 
 	<?php
 	if ( $checkout->get_checkout_fields() ) :
-		;
 		?>
 
 		<?php do_action( 'woocommerce_checkout_before_customer_details' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds support for shipping info during the modal checkout flow, to bring our modal checkout to closer parity with the default Woo checkout flow.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. In WP admin > WooCommerce > Settings > Shipping, add at least one shipping zone and one shipping method to the zone (preferably one that costs some amount of money).
3. In Reader Revenue > Donations enable all of the billing fields.
4. Publish at least one product that is NOT virtual. Ensure that it has some available inventory.
5. Create a Checkout Button block pointing to your non-virtual product.
6. As a new reader, purchase the product using the Checkout Button. Confirm that the modal now shows an order summary that shows the total cost of the purchase including shipping fees, and a toggle to ship to a different address.

<img width="619" alt="Screenshot 2023-11-03 at 9 27 39 AM" src="https://github.com/Automattic/newspack-blocks/assets/2230142/44fb8561-ab3e-450c-81d7-0cf4b8946ac0">

7. Complete the purchase without touching the toggle. In WP admin > Users, find the customer's WP user account and confirm that the shipping address fields are automatically filled to match the billing address fields.
8. In another new session, purchase the same product again. This time toggle ON the "ship to a different address?" option and fill in a different address in the fields that are unhidden. Make sure you fill in the optional order notes.
9. On the payment modal screen, confirm that the separate shipping address is shown underneath the billing address, and that you can go back to edit them (unfortunately the "ship to a different address?" option doesn't seem to be saved if you go back to edit, but the address fields themselves are, so this doesn't seem like a blocker to me).
10. Also go to the order for this last purchase and confirm that the "Customer provided note" field shows the text you entered into the order notes field during checkout.
11. Complete the transaction. In WP admin > Users, find the customer's WP user account and confirm that the shipping address fields are filled in and match the address you inputted in the second purchase.
12. Check out https://github.com/Automattic/newspack-plugin/pull/2733.
13. Navigate to or log into My Account. Confirm that there's an "Addresses" menu item and that clicking on it allows you to see/edit the billing and shipping address info you've entered previously.
14. Smoke test a regular donation and a purchase of a virtual product. Both should work as before with no changes. 
15. In Newspack > Reader Revenue disable all billing fields except for First/Last Name and email. Complete a new donation and purchase of a virtual product and confirm that My Account doesn't show the Addresses menu item (because your account has no address info).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
