### PR TITLE
fix(modal-checkout): place order button width

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -101,6 +101,7 @@
 			margin-bottom: 0;
 		}
 		.checkout-billing button[type='submit'],
+		button[name='woocommerce_checkout_place_order'],
 		button.modal-continue {
 			display: block;
 			width: 100%;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a regression introduced by #1572
 
⚠️ The regression is part of the latest alpha release, so this change should also be merged into alpha. 

### How to test the changes in this Pull Request:

1. On `master`, trigger the modal checkout for a one-time donation
2. Observe the "Place order" button at the second step is not 100% wide
3. Switch to this branch, observe it is

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->