### PR TITLE
fix: modal checkout template markup and shortcode

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -393,14 +393,23 @@ final class Modal_Checkout {
 			return $template;
 		}
 		ob_start();
-		wp_head();
-		while ( have_posts() ) {
-			the_post();
-			echo '<div id="newspack_modal_checkout">';
-			the_content();
-			echo '</div>';
-		}
-		wp_footer();
+		?>
+		<!doctype html>
+		<html <?php language_attributes(); ?>>
+		<head>
+			<meta charset="<?php bloginfo( 'charset' ); ?>" />
+			<meta name="viewport" content="width=device-width, initial-scale=1" />
+			<link rel="profile" href="https://gmpg.org/xfn/11" />
+			<?php wp_head(); ?>
+		</head>
+		<body id="newspack_modal_checkout">
+			<?php
+			echo do_shortcode( '[woocommerce_checkout]' );
+			wp_footer();
+			?>
+		</body>
+		</html>
+		<?php
 		ob_end_flush();
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The current modal checkout template is not rendering valid markup. It's currently missing the doctype, html, head, and body tags. This PR ensures the template outputs valid markup and also changes the output so it always renders WC's `[woocommerce_checkout]` shortcode instead of the contents of the checkout page.

This change is to make sure that a checkout template using the new [WooCommerce blocks](https://woo.com/checkout-blocks/) never renders in the modal checkout, since we're not expecting to support it at the moment.

### How to test the changes in this Pull Request:

1. Checkout this branch and go through the modal checkout flow using the donate block
2. Confirm you're able to complete the flow without issues
3. Edit the checkout page to use the new WooCommerce checkout blocks
4. Go through the flow again and confirm the modal checkout is preserved and works as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
