### PR TITLE
feat(modal-checkout): allow anonymous purchase for registered email

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -978,7 +978,7 @@ final class Modal_Checkout {
 	}
 
 	/**
-	 * If a reader tries to make a recurring donation with an email address that
+	 * If a reader tries to make a purchase with an email address that
 	 * has been previously registered, automatically associate the transaction
 	 * with the user.
 	 *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Moves a logic that is [currently placed behind RAS](https://github.com/Automattic/newspack-plugin/blob/fcad059abbe0314ba8a6f3eaaf92d5c96350e248/includes/reader-activation/class-reader-activation.php#L89-L90) but is designed for the modal checkout.

If an anonymous purchase is made for a registered email, it should be attached to that account regardless of them being authenticated.

### How to test the changes in this Pull Request:

1. Checkout this branch and https://github.com/Automattic/newspack-plugin/pull/2781
2. Make sure RAS is toggled off (`$ wp option delete newspack_reader_activation_enabled`)
3. Disable the "Allow customers to create an account during checkout" option from the "Accounts & Privacy" section of WC:
<img width="1172" alt="image" src="https://github.com/Automattic/newspack-blocks/assets/820752/fb8146f2-4fff-406e-8c40-73d929673514">

4. Go through the regular checkout flow anonymously and use an existing email
5. Confirm the order goes through and in the dashboard the order is not assigned to any user (shown as "guest" customer)
6. Also anonymously, go through the modal checkout flow (either through the Checkout Button block or Donate block) using an existing email
7. Confirm the order has been placed and assigned to the user
8. Visit `/my-account` and confirm you're still logged out

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
