### PR TITLE
feat(ci): add `epic/*` release workflow and rename `master` to `trunk`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - trunk
       - newspack/release:
           requires:
             - newspack/build
@@ -34,6 +34,7 @@ workflows:
                 - release
                 - alpha
                 - /^hotfix\/.*/
+                - /^epic\/.*/
       - newspack/post-release:
           requires:
             - newspack/release

--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -2,7 +2,7 @@
 
 branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
 
-if [[ "$branch" = "master" ]]; then
-    echo "Error: pushing directly to the master branch is prohibited"
+if [[ "$branch" = "trunk" ]]; then
+    echo "Error: pushing directly to the trunk branch is prohibited"
     exit 1
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"html-entities": "^2.4.0",
 				"identity-obj-proxy": "^3.0.0",
 				"lint-staged": "^15.2.0",
-				"newspack-scripts": "^5.2.1",
+				"newspack-scripts": "^5.3.0",
 				"postcss-scss": "^4.0.9",
 				"prettier": "npm:wp-prettier@^2.6.2-beta-1",
 				"stylelint": "^15.11.0"
@@ -20035,9 +20035,9 @@
 			}
 		},
 		"node_modules/newspack-scripts": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.2.1.tgz",
-			"integrity": "sha512-aNgntGMEQJVMo28Hjf4PKqnJsiGGqvbvicvbYidj6Ihw71AmyqCqC68MTbvmmmP+6wmw+mE8UjXkuO7P9XkVJg==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.3.0.tgz",
+			"integrity": "sha512-rzvctV0e2QCRZOlRNyudCIGOkcK5XiqXZODuqtICDIh+bNyARxCDfpjJZPT1UUTdDXIsM/McH68ItHy3aa08aQ==",
 			"dev": true,
 			"dependencies": {
 				"@automattic/calypso-build": "^10.0.0",
@@ -45781,9 +45781,9 @@
 			}
 		},
 		"newspack-scripts": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.2.1.tgz",
-			"integrity": "sha512-aNgntGMEQJVMo28Hjf4PKqnJsiGGqvbvicvbYidj6Ihw71AmyqCqC68MTbvmmmP+6wmw+mE8UjXkuO7P9XkVJg==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.3.0.tgz",
+			"integrity": "sha512-rzvctV0e2QCRZOlRNyudCIGOkcK5XiqXZODuqtICDIh+bNyARxCDfpjJZPT1UUTdDXIsM/McH68ItHy3aa08aQ==",
 			"dev": true,
 			"requires": {
 				"@automattic/calypso-build": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"html-entities": "^2.4.0",
 		"identity-obj-proxy": "^3.0.0",
 		"lint-staged": "^15.2.0",
-		"newspack-scripts": "^5.2.1",
+		"newspack-scripts": "^5.3.0",
 		"postcss-scss": "^4.0.9",
 		"prettier": "npm:wp-prettier@^2.6.2-beta-1",
 		"stylelint": "^15.11.0"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1. Adds a new `epic/*` release workflow for creating release builds that we can use for beta testing and other QA purposes. This workflow is similar to `alpha` and `hotfix/*` workflows, but kind of in between them.
2. Renames the `master` branch to `trunk`.

### How to test the changes in this Pull Request:

Follow testing instructions in https://github.com/Automattic/newspack-plugin/pull/2895, but for the Newspack Blocks repo.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
