### PR TITLE
feat: add width control to the Checkout block

### DIFF
--- a/src/blocks/checkout-button/block.json
+++ b/src/blocks/checkout-button/block.json
@@ -45,6 +45,9 @@
 		},
 		"afterSuccessURL": {
 			"type": "string"
+		},
+		"width": {
+			"type": "number"
 		}
 	},
 	"supports": {

--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -25,6 +25,7 @@ import {
 	SelectControl,
 	FormTokenField,
 	Button,
+	ButtonGroup,
 	Spinner,
 } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
@@ -51,6 +52,35 @@ function getNYP( product ) {
 		minPrice: product?.meta_data?.find( meta => meta.key === '_min_price' )?.value,
 		maxPrice: product?.meta_data?.find( meta => meta.key === '_maximum_price' )?.value,
 	};
+}
+
+function WidthPanel( { selectedWidth, setAttributes } ) {
+	function handleChange( newWidth ) {
+		// Check if we are toggling the width off
+		const width = selectedWidth === newWidth ? undefined : newWidth;
+
+		// Update attributes.
+		setAttributes( { width } );
+	}
+
+	return (
+		<PanelBody title={ __( 'Width settings', 'newspack-blocks' ) }>
+			<ButtonGroup aria-label={ __( 'Button width', 'newspack-blocks' ) }>
+				{ [ 25, 50, 75, 100 ].map( widthValue => {
+					return (
+						<Button
+							key={ widthValue }
+							size="small"
+							variant={ widthValue === selectedWidth ? 'primary' : undefined }
+							onClick={ () => handleChange( widthValue ) }
+						>
+							{ widthValue }%
+						</Button>
+					);
+				} ) }
+			</ButtonGroup>
+		</PanelBody>
+	);
 }
 
 function ProductControl( props ) {
@@ -156,7 +186,7 @@ function ProductControl( props ) {
 
 function CheckoutButtonEdit( props ) {
 	const { attributes, setAttributes, className } = props;
-	const { placeholder, style, text, product, price, variation } = attributes;
+	const { placeholder, style, text, product, price, variation, width } = attributes;
 
 	const [ productData, setProductData ] = useState( {} );
 	const [ variations, setVariations ] = useState( [] );
@@ -214,6 +244,7 @@ function CheckoutButtonEdit( props ) {
 				className={ classnames( blockProps.className, {
 					[ `wp-block-button` ]: true,
 					[ `has-custom-font-size` ]: blockProps.style.fontSize,
+					[ `has-custom-width wp-block-button__width-${ width }` ]: width,
 				} ) }
 			>
 				<RichText
@@ -330,6 +361,9 @@ function CheckoutButtonEdit( props ) {
 						/>
 					</PanelBody>
 				) }
+			</InspectorControls>
+			<InspectorControls>
+				<WidthPanel selectedWidth={ width } setAttributes={ setAttributes } />
 			</InspectorControls>
 		</>
 	);

--- a/src/blocks/checkout-button/save.js
+++ b/src/blocks/checkout-button/save.js
@@ -16,7 +16,8 @@ import {
 } from '@wordpress/block-editor';
 
 export default function save( { attributes, className } ) {
-	const { textAlign, fontSize, style, text, product, price, variation, is_variable } = attributes;
+	const { textAlign, fontSize, style, text, product, price, variation, is_variable, width } =
+		attributes;
 
 	if ( ! text || ! product ) {
 		return null;
@@ -44,6 +45,7 @@ export default function save( { attributes, className } ) {
 
 	const wrapperClasses = classnames( className, {
 		[ `has-custom-font-size` ]: fontSize || style?.typography?.fontSize,
+		[ `has-custom-width wp-block-button__width-${ width }` ]: width,
 	} );
 
 	return (

--- a/src/blocks/checkout-button/view.scss
+++ b/src/blocks/checkout-button/view.scss
@@ -6,13 +6,26 @@
 		}
 	}
 	&.aligncenter {
-    form {
-      display: flex;
-      flex-direction: column;
-    }
-		button {
-      margin-left: auto;
-      margin-right: auto;
+		form {
+			display: flex;
+			flex-direction: column;
 		}
+		button {
+			margin-left: auto;
+			margin-right: auto;
+		}
+	}
+
+	&.wp-block-button__width-25 button {
+		width: 25%;
+	}
+	&.wp-block-button__width-50 button {
+		width: 50%;
+	}
+	&.wp-block-button__width-75 button {
+		width: 75%;
+	}
+	&.wp-block-button__width-100 button {
+		width: 100%;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a 'width' control to the Checkout Button block, so you can set it to 25, 50, 75, or 100% of the available space. 

See 1200550061930446-as-1205525005864243

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Add a Checkout button to the editor. Click it and confirm that there's a 'Width settings' panel under the 'Settings' tab (which, oddly, is the same location as the Button block - it's not under the Styles tab). 

![image](https://github.com/Automattic/newspack-blocks/assets/177561/d274c6c4-27dc-4d0f-9cca-807108a14419)

3. Try changing the width to one of the different settings; confirm that it's applied in the editor and on the front end. Repeat with all of the options.

![image](https://github.com/Automattic/newspack-blocks/assets/177561/3928b080-08d6-46a4-8d82-724ee86d2a9c)

4. When done, click again on the selected option to clear the width and confirm the button returns to the default width (the width of its text label). Publish to confirm that this is the case on the front-end, too.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
