### PR TITLE
 fix: avoid use of @wordpress modules on front-end 

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -416,7 +416,17 @@ final class Modal_Checkout {
 			[
 				'newspack_class_prefix' => self::get_class_prefix(),
 				'labels'                => [
-					'auth_modal_title' => self::get_modal_title(),
+					'auth_modal_title'     => self::get_modal_title(),
+					'signin_modal_title'   => _x(
+						'Sign in to complete transaction',
+						'Login modal title when logged out user attempts to checkout.',
+						'newspack-blocks'
+					),
+					'register_modal_title' => _x(
+						'Register to complete transaction',
+						'Login modal title when unregistered user attempts to checkout',
+						'newspack-blocks'
+					),
 				],
 			]
 		);

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -1,7 +1,5 @@
 /* globals newspackBlocksModal */
 
-import { _x } from '@wordpress/i18n';
-
 /**
  * Style dependencies
  */
@@ -220,18 +218,10 @@ domReady( () => {
 							skipSuccess: true,
 							labels: {
 								signin: {
-									title: _x(
-										'Sign in to complete transaction',
-										'Login modal title when logged out user attempts to checkout.',
-										'newspack-blocks'
-									),
+									title: newspackBlocksModal.labels.signin_modal_title,
 								},
 								register: {
-									title: _x(
-										'Register to complete transaction',
-										'Login modal title when unregistered user attempts to checkout',
-										'newspack-blocks'
-									),
+									title: newspackBlocksModal.labels.register_modal_title,
 								},
 							},
 						} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

I'm not sure this is 100% true all the time, but at least on my local site `@wordpress/*` JS packages are not automatically present on the front-end unless explicitly enqueued, and in my experience tend to be pretty bloated and non-performant for front-end purposes anyway. This change avoids a potential unhandled JS error if `@wordpress/i18n` can't be loaded on the front-end, and moves the string translation functions to the back-end where we can be certain `_x()` already exists.

### How to test the changes in this Pull Request:

Confirm that the strings translated via `_x()` and localized to the `newspackBlocksModal.labels` object display correctly when loading a checkout modal.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
