### PR TITLE
fix(hpp): translate dates in hpp block posts

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -1567,8 +1567,10 @@ class Newspack_Blocks {
 		if ( $post === null ) {
 			$post = get_post();
 		}
-		$date = self::get_displayed_post_date( $post );
-		$date_formatted = ( new DateTime( $date ) )->format( get_option( 'date_format' ) );
+		$date           = self::get_displayed_post_date( $post );
+		$date           = new DateTime( $date );
+		$date_format    = get_option( 'date_format' );
+		$date_formatted = date_i18n( $date_format, $date->getTimestamp() );
 		return apply_filters( 'newspack_blocks_formatted_displayed_post_date', $date_formatted, $post );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes [0/1200550061930446/1206952198365196/f](https://app.asana.com/0/1200550061930446/1206952198365196/f)

This fixes an issue where hpp block post dates are not translated on the frontend.

![Screenshot 2024-03-28 at 12 23 18](https://github.com/Automattic/newspack-blocks/assets/17905991/8e1eed0f-e7dd-42d3-a889-b8ee5daa1443)


### How to test the changes in this Pull Request:

1. On a test site add the homepage posts block to a page
2. Change the language and date formatting of your test site to something other than English (Settings > General in WPAdmin)
3. View the page from step 1 on the frontend
4. On `release` the date is not correctly translated. On this branch it should be.
5. Repeat these steps with some other languages and date formats

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
