### PR TITLE
fix(homepage-articles): use map_deep to construct articles_rest_url and resolve PHP 8.1 warnings

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -320,11 +320,11 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 
 	$articles_rest_url = add_query_arg(
 		array_merge(
-			array_map(
+			map_deep(
+				$attributes,
 				function( $attribute ) {
 					return false === $attribute ? '0' : $attribute;
-				},
-				$attributes
+				}
 			),
 			[
 				'page' => 2,


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

The `newspack_blocks_render_block_homepage_articles()` function does this:

```php
	$articles_rest_url = add_query_arg(
		array_merge(
			array_map(
				function( $attribute ) {
					return false === $attribute ? '0' : $attribute;
				},
				$attributes
			),
			[
				'page' => 2,
			]
		),
		rest_url( '/newspack-blocks/v1/articles' )
	);
```

However, array_map only works one level deep into arrays. When nested arrays are passed in, this code converts the sub array's value to the string "Array" which generates a warning:
```
[30-Jan-2024 18:51:17 UTC] Warning: Array to string conversion in (...)/wp-content/plugins/editing-toolkit-plugin/prod/newspack-blocks/synced-newspack-blocks/blocks/homepage-articles/view.php on line 160 
```

Fix: Use `map_deep()` from WordPress instead ( https://developer.wordpress.org/reference/functions/map_deep/ ).

Example of one of the values passed in that causes this warning, before and after the mapping:
```
    [before] => Array                                                                                                       
        (                                                                                                                   
            [action] => hide                                                                                                
            [rules] => Array                                                                                                
                (                                                                                                           
                    [0] => Array                                                                                            
                        (                                                                                                   
                            [major] => category                                                                             
                            [minor] => 22388                                                                                
                        )                                                                                                   
                                                                                                                            
                )                                                                                                           
                                                                                                                            
            [match_all] => 0                                                                                                
        )                                                                                                                   

    [after] => Array
        (
            [action] => hide
            [rules] => Array
            [match_all] => 0
        )

```
Notice that $v['rules'] is transformed from an actual array to the string `Array`.


### How to test the changes in this Pull Request:

1. See D136469-code for an example of this applied to WPCOM, with specific sites listed that exhibit the warning and testing directions.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
