### PR TITLE
feat(modal-checkout): redesign variation selection

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -332,7 +332,6 @@ final class Modal_Checkout {
 		*/
 		$title    = apply_filters( 'newspack_blocks_modal_checkout_title', __( 'Complete your transaction', 'newspack-blocks' ) );
 		$products = array_keys( self::$products );
-		error_log( print_r( $products, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 		foreach ( $products as $product_id ) {
 			$product = wc_get_product( $product_id );
 			if ( ! $product->is_type( 'variable' ) ) {

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -311,9 +311,20 @@ final class Modal_Checkout {
 	}
 
 	/**
+	 * Update product price string for subscriptions to use "per" instead of "/".
+	 *
+	 * @param string $price_string The price string.
+	 */
+	public static function update_subscriptions_product_price_string( $price_string ) {
+		$price_string = str_replace( ' / ', ' ' . __( 'per', 'newspack-blocks' ) . ' ', $price_string );
+		return $price_string;
+	}
+
+	/**
 	 * Render variation selection modal for variable products.
 	 */
 	public static function render_variation_selection() {
+		add_filter( 'woocommerce_subscriptions_product_price_string', [ __CLASS__, 'update_subscriptions_product_price_string' ] );
 		/**
 		* Filters the header title for the modal checkout.
 		*
@@ -341,35 +352,33 @@ final class Modal_Checkout {
 					<section class="newspack-blocks-modal__content">
 						<div class="newspack-blocks-variation-modal__selection" data-product-id="<?php echo esc_attr( $product_id ); ?>">
 							<h3><?php echo esc_html( $product->get_name() ); ?></h3>
-							<p><?php esc_html_e( 'Select an option below:', 'newspack-blocks' ); ?></p>
-							<?php
-							$variations = $product->get_available_variations( 'objects' );
-							foreach ( $variations as $variation ) {
-								$name        = wc_get_formatted_variation( $variation, true );
-								$price       = $variation->get_price_html();
-								$description = $variation->get_description();
-								?>
-								<form>
-									<input type="hidden" name="newspack_checkout" value="1" />
-									<input type="hidden" name="product_id" value="<?php echo esc_attr( $variation->get_id() ); ?>" />
-									<button>
-										<span class="summary">
-											<span class="price"><?php echo $price; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
-											<span class="variation_name"><?php echo esc_html( $name ); ?></span>
-										</span>
-										<?php if ( ! empty( $description ) ) : ?>
-											<span class="description"><?php echo esc_html( $description ); ?></span>
-										<?php endif; ?>
-									</button>
-								</form>
+							<p><?php esc_html_e( 'Select an option to continue:', 'newspack-blocks' ); ?></p>
+							<ul class="newspack-blocks-variation-modal__options">
 								<?php
-							}
-							?>
+								$variations = $product->get_available_variations( 'objects' );
+								foreach ( $variations as $variation ) :
+									$name  = wc_get_formatted_variation( $variation, true );
+									$price = $variation->get_price_html();
+									?>
+									<li class="newspack-blocks-variation-modal__options__item">
+										<div class="summary">
+											<span class="price"><?php echo $price; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
+										</div>
+										<div class="variation"><?php echo esc_html( $name ); ?></div>
+										<form>
+											<input type="hidden" name="newspack_checkout" value="1" />
+											<input type="hidden" name="product_id" value="<?php echo esc_attr( $variation->get_id() ); ?>" />
+											<button><?php esc_html_e( 'Purchase', 'newspack-blocks' ); ?></button>
+										</form>
+									</li>
+								<?php endforeach; ?>
+							</ul>
 						</div>
 					</section>
 				</div>
 			</div>
 			<?php
+			remove_filter( 'woocommerce_subscriptions_product_price_string', [ __CLASS__, 'update_subscriptions_product_price_string' ] );
 		}
 	}
 

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -311,12 +311,19 @@ final class Modal_Checkout {
 	}
 
 	/**
-	 * Update product price string for subscriptions to use "per" instead of "/".
+	 * Update product price string for subscriptions to use "per" instead of "/"
+	 * and remove the cents when the price is over 3 digits.
 	 *
 	 * @param string $price_string The price string.
 	 */
 	public static function update_subscriptions_product_price_string( $price_string ) {
 		$price_string = str_replace( ' / ', ' ' . __( 'per', 'newspack-blocks' ) . ' ', $price_string );
+		// For prices over 3 digits and 00 cents, remove the cents.
+		$pattern = '/\b\d{3,}\.\d{2}\b/';
+		preg_match( $pattern, $price_string, $matches );
+		if ( ! empty( $matches ) ) {
+			$price_string = preg_replace( $pattern, preg_replace( '/\.00$/', '', $matches[0] ), $price_string );
+		}
 		return $price_string;
 	}
 

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -324,7 +324,7 @@ final class Modal_Checkout {
 	 * Render variation selection modal for variable products.
 	 */
 	public static function render_variation_selection() {
-		add_filter( 'woocommerce_subscriptions_product_price_string', [ __CLASS__, 'update_subscriptions_product_price_string' ] );
+		add_filter( 'woocommerce_subscriptions_product_price_string', [ __CLASS__, 'update_subscriptions_product_price_string' ], 10, 1 );
 		/**
 		* Filters the header title for the modal checkout.
 		*
@@ -332,6 +332,7 @@ final class Modal_Checkout {
 		*/
 		$title    = apply_filters( 'newspack_blocks_modal_checkout_title', __( 'Complete your transaction', 'newspack-blocks' ) );
 		$products = array_keys( self::$products );
+		error_log( print_r( $products, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 		foreach ( $products as $product_id ) {
 			$product = wc_get_product( $product_id );
 			if ( ! $product->is_type( 'variable' ) ) {
@@ -378,8 +379,8 @@ final class Modal_Checkout {
 				</div>
 			</div>
 			<?php
-			remove_filter( 'woocommerce_subscriptions_product_price_string', [ __CLASS__, 'update_subscriptions_product_price_string' ] );
 		}
+		remove_filter( 'woocommerce_subscriptions_product_price_string', [ __CLASS__, 'update_subscriptions_product_price_string' ], 10, 1 );
 	}
 
 	/**

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -319,10 +319,12 @@ final class Modal_Checkout {
 	public static function update_subscriptions_product_price_string( $price_string ) {
 		$price_string = str_replace( ' / ', ' ' . __( 'per', 'newspack-blocks' ) . ' ', $price_string );
 		// For prices over 3 digits and 00 cents, remove the cents.
-		$pattern = '/\b\d{3,}\.\d{2}\b/';
+		$decimal_separator = wc_get_price_decimal_separator();
+		$pattern           = '/\b\d{3,}' . preg_quote( $decimal_separator, '/' ) . '00\b/';
 		preg_match( $pattern, $price_string, $matches );
 		if ( ! empty( $matches ) ) {
-			$price_string = preg_replace( $pattern, preg_replace( '/\.00$/', '', $matches[0] ), $price_string );
+			$replace_pattern = '/\\' . preg_quote( $decimal_separator, '/' ) . '00$/';
+			$price_string    = preg_replace( $pattern, preg_replace( $replace_pattern, '', $matches[0] ), $price_string );
 		}
 		return $price_string;
 	}

--- a/src/modal-checkout/modal.scss
+++ b/src/modal-checkout/modal.scss
@@ -143,6 +143,7 @@
 				max-width: calc( 50% - 10px );
 			}
 			.summary {
+				font-size: 14px;
 				padding: 12px;
 				border-bottom: 1px solid #ddd;
 				bdi {

--- a/src/modal-checkout/modal.scss
+++ b/src/modal-checkout/modal.scss
@@ -132,15 +132,18 @@
 		margin: 0;
 		padding: 0;
 		&__item {
-			flex: 1 1 30%;
-			max-width: calc( 33.3333% - 10px );
 			border: 1px solid #ddd;
 			border-radius: 6px;
 			text-align: center;
-			&:first-child:nth-last-child( 2 ),
-			&:first-child:nth-last-child( 2 ) ~ li {
-				flex: 1 1 40%;
-				max-width: calc( 50% - 10px );
+			flex: 1 1 100%;
+			@media ( min-width: 600px ) {
+				flex: 1 1 30%;
+				max-width: calc( 33.3333% - 10px );
+				&:first-child:nth-last-child( 2 ),
+				&:first-child:nth-last-child( 2 ) ~ li {
+					flex: 1 1 40%;
+					max-width: calc( 50% - 10px );
+				}
 			}
 			.summary {
 				font-size: 14px;

--- a/src/modal-checkout/modal.scss
+++ b/src/modal-checkout/modal.scss
@@ -116,58 +116,54 @@
 			overflow: auto;
 			border-radius: 5px;
 			h3 {
-				margin: 0 0 1em;
+				font-size: 16px;
+				margin: 0;
 			}
 			p {
 				font-size: 0.8em;
 			}
-			form {
-				margin: 0 0 0.5em;
-				&:last-child {
-					margin: 0;
+		}
+	}
+	&__options {
+		list-style: none;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 16px;
+		margin: 0;
+		padding: 0;
+		&__item {
+			flex: 1 1 30%;
+			max-width: calc( 33.3333% - 10px );
+			border: 1px solid #ddd;
+			border-radius: 6px;
+			text-align: center;
+			&:first-child:nth-last-child( 2 ),
+			&:first-child:nth-last-child( 2 ) ~ li {
+				flex: 1 1 40%;
+				max-width: calc( 50% - 10px );
+			}
+			.summary {
+				padding: 12px;
+				border-bottom: 1px solid #ddd;
+				bdi {
+					display: block;
+					font-weight: 600;
+					font-size: 32px;
 				}
+			}
+			.variation {
+				padding: 12px;
+				font-size: 14px;
+				line-height: 1.5;
+				border-bottom: 1px solid #ddd;
+				font-weight: 600;
+			}
+			form {
+				padding: 12px;
 				button {
 					display: block;
 					width: 100%;
-					padding: 16px;
-					margin: 0;
-					border: 1px solid colors.$color__border;
-					background: transparent;
-					color: colors.$color__text-main;
-					text-align: inherit;
-					font-weight: inherit;
-					> span {
-						display: block;
-					}
-					.summary {
-						width: 100%;
-						display: flex;
-						justify-content: space-between;
-						align-items: flex-end;
-						.subscription-details {
-							bdi {
-								font-size: inherit;
-							}
-						}
-					}
-					.price {
-						max-width: 65%;
-					}
-					.variation_name {
-						font-weight: 600;
-						font-size: 0.9em;
-						margin-left: 0.5em;
-					}
-					.description {
-						padding-top: 1em;
-						margin-top: 1em;
-						font-size: 0.9em;
-						border-top: 1px solid colors.$color__border;
-					}
-					bdi {
-						font-weight: 600;
-						font-size: 1.8em;
-					}
+					font-size: 14px;
 				}
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1205234045751551-as-1206185519218321

Redesign the modal checkout's variation selection according to 1205234045751551-as-1206122717080146.

The styles should still be updated to integrate with https://github.com/Automattic/newspack-plugin/pull/2810

<img width="632" alt="image" src="https://github.com/Automattic/newspack-blocks/assets/820752/d5397493-314e-48af-a2f7-03923b09fc12">

<img width="624" alt="image" src="https://github.com/Automattic/newspack-blocks/assets/820752/a337a1be-d416-4ee7-80dd-62c9d5b55332">

<img width="417" alt="image" src="https://github.com/Automattic/newspack-blocks/assets/820752/8c348009-a2a6-46c3-b0e9-114c25ea9d64">


### How to test the changes in this Pull Request:

1. Checkout this branch and https://github.com/Automattic/newspack-plugin/tree/epic/ras-acc
2. Create 2 variable subscription products in Woo, one with 4 variations, other with 2, as represented in the images above
3. Draft a page and add a Checkout Button block each of the created products
4. Make sure "Allow the reader to select the variation before checkout." in the block setting is toggled on, so the variation selection becomes available
5. Visit the page, click the button for the 4 variations, and confirm it renders in 3 columns as above
6. Switch to mobile viewport (below 600 pixels of width) and confirm the options stack as above
8. Click "Purchase" on any variation and confirm the modal checkout renders for the selected variation
9. Exit the modal checkout, click the button for the 2 variations, and confirm it renders in 2 columns as above
10. Click "Purchase" and confirm the modal checkout renders as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
