### PR TITLE
fix(modal-checkout): ensure customer location when state is required but country is not

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1028,9 +1028,11 @@ final class Modal_Checkout {
 		}
 
 		// If billing state is required but billing country is not, we need to ensure a default location is set.
-		$billing_fields = get_option( Donations::DONATION_BILLING_FIELDS_OPTION, [] );
-		if ( ! in_array( 'billing_country', $billing_fields, true ) && in_array( 'billing_state', $billing_fields, true ) ) {
-			return 'base';
+		if ( defined( '\Newspack\Donations::DONATION_BILLING_FIELDS_OPTION' ) ) {
+			$billing_fields = get_option( \Newspack\Donations::DONATION_BILLING_FIELDS_OPTION, [] );
+			if ( ! in_array( 'billing_country', $billing_fields, true ) && in_array( 'billing_state', $billing_fields, true ) ) {
+				return 'base';
+			}
 		}
 
 		return $option_value;

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -51,6 +51,8 @@ final class Modal_Checkout {
 		add_filter( 'wcs_place_subscription_order_text', [ __CLASS__, 'order_button_text' ], 1 );
 		add_filter( 'woocommerce_order_button_text', [ __CLASS__, 'order_button_text' ] );
 		add_filter( 'option_woocommerce_subscriptions_order_button_text', [ __CLASS__, 'order_button_text' ] );
+		add_action( 'option_woocommerce_default_customer_address', [ __CLASS__, 'ensure_base_default_customer_address' ] );
+		add_action( 'default_option_woocommerce_default_customer_address', [ __CLASS__, 'ensure_base_default_customer_address' ] );
 
 		/** Custom handling for registered users. */
 		add_filter( 'woocommerce_checkout_customer_id', [ __CLASS__, 'associate_existing_user' ] );
@@ -994,6 +996,44 @@ final class Modal_Checkout {
 			return __( 'Donate now', 'newspack-blocks' );
 		}
 		return $text;
+	}
+
+	/**
+	 * Force option for base country for new customers if unset and billing country optional while state is required
+	 * unless the NEWSPACK_PREVENT_FORCE_BASE_DEFAULT_CUSTOMER_ADDRESS constant is set.
+	 *
+	 * If this option is empty AND billing state is set as a required field AND billing country is not,
+	 * validation of the state value will fail during modal checkout.
+	 *
+	 * See Default Customer Location in: https://woo.com/document/configuring-woocommerce-settings/#general-options
+	 *
+	 * @param string $option_value The value of the default customer address option.
+	 *
+	 * @return string Option value.
+	 */
+	public static function ensure_base_default_customer_address( $option_value ) {
+		// If the option is set, we're good.
+		if ( ! empty( $option_value ) ) {
+			return $option_value;
+		}
+
+		// Only in modal checkout.
+		if ( ! self::is_modal_checkout() ) {
+			return $option_value;
+		}
+
+		// Escape hatch in case we want the standard behavior even in modal checkout.
+		if ( defined( 'NEWSPACK_PREVENT_FORCE_BASE_DEFAULT_CUSTOMER_ADDRESS' ) && NEWSPACK_PREVENT_FORCE_BASE_DEFAULT_CUSTOMER_ADDRESS ) {
+			return $option_value;
+		}
+
+		// If billing state is required but billing country is not, we need to ensure a default location is set.
+		$billing_fields = get_option( Donations::DONATION_BILLING_FIELDS_OPTION, [] );
+		if ( ! in_array( 'billing_country', $billing_fields, true ) && in_array( 'billing_state', $billing_fields, true ) ) {
+			return 'base';
+		}
+
+		return $option_value;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Alternative version of https://github.com/Automattic/newspack-plugin/pull/2960, but isolated only to modal checkout instances.

### How to test the changes in this Pull Request:

Follow testing instructions ins https://github.com/Automattic/newspack-plugin/pull/2960

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
