### PR TITLE
Donate Block: Update selected tier behaviour

### DIFF
--- a/src/blocks/donate/tiers-based/view.ts
+++ b/src/blocks/donate/tiers-based/view.ts
@@ -52,9 +52,11 @@ export default ( parentEl: HTMLElement ) => {
 
 			// Toggle the frequency buttons' active states.
 			frequencyButtonsEls.forEach( el => {
-				selectedFrequency === el.getAttribute( 'data-frequency-slug')
-					? el.classList.add( BUTTON_ACTIVE_CLASSNAME )
-					: el.classList.remove( BUTTON_ACTIVE_CLASSNAME );
+				if ( selectedFrequency === el.getAttribute( 'data-frequency-slug' ) ) {
+					el.classList.add( BUTTON_ACTIVE_CLASSNAME );
+				} else {
+					el.classList.remove( BUTTON_ACTIVE_CLASSNAME );
+				}
 			} );
 
 			// Update the value attributes in the form's submit buttons.

--- a/src/blocks/donate/tiers-based/view.ts
+++ b/src/blocks/donate/tiers-based/view.ts
@@ -51,7 +51,11 @@ export default ( parentEl: HTMLElement ) => {
 			selectedAmountEls.forEach( el => ( el.style.display = 'inline' ) );
 
 			// Toggle the frequency buttons' active states.
-			frequencyButtonsEls.forEach( el => el.classList.toggle( BUTTON_ACTIVE_CLASSNAME ) );
+			frequencyButtonsEls.forEach( el => {
+				selectedFrequency === el.getAttribute( 'data-frequency-slug')
+					? el.classList.add( BUTTON_ACTIVE_CLASSNAME )
+					: el.classList.remove( BUTTON_ACTIVE_CLASSNAME );
+			} );
 
 			// Update the value attributes in the form's submit buttons.
 			const submitButtonsEls = parentEl.querySelectorAll( 'button[type="submit"]' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Queuing this up for release early next week! 

This PR updates the logic used to toggle the tab status (active or inactive) in the tiers view of the Donate block.

Originally the tabs, when one was selected, would all toggle the active CSS class -- meaning either one or two would appear active, and they wouldn't necessarily line up with the actual active tab. This was only on the front-end -- it worked as expected in the editor. This PR updates it to check for current status and update; if there's a more elegant way to do this, I'm all ears! 

See 1200550061930446-as-1206029652902709

### How to test the changes in this Pull Request:

1. Add a Donate block to your test set, and change the Layout to Tiers; make sure the block is showing all three tabs (One time, Monthly, Annually). Publish you page.
2. View on front end, and click between the different tabs; note that the selected state appears to alternate between One Time, and Monthly+Annually, regardless which you click. You can tell which one is truly active by the "per X" or "once" text after each dollar amount:

![before](https://github.com/Automattic/newspack-blocks/assets/177561/8677d739-d7ac-4137-884e-fa441ecf2399)

4. Apply the PR and run `npm run build`.
5. Repeat step two; confirm that only the clicked tab appears selected.

![after](https://github.com/Automattic/newspack-blocks/assets/177561/af7a08a4-5367-4f07-b786-361838229ae3)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
