### PR TITLE
feat(modal-checkout): custom coupon form

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -255,6 +255,13 @@
 				flex-grow: 1;
 			}
 		}
+		p.result {
+			margin: 0;
+			font-size: 14px;
+			&.error {
+				color: #cc1818;
+			}
+		}
 	}
 	#checkout_details { /* stylelint-disable-line */
 		display: flex;

--- a/src/modal-checkout/templates/form-coupon.php
+++ b/src/modal-checkout/templates/form-coupon.php
@@ -13,7 +13,7 @@ if ( ! wc_coupons_enabled() ) { // @codingStandardsIgnoreLine.
 }
 
 ?>
-<form class="checkout_coupon woocommerce-form-coupon" method="post">
+<form class="modal_checkout_coupon woocommerce-form-coupon" method="post">
 	<h3><?php esc_html_e( 'Apply a coupon code', 'newspack-blocks' ); ?></h3>
 	<p>
 		<input type="text" name="coupon_code" class="input-text" placeholder="<?php esc_attr_e( 'Coupon code', 'newspack-blocks' ); ?>" id="coupon_code" value="" />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Requires #1602.

Implements a custom coupon form handling so it doesn't inherit Woo's default UI handling of the form. The custom handling is implemented by changing the class name of the form.

<img width="508" alt="image" src="https://github.com/Automattic/newspack-blocks/assets/820752/9151f036-4c7e-4f29-8db7-60b8c4acbdc7">

<img width="519" alt="image" src="https://github.com/Automattic/newspack-blocks/assets/820752/6a1de640-a222-41b1-aa94-131e6896590e">


### How to test the changes in this Pull Request:

1. Check out this branch and make sure you have coupons enabled and at least 1 enabled coupon code
2. Go through the modal checkout flow through a Checkout Button block (make sure it's not a donation product, which has coupons disabled)
3. Enter an invalid coupon code and confirm you get the error message as above and the input is focused
4. Enter a valid coupon code and confirm the checkout is updated to include the discount
5. Click to remove the coupon code in the order review table and confirm the coupon is removed and the coupon form input is focused

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
