### PR TITLE
fix(homepage-posts): placement for inline styles

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -229,7 +229,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	$block_name = apply_filters( 'newspack_blocks_block_name', 'newspack-blocks/homepage-articles' );
 
 	// Gather all Homepage Articles blocks on the page and output only the needed CSS.
-	// This CSS will be printed right after .entry-content.
+	// This CSS will be printed along with the first found block markup.
 	global $newspack_blocks_hpb_all_blocks;
 	$inline_style_html = '';
 	if ( ! is_array( $newspack_blocks_hpb_all_blocks ) ) {
@@ -358,6 +358,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 			class="<?php echo esc_attr( $classes ); ?>"
 			style="<?php echo esc_attr( $styles ); ?>"
 			>
+			<?php echo $inline_style_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			<div data-posts data-current-post-id="<?php the_ID(); ?>">
 				<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
 					<h2 class="article-section-title">
@@ -404,7 +405,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	$content = ob_get_clean();
 	Newspack_Blocks::enqueue_view_assets( 'homepage-articles' );
 
-	return $inline_style_html . $content;
+	return $content;
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The inline styles for the Homepage Posts block are not rendered right after `.entry-content` as documented in the code. They are rendered alongside the first rendered HPP block. This can cause containers that leverage pseudo classes like `:first-child` or `:last-child` to not behave as expected, since the style tag can get picked up.

| Before | After |
| --- | --- |
| <img width="1255" alt="image" src="https://github.com/Automattic/newspack-blocks/assets/820752/17e6b0e2-db14-4f65-a801-a2b8669b2def"> | <img width="1257" alt="image" src="https://github.com/Automattic/newspack-blocks/assets/820752/01e112a5-6bd6-40f2-a138-29218e379bd1"> |



This PR changes the placement for the inline CSS so it's printed inside the block container. The improved CLS implemented in the original PR (#1548) should be preserved.

### How to test the changes in this Pull Request:

1. Confirm the bug by adding a 2 column block with a HPP block on each column and visiting the front-end (see image above)
2. Check out this branch and confirm there's no longer a top margin on the first block
3. Open DevTools, change to mobile viewport and apply network throttling to slow 3g (see #1548 for further details if needed)
4. Refresh the page and confirm the slowly rendered layout doesn't shift

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
