### PR TITLE
fix: correct carousel button styles in editor

### DIFF
--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -250,8 +250,8 @@ class Edit extends Component {
 						<Fragment>
 							{ autoplay && (
 								<Fragment>
-									<button ref={ this.btnPauseRef } />
-									<button ref={ this.btnPlayRef } />
+									<button className="swiper-button swiper-button-pause" ref={ this.btnPauseRef } />
+									<button className="swiper-button swiper-button-play" ref={ this.btnPlayRef } />
 								</Fragment>
 							) }
 							<div className="swiper-wrapper">
@@ -339,8 +339,8 @@ class Edit extends Component {
 							</div>
 							{ ! hasNoPosts && ! hasOnePost && (
 								<>
-									<button className="swiper-button-prev" ref={ this.btnPrevRef } />
-									<button className="swiper-button-next" ref={ this.btnNextRef } />
+									<button className="swiper-button-prev swiper-button" ref={ this.btnPrevRef } />
+									<button className="swiper-button-next swiper-button" ref={ this.btnNextRef } />
 									<div
 										className="swiper-pagination swiper-pagination-bullets"
 										ref={ this.paginationRef }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a minor display issue with the Post Carousel block in the editor. 

See 1200550061930446-as-1206209020023321

### How to test the changes in this Pull Request:

1. Add a Post Carousel block to the editor, and enable AutoPlay (so the play/pause button appears over the carousel).
2. Publish the page and compare the editor to the front-end -- note that the previous/next buttons in the editor look weird, and the play/pause buttons are not styled at all, and appear above the slideshow on the left:

![image](https://github.com/Automattic/newspack-blocks/assets/177561/fb8bc3a0-bc04-48a0-85bc-e519528da034)

3. Apply the PR and run `npm run build`.
4. Confirm that the buttons in the editor match the appearance of the front-end; as part of this, pause the slideshow in the editor and confirm it displays a normal looking play button instead of the pause button:

![image](https://github.com/Automattic/newspack-blocks/assets/177561/3299f70e-7b06-459d-bba7-fd7a4c123839)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
