### PR TITLE
fix: show credit option for homepage posts & carousel blocks

### DIFF
--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -74,16 +74,6 @@ class Newspack_Blocks_API {
 	}
 
 	/**
-	 * Get thumbnail featured image captions for the rest field.
-	 *
-	 * @param array $object_info The object info.
-	 * @return string|null Image caption on success, null on failure.
-	 */
-	public static function newspack_blocks_get_image_caption( $object_info ) {
-		return (int) $object_info['featured_media'] > 0 ? trim( wp_get_attachment_caption( $object_info['featured_media'] ) ) : null;
-	}
-
-	/**
 	 * Get author info for the rest field.
 	 *
 	 * @param array $object_info The object info.
@@ -320,7 +310,7 @@ class Newspack_Blocks_API {
 				'newspack_article_classes'          => Newspack_Blocks::get_term_classes( $data['id'] ),
 				'newspack_author_info'              => self::newspack_blocks_get_author_info( $data ),
 				'newspack_category_info'            => self::newspack_blocks_get_primary_category( $data ),
-				'newspack_featured_image_caption'   => self::newspack_blocks_get_image_caption( $data ),
+				'newspack_featured_image_caption'   => Newspack_Blocks::get_image_caption( $data['featured_media'], $attributes['showCaption'], $attributes['showCredit'] ),
 				'newspack_featured_image_src'       => self::newspack_blocks_get_image_src( $data ),
 				'newspack_has_custom_excerpt'       => self::newspack_blocks_has_custom_excerpt( $data ),
 				'newspack_post_sponsors'            => self::newspack_blocks_sponsor_info( $data ),

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -1615,10 +1615,15 @@ class Newspack_Blocks {
 			$credit = \Newspack\Newspack_Image_Credits::get_media_credit_string( $attachment_id );
 		}
 
+		$full_caption = trim( $caption . ' ' . $credit );
+		if ( empty( $full_caption ) ) {
+			return '';
+		}
+
 		$combined_caption = sprintf(
-			'<figcaption>%1$s %2$s</figcaption>',
-			$caption,
-			$credit
+			'<figcaption%1$s>%2$s</figcaption>',
+			! empty( $credit ) ? ' class="has-credit"' : '',
+			$full_caption
 		);
 
 		return $combined_caption;

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -1593,5 +1593,35 @@ class Newspack_Blocks {
 
 		return '<span class="wpbnbd__tiers__amount__value">' . $wc_formatted_amount . '</span>';
 	}
+
+	/**
+	 * Get an image caption, optionally with credit appended.
+	 *
+	 * @param int  $attachment_id Attachment ID of the image.
+	 * @param bool $include_caption Whether to include the caption.
+	 * @param bool $include_credit Whether to include the credit.
+	 *
+	 * @return string
+	 */
+	public static function get_image_caption( $attachment_id = null, $include_caption = true, $include_credit = false ) {
+		if ( ! $attachment_id || ( ! $include_caption && ! $include_credit ) ) {
+			return '';
+		}
+
+		$caption = $include_caption ? wp_get_attachment_caption( $attachment_id ) : '';
+		$credit  = '';
+
+		if ( $include_credit && method_exists( 'Newspack\Newspack_Image_Credits', 'get_media_credit_string' ) ) {
+			$credit = \Newspack\Newspack_Image_Credits::get_media_credit_string( $attachment_id );
+		}
+
+		$combined_caption = sprintf(
+			'<figcaption>%1$s %2$s</figcaption>',
+			$caption,
+			$credit
+		);
+
+		return $combined_caption;
+	}
 }
 Newspack_Blocks::init();

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -161,6 +161,8 @@ class Edit extends Component {
 			showDate,
 			showAuthor,
 			showAvatar,
+			showCaption,
+			showCredit,
 			showTitle,
 			slidesPerView,
 			specificMode,
@@ -280,7 +282,9 @@ class Edit extends Component {
 											showCategory ||
 											showTitle ||
 											showAuthor ||
-											showDate ) && (
+											showDate ||
+											showCaption ||
+											showCredit ) && (
 											<div className="entry-wrapper">
 												{ ( post.newspack_post_sponsors ||
 													( showCategory && 0 < post.newspack_category_info.length ) ) && (
@@ -331,6 +335,14 @@ class Edit extends Component {
 															{ dateI18n( dateFormat, post.date ) }
 														</time>
 													) }
+													{ ( showCaption || showCredit ) && post.newspack_featured_image_caption && (
+														<div
+															className="entry-caption"
+															dangerouslySetInnerHTML={ {
+																__html: post.newspack_featured_image_caption,
+															} }
+														/>
+													) }
 												</div>
 											</div>
 										) }
@@ -339,8 +351,8 @@ class Edit extends Component {
 							</div>
 							{ ! hasNoPosts && ! hasOnePost && (
 								<>
-									<button className="swiper-button-prev" ref={ this.btnPrevRef } />
-									<button className="swiper-button-next" ref={ this.btnNextRef } />
+									<button className="swiper-button swiper-button-prev" ref={ this.btnPrevRef } />
+									<button className="swiper-button swiper-button-next" ref={ this.btnNextRef } />
 									<div
 										className="swiper-pagination swiper-pagination-bullets"
 										ref={ this.paginationRef }
@@ -534,6 +546,20 @@ class Edit extends Component {
 								/>
 							</PanelRow>
 						) }
+						<PanelRow>
+							<ToggleControl
+								label={ __( 'Show Featured Image Caption', 'newspack-blocks' ) }
+								checked={ showCaption }
+								onChange={ () => setAttributes( { showCaption: ! showCaption } ) }
+							/>
+						</PanelRow>
+						<PanelRow>
+							<ToggleControl
+								label={ __( 'Show Featured Image Credit', 'newspack-blocks' ) }
+								checked={ showCredit }
+								onChange={ () => setAttributes( { showCredit: ! showCredit } ) }
+							/>
+						</PanelRow>
 					</PanelBody>
 					<PostTypesPanel attributes={ attributes } setAttributes={ setAttributes } />
 					<PostStatusesPanel attributes={ attributes } setAttributes={ setAttributes } />

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -86,6 +86,14 @@ export const settings = {
 			type: 'boolean',
 			default: true,
 		},
+		showCaption: {
+			type: 'boolean',
+			default: false,
+		},
+		showCredit: {
+			type: 'boolean',
+			default: false,
+		},
 		showCategory: {
 			type: 'boolean',
 			default: false,

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -196,10 +196,13 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 								);
 							endif;
 							if ( $show_caption || $show_credit ) :
-								?>
-								<div class="entry-caption">
-									<?php echo wp_kses_post( Newspack_Blocks::get_image_caption( get_post_thumbnail_id(), $show_caption, $show_credit ) ); ?>
-								<?php
+								$full_caption = Newspack_Blocks::get_image_caption( get_post_thumbnail_id(), $show_caption, $show_credit );
+								if ( $full_caption ) :
+									?>
+									<div class="entry-caption">
+										<?php echo wp_kses_post( $full_caption ); ?>
+									<?php
+								endif;
 							endif;
 							?>
 						</div><!-- .entry-meta -->

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -68,6 +68,8 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 			$hide_publish_date = apply_filters( 'newspack_listings_hide_publish_date', false ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 			$show_author       = $attributes['showAuthor'] && ! $hide_author;
 			$show_date         = $attributes['showDate'] && ! $hide_publish_date;
+			$show_caption      = $attributes['showCaption'];
+			$show_credit       = $attributes['showCredit'];
 
 			// Validate the value of the "image fit" attribute.
 			$image_fits = [ 'cover', 'contain' ];
@@ -100,7 +102,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 					<?php endif; ?>
 				</figure>
 
-				<?php if ( ! empty( $sponsors ) || $attributes['showCategory'] || $attributes['showTitle'] || $show_author || $show_date ) : ?>
+				<?php if ( ! empty( $sponsors ) || $attributes['showCategory'] || $attributes['showTitle'] || $show_author || $show_date || $show_caption || $show_credit ) : ?>
 					<div class="entry-wrapper">
 						<?php if ( ! empty( $sponsors ) || $attributes['showCategory'] ) : ?>
 							<div class="cat-links <?php if ( ! empty( $sponsors ) ) : ?>sponsor-label<?php endif; // phpcs:ignore Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace ?>">
@@ -192,6 +194,12 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 									esc_attr( get_the_date( DATE_W3C ) ),
 									esc_html( get_the_date() )
 								);
+							endif;
+							if ( $show_caption || $show_credit ) :
+								?>
+								<div class="entry-caption">
+									<?php echo wp_kses_post( Newspack_Blocks::get_image_caption( get_post_thumbnail_id(), $show_caption, $show_credit ) ); ?>
+								<?php
 							endif;
 							?>
 						</div><!-- .entry-meta -->
@@ -349,6 +357,14 @@ function newspack_blocks_register_carousel() {
 					'showAvatar'       => array(
 						'type'    => 'boolean',
 						'default' => true,
+					),
+					'showCaption'      => array(
+						'type'    => 'boolean',
+						'default' => false,
+					),
+					'showCredit'       => array(
+						'type'    => 'boolean',
+						'default' => false,
 					),
 					'showCategory'     => array(
 						'type'    => 'boolean',

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -77,6 +77,21 @@
 				}
 			}
 		}
+
+		.entry-caption {
+			margin-top: 1em;
+			width: 100%;
+
+			figcaption {
+				color: #fff;
+				font-size: 0.75em;
+
+				a {
+					font-weight: 400;
+					text-decoration: underline;
+				}
+			}
+		}
 	}
 	.post-thumbnail {
 		margin: 0;

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -79,12 +79,13 @@
 		}
 
 		.entry-caption {
-			margin-top: 1em;
+			margin-top: var( --wp--preset--spacing--00, var( --wp--preset--spacing--20, 0.5rem ) );
 			width: 100%;
 
 			figcaption {
 				color: #fff;
-				font-size: 0.75em;
+				font-size: var( --wp--preset--font-size--x-small, var( --newspack-theme-font-size-sm, 0.8em ) );
+				line-height: var( --wp--custom--line-height--x-small, var( --newspack-theme-font-line-height-body, 1.6 ) );
 
 				a {
 					font-weight: 400;

--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -34,6 +34,10 @@
 			"type": "boolean",
 			"default": false
 		},
+		"showCredit": {
+			"type": "boolean",
+			"default": false
+		},
 		"disableImageLazyLoad": {
 			"type": "boolean",
 			"default": false
@@ -93,12 +97,16 @@
 		"authors": {
 			"type": "array",
 			"default": [],
-			"items": { "type": "integer" }
+			"items": {
+				"type": "integer"
+			}
 		},
 		"categories": {
 			"type": "array",
 			"default": [],
-			"items": { "type": "integer" }
+			"items": {
+				"type": "integer"
+			}
 		},
 		"includeSubcategories": {
 			"type": "boolean",
@@ -107,7 +115,9 @@
 		"tags": {
 			"type": "array",
 			"default": [],
-			"items": { "type": "integer" }
+			"items": {
+				"type": "integer"
+			}
 		},
 		"customTaxonomies": {
 			"type": "array",
@@ -130,12 +140,16 @@
 		"tagExclusions": {
 			"type": "array",
 			"default": [],
-			"items": { "type": "integer" }
+			"items": {
+				"type": "integer"
+			}
 		},
 		"categoryExclusions": {
 			"type": "array",
 			"default": [],
-			"items": { "type": "integer" }
+			"items": {
+				"type": "integer"
+			}
 		},
 		"customTaxonomyExclusions": {
 			"type": "array",
@@ -158,7 +172,9 @@
 		"specificPosts": {
 			"type": "array",
 			"default": [],
-			"items": { "type": "integer" }
+			"items": {
+				"type": "integer"
+			}
 		},
 		"typeScale": {
 			"type": "integer",
@@ -198,8 +214,12 @@
 		},
 		"postType": {
 			"type": "array",
-			"default": [ "post" ],
-			"items": { "type": "string" }
+			"default": [
+				"post"
+			],
+			"items": {
+				"type": "string"
+			}
 		},
 		"textAlign": {
 			"type": "string",
@@ -207,8 +227,12 @@
 		},
 		"includedPostStatuses": {
 			"type": "array",
-			"default": [ "publish" ],
-			"items": { "type": "string" }
+			"default": [
+				"publish"
+			],
+			"items": {
+				"type": "string"
+			}
 		},
 		"deduplicate": {
 			"type": "boolean",

--- a/src/blocks/homepage-articles/edit.js
+++ b/src/blocks/homepage-articles/edit.js
@@ -111,6 +111,7 @@ class Edit extends Component {
 			mediaPosition,
 			minHeight,
 			showCaption,
+			showCredit,
 			showExcerpt,
 			showReadMore,
 			readMoreLabel,
@@ -164,8 +165,12 @@ class Edit extends Component {
 								<img src={ post.newspack_featured_image_src.uncropped } alt="" />
 							) }
 						</a>
-						{ showCaption && '' !== post.newspack_featured_image_caption && (
-							<figcaption>{ post.newspack_featured_image_caption }</figcaption>
+						{ ( showCaption || showCredit ) && (
+							<div
+								dangerouslySetInnerHTML={ {
+									__html: post.newspack_featured_image_caption,
+								} }
+							/>
 						) }
 					</figure>
 				) }
@@ -273,6 +278,7 @@ class Edit extends Component {
 			postType,
 			showImage,
 			showCaption,
+			showCredit,
 			imageScale,
 			mobileStack,
 			minHeight,
@@ -458,13 +464,22 @@ class Edit extends Component {
 					</PanelRow>
 
 					{ showImage && (
-						<PanelRow>
-							<ToggleControl
-								label={ __( 'Show Featured Image Caption', 'newspack-blocks' ) }
-								checked={ showCaption }
-								onChange={ () => setAttributes( { showCaption: ! showCaption } ) }
-							/>
-						</PanelRow>
+						<>
+							<PanelRow>
+								<ToggleControl
+									label={ __( 'Show Featured Image Caption', 'newspack-blocks' ) }
+									checked={ showCaption }
+									onChange={ () => setAttributes( { showCaption: ! showCaption } ) }
+								/>
+							</PanelRow>
+							<PanelRow>
+								<ToggleControl
+									label={ __( 'Show Featured Image Credit', 'newspack-blocks' ) }
+									checked={ showCredit }
+									onChange={ () => setAttributes( { showCredit: ! showCredit } ) }
+								/>
+							</PanelRow>
+						</>
 					) }
 
 					{ showImage && mediaPosition !== 'top' && mediaPosition !== 'behind' && (

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -79,8 +79,8 @@ call_user_func(
 				</a>
 				<?php endif; ?>
 
-				<?php if ( $attributes['showCaption'] && '' !== get_the_post_thumbnail_caption() ) : ?>
-					<figcaption><?php the_post_thumbnail_caption(); ?></figcaption>
+				<?php if ( $attributes['showCaption'] || $attributes['showCredit'] ) : ?>
+					<?php echo wp_kses_post( Newspack_Blocks::get_image_caption( get_post_thumbnail_id(), $attributes['showCaption'], $attributes['showCredit'] ) ); ?>
 				<?php endif; ?>
 			</figure><!-- .featured-image -->
 		<?php endif; ?>

--- a/src/blocks/homepage-articles/utils.ts
+++ b/src/blocks/homepage-articles/utils.ts
@@ -40,6 +40,8 @@ const POST_QUERY_ATTRIBUTES = [
 	'postType',
 	'includedPostStatuses',
 	'deduplicate',
+	'showCaption',
+	'showCredit',
 ];
 
 type HomepageArticlesAttributes = {
@@ -57,6 +59,8 @@ type HomepageArticlesAttributes = {
 	tagExclusions: TagId[];
 	categoryExclusions: CategoryId[];
 	customTaxonomyExclusions: Taxonomy[];
+	showCaption: boolean;
+	showCredit: boolean;
 };
 
 type HomepageArticlesProps = {
@@ -96,6 +100,8 @@ export const queryCriteriaFromAttributes = ( attributes: Block[ 'attributes' ] )
 		excerptLength,
 		postType,
 		showExcerpt,
+		showCaption,
+		showCredit,
 		tags,
 		customTaxonomies,
 		specificPosts = [],
@@ -132,6 +138,8 @@ export const queryCriteriaFromAttributes = ( attributes: Block[ 'attributes' ] )
 	);
 	criteria.excerptLength = excerptLength;
 	criteria.showExcerpt = showExcerpt;
+	criteria.showCaption = showCaption;
+	criteria.showCredit = showCredit;
 	return criteria;
 };
 
@@ -155,6 +163,7 @@ export const getBlockQueries = (
 		const homepageArticleBlocks = [];
 		if ( blockNames.indexOf( block.name ) >= 0 ) {
 			const postsQuery = queryCriteriaFromAttributes( block.attributes );
+			console.log( postsQuery );
 			homepageArticleBlocks.push( { postsQuery, clientId: block.clientId } );
 		}
 		return homepageArticleBlocks.concat( getBlockQueries( block.innerBlocks, blockNames ) );

--- a/src/blocks/homepage-articles/utils.ts
+++ b/src/blocks/homepage-articles/utils.ts
@@ -163,7 +163,6 @@ export const getBlockQueries = (
 		const homepageArticleBlocks = [];
 		if ( blockNames.indexOf( block.name ) >= 0 ) {
 			const postsQuery = queryCriteriaFromAttributes( block.attributes );
-			console.log( postsQuery );
 			homepageArticleBlocks.push( { postsQuery, clientId: block.clientId } );
 		}
 		return homepageArticleBlocks.concat( getBlockQueries( block.innerBlocks, blockNames ) );

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -282,6 +282,9 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	if ( $attributes['showCaption'] ) {
 		$classes .= ' show-caption';
 	}
+	if ( $attributes['showCredit'] ) {
+		$classes .= ' show-credit';
+	}
 	if ( $attributes['showCategory'] ) {
 		$classes .= ' show-category';
 	}

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -346,10 +346,6 @@
 			text-overflow: ellipsis;
 			z-index: 3;
 
-			&.has-credit {
-				text-align: left;
-			}
-
 			@include mixins.media( desktop ) {
 				padding: 0 1.5rem;
 			}

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -345,6 +345,11 @@
 			text-align: right;
 			text-overflow: ellipsis;
 			z-index: 3;
+			
+			a,
+			a:visited {
+			    color: #fff;
+			}
 
 			@include mixins.media( desktop ) {
 				padding: 0 1.5rem;

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -344,7 +344,11 @@
 			right: 0;
 			text-align: right;
 			text-overflow: ellipsis;
-			z-index: 2;
+			z-index: 3;
+
+			&.has-credit {
+				text-align: left;
+			}
 
 			@include mixins.media( desktop ) {
 				padding: 0 1.5rem;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -38,6 +38,8 @@ declare global {
 		include?: PostId[];
 		excerptLength?: number;
 		showExcerpt?: boolean;
+		showCaption?: boolean,
+		showCredit?: boolean,
 	};
 
 	type Block = {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds new block attribute options to show credits for Homepage Posts and Post Carousel blocks (and to show captions for the latter, too).

Closes `1206709674365921/1206688511006431`.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Add a Homepage Posts block and a Post Carousel block to the page, and configure so they show articles with featured images that have captions and credits.
3. Enable captions + credits for both blocks and confirm the captions are shown in both editor and front-end context:

| Editor  | Front-end |
| ------------- | ------------- |
| <img width="1061" alt="Screenshot 2024-03-05 at 2 14 27 PM" src="https://github.com/Automattic/newspack-blocks/assets/2230142/5329e5d6-94f2-432e-af3a-b06642ade653">  | <img width="1216" alt="Screenshot 2024-03-05 at 2 19 19 PM" src="https://github.com/Automattic/newspack-blocks/assets/2230142/8ac70988-5db9-4b54-96c3-123b950974f6">  |

4. Play with different combinations of caption and/or credit and confirm that the right info appears as expected in both editor and front-end. Try:
  - Caption enabled, credit disabled
  - Caption disabled, credit enabled
  - Both disabled

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206688511006431