### PR TITLE
refactor(modal-checkout): order review table appearance

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -191,7 +191,7 @@
 			}
 		}
 	}
-	#order_review_wrapper.hidden { /* stylelint-disable-line */
+	.order-review-wrapper.hidden {
 		display: none;
 	}
 	#order_review { /* stylelint-disable-line */

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -191,6 +191,9 @@
 			}
 		}
 	}
+	#order_review_wrapper.hidden { /* stylelint-disable-line */
+		display: none;
+	}
 	#order_review { /* stylelint-disable-line */
 		margin: 0 0 24px;
 		padding: 16px 24px;
@@ -201,6 +204,11 @@
 			line-height: 24px;
 			border: 0;
 			margin: 0;
+			&.empty {
+				display: none;
+				margin: 0;
+				padding: 0;
+			}
 			th,
 			td {
 				font-size: 14px; // Prevent relative font size

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -69,6 +69,25 @@ import './checkout.scss';
 		} );
 
 		/**
+		 * Handle order review table appearance.
+		 */
+		$( document ).on( 'updated_checkout', function () {
+			const $wrapper = $( '#order_review_wrapper' );
+			if ( ! $wrapper.length ) {
+				return;
+			}
+			// Move order review table to the right place.
+			$( '.payment_methods' ).after( $wrapper );
+			// Toggle visibility according to table content.
+			const $table = $wrapper.find( 'table' );
+			if ( $table.is( '.empty' ) ) {
+				$wrapper.addClass( 'hidden' );
+			} else {
+				$wrapper.removeClass( 'hidden' );
+			}
+		} );
+
+		/**
 		 * Handle gift options.
 		 */
 		if ( $gift_options.length ) {

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -72,20 +72,21 @@ import './checkout.scss';
 		 * Handle order review table appearance.
 		 */
 		$( document ).on( 'updated_checkout', function () {
-			const $wrapper = $( '#order_review_wrapper' ).clone();
+			const $wrapper = $( '#after_customer_details > .order-review-wrapper' );
 			if ( ! $wrapper.length ) {
 				return;
 			}
+			const $el = $wrapper.clone();
 			// Remove existing table from inside the payment methods.
-			$( '#payment #order_review_wrapper' ).remove();
+			$( '#payment .order-review-wrapper' ).remove();
 			// Move new order review table to the payment methods.
-			$( '.payment_methods' ).after( $wrapper );
+			$( '.payment_methods' ).after( $el );
 			// Toggle visibility according to table content.
-			const $table = $wrapper.find( 'table' );
+			const $table = $el.find( 'table' );
 			if ( $table.is( '.empty' ) ) {
-				$wrapper.addClass( 'hidden' );
+				$el.addClass( 'hidden' );
 			} else {
-				$wrapper.removeClass( 'hidden' );
+				$el.removeClass( 'hidden' );
 			}
 		} );
 

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -72,11 +72,13 @@ import './checkout.scss';
 		 * Handle order review table appearance.
 		 */
 		$( document ).on( 'updated_checkout', function () {
-			const $wrapper = $( '#order_review_wrapper' );
+			const $wrapper = $( '#order_review_wrapper' ).clone();
 			if ( ! $wrapper.length ) {
 				return;
 			}
-			// Move order review table to the right place.
+			// Remove existing table from inside the payment methods.
+			$( '#payment #order_review_wrapper' ).remove();
+			// Move new order review table to the payment methods.
 			$( '.payment_methods' ).after( $wrapper );
 			// Toggle visibility according to table content.
 			const $table = $wrapper.find( 'table' );

--- a/src/modal-checkout/templates/form-checkout.php
+++ b/src/modal-checkout/templates/form-checkout.php
@@ -32,6 +32,15 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 			<button id="checkout_continue" type="submit"><?php esc_html_e( 'Continue', 'newspack-blocks' ); ?></button>
 		</div>
 		<div id="after_customer_details">
+			<div id="order_review_wrapper" class="hidden">
+				<?php do_action( 'woocommerce_checkout_before_order_review_heading' ); ?>
+				<h3 id="order_review_heading"><?php esc_html_e( 'Transaction details', 'newspack-blocks' ); ?></h3>
+				<?php do_action( 'woocommerce_checkout_before_order_review' ); ?>
+				<div id="order_review" class="woocommerce-checkout-review-order">
+					<?php do_action( 'woocommerce_checkout_order_review' ); ?>
+				</div>
+				<?php do_action( 'woocommerce_checkout_after_order_review' ); ?>
+			</div>
 			<?php do_action( 'woocommerce_checkout_after_customer_details' ); ?>
 			<button id="checkout_back" type="button"><?php esc_html_e( 'Back', 'newspack-blocks' ); ?></button>
 		</div>

--- a/src/modal-checkout/templates/form-checkout.php
+++ b/src/modal-checkout/templates/form-checkout.php
@@ -32,7 +32,7 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 			<button id="checkout_continue" type="submit"><?php esc_html_e( 'Continue', 'newspack-blocks' ); ?></button>
 		</div>
 		<div id="after_customer_details">
-			<div id="order_review_wrapper" class="hidden">
+			<div class="order-review-wrapper hidden">
 				<?php do_action( 'woocommerce_checkout_before_order_review_heading' ); ?>
 				<h3 id="order_review_heading"><?php esc_html_e( 'Transaction details', 'newspack-blocks' ); ?></h3>
 				<?php do_action( 'woocommerce_checkout_before_order_review' ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1205234045751551-as-1206299115205369

#1602 introduced changes to the order review table by placing it as a part of Woo's "payment" HTML fragment, making it render in the desired position and simplifying how the backend handle the visibility toggling.

This turns out to be problematic for the payment method form when the order review table changes, causing the HTML to be replaced, due to the new fragment content, and clearing the form inputs.

This PR restores the original strategy and implements a way to move the order review table to the intended placement through javascript.

Closes #1636 

### How to test the changes in this Pull Request:

1. Checkout this branch and https://github.com/Automattic/newspack-plugin/tree/epic/ras-acc, and start a new donation through the Donate Block
2. Fill Stripe's CC details and toggle the "cover fee" option
3. Confirm the table visibility changes and the CC details are not modified
4. Donate and confirm the donation goes through and the modal checkout resolves

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
