### PR TITLE
feat(modal-checkout): display item name on success

### DIFF
--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -47,7 +47,8 @@ function newspack_blocks_replace_login_with_order_summary() {
 		return;
 	}
 
-	$is_success = ! $order->has_status( 'failed' );
+	$is_success      = ! $order->has_status( 'failed' );
+	$order_item_name = array_values( $order->get_items() )[0]->get_name();
 
 	?>
 
@@ -78,6 +79,11 @@ function newspack_blocks_replace_login_with_order_summary() {
 						<strong><?php echo wp_kses_post( $order->get_payment_method_title() ); ?></strong>
 					</li>
 				<?php endif; ?>
+
+				<li>
+					<?php esc_html_e( 'Item:', 'newspack-blocks' ); ?>
+					<strong><?php echo esc_html( $order_item_name ); ?></strong>
+				</li>
 
 				<li class="woocommerce-order-overview__order order">
 					<?php esc_html_e( 'Transaction:', 'newspack-blocks' ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds "Item: <item-name>" line to modal checkout success state, so the donor can double-check what they've paid for.

<img width="405" alt="image" src="https://github.com/Automattic/newspack-blocks/assets/7383192/1a04d28c-6ba8-4e33-9af4-60aea0c24329">

### How to test the changes in this Pull Request:

1. Complete a donation using modal checkout
2. Observe the item name is displayed (e.g. "Donate: Monthly")

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->