### PR TITLE
fix(homepage-posts): handle empty block when printing inline styles

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -352,13 +352,14 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 	ob_start();
 
+	echo $inline_style_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
 	if ( $article_query->have_posts() ) :
 		?>
 		<div
 			class="<?php echo esc_attr( $classes ); ?>"
 			style="<?php echo esc_attr( $styles ); ?>"
 			>
-			<?php echo $inline_style_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			<div data-posts data-current-post-id="<?php the_ID(); ?>">
 				<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
 					<h2 class="article-section-title">

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -227,6 +227,10 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	}
 
 	$block_name = apply_filters( 'newspack_blocks_block_name', 'newspack-blocks/homepage-articles' );
+	$article_query = new WP_Query( Newspack_Blocks::build_articles_query( $attributes, $block_name ) );
+	if ( ! $article_query->have_posts() ) {
+		return;
+	}
 
 	// Gather all Homepage Articles blocks on the page and output only the needed CSS.
 	// This CSS will be printed along with the first found block markup.
@@ -248,8 +252,6 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 	// This will let the FSE plugin know we need CSS/JS now.
 	do_action( 'newspack_blocks_render_homepage_articles' );
-
-	$article_query = new WP_Query( Newspack_Blocks::build_articles_query( $attributes, $block_name ) );
 
 	$classes = Newspack_Blocks::block_classes( 'homepage-articles', $attributes, [ 'wpnbha' ] );
 
@@ -352,56 +354,53 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 	ob_start();
 
-	echo $inline_style_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-
-	if ( $article_query->have_posts() ) :
-		?>
-		<div
-			class="<?php echo esc_attr( $classes ); ?>"
-			style="<?php echo esc_attr( $styles ); ?>"
-			>
-			<div data-posts data-current-post-id="<?php the_ID(); ?>">
-				<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
-					<h2 class="article-section-title">
-						<span><?php echo wp_kses_post( $attributes['sectionHeader'] ); ?></span>
-					</h2>
-				<?php endif; ?>
-				<?php
-				echo Newspack_Blocks::template_inc( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					__DIR__ . '/templates/articles-list.php',
-					[
-						'articles_rest_url' => $articles_rest_url, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						'article_query'     => $article_query, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						'attributes'        => $attributes, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					]
-				);
-				?>
-			</div>
-			<?php
-
-			if ( $has_more_button ) :
-				?>
-				<button type="button" class="wp-block-button__link" data-next="<?php echo esc_url( $articles_rest_url ); ?>">
-				<?php
-				if ( ! empty( $attributes['moreButtonText'] ) ) {
-					echo esc_html( $attributes['moreButtonText'] );
-				} else {
-					esc_html_e( 'Load more posts', 'newspack-blocks' );
-				}
-				?>
-				</button>
-				<p class="loading">
-					<?php esc_html_e( 'Loading...', 'newspack-blocks' ); ?>
-				</p>
-				<p class="error">
-					<?php esc_html_e( 'Something went wrong. Please refresh the page and/or try again.', 'newspack-blocks' ); ?>
-				</p>
-
+	?>
+	<div
+		class="<?php echo esc_attr( $classes ); ?>"
+		style="<?php echo esc_attr( $styles ); ?>"
+		>
+		<?php echo $inline_style_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+		<div data-posts data-current-post-id="<?php the_ID(); ?>">
+			<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
+				<h2 class="article-section-title">
+					<span><?php echo wp_kses_post( $attributes['sectionHeader'] ); ?></span>
+				</h2>
 			<?php endif; ?>
-
+			<?php
+			echo Newspack_Blocks::template_inc( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				__DIR__ . '/templates/articles-list.php',
+				[
+					'articles_rest_url' => $articles_rest_url, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					'article_query'     => $article_query, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					'attributes'        => $attributes, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				]
+			);
+			?>
 		</div>
 		<?php
-	endif;
+
+		if ( $has_more_button ) :
+			?>
+			<button type="button" class="wp-block-button__link" data-next="<?php echo esc_url( $articles_rest_url ); ?>">
+			<?php
+			if ( ! empty( $attributes['moreButtonText'] ) ) {
+				echo esc_html( $attributes['moreButtonText'] );
+			} else {
+				esc_html_e( 'Load more posts', 'newspack-blocks' );
+			}
+			?>
+			</button>
+			<p class="loading">
+				<?php esc_html_e( 'Loading...', 'newspack-blocks' ); ?>
+			</p>
+			<p class="error">
+				<?php esc_html_e( 'Something went wrong. Please refresh the page and/or try again.', 'newspack-blocks' ); ?>
+			</p>
+
+		<?php endif; ?>
+
+	</div>
+	<?php
 
 	$content = ob_get_clean();
 	Newspack_Blocks::enqueue_view_assets( 'homepage-articles' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

If the HP block is empty, and it happens to be the first one on the page, the inline styles won't be printed. 

### How to test the changes in this Pull Request:

1. Set up a page with at least two HP blocks – the first one should be empty*
2. For the second block, choose a large type scale
3. On `release`, observe that the inline styles are not applied – the type scale is not reflected on the frontend 
4. Switch to this branch, observe the styles are applied

\* e.g. set it to display posts from a category with no posts

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->