### PR TITLE
Update existence checks in newspack_blocks_format_categories

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -536,4 +536,3 @@ function newspack_blocks_format_categories( $post_id ) {
 
 	return apply_filters( 'newspack_blocks_categories', $category_formatted );
 }
-

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -523,14 +523,18 @@ function newspack_blocks_format_categories( $post_id ) {
 		}
 	}
 
-	$category_link      = get_category_link( $category->term_id );
-	$category_formatted = esc_html( $category->name );
+	// Check if $category is a valid object and has the required properties.
+	if ( is_a( $category, 'WP_Term' ) && isset( $category->term_id ) && isset( $category->name ) ) {
+		$category_link      = get_category_link( $category->term_id );
+		$category_formatted = esc_html( $category->name );
 
-	if ( ! empty( $category_link ) ) {
-		$category_formatted = '<a href="' . esc_attr( $category_link ) . '">' . esc_html( $category->name ) . '</a>';
-	}
+		if ( ! empty( $category_link ) ) {
+			$category_formatted = '<a href="' . esc_url( $category_link ) . '">' . $category_formatted . '</a>';
+		}
 
-	if ( $category ) {
 		return apply_filters( 'newspack_blocks_categories', $category_formatted );
 	}
+
+	return '';
 }
+

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -524,7 +524,7 @@ function newspack_blocks_format_categories( $post_id ) {
 	}
 
 	// Check if $category is a valid object and has the required properties.
-	if ( is_a( $category, 'WP_Term' ) && isset( $category->term_id ) && isset( $category->name ) ) {
+	if ( is_a( $category, 'WP_Term' ) ) {
 		$category_link      = get_category_link( $category->term_id );
 		$category_formatted = esc_html( $category->name );
 

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -523,7 +523,7 @@ function newspack_blocks_format_categories( $post_id ) {
 		}
 	}
 
-	if( ! is_a( $category, 'WP_Term' ) ) {
+	if ( ! is_a( $category, 'WP_Term' ) ) {
 		return '';
 	}
 

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -523,18 +523,17 @@ function newspack_blocks_format_categories( $post_id ) {
 		}
 	}
 
-	// Check if $category is a valid object and has the required properties.
-	if ( is_a( $category, 'WP_Term' ) ) {
-		$category_link      = get_category_link( $category->term_id );
-		$category_formatted = esc_html( $category->name );
-
-		if ( ! empty( $category_link ) ) {
-			$category_formatted = '<a href="' . esc_url( $category_link ) . '">' . $category_formatted . '</a>';
-		}
-
-		return apply_filters( 'newspack_blocks_categories', $category_formatted );
+	if( ! is_a( $category, 'WP_Term' ) ){
+		return '';
 	}
 
-	return '';
+	$category_link      = get_category_link( $category->term_id );
+	$category_formatted = esc_html( $category->name );
+
+	if ( ! empty( $category_link ) ) {
+		$category_formatted = '<a href="' . esc_url( $category_link ) . '">' . $category_formatted . '</a>';
+	}
+
+	return apply_filters( 'newspack_blocks_categories', $category_formatted );
 }
 

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -523,7 +523,7 @@ function newspack_blocks_format_categories( $post_id ) {
 		}
 	}
 
-	if( ! is_a( $category, 'WP_Term' ) ){
+	if( ! is_a( $category, 'WP_Term' ) ) {
 		return '';
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR updates existence checks to prevent `Attempt to read property "name"|"term_id" on bool` warnings.

Closes p1700077484817269/1700025334.541069-slack-CKZHG0QCR

### How to test the changes in this Pull Request:

Follow the testing instructions on this [PR](https://github.com/Automattic/newspack-blocks/pull/1528) to check for regressions.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
