### PR TITLE
fix: prevent get_the_content() on 404 pages to fix PHP 8.1 warnings

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -616,7 +616,10 @@ class Newspack_Blocks {
 		// Get all blocks and gather specificPosts ids of all eligible blocks.
 		global $newspack_blocks_all_specific_posts_ids;
 		if ( ! is_array( $newspack_blocks_all_specific_posts_ids ) ) {
-			$blocks                                 = parse_blocks( get_the_content() );
+			$blocks = [];
+			if ( ! is_404() ) {
+				$blocks = parse_blocks( get_the_content() );
+			}
 			$newspack_blocks_all_specific_posts_ids = self::get_specific_posts_from_blocks( $blocks, $block_name );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:

Fix these warnings new to PHP 8.1:
```
[17-Jan-2024 19:28:34 UTC] Warning: Trying to access array offset on value of type bool in /home/wpcom/public_html/wp-includes/post-template.php on line 354 [example.com/thispagedoesnotexist] [/plugins/editing-toolkit-plugin/prod/newspack-blocks/synced-newspack-blocks/class-newspack-blocks.php:621 get_the_content(), /plugins/editing-toolkit-plugin/prod/newspack-blocks/synced-newspack-blocks/blocks/homepage-articles/view.php:89 build_articles_query(), wp-includes/class-wp-block.php:263 newspack_blocks_render_block_homepage_articles(), wp-includes/blocks.php:1522 render(), wp-includes/blocks.php:1560 render_block(), wp-includes/class-wp-hook.php:326 do_blocks()
```

There are a large volume of these on WPCOM's test PHP 8.1 traffic and we'd like to reduce the number of warnings before upgrading PHP versions in order to not flood our tracking servers.

These warnings come from running `get_the_content()` on a 404 page.  I believe this is specific to WPCOM.

The fix here is relatively straightforward and will reduce the warning volume significantly.  Instead of running:
```
$blocks = parse_blocks( get_the_content() );
```
Since `get_the_content()` will return an empty string on a 404 page anyway, check to see if it's a 404 page before running `get_the_content()`:
```
			$blocks = [];
			if ( ! is_404() ) {
				$blocks = parse_blocks( get_the_content() );
			}
``` 

### How to test the changes in this Pull Request:

Apply D135062-code and see the testing directions in there.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
