### PR TITLE
feat: improve performance of modal checkout

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -53,6 +53,8 @@ final class Modal_Checkout {
 		add_filter( 'option_woocommerce_subscriptions_order_button_text', [ __CLASS__, 'order_button_text' ] );
 
 		add_filter( 'cmplz_site_needs_cookiewarning', [ __CLASS__, 'is_not_modal_checkout_filter' ] );
+		add_filter( 'newspack_reader_activation_should_render_auth', [ __CLASS__, 'is_not_modal_checkout_filter' ] );
+		add_filter( 'newspack_theme_enqueue_js', [ __CLASS__, 'is_not_modal_checkout_filter' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'dequeue_scripts' ], 11 );
 	}
 

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -52,10 +52,17 @@ final class Modal_Checkout {
 		add_filter( 'woocommerce_order_button_text', [ __CLASS__, 'order_button_text' ] );
 		add_filter( 'option_woocommerce_subscriptions_order_button_text', [ __CLASS__, 'order_button_text' ] );
 
-		add_filter( 'cmplz_site_needs_cookiewarning', [ __CLASS__, 'is_not_modal_checkout_filter' ] );
-		add_filter( 'newspack_reader_activation_should_render_auth', [ __CLASS__, 'is_not_modal_checkout_filter' ] );
-		add_filter( 'newspack_theme_enqueue_js', [ __CLASS__, 'is_not_modal_checkout_filter' ] );
+		// Remove some stuff from the modal checkout page. It's displayed in an iframe, so it should not be treated as a separate page.
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'dequeue_scripts' ], 11 );
+		add_filter( 'newspack_reader_activation_should_render_auth', [ __CLASS__, 'is_not_modal_checkout_filter' ] );
+		add_filter( 'newspack_ads_should_show_ads', [ __CLASS__, 'is_not_modal_checkout_filter' ] );
+		add_filter( 'newspack_theme_enqueue_js', [ __CLASS__, 'is_not_modal_checkout_filter' ] );
+		add_filter( 'newspack_theme_enqueue_print_styles', [ __CLASS__, 'is_not_modal_checkout_filter' ] );
+		add_filter( 'cmplz_site_needs_cookiewarning', [ __CLASS__, 'is_not_modal_checkout_filter' ] );
+		add_filter( 'googlesitekit_analytics_tag_blocked', [ __CLASS__, 'is_modal_checkout' ] );
+		add_filter( 'googlesitekit_analytics-4_tag_blocked', [ __CLASS__, 'is_modal_checkout' ] );
+		add_filter( 'googlesitekit_adsense_tag_blocked', [ __CLASS__, 'is_modal_checkout' ] );
+		add_filter( 'googlesitekit_tagmanager_tag_blocked', [ __CLASS__, 'is_modal_checkout' ] );
 	}
 
 	/**

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -63,6 +63,7 @@ final class Modal_Checkout {
 		add_filter( 'googlesitekit_analytics-4_tag_blocked', [ __CLASS__, 'is_modal_checkout' ] );
 		add_filter( 'googlesitekit_adsense_tag_blocked', [ __CLASS__, 'is_modal_checkout' ] );
 		add_filter( 'googlesitekit_tagmanager_tag_blocked', [ __CLASS__, 'is_modal_checkout' ] );
+		add_filter( 'jetpack_active_modules', [ __CLASS__, 'jetpack_active_modules' ] );
 	}
 
 	/**
@@ -965,6 +966,18 @@ final class Modal_Checkout {
 			return false;
 		}
 		return $value;
+	}
+
+	/**
+	 * Deactivate all Jetpack modules on the modal checkout.
+	 *
+	 * @param bool $modules JP modules.
+	 */
+	public static function jetpack_active_modules( $modules ) {
+		if ( self::is_modal_checkout() ) {
+			return [];
+		}
+		return $modules;
 	}
 }
 Modal_Checkout::init();

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -51,6 +51,9 @@ final class Modal_Checkout {
 		add_filter( 'wcs_place_subscription_order_text', [ __CLASS__, 'order_button_text' ], 1 );
 		add_filter( 'woocommerce_order_button_text', [ __CLASS__, 'order_button_text' ] );
 		add_filter( 'option_woocommerce_subscriptions_order_button_text', [ __CLASS__, 'order_button_text' ] );
+
+		add_filter( 'cmplz_site_needs_cookiewarning', [ __CLASS__, 'is_not_modal_checkout_filter' ] );
+		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'dequeue_scripts' ], 11 );
 	}
 
 	/**
@@ -348,6 +351,16 @@ final class Modal_Checkout {
 			[],
 			\NEWSPACK_BLOCKS__VERSION
 		);
+	}
+
+	/**
+	 * Dequeue scripts not needed in the modal checkout.
+	 */
+	public static function dequeue_scripts() {
+		if ( ! self::is_modal_checkout() ) {
+			return;
+		}
+		wp_dequeue_style( 'cmplz-general' );
 	}
 
 	/**
@@ -931,6 +944,18 @@ final class Modal_Checkout {
 			return __( 'Donate now', 'newspack-blocks' );
 		}
 		return $text;
+	}
+
+	/**
+	 * Filter the a value dependent on the page not being modal checkout.
+	 *
+	 * @param bool $value The value.
+	 */
+	public static function is_not_modal_checkout_filter( $value ) {
+		if ( self::is_modal_checkout() ) {
+			return false;
+		}
+		return $value;
 	}
 }
 Modal_Checkout::init();

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -492,9 +492,7 @@ final class Modal_Checkout {
 		// This is for the initial display – the markup will be refetched on cart updates (e.g. applying a coupon).
 		// Then it'd be handled by the `woocommerce_update_order_review_fragments` filter.
 		if ( 'checkout/review-order.php' === $template_name && ! self::should_show_order_details() ) {
-			ob_start();
-			echo '<table class="shop_table woocommerce-checkout-review-order-table empty"></table>';
-			return ob_end_flush();
+			$located = NEWSPACK_BLOCKS__PLUGIN_DIR . 'src/modal-checkout/templates/empty-order-details.php';
 		}
 
 		return $located;

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -373,6 +373,8 @@ final class Modal_Checkout {
 			return;
 		}
 		wp_dequeue_style( 'cmplz-general' );
+		wp_deregister_script( 'wp-mediaelement' );
+		wp_deregister_style( 'wp-mediaelement' );
 	}
 
 	/**

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -55,6 +55,8 @@ final class Modal_Checkout {
 		// Remove some stuff from the modal checkout page. It's displayed in an iframe, so it should not be treated as a separate page.
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'dequeue_scripts' ], 11 );
 		add_filter( 'newspack_reader_activation_should_render_auth', [ __CLASS__, 'is_not_modal_checkout_filter' ] );
+		add_filter( 'newspack_enqueue_reader_activation_block', [ __CLASS__, 'is_not_modal_checkout_filter' ] );
+		add_filter( 'newspack_enqueue_memberships_block_patterns', [ __CLASS__, 'is_not_modal_checkout_filter' ] );
 		add_filter( 'newspack_ads_should_show_ads', [ __CLASS__, 'is_not_modal_checkout_filter' ] );
 		add_filter( 'newspack_theme_enqueue_js', [ __CLASS__, 'is_not_modal_checkout_filter' ] );
 		add_filter( 'newspack_theme_enqueue_print_styles', [ __CLASS__, 'is_not_modal_checkout_filter' ] );

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -266,3 +266,7 @@
 		transform: scale( 1 );
 	}
 }
+
+.grecaptcha-badge {
+	display: none !important;
+}

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -266,7 +266,3 @@
 		transform: scale( 1 );
 	}
 }
-
-.grecaptcha-badge {
-	display: none !important;
-}

--- a/src/modal-checkout/templates/empty-order-details.php
+++ b/src/modal-checkout/templates/empty-order-details.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Empty order details.
+ *
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates
+ * @version 8.1.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+?>
+	<table class="shop_table woocommerce-checkout-review-order-table empty"></table>
+<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Improves the performance of the modal checkout by skipping unnecessary markup. 

It also fixes a PHP Notice caused by changes in #1601. 

### How to test the changes in this Pull Request:

1. On `master`, start a new session (or clear the cookies)
2. Trigger the modal checkout, copy the URL of the modal's iframe and visit it directly*
3. Observe the issues (deactivate Perfmatters if active, because it will make it more difficult to inspect):
    1. [Complianz](https://wordpress.org/plugins/complianz-gdpr/) cookie banner is displayed in the iframe
    2. reCaptcha badge, too
    3. Newspack Ads' JS is loaded (if configured) 
    4. Newspack print styles are loaded
    5. GA is loaded 
    6. If Jetpack "WooCommerce Analytics" module is active**, a whole bunch of React and Redux JS is loaded
    7. WP mediaelement scripts and styles are loaded
    8. PHP Notice is logged, notifying that "Function wc_get_template was called incorrectly"
4. Switch to this branch, and to https://github.com/Automattic/newspack-plugin/pull/2768 and https://github.com/Automattic/newspack-theme/pull/2207 on Plugin and Theme repos
5. Observe errors gone 💨
6. Complete a transaction using the modal checkout, verify that it works as before

\* `copy(document.querySelector('iframe[name="newspack_modal_checkout"]').contentWindow.location.href)` in the JS console
\** `/wp-admin/admin.php?page=jetpack_modules`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->