### PR TITLE
fix(author-profile): only display guest author profile when linked

### DIFF
--- a/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
+++ b/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
@@ -84,12 +84,13 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 		// Total number of users and guest authors.
 		$guest_author_total = 0;
 		$user_total         = 0;
-		$guest_authors = [];
-		$linked_guest_authors = [];
+		$guest_authors      = [];
+		$users              = [];
 
 		// Get Co-authors guest authors.
 		if ( $is_guest_author ) {
-			$guest_author_args = [
+			$unlinked_guest_authors = [];
+			$guest_author_args      = [
 				'post_type'      => 'guest-author',
 				'posts_per_page' => $per_page,
 				'offset'         => $offset,
@@ -98,45 +99,39 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 			if ( $search && ! $author_id ) {
 				$guest_author_args['s'] = $search;
 			}
+
 			if ( $author_id ) {
 				$guest_author_args['p'] = $author_id;
 			}
+
 			if ( $include ) {
 				$guest_author_args['post__in']            = $include;
 				$guest_author_args['ignore_sticky_posts'] = true;
 			}
 
-			$guest_authors      = get_posts( $guest_author_args );
+			$guest_authors = get_posts( $guest_author_args );
+
+			// We only want unlinked guest authors in guest_authors array.
+			foreach ( $guest_authors as $ga ) {
+				$linked_guest_author = get_post_meta( $ga->ID, 'cap-linked_account', true );
+
+				if ( $linked_guest_author ) {
+					continue;
+				}
+
+				$unlinked_guest_authors[] = $ga;
+			}
+
+			$guest_authors      = $unlinked_guest_authors;
 			$guest_author_total = count( $guest_authors );
 		}
 
-		foreach ( $guest_authors as $ga ) {
-			$linked_guest_author = get_post_meta( $ga->ID, 'cap-linked_account', true );
-
-			if ( $linked_guest_author ) {
-				$linked_guest_authors[] = $linked_guest_author;
-			}
-		}
-
-		$users = [];
-
 		// If passed an author ID.
-		if ( $author_id ) {
-			if ( 0 === $guest_author_total ) {
-				$user = get_user_by( 'id', $author_id ); // Get the WP user.
+		if ( $author_id && 0 === $guest_author_total ) {
+			$user = get_user_by( 'id', $author_id ); // Get the WP user.
 
-				// We have a WP user, let's use it.
-				if ( $user ) {
-					// But wait, there's more! Let's see if this user is linked to a guest author.
-					$linked_guest_author = self::get_linked_guest_author( $user->user_login );
-
-					// If it is, let's use that instead.
-					if ( $linked_guest_author ) {
-						$guest_authors = [ $linked_guest_author ];
-					} else {
-						$users = [ $user ];
-					}
-				}
+			if ( $user ) {
+				$users = [ $user ];
 			}
 		} else {
 			$user_args = [
@@ -160,6 +155,23 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 			$user_query = new \WP_User_Query( $user_args );
 			$users      = $user_query->get_results();
 			$user_total = $user_query->get_total();
+		}
+
+		if ( 0 < $user_total ) {
+			// But wait, there's more! Let's see if this user is linked to a guest author.
+			$unlinked_users = [];
+			foreach ( $users as $user ) {
+				$linked_guest_author = self::get_linked_guest_author( $user->user_login );
+
+				// If it is, let's use that instead.
+				if ( $linked_guest_author ) {
+					$guest_authors[] = $linked_guest_author;
+				} else {
+					$unlinked_users[] = $user;
+				}
+			}
+
+			$users = $unlinked_users;
 		}
 
 		// Format and combine results.
@@ -197,14 +209,8 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 			),
 			array_reduce(
 				$users,
-				function( $acc, $user ) use ( $fields, $avatar_hide_default, $linked_guest_authors ) {
+				function( $acc, $user ) use ( $fields, $avatar_hide_default ) {
 					if ( $user ) {
-
-						// This user is linked to a guest author already returned in the query, so skip it.
-						if ( in_array( $user->data->user_login, $linked_guest_authors, true ) ) {
-							return $acc;
-						}
-
 						$user_data = [
 							'id'         => intval( $user->data->ID ),
 							'registered' => $user->data->user_registered,

--- a/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
+++ b/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
@@ -111,27 +111,33 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 
 			$guest_authors = get_posts( $guest_author_args );
 
-			// We only want unlinked guest authors in guest_authors array.
-			foreach ( $guest_authors as $ga ) {
-				$linked_guest_author = get_post_meta( $ga->ID, 'cap-linked_account', true );
+			// If we are searching for a specific ID we want to return the guest author regardless of if it is linked or not.
+			if ( ! $author_id ) {
+				foreach ( $guest_authors as $ga ) {
+					$linked_guest_author = get_post_meta( $ga->ID, 'cap-linked_account', true );
 
-				if ( $linked_guest_author ) {
-					continue;
+					if ( $linked_guest_author ) {
+						continue;
+					}
+
+					$unlinked_guest_authors[] = $ga;
 				}
 
-				$unlinked_guest_authors[] = $ga;
+				$guest_authors = $unlinked_guest_authors;
 			}
 
-			$guest_authors      = $unlinked_guest_authors;
 			$guest_author_total = count( $guest_authors );
 		}
 
-		// If passed an author ID.
-		if ( $author_id && 0 === $guest_author_total ) {
-			$user = get_user_by( 'id', $author_id ); // Get the WP user.
+		// If we are searching for a specific ID we just want to return the specific user.
+		if ( $author_id ) {
+			// Unless we've already identified a guest author.
+			if ( 0 === $guest_author_total ) {
+				$user = get_user_by( 'id', $author_id ); // Get the WP user.
 
-			if ( $user ) {
-				$users = [ $user ];
+				if ( $user ) {
+					$users = [ $user ];
+				}
 			}
 		} else {
 			$user_args = [


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes [0/1206709674365921/1205704843507324/f](https://app.asana.com/0/1206709674365921/1205704843507324/f)

This PR addresses an issue where it was possible to select a WP user account that was linked to a guest author account in the author profile block. Previously we weren't correctly filtering out linked WP users in the block whenever a search term was input that matched the WP user but not the linked guest author.

This PR fixes this by changing the strategy for fetching authors to first fetch only unlinked guest authors, then fetch users, and finally swap out any linked WP users with their respective guest author accounts.

![Screenshot 2024-03-06 at 14 50 34](https://github.com/Automattic/newspack-blocks/assets/17905991/220ef421-cea4-42d8-949e-86874f187400)

### How to test the changes in this Pull Request:

1. With Co-Authors Plus installed, add some guest authors and link them to some WP users that are at least author roles. Make sure you also have some unlinked authors as well. Also make sure the names are very different from one another (i.e. `I Am Author` / `The Best Guest`)
2. Add an Author Profile block to any page and search for a linked WP author. Confirm there are no results in the suggestion dropdown and you cannot select the linked WP author.
4. Now search for the corresponding guest author. Confirm the author does appear in the dropdown and is selectable.
5. Confirm the correct Guest Author info appears in the block in both the editor and site front end.
6. Repeat the above steps for a non-linked author and confirm you are able to select this account as well
7. Do some additional smoke tests with other accounts with different naming similarity levels (i.e. `Test Author` / `Test Guest Author`)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205704843507324