### PR TITLE
feat(modal-checkout): pre-modal authentication

### DIFF
--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -168,21 +168,22 @@ domReady( () => {
 						modalContent.style.height = contentRect.top + contentRect.bottom + 'px';
 					}
 				} );
-				const doCheckout = reload => {
+				const openCheckout = ( submit = false ) => {
 					spinner.style.display = 'flex';
 					modalCheckout.classList.add( 'open' );
 					document.body.classList.add( 'newspack-modal-checkout-open' );
 					if ( window.newspackReaderActivation?.overlays ) {
 						modalCheckout.overlayId = window.newspackReaderActivation?.overlays.add();
 					}
-					if ( reload ) {
+					if ( submit ) {
 						form.submit();
 					}
 				};
 				if ( window.newspackReaderActivation?.doAuthModal ) {
+					ev.preventDefault();
 					window.newspackReaderActivation.doAuthModal( {
 						title: 'Complete your transaction',
-						callback: () => doCheckout( true ),
+						callback: () => openCheckout( true ),
 						skipSuccess: true,
 						labels: {
 							signin: {
@@ -195,7 +196,7 @@ domReady( () => {
 						content: '<p>Product Information Here</p>',
 					} );
 				} else {
-					doCheckout( false );
+					openCheckout( false );
 				}
 			} );
 		} );

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -159,13 +159,6 @@ domReady( () => {
 						return;
 					}
 				}
-				// Continue with checkout modal.
-				spinner.style.display = 'flex';
-				modalCheckout.classList.add( 'open' );
-				document.body.classList.add( 'newspack-modal-checkout-open' );
-				if ( window.newspackReaderActivation?.overlays ) {
-					modalCheckout.overlayId = window.newspackReaderActivation?.overlays.add();
-				}
 				iframeResizeObserver = new ResizeObserver( entries => {
 					if ( ! entries || ! entries.length ) {
 						return;
@@ -175,6 +168,36 @@ domReady( () => {
 						modalContent.style.height = contentRect.top + contentRect.bottom + 'px';
 					}
 				} );
+				const doCheckout = reload => {
+					spinner.style.display = 'flex';
+					modalCheckout.classList.add( 'open' );
+					document.body.classList.add( 'newspack-modal-checkout-open' );
+					if ( window.newspackReaderActivation?.overlays ) {
+						modalCheckout.overlayId = window.newspackReaderActivation?.overlays.add();
+					}
+					if ( reload ) {
+						form.submit();
+					}
+				};
+				if ( window.newspackReaderActivation?.doAuthModal ) {
+					window.newspackReaderActivation.doAuthModal( {
+						title: 'Complete your transaction',
+						callback: () => doCheckout( true ),
+						initialState: 'register',
+						skipSuccess: true,
+						labels: {
+							signin: {
+								title: 'Sign in to complete transaction',
+							},
+							register: {
+								title: 'Complete your transaction',
+							},
+						},
+						content: '',
+					} );
+				} else {
+					doCheckout( false );
+				}
 			} );
 		} );
 	} );

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -183,7 +183,6 @@ domReady( () => {
 					window.newspackReaderActivation.doAuthModal( {
 						title: 'Complete your transaction',
 						callback: () => doCheckout( true ),
-						initialState: 'register',
 						skipSuccess: true,
 						labels: {
 							signin: {

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -179,9 +179,9 @@ domReady( () => {
 						form.submit();
 					}
 				};
-				if ( window.newspackReaderActivation?.doAuthModal ) {
+				if ( window.newspackReaderActivation?.openAuthModal ) {
 					ev.preventDefault();
-					window.newspackReaderActivation.doAuthModal( {
+					window.newspackReaderActivation.openAuthModal( {
 						title: 'Complete your transaction',
 						callback: () => openCheckout( true ),
 						skipSuccess: true,

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -192,7 +192,7 @@ domReady( () => {
 								title: 'Complete your transaction',
 							},
 						},
-						content: '',
+						content: '<p>Product Information Here</p>',
 					} );
 				} else {
 					doCheckout( false );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Implements the `openAuthModal( config )` function from https://github.com/Automattic/newspack-plugin/pull/2860 in the modal checkout.

Readers should authenticate before initiating the modal checkout.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
