### PR TITLE
fix(author-blocks): handle HTML in author bio

### DIFF
--- a/src/blocks/author-profile/single-author.js
+++ b/src/blocks/author-profile/single-author.js
@@ -4,6 +4,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { RawHTML } from '@wordpress/element';
 
 /**
  * External dependencies
@@ -91,7 +92,7 @@ export const SingleAuthor = ( { author, attributes } ) => {
 				) }
 				{ showBio && author.bio && (
 					<p>
-						{ author.bio }{ ' ' }
+						<RawHTML>{ author.bio } </RawHTML>
 						{ showArchiveLink && (
 							<a href="#" className="no-op">
 								{ __( 'More by', 'newspack-blocks' ) + ' ' + author.name }

--- a/src/blocks/author-profile/single-author.js
+++ b/src/blocks/author-profile/single-author.js
@@ -5,6 +5,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { RawHTML } from '@wordpress/element';
+import { autop } from '@wordpress/autop';
 
 /**
  * External dependencies
@@ -92,7 +93,7 @@ export const SingleAuthor = ( { author, attributes } ) => {
 				) }
 				{ showBio && author.bio && (
 					<p>
-						<RawHTML>{ author.bio } </RawHTML>
+						<RawHTML>{ autop( author.bio ) } </RawHTML>
 						{ showArchiveLink && (
 							<a href="#" className="no-op">
 								{ __( 'More by', 'newspack-blocks' ) + ' ' + author.name }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds HTML handling to the editing part of author blocks. 

See 1200550061930446-as-1205128714156103/f

### How to test the changes in this Pull Request:

1. Edit an author and insert some HTML in their bio
2. Insert Author Profile and Author List blocks on a page, and set them to display the edited author 
3. Observe the HTML is rendered correctly in the editor

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->