### PR TITLE
fix(modal-checkout): treat express checkouts as modal checkouts

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -967,7 +967,8 @@ final class Modal_Checkout {
 		}
 
 		// Express checkout payment requests are separate requests, so they won't have the modal checkout flag. We'll have to check the HTTP_REFERER insteaad.
-		$is_express_checkout = ! empty( filter_input( INPUT_POST, 'payment_request_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+		$payment_request_type = filter_input( INPUT_POST, 'payment_request_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$is_express_checkout  = ! empty( $payment_request_type ) && in_array( $payment_request_type, [ 'apple_pay', 'google_pay', 'payment_request_api' ], true ); // Validate payment request types: https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/payment-methods/class-wc-stripe-payment-request.php#L529-L548.
 		if ( $is_express_checkout ) {
 			$referrer = isset( $_SERVER['HTTP_REFERER'] ) ? \esc_url_raw( \wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			if ( $referrer ) {

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -965,6 +965,11 @@ final class Modal_Checkout {
 		if ( ! $is_modal_checkout && isset( $_REQUEST['post_data'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$is_modal_checkout = strpos( $_REQUEST['post_data'], 'modal_checkout=1' ) !== false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		}
+
+		// Express checkout payments won't have the modal checkout flag even if triggered from the modal, so let's treat those as modal checkouts.
+		if ( ! $is_modal_checkout && ! empty( filter_input( INPUT_POST, 'payment_request_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) ) {
+			$is_modal_checkout = true;
+		}
 		return $is_modal_checkout;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes some issues with checkout when using express checkout methods (also called "payment requests" in Stripe terminology) in modal checkout. Our `is_modal_checkout` method isn't recognizing express checkout requests as being triggered by modal checkout, so there can be mismatches in the data we're providing via modal checkout and what WooCommerce would expect, thinking the checkout requests is happening via a standard checkout flow. This could affect any behavior we customize for the modal checkout, including:

- Required billing fields (e.g. if you partially set up Google Pay but don't add an address, and your site is set to not collect address fields during modal checkout, Woo might still throw errors about missing required address fields).
- Behavior we enforce to allow guest checkout and account registration during checkout

I'm not sure if this is the right answer, but this PR makes all express checkouts behave as modal checkouts. I couldn't figure out a way to differentiate between express checkout requests from modal checkout vs. standard, but if we have to choose it seems making it inherit modal checkout behavior is preferable.

### How to test the changes in this Pull Request:

1. There are some prerequisites for testing these features. Set up your local site with Newspack + Stripe Gateway for reader revenue. In the Stripe Gateway settings, make sure express checkout methods are enabled, and in your [connected Stripe account dashboard](https://dashboard.stripe.com/test/settings/payment_method_domains), make sure to whitelist your test site's domain.
2. To set up Apple Pay, you'll need to log into an Apple ID account on your dev machine and connect a real credit card with a valid billing address to your Apple Wallet. When completing transactions on a site where Stripe is set to test mode, the card won't be charged.
3. To set up Google Pay, you'll need to connect a real credit card + billing address to your Google account at https://pay.google.com/. You'll also need to log in with this Google account in your Chrome browser and enable account syncing and autofilling of both payment methods and credit cards in browser settings. After doing all this you may also have to clear all browser data and wait several minutes in order for these things to take effect.
4. Test Apple Pay: on `release`, visit your site in Safari and make a donation. You should be able to see the "Buy with Apple Pay" button and use it to complete the transaction.

<img width="651" alt="Screenshot 2024-01-26 at 4 12 40 PM" src="https://github.com/Automattic/newspack-blocks/assets/2230142/6f558a48-fc2b-4ecf-82ac-1685979155d3">

6. Still on `release`, open a new session and attempt to complete another transaction with Apple Pay. This time you should see an error stating "An account is already registered with your email address. Please log in" even though modal checkout should allow the unauthenticated checkout to occur.
7. Check out this branch and repeat step 6. Confirm that it completes this time, and that the order/subscription is tied to the same reader account in WP admin.
8. Try to test with Google Pay in Chrome, too, but this is a bit more challenging to make appear. The logic/behavior should be the same as Apple Pay.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
