### PR TITLE
fix: flush WC template cache on template updates

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -464,6 +464,14 @@ final class Modal_Checkout {
 			return $located;
 		}
 
+		// Flush WC template cache when the templates version changes.
+		// Increase this number after making changes to the templates.
+		$current_templates_version = 1;
+		if ( get_option( 'newspack_modal_checkout_templates_version', 0 ) !== $current_templates_version ) {
+			wc_clear_template_cache();
+			update_option( 'newspack_modal_checkout_templates_version', $current_templates_version );
+		}
+
 		$custom_templates = [
 			'checkout/form-checkout.php' => 'src/modal-checkout/templates/checkout-form.php',
 			'checkout/form-billing.php'  => 'src/modal-checkout/templates/billing-form.php',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Ensures the WC template cache is cleared (once) when the templates are updated.

⚠️ This change should be merged into the current alpha, too. 

### How to test the changes in this Pull Request:

The issue with cached templates was only encountered on live sites, we could not reproduce it locally, on JN, or even staging. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->