### PR TITLE
feat(modal-checkout): update "place order" text to "donate now"

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -48,6 +48,9 @@ final class Modal_Checkout {
 		add_filter( 'newspack_donations_cart_item_data', [ __CLASS__, 'amend_cart_item_data' ] );
 		add_filter( 'newspack_recaptcha_verify_captcha', [ __CLASS__, 'recaptcha_verify_captcha' ], 10, 2 );
 		add_filter( 'woocommerce_enqueue_styles', [ __CLASS__, 'dequeue_woocommerce_styles' ] );
+		add_filter( 'wcs_place_subscription_order_text', [ __CLASS__, 'order_button_text' ], 1 );
+		add_filter( 'woocommerce_order_button_text', [ __CLASS__, 'order_button_text' ] );
+		add_filter( 'option_woocommerce_subscriptions_order_button_text', [ __CLASS__, 'order_button_text' ] );
 	}
 
 	/**
@@ -898,7 +901,23 @@ final class Modal_Checkout {
 	 * Is this request using the modal checkout?
 	 */
 	public static function is_modal_checkout() {
-		return isset( $_REQUEST['modal_checkout'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$is_modal_checkout = isset( $_REQUEST['modal_checkout'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! $is_modal_checkout && isset( $_REQUEST['post_data'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$is_modal_checkout = strpos( $_REQUEST['post_data'], 'modal_checkout=1' ) !== false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		}
+		return $is_modal_checkout;
+	}
+
+	/**
+	 * Set the "Place order" button text.
+	 *
+	 * @param string $text The button text.
+	 */
+	public static function order_button_text( $text ) {
+		if ( ! self::is_modal_checkout() ) {
+			return $text;
+		}
+		return __( 'Donate now', 'newspack-blocks' );
 	}
 }
 Modal_Checkout::init();

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -914,10 +914,10 @@ final class Modal_Checkout {
 	 * @param string $text The button text.
 	 */
 	public static function order_button_text( $text ) {
-		if ( ! self::is_modal_checkout() ) {
-			return $text;
+		if ( self::is_modal_checkout() && method_exists( 'Newspack\Donations', 'is_donation_cart' ) && \Newspack\Donations::is_donation_cart() ) {
+			return __( 'Donate now', 'newspack-blocks' );
 		}
-		return __( 'Donate now', 'newspack-blocks' );
+		return $text;
 	}
 }
 Modal_Checkout::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updates the "Place order" text in modal checkout to "Donate now".

⚠️  This is an alpha-hotfix, merging to `alpha`.

### How to test the changes in this Pull Request:

1. Test with a one-time and recurring donation via modal checkout – the CTA on the second step should always say "Donate now"
2. Use the regular checkout, confirm the corresponding button says "Place order" for regular items and "Sign up now" for subscription items

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->