### PR TITLE
fix(modal-checkout): align Stripe's "save payment" checkbox

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -137,6 +137,15 @@
 		p {
 			margin-top: 0;
 		}
+		p.woocommerce-SavedPaymentMethods-saveNew,
+		p.newspack-cover-fees {
+			display: flex;
+			margin: 8px 0;
+			align-items: flex-start;
+			input[type='checkbox'] {
+				margin-right: 8px;
+			}
+		}
 	}
 	.wc-saved-payment-methods {
 		padding: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Tweaks the alignment of the "Save payment information to my account for future purchases." checkbox.

| Before | After |
| --- | --- |
| <img width="543" alt="image" src="https://github.com/Automattic/newspack-blocks/assets/820752/8a705f2f-3fee-4854-aa02-30aebd03d349"> | <img width="541" alt="image" src="https://github.com/Automattic/newspack-blocks/assets/820752/806bdb7d-782c-415b-96e6-0bd118500b1d"> | 

### How to test the changes in this Pull Request:

Checkout this branch, go through the modal checkout flow, and confirm the checkbox is not misaligned.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
