### PR TITLE
Hotfix/update subtitle selector

### DIFF
--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -195,7 +195,10 @@ class Edit extends Component {
 						</h3>
 					) }
 					{ IS_SUBTITLE_SUPPORTED_IN_THEME && showSubtitle && (
-						<RawHTML key="subtitle" className="newspack-post-subtitle">
+						<RawHTML
+							key="subtitle"
+							className="newspack-post-subtitle newspack-post-subtitle--in-homepage-block"
+						>
 							{ post.meta.newspack_post_subtitle || '' }
 						</RawHTML>
 					) }

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -1,11 +1,16 @@
 @use '../../shared/sass/variables';
 @use '../../shared/sass/placeholder';
 @use '../../shared/sass/colors';
+@use '../../shared/sass/mixins';
 
 .wpnbha {
-	article {
-		.entry-title {
-			margin: 0 0 0.25em;
+	article .entry-title {
+		margin: 0 0 0.25em;
+	}
+
+	@include mixins.media( tablet ) {
+		&.ts-4 article .entry-title {
+			font-size: 1.6em;
 		}
 	}
 
@@ -30,6 +35,8 @@
 	.excerpt-contain p {
 		margin: 0.5em 0;
 	}
+
+
 }
 
 .editor-styles-wrapper.wpnbha__wp-block-button__wrapper {

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -123,7 +123,7 @@ call_user_func(
 				$subtitle = get_post_meta( $post_id, 'newspack_post_subtitle', true );
 
 				?>
-				<div class="newspack-post-subtitle">
+				<div class="newspack-post-subtitle newspack-post-subtitle--in-homepage-block">
 					<?php
 					$allowed_tags = array(
 						'b'      => true,

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -200,7 +200,7 @@ function newspack_blocks_get_homepage_articles_css_string( $attrs ) {
 		}
 		if ( isset( $attrs['showSubtitle'] ) && in_array( 1, $attrs['showSubtitle'], false ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.FoundNonStrictFalse
 			echo esc_html(
-				'.newspack-post-subtitle {
+				'.newspack-post-subtitle--in-homepage-block {
 					margin-top: 0.3em;
 					margin-bottom: 0;
 					line-height: 1.4;

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -134,7 +134,7 @@ function newspack_blocks_get_homepage_articles_css_string( $attrs ) {
 
 	ob_start();
 	?>
-		.wpnbha .entry-title {
+		.wpnbha article .entry-title {
 			font-size: 1.2em;
 		}
 		.wpnbha .entry-meta {
@@ -193,7 +193,7 @@ function newspack_blocks_get_homepage_articles_css_string( $attrs ) {
 				}
 				if ( in_array( $scale, [ 1, 2, 3 ], true ) ) {
 					echo esc_html(
-						".wpnbha.ts-$scale article .newspack-post-subtitle,.entry-wrapper p,.entry-wrapper .more-link,.entry-meta {font-size: 0.8em;}"
+						".wpnbha.ts-$scale article .newspack-post-subtitle, .wpnbha.ts-$scale article .entry-wrapper p, .wpnbha.ts-$scale article .entry-wrapper .more-link, .wpnbha.ts-$scale article .entry-meta {font-size: 0.8em;}"
 					);
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**Edited to add:** The testing steps have been updated to cover an additional fix I've added to this PR.

**Subtitles:**
This PR fixes a weird edge case where if you have:

* A single post with a subtitle displaying
* A homepage posts block on that single post

... the styles from the homepage posts block subtitle override the styles coming from the theme, and remove the space from underneath the subtitle in the post header. The issue is that the CSS selector changed in the release.

**Font sizes:**
It also updates the selectors for the smaller homepage post block sizes. The sizes for type scale 3 and smaller don't include the .ts-# selector in front of all elements, so that font size is getting picked up by other homepage post blocks with larger font sizes that normally use the theme's defaults.

I've updated the selectors to make sure styles for type scale 3 and lower don't "bleed" into other blocks on the page. I also tweaked the title size for type scale 4's headers -- it's the "default" size so the styles weren't set up exactly the same as the others originally, and weren't inheriting the right font size on different screen sizes.

### How to test the changes in this Pull Request:

#### Testing the subtitle fix:

1. Create a post and add a subtitle.
2. Add a Homepage Posts block to the body of the post, and turn on the subtitles on the block.
3. Publish and view on the front-end:

![image](https://github.com/Automattic/newspack-blocks/assets/177561/f43a495d-6bf8-4d03-8c23-1525c482dce6)

4. Apply the PR. 
5. Confirm that the spacing in the header is changed, and also that the subtitle has no bottom margin when it appears in the block.

![image](https://github.com/Automattic/newspack-blocks/assets/177561/4e348912-7900-4ad7-83ca-cac0fcb6a6c8)

![image](https://github.com/Automattic/newspack-blocks/assets/177561/101503c9-5735-491d-9cbb-6b0d9c5e42d9)

#### Testing the smaller font size fix: 

1. Add a series of homepage post blocks to a page, of all sizes -- sizes 1-4 specifically should be tested, but it wouldn't hurt to add others. You can also copy-paste the example code of all sizes below.

<details>
<summary>HPB - different sizes</summary>

```
<!-- wp:newspack-blocks/homepage-articles {"showCategory":true,"columns":2,"postsToShow":1,"typeScale":10,"sectionHeader":"Ts 10"} /-->

<!-- wp:newspack-blocks/homepage-articles {"showCategory":true,"postLayout":"grid","columns":2,"postsToShow":2,"typeScale":9,"sectionHeader":"Ts 9"} /-->

<!-- wp:newspack-blocks/homepage-articles {"showCategory":true,"postLayout":"grid","columns":2,"postsToShow":2,"typeScale":8,"sectionHeader":"Ts 8"} /-->

<!-- wp:newspack-blocks/homepage-articles {"showCategory":true,"postLayout":"grid","typeScale":7,"sectionHeader":"Ts 7"} /-->

<!-- wp:newspack-blocks/homepage-articles {"showCategory":true,"postLayout":"grid","typeScale":6,"sectionHeader":"Ts 6"} /-->

<!-- wp:newspack-blocks/homepage-articles {"showCategory":true,"postLayout":"grid","typeScale":5,"sectionHeader":"Ts 5"} /-->

<!-- wp:newspack-blocks/homepage-articles {"showCategory":true,"postLayout":"grid","sectionHeader":"Default"} /-->

<!-- wp:newspack-blocks/homepage-articles {"showCategory":true,"postLayout":"grid","typeScale":3,"sectionHeader":"TS 3"} /-->

<!-- wp:newspack-blocks/homepage-articles {"showCategory":true,"postLayout":"grid","typeScale":2,"sectionHeader":"TS 2"} /-->

<!-- wp:newspack-blocks/homepage-articles {"showCategory":true,"postLayout":"grid","typeScale":1,"sectionHeader":"TS 1"} /-->
```

</details>

2. Compare against [this test page](https://outer-catfish.jurassic.ninja/), running an older block release. On the front-end, note that the paragraph font size on master is smaller throughout, and if make the browser window smaller, the font size on the 'default' (type scale 4) block's post titles doesn't decrease in size. In the editor, the 'default' (type scale 4) block's post titles will appear smaller than they should.
3. (Also look for any other weirdness in case I'm missing something!).
4. Apply the PR and run `npm run build`.
5. Compare your localhost against the demo site again; confirm that the font sizes appear consistent on the front-end and in the editor. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
