### PR TITLE
Replace FILTER_SANITIZE_STRING

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -136,9 +136,9 @@ final class Modal_Checkout {
 		$is_newspack_checkout       = filter_input( INPUT_GET, 'newspack_checkout', FILTER_SANITIZE_NUMBER_INT );
 		$product_id                 = filter_input( INPUT_GET, 'product_id', FILTER_SANITIZE_NUMBER_INT );
 		$variation_id               = filter_input( INPUT_GET, 'variation_id', FILTER_SANITIZE_NUMBER_INT );
-		$after_success_behavior     = filter_input( INPUT_GET, 'after_success_behavior', FILTER_SANITIZE_STRING );
-		$after_success_url          = filter_input( INPUT_GET, 'after_success_url', FILTER_SANITIZE_STRING );
-		$after_success_button_label = filter_input( INPUT_GET, 'after_success_button_label', FILTER_SANITIZE_STRING );
+		$after_success_behavior     = filter_input( INPUT_GET, 'after_success_behavior', FILTER_UNSAFE_RAW );
+		$after_success_url          = filter_input( INPUT_GET, 'after_success_url', FILTER_UNSAFE_RAW );
+		$after_success_button_label = filter_input( INPUT_GET, 'after_success_button_label', FILTER_UNSAFE_RAW );
 
 		if ( ! $is_newspack_checkout || ! $product_id ) {
 			return;

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -136,9 +136,9 @@ final class Modal_Checkout {
 		$is_newspack_checkout       = filter_input( INPUT_GET, 'newspack_checkout', FILTER_SANITIZE_NUMBER_INT );
 		$product_id                 = filter_input( INPUT_GET, 'product_id', FILTER_SANITIZE_NUMBER_INT );
 		$variation_id               = filter_input( INPUT_GET, 'variation_id', FILTER_SANITIZE_NUMBER_INT );
-		$after_success_behavior     = filter_input( INPUT_GET, 'after_success_behavior', FILTER_UNSAFE_RAW );
-		$after_success_url          = filter_input( INPUT_GET, 'after_success_url', FILTER_UNSAFE_RAW );
-		$after_success_button_label = filter_input( INPUT_GET, 'after_success_button_label', FILTER_UNSAFE_RAW );
+		$after_success_behavior     = filter_input( INPUT_GET, 'after_success_behavior', FILTER_SANITIZE_SPECIAL_CHARS );
+		$after_success_url          = filter_input( INPUT_GET, 'after_success_url', FILTER_SANITIZE_SPECIAL_CHARS );
+		$after_success_button_label = filter_input( INPUT_GET, 'after_success_button_label', FILTER_SANITIZE_SPECIAL_CHARS );
 
 		if ( ! $is_newspack_checkout || ! $product_id ) {
 			return;

--- a/src/modal-checkout/templates/checkout-form.php
+++ b/src/modal-checkout/templates/checkout-form.php
@@ -24,9 +24,9 @@ $form_class          = 'checkout woocommerce-checkout';
 $form_method         = $edit_billing ? 'get' : 'post';
 $form_billing_fields = \Newspack_Blocks\Modal_Checkout::get_prefilled_fields();
 
-$after_success_behavior     = filter_input( INPUT_GET, 'after_success_behavior', FILTER_UNSAFE_RAW );
-$after_success_url          = filter_input( INPUT_GET, 'after_success_url', FILTER_UNSAFE_RAW );
-$after_success_button_label = filter_input( INPUT_GET, 'after_success_button_label', FILTER_UNSAFE_RAW );
+$after_success_behavior     = filter_input( INPUT_GET, 'after_success_behavior', FILTER_SANITIZE_SPECIAL_CHARS );
+$after_success_url          = filter_input( INPUT_GET, 'after_success_url', FILTER_SANITIZE_SPECIAL_CHARS );
+$after_success_button_label = filter_input( INPUT_GET, 'after_success_button_label', FILTER_SANITIZE_SPECIAL_CHARS );
 
 if ( $edit_billing ) {
 	$form_class .= ' edit-billing';

--- a/src/modal-checkout/templates/checkout-form.php
+++ b/src/modal-checkout/templates/checkout-form.php
@@ -24,9 +24,9 @@ $form_class          = 'checkout woocommerce-checkout';
 $form_method         = $edit_billing ? 'get' : 'post';
 $form_billing_fields = \Newspack_Blocks\Modal_Checkout::get_prefilled_fields();
 
-$after_success_behavior     = filter_input( INPUT_GET, 'after_success_behavior', FILTER_SANITIZE_STRING );
-$after_success_url          = filter_input( INPUT_GET, 'after_success_url', FILTER_SANITIZE_STRING );
-$after_success_button_label = filter_input( INPUT_GET, 'after_success_button_label', FILTER_SANITIZE_STRING );
+$after_success_behavior     = filter_input( INPUT_GET, 'after_success_behavior', FILTER_UNSAFE_RAW );
+$after_success_url          = filter_input( INPUT_GET, 'after_success_url', FILTER_UNSAFE_RAW );
+$after_success_button_label = filter_input( INPUT_GET, 'after_success_button_label', FILTER_UNSAFE_RAW );
 
 if ( $edit_billing ) {
 	$form_class .= ' edit-billing';


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

With Newspack sites moving from PHP 7.4 and 8.0 to 8.1, we should update all instances of the constant `FILTER_SANITIZE_STRING`, which is now deprecated. This PR updates `class-modal-checkout.php` and `checkout-form.php` by replacing `FILTER_SANITIZE_STRING` with `FILTER_UNSAFE_RAW`.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
