### PR TITLE
fix: add encoding to all attributes in rest URL

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -326,7 +326,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 			map_deep(
 				$attributes,
 				function( $attribute ) {
-					return false === $attribute ? '0' : $attribute;
+					return false === $attribute ? '0' : rawurlencode( $attribute );
 				}
 			),
 			[


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue where, if you add a custom colour to the homepage posts block, it messes up the Load More button when paired with other settings.

It looks like the issue was the `#` passed along with the custom colour's hex value to the Load More button's `data-next` attribute, as part of the `articles_rest_url`.

I fixed it by encoding each attribute that gets added to the URL; I'm not sure if all the attributes are needed, though. If not, it might be better to pare them down to what's actually required for the Load More button to work.

See: 1200550061930446-as-1206673209369531

### How to test the changes in this Pull Request:

1. Set up a Homepage Posts block, and give it the following settings:
   * Set it to Grid View
   * Choose a category, include sub categories
   * Turn on 'Allow duplicate stories'
   * Set the text color to a custom value (not one of the presets)
2. View your block on the front-end, and click the Load More button a couple times.
3. Note that the first time repeats the same first three stories.
4. Apply this PR.
5. Try re-testing the Load More button, and confirm that the stories aren't duplicated in the block.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
