### PR TITLE
fix(modal-checkout): show order details table with fees

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -701,6 +701,9 @@ final class Modal_Checkout {
 		if ( 1 < $cart->get_cart_contents_count() ) {
 			return true;
 		}
+		if ( ! empty( $cart->get_fees() ) ) {
+			return true;
+		}
 		return false;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Show order details table on the modal checkout if the cart contains fees.

### How to test the changes in this Pull Request:

Instructions at https://github.com/Automattic/newspack-plugin/pull/2820

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
