### PR TITLE
feat(ras-acc): add newsletter signup option to checkout button and donation blocks

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -909,7 +909,7 @@ final class Modal_Checkout {
 		if ( ! $email_address ) {
 			return;
 		}
-		if ( ! method_exists( '\Newspack\Reader_Activation', 'get_registration_newsletter_lists' ) ) {
+		if ( ! class_exists( 'Newspack\Reader_Activation' ) || ! class_exists( 'Newspack_Newsletters_Subscription' ) ) {
 			return;
 		}
 		$newsletters_lists = array_filter(
@@ -1016,10 +1016,10 @@ final class Modal_Checkout {
 			} else {
 				$result = self::subscribe_newsletter_contact( $signup_data['email'], $signup_data['lists'] );
 			}
-			if ( \is_wp_error( $result ) ) {
-				return $result;
+			if ( ! \is_wp_error( $result ) ) {
+				$result = true;
 			}
-			return true;
+			return $result;
 		}
 		return false;
 	}
@@ -1033,20 +1033,24 @@ final class Modal_Checkout {
 	 * @return bool|\WP_Error
 	 */
 	public static function subscribe_newsletter_contact( $email_address, $lists ) {
-		$result = \Newspack_Newsletters_Subscription::add_contact(
-			[
-				'email'    => $email_address,
-				'metadata' => [
-					'current_page_url'                => home_url( add_query_arg( array(), \wp_get_referer() ) ),
-					'newsletters_subscription_method' => 'post-checkout',
+		if ( ! class_exists( 'Newspack_Newsletters_Subscription' ) ) {
+			$result = false;
+		} else {
+			$result = \Newspack_Newsletters_Subscription::add_contact(
+				[
+					'email'    => $email_address,
+					'metadata' => [
+						'current_page_url'                => home_url( add_query_arg( array(), \wp_get_referer() ) ),
+						'newsletters_subscription_method' => 'post-checkout',
+					],
 				],
-			],
-			$lists
-		);
-		if ( \is_wp_error( $result ) ) {
-			return $result;
+				$lists
+			);
 		}
-		return true;
+		if ( ! \is_wp_error( $result ) ) {
+			$result = true;
+		}
+		return $result;
 	}
 
 	/**

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -954,16 +954,7 @@ final class Modal_Checkout {
 			if ( empty( $signup_data['lists'] ) ) {
 				return new \WP_Error( 'newspack_no_lists_selected', __( 'No lists selected.', 'newspack-blocks' ) );
 			} else {
-				$result = \Newspack_Newsletters_Subscription::add_contact(
-					[
-						'email'    => $signup_data['email'],
-						'metadata' => [
-							'current_page_url' => home_url( add_query_arg( array(), \wp_get_referer() ) ),
-							'newsletters_subscription_method' => 'post-checkout',
-						],
-					],
-					$signup_data['lists']
-				);
+				$result = self::subscribe_newsletter_contact( $signup_data['email'], $signup_data['lists'] );
 			}
 			if ( \is_wp_error( $result ) ) {
 				return $result;
@@ -971,6 +962,32 @@ final class Modal_Checkout {
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Subscribe_newsletter_contact.
+	 *
+	 * @param string $email_address Email address.
+	 * @param array  $lists Array of newsletter lists.
+	 *
+	 * @return bool|\WP_Error
+	 */
+	public static function subscribe_newsletter_contact( $email_address, $lists ) {
+		// TODO: confirm contact is not already subscribed to the list.
+		$result = \Newspack_Newsletters_Subscription::add_contact(
+			[
+				'email'    => $email_address,
+				'metadata' => [
+					'current_page_url'                => home_url( add_query_arg( array(), \wp_get_referer() ) ),
+					'newsletters_subscription_method' => 'post-checkout',
+				],
+			],
+			$lists
+		);
+		if ( \is_wp_error( $result ) ) {
+			return $result;
+		}
+		return true;
 	}
 
 	/**

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -272,6 +272,7 @@ class Newspack_Blocks {
 				'custom_taxonomies'          => self::get_custom_taxonomies(),
 				'can_use_name_your_price'    => self::can_use_name_your_price(),
 				'tier_amounts_template'      => self::get_formatted_amount(),
+				'has_newsletters'            => method_exists( 'Newspack_Newsletters_Subscription', 'add_contact' ),
 			];
 
 			if ( class_exists( 'WP_REST_Newspack_Author_List_Controller' ) ) {

--- a/src/blocks/checkout-button/block.json
+++ b/src/blocks/checkout-button/block.json
@@ -53,6 +53,10 @@
 			"type": "boolean",
 			"default": false
 		},
+		"hideSubscriptionInput": {
+			"type": "boolean",
+			"default": false
+		},
 		"lists": {
 			"type": "array",
 			"default": [],

--- a/src/blocks/checkout-button/block.json
+++ b/src/blocks/checkout-button/block.json
@@ -48,6 +48,17 @@
 		},
 		"width": {
 			"type": "number"
+		},
+		"newsletterSubscription": {
+			"type": "boolean",
+			"default": false
+		},
+		"lists": {
+			"type": "array",
+			"default": [],
+			"items": {
+				"type": "string"
+			}
 		}
 	},
 	"supports": {

--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -28,9 +28,7 @@ import {
 	FormTokenField,
 	Button,
 	ButtonGroup,
-	Notice,
 	Spinner,
-	ToggleControl,
 } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
@@ -40,6 +38,7 @@ import apiFetch from '@wordpress/api-fetch';
  */
 import './edit.scss';
 import RedirectAfterSuccess from '../../components/redirect-after-success';
+import NewsletterSubscription from '../../components/newsletter-subscription';
 
 function getVariationName( variation ) {
 	const attributes = [];
@@ -192,18 +191,8 @@ function ProductControl( props ) {
 
 function CheckoutButtonEdit( props ) {
 	const { attributes, setAttributes, className } = props;
-	const {
-		placeholder,
-		style,
-		text,
-		product,
-		price,
-		variation,
-		width,
-		hideSubscriptionInput,
-		lists,
-		newsletterSubscription,
-	} = attributes;
+	const { placeholder, style, text, product, price, variation, width, newsletterSubscription } =
+		attributes;
 
 	const [ productData, setProductData ] = useState( {} );
 	const [ variations, setVariations ] = useState( [] );
@@ -398,66 +387,12 @@ function CheckoutButtonEdit( props ) {
 				) }
 				{ newspack_blocks_data.has_newsletters && (
 					<PanelBody title={ __( 'Newsletter Subscription', 'newspack-blocks' ) }>
-						<ToggleControl
-							label={ __( 'Enable newsletter subscription', 'newspack-blocks' ) }
-							checked={ !! newsletterSubscription }
-							disabled={ inFlight }
-							onChange={ () =>
-								setAttributes( { newsletterSubscription: ! newsletterSubscription } )
-							}
+						<NewsletterSubscription
+							attributes={ attributes }
+							setAttributes={ setAttributes }
+							inFlight={ inFlight }
+							listsConfig={ listsConfig }
 						/>
-						{ newsletterSubscription && (
-							<>
-								{ ! inFlight && ! Object.keys( listsConfig ).length && (
-									<div style={ { marginBottom: '1.5rem' } }>
-										{ __(
-											'To enable newsletter subscription, you must configure subscription lists on Newspack Newsletters.',
-											'newspack-blocks'
-										) }
-									</div>
-								) }
-								{ inFlight || ! Object.keys( listsConfig ).length ? (
-									<Spinner />
-								) : (
-									<>
-										<ToggleControl
-											label={ __(
-												'Hide newsletter selection and always subscribe',
-												'newspack-blocks'
-											) }
-											checked={ hideSubscriptionInput }
-											disabled={ inFlight || lists.length !== 1 }
-											onChange={ () =>
-												setAttributes( { hideSubscriptionInput: ! hideSubscriptionInput } )
-											}
-										/>
-										{ lists.length < 1 && (
-											<div style={ { marginBottom: '1.5rem' } }>
-												<Notice isDismissible={ false } status="error">
-													{ __( 'You must select at least one list.', 'newspack-blocks' ) }
-												</Notice>
-											</div>
-										) }
-										<p>{ __( 'Lists', 'newspack-blocks' ) }:</p>
-										{ Object.keys( listsConfig ).map( listId => (
-											<ToggleControl
-												key={ listId }
-												label={ listsConfig[ listId ].title }
-												checked={ lists.includes( listId ) }
-												disabled={ inFlight }
-												onChange={ () => {
-													if ( ! lists.includes( listId ) ) {
-														setAttributes( { lists: lists.concat( listId ) } );
-													} else {
-														setAttributes( { lists: lists.filter( id => id !== listId ) } );
-													}
-												} }
-											/>
-										) ) }
-									</>
-								) }
-							</>
-						) }
 					</PanelBody>
 				) }
 			</InspectorControls>

--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -200,6 +200,7 @@ function CheckoutButtonEdit( props ) {
 		price,
 		variation,
 		width,
+		hideSubscriptionInput,
 		lists,
 		newsletterSubscription,
 	} = attributes;
@@ -376,6 +377,17 @@ function CheckoutButtonEdit( props ) {
 									<Spinner />
 								) : (
 									<>
+										<ToggleControl
+											label={ __(
+												'Hide newsletter selection and always subscribe',
+												'newspack-plugin'
+											) }
+											checked={ hideSubscriptionInput }
+											disabled={ inFlight || lists.length !== 1 }
+											onChange={ () =>
+												setAttributes( { hideSubscriptionInput: ! hideSubscriptionInput } )
+											}
+										/>
 										{ lists.length < 1 && (
 											<div style={ { marginBottom: '1.5rem' } }>
 												<Notice isDismissible={ false } status="error">

--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -217,7 +217,12 @@ function CheckoutButtonEdit( props ) {
 			apiFetch( {
 				path: '/newspack-newsletters/v1/lists_config',
 			} )
-				.then( result => setListsConfig( result ) )
+				.then( result => {
+					if ( Object.keys( result ).length && ! attributes.lists.length ) {
+						setAttributes( { lists: [ Object.keys( result )[ 0 ] ] } );
+					}
+					setListsConfig( result );
+				} )
 				.finally( () => setInFlight( false ) );
 		}
 	}, [ newsletterSubscription ] );
@@ -353,70 +358,6 @@ function CheckoutButtonEdit( props ) {
 						) }
 					</ProductControl>
 				</PanelBody>
-				{ newspack_blocks_data.has_newsletters && (
-					<PanelBody title={ __( 'Newsletter Subscription', 'newspack-plugin' ) }>
-						<ToggleControl
-							label={ __( 'Enable newsletter subscription', 'newspack-plugin' ) }
-							checked={ !! newsletterSubscription }
-							disabled={ inFlight }
-							onChange={ () =>
-								setAttributes( { newsletterSubscription: ! newsletterSubscription } )
-							}
-						/>
-						{ newsletterSubscription && (
-							<>
-								{ ! inFlight && ! Object.keys( listsConfig ).length && (
-									<div style={ { marginBottom: '1.5rem' } }>
-										{ __(
-											'To enable newsletter subscription, you must configure subscription lists on Newspack Newsletters.',
-											'newspack-plugin'
-										) }
-									</div>
-								) }
-								{ inFlight || ! Object.keys( listsConfig ).length ? (
-									<Spinner />
-								) : (
-									<>
-										<ToggleControl
-											label={ __(
-												'Hide newsletter selection and always subscribe',
-												'newspack-plugin'
-											) }
-											checked={ hideSubscriptionInput }
-											disabled={ inFlight || lists.length !== 1 }
-											onChange={ () =>
-												setAttributes( { hideSubscriptionInput: ! hideSubscriptionInput } )
-											}
-										/>
-										{ lists.length < 1 && (
-											<div style={ { marginBottom: '1.5rem' } }>
-												<Notice isDismissible={ false } status="error">
-													{ __( 'You must select at least one list.', 'newspack-plugin' ) }
-												</Notice>
-											</div>
-										) }
-										<p>{ __( 'Lists', 'newspack-plugin' ) }:</p>
-										{ Object.keys( listsConfig ).map( listId => (
-											<ToggleControl
-												key={ listId }
-												label={ listsConfig[ listId ].title }
-												checked={ lists.includes( listId ) }
-												disabled={ inFlight }
-												onChange={ () => {
-													if ( ! lists.includes( listId ) ) {
-														setAttributes( { lists: lists.concat( listId ) } );
-													} else {
-														setAttributes( { lists: lists.filter( id => id !== listId ) } );
-													}
-												} }
-											/>
-										) ) }
-									</>
-								) }
-							</>
-						) }
-					</PanelBody>
-				) }
 				<PanelBody title={ __( 'After purchase', 'newspack-blocks' ) }>
 					<RedirectAfterSuccess setAttributes={ setAttributes } attributes={ attributes } />
 				</PanelBody>
@@ -453,6 +394,70 @@ function CheckoutButtonEdit( props ) {
 							max={ parseFloat( nyp.maxPrice ) || null }
 							onChange={ value => setAttributes( { price: value } ) }
 						/>
+					</PanelBody>
+				) }
+				{ newspack_blocks_data.has_newsletters && (
+					<PanelBody title={ __( 'Newsletter Subscription', 'newspack-blocks' ) }>
+						<ToggleControl
+							label={ __( 'Enable newsletter subscription', 'newspack-blocks' ) }
+							checked={ !! newsletterSubscription }
+							disabled={ inFlight }
+							onChange={ () =>
+								setAttributes( { newsletterSubscription: ! newsletterSubscription } )
+							}
+						/>
+						{ newsletterSubscription && (
+							<>
+								{ ! inFlight && ! Object.keys( listsConfig ).length && (
+									<div style={ { marginBottom: '1.5rem' } }>
+										{ __(
+											'To enable newsletter subscription, you must configure subscription lists on Newspack Newsletters.',
+											'newspack-blocks'
+										) }
+									</div>
+								) }
+								{ inFlight || ! Object.keys( listsConfig ).length ? (
+									<Spinner />
+								) : (
+									<>
+										<ToggleControl
+											label={ __(
+												'Hide newsletter selection and always subscribe',
+												'newspack-blocks'
+											) }
+											checked={ hideSubscriptionInput }
+											disabled={ inFlight || lists.length !== 1 }
+											onChange={ () =>
+												setAttributes( { hideSubscriptionInput: ! hideSubscriptionInput } )
+											}
+										/>
+										{ lists.length < 1 && (
+											<div style={ { marginBottom: '1.5rem' } }>
+												<Notice isDismissible={ false } status="error">
+													{ __( 'You must select at least one list.', 'newspack-blocks' ) }
+												</Notice>
+											</div>
+										) }
+										<p>{ __( 'Lists', 'newspack-blocks' ) }:</p>
+										{ Object.keys( listsConfig ).map( listId => (
+											<ToggleControl
+												key={ listId }
+												label={ listsConfig[ listId ].title }
+												checked={ lists.includes( listId ) }
+												disabled={ inFlight }
+												onChange={ () => {
+													if ( ! lists.includes( listId ) ) {
+														setAttributes( { lists: lists.concat( listId ) } );
+													} else {
+														setAttributes( { lists: lists.filter( id => id !== listId ) } );
+													}
+												} }
+											/>
+										) ) }
+									</>
+								) }
+							</>
+						) }
 					</PanelBody>
 				) }
 			</InspectorControls>

--- a/src/blocks/checkout-button/save.js
+++ b/src/blocks/checkout-button/save.js
@@ -86,6 +86,20 @@ export default function save( { attributes, className } ) {
 						value={ attributes.afterSuccessURL || '' }
 					/>
 				) }
+				{ attributes.newsletterSubscription && attributes.lists.length && (
+					<>
+						<input
+							type="hidden"
+							name="newsletter_subscription_force_subscribe"
+							value={ attributes.hideSubscriptionInput ? '1' : '' }
+						/>
+						<input
+							type="hidden"
+							name="newsletter_subscription_lists"
+							value={ attributes.lists.join( ',' ) }
+						/>
+					</>
+				) }
 			</form>
 		</div>
 	);

--- a/src/blocks/donate/block.json
+++ b/src/blocks/donate/block.json
@@ -88,6 +88,21 @@
 		},
 		"afterSuccessURL": {
 			"type": "string"
+		},
+		"newsletterSubscription": {
+			"type": "boolean",
+			"default": false
+		},
+		"hideSubscriptionInput": {
+			"type": "boolean",
+			"default": false
+		},
+		"lists": {
+			"type": "array",
+			"default": [],
+			"items": {
+				"type": "string"
+			}
 		}
 	},
 	"supports": {

--- a/src/blocks/donate/edit/index.tsx
+++ b/src/blocks/donate/edit/index.tsx
@@ -35,6 +35,7 @@ import type {
 	DonationAmountsArray,
 	EditState,
 	EditProps,
+	NewsletterSubscriptionLists,
 } from '../types';
 import TierBasedLayout from './TierBasedLayout';
 import FrequencyBasedLayout from './FrequencyBasedLayout';
@@ -57,7 +58,7 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ error, setError ] = useState( '' );
 	const [ inFlight, setInFlight ] = useState( false );
-	const [ listsConfig, setListsConfig ] = useState( {} );
+	const [ listsConfig, setListsConfig ] = useState< NewsletterSubscriptionLists >( {} );
 
 	const [ settings, setSettings ] = hooks.useObjectState< EditState >( {
 		amounts: {},
@@ -116,12 +117,12 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 	}, [] );
 
 	useEffect( () => {
-		if ( newspack_blocks_data.has_newsletters && attributes.newsletterSubscription ) {
+		if ( window.newspack_blocks_data.has_newsletters && attributes.newsletterSubscription ) {
 			setInFlight( true );
-			apiFetch( {
+			apiFetch< NewsletterSubscriptionLists >( {
 				path: '/newspack-newsletters/v1/lists_config',
 			} )
-				.then( result => {
+				.then( ( result: NewsletterSubscriptionLists ) => {
 					if ( Object.keys( result ).length && ! attributes.lists.length ) {
 						setAttributes( { lists: [ Object.keys( result )[ 0 ] ] } );
 					}
@@ -159,6 +160,7 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 		return <Placeholder icon={ <Spinner /> } className="component-placeholder__align-center" />;
 	}
 
+	// tslint:disable-next-line
 	const canUseNameYourPrice = window.newspack_blocks_data?.can_use_name_your_price;
 	const isManual = attributes.manual && canUseNameYourPrice;
 	const isTiered = isManual ? attributes.tiered : settings.tiered;
@@ -453,7 +455,7 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 				<PanelBody title={ __( 'After purchase', 'newspack-blocks' ) }>
 					<RedirectAfterSuccess setAttributes={ setAttributes } attributes={ attributes } />
 				</PanelBody>
-				{ newspack_blocks_data.has_newsletters && (
+				{ window.newspack_blocks_data.has_newsletters && (
 					<PanelBody title={ __( 'Newsletter Subscription', 'newspack-blocks' ) }>
 						<ToggleControl
 							label={ __( 'Enable newsletter subscription', 'newspack-blocks' ) }

--- a/src/blocks/donate/edit/index.tsx
+++ b/src/blocks/donate/edit/index.tsx
@@ -47,6 +47,7 @@ import {
 	DISABLED_IN_TIERS_BASED_LAYOUT_TIER_INDEX,
 } from '../consts';
 import RedirectAfterSuccess from '../../../components/redirect-after-success';
+import NewsletterSubscription from '../../../components/newsletter-subscription';
 
 const TIER_LABELS = [
 	__( 'Low-tier', 'newspack-blocks' ),
@@ -457,70 +458,12 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 				</PanelBody>
 				{ window.newspack_blocks_data.has_newsletters && (
 					<PanelBody title={ __( 'Newsletter Subscription', 'newspack-blocks' ) }>
-						<ToggleControl
-							label={ __( 'Enable newsletter subscription', 'newspack-blocks' ) }
-							checked={ !! attributes.newsletterSubscription }
-							disabled={ inFlight }
-							onChange={ () =>
-								setAttributes( { newsletterSubscription: ! attributes.newsletterSubscription } )
-							}
+						<NewsletterSubscription
+							attributes={ attributes }
+							setAttributes={ setAttributes }
+							inFlight={ inFlight }
+							listsConfig={ listsConfig }
 						/>
-						{ attributes.newsletterSubscription && (
-							<>
-								{ ! inFlight && ! Object.keys( listsConfig ).length && (
-									<div style={ { marginBottom: '1.5rem' } }>
-										{ __(
-											'To enable newsletter subscription, you must configure subscription lists on Newspack Newsletters.',
-											'newspack-blocks'
-										) }
-									</div>
-								) }
-								{ inFlight || ! Object.keys( listsConfig ).length ? (
-									<Spinner />
-								) : (
-									<>
-										<ToggleControl
-											label={ __(
-												'Hide newsletter selection and always subscribe',
-												'newspack-blocks'
-											) }
-											checked={ attributes.hideSubscriptionInput }
-											disabled={ inFlight || attributes.lists.length !== 1 }
-											onChange={ () =>
-												setAttributes( {
-													hideSubscriptionInput: ! attributes.hideSubscriptionInput,
-												} )
-											}
-										/>
-										{ attributes.lists.length < 1 && (
-											<div style={ { marginBottom: '1.5rem' } }>
-												<Notice isDismissible={ false } status="error">
-													{ __( 'You must select at least one list.', 'newspack-blocks' ) }
-												</Notice>
-											</div>
-										) }
-										<p>{ __( 'Lists', 'newspack-blocks' ) }:</p>
-										{ Object.keys( listsConfig ).map( listId => (
-											<ToggleControl
-												key={ listId }
-												label={ listsConfig[ listId ].title }
-												checked={ attributes.lists.includes( listId ) }
-												disabled={ inFlight }
-												onChange={ () => {
-													if ( ! attributes.lists.includes( listId ) ) {
-														setAttributes( { lists: attributes.lists.concat( listId ) } );
-													} else {
-														setAttributes( {
-															lists: attributes.lists.filter( id => id !== listId ),
-														} );
-													}
-												} }
-											/>
-										) ) }
-									</>
-								) }
-							</>
-						) }
 					</PanelBody>
 				) }
 			</InspectorControls>

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
@@ -179,6 +179,8 @@ abstract class Newspack_Blocks_Donate_Renderer_Base {
 	 * Render hidden form inputs.
 	 *
 	 * @param array $attributes The block attributes.
+	 *
+	 * @return string|bool
 	 */
 	protected static function render_hidden_form_inputs( $attributes ) {
 		ob_start();
@@ -191,19 +193,25 @@ abstract class Newspack_Blocks_Donate_Renderer_Base {
 			<input type='hidden' name='newspack_donate' value='1' />
 		<?php
 
-		foreach ( [ [ 'afterSuccessBehavior', 'after_success_behavior' ], [ 'afterSuccessButtonLabel', 'after_success_button_label' ], [ 'afterSuccessURL', 'after_success_url' ] ] as $attribute ) {
+		foreach (
+			[
+				[ 'afterSuccessBehavior', 'after_success_behavior' ],
+				[ 'afterSuccessButtonLabel', 'after_success_button_label' ],
+				[ 'afterSuccessURL', 'after_success_url' ],
+				[ 'hideSubscriptionInput', 'newsletter_subscription_force_subscribe' ],
+				[ 'lists', 'newsletter_subscription_lists' ],
+			] as $attribute
+		) {
 			$attribute_name = $attribute[0];
 			$param_name     = $attribute[1];
-			$value          = isset( $attributes[ $attribute_name ] ) ? $attributes[ $attribute_name ] : '';
+			// Handle the newsletter lists as a comma-separated string.
+			if ( $param_name === 'newsletter_subscription_lists' ) {
+				$value = isset( $attributes[ $attribute_name ] ) ? implode( ',', $attributes[ $attribute_name ] ) : '';
+			} else {
+				$value = isset( $attributes[ $attribute_name ] ) ? $attributes[ $attribute_name ] : '';
+			}
 			?>
 				<input type='hidden' name='<?php echo esc_attr( $param_name ); ?>' value='<?php echo esc_attr( $value ); ?>' />
-			<?php
-		}
-
-		if ( isset( $attributes['newsletterSubscription'], $attributes['lists'], $attributes['hideSubscriptionInput'] ) && $attributes['newsletterSubscription'] ) {
-			?>
-				<input type='hidden' name='newsletter_subscription_force_subscribe' value='<?php isset( $attributes['hideSubscriptionInput'] ) ? '1' : ''; ?>' />
-				<input type='hidden' name='newsletter_subscription_lists' value='<?php implode( ',', $attributes['lists'] ); ?>' />
 			<?php
 		}
 

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
@@ -200,6 +200,13 @@ abstract class Newspack_Blocks_Donate_Renderer_Base {
 			<?php
 		}
 
+		if ( isset( $attributes['newsletterSubscription'], $attributes['lists'], $attributes['hideSubscriptionInput'] ) && $attributes['newsletterSubscription'] ) {
+			?>
+				<input type='hidden' name='newsletter_subscription_force_subscribe' value='<?php isset( $attributes['hideSubscriptionInput'] ) ? '1' : ''; ?>' />
+				<input type='hidden' name='newsletter_subscription_lists' value='<?php implode( ',', $attributes['lists'] ); ?>' />
+			<?php
+		}
+
 		return ob_get_clean();
 	}
 

--- a/src/blocks/donate/types.ts
+++ b/src/blocks/donate/types.ts
@@ -89,6 +89,9 @@ export type DonateBlockAttributes = OverridableConfiguration & {
 	suggestedAmounts?: [ number, number, number ];
 	suggestedAmountUntiered?: number;
 	minimumDonation: number;
+	lists: string[];
+	hideSubscriptionInput: boolean;
+	newsletterSubscription: boolean;
 };
 
 export type ComponentProps = {
@@ -105,3 +108,11 @@ export type EditProps = {
 	setAttributes: ( attributes: Partial< DonateBlockAttributes > ) => void;
 	className: string;
 };
+
+interface NewsletterSubscriptionList {
+	[ key: string ]: string;
+}
+
+export interface NewsletterSubscriptionLists {
+	[ key: string ]: NewsletterSubscriptionList;
+}

--- a/src/components/newsletter-subscription.tsx
+++ b/src/components/newsletter-subscription.tsx
@@ -1,0 +1,92 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Notice, Spinner, ToggleControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import type { NewsletterSubscriptionLists } from '../types';
+
+type Props = {
+	attributes: {
+		hideSubscriptionInput: bool;
+		lists: string[];
+		newsletterSubscription: bool;
+	};
+	setAttributes: ( attributes: Partial< Props[ 'attributes' ] > ) => void;
+	inFlight: boolean;
+	listsConfig: NewsletterSubscriptionLists;
+};
+
+const NewsletterSubscription = ( { attributes, setAttributes, inFlight, listsConfig }: Props ) => {
+	const { hideSubscriptionInput, lists, newsletterSubscription } = attributes;
+	return (
+		<>
+			<ToggleControl
+				label={ __( 'Enable newsletter subscription', 'newspack-blocks' ) }
+				checked={ !! attributes.newsletterSubscription }
+				disabled={ inFlight }
+				onChange={ () =>
+					setAttributes( { newsletterSubscription: ! attributes.newsletterSubscription } )
+				}
+			/>
+			{ newsletterSubscription && (
+				<>
+					{ ! inFlight && ! Object.keys( listsConfig ).length && (
+						<div style={ { marginBottom: '1.5rem' } }>
+							{ __(
+								'To enable newsletter subscription, you must configure subscription lists on Newspack Newsletters.',
+								'newspack-blocks'
+							) }
+						</div>
+					) }
+					{ inFlight || ! Object.keys( listsConfig ).length ? (
+						<Spinner />
+					) : (
+						<>
+							<ToggleControl
+								label={ __( 'Hide newsletter selection and always subscribe', 'newspack-blocks' ) }
+								checked={ hideSubscriptionInput }
+								disabled={ inFlight || lists.length !== 1 }
+								onChange={ () =>
+									setAttributes( {
+										hideSubscriptionInput: ! hideSubscriptionInput,
+									} )
+								}
+							/>
+							{ lists.length < 1 && (
+								<div style={ { marginBottom: '1.5rem' } }>
+									<Notice isDismissible={ false } status="error">
+										{ __( 'You must select at least one list.', 'newspack-blocks' ) }
+									</Notice>
+								</div>
+							) }
+							<p>{ __( 'Lists', 'newspack-blocks' ) }:</p>
+							{ Object.keys( listsConfig ).map( listId => (
+								<ToggleControl
+									key={ listId }
+									label={ listsConfig[ listId ].title }
+									checked={ lists.includes( listId ) }
+									disabled={ inFlight }
+									onChange={ () => {
+										if ( ! lists.includes( listId ) ) {
+											setAttributes( { lists: lists.concat( listId ) } );
+										} else {
+											setAttributes( {
+												lists: lists.filter( id => id !== listId ),
+											} );
+										}
+									} }
+								/>
+							) ) }
+						</>
+					) }
+				</>
+			) }
+		</>
+	);
+};
+
+export default NewsletterSubscription;

--- a/src/components/newsletter-subscription.tsx
+++ b/src/components/newsletter-subscription.tsx
@@ -7,13 +7,13 @@ import { Notice, Spinner, ToggleControl } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import type { NewsletterSubscriptionLists } from '../types';
+import type { NewsletterSubscriptionLists } from '../blocks/donate/types';
 
 type Props = {
 	attributes: {
-		hideSubscriptionInput: bool;
+		hideSubscriptionInput: boolean;
 		lists: string[];
-		newsletterSubscription: bool;
+		newsletterSubscription: boolean;
 	};
 	setAttributes: ( attributes: Partial< Props[ 'attributes' ] > ) => void;
 	inFlight: boolean;

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -1,3 +1,5 @@
+@use '../shared/sass/colors';
+
 /* stylelint-disable-next-line */
 #newspack_modal_checkout_container { /* stylelint-disable-line */
 	padding: 24px;
@@ -38,5 +40,45 @@
 				visibility: visible;
 			}
 		}
+	}
+}
+
+.newspack-modal-newsletters {
+	margin-top: 20px;
+	padding-top: 22px;
+	border-top: 1px solid colors.$color__border;
+	&__info {
+		margin-bottom: 35px;
+		span {
+			color: colors.$color__text-light;
+		}
+	}
+	&__list-item {
+		display: flex;
+		align-items: center;
+		margin-bottom: 18px;
+		padding: 12px;
+		border: 1px solid colors.$color__border;
+		border-radius: 6px;
+		b {
+			display: block;
+			margin-bottom: 2px;
+		}
+	}
+	label {
+		flex: 1;
+		cursor: pointer;
+		margin-bottom: 0;
+	}
+	input[type='checkbox'] {
+		padding: 10px;
+		margin-right: 10px !important;
+	}
+	input[type='submit'],
+	&__button {
+		margin-top: 25px;
+		width: 100%;
+		padding: 22px !important;
+		font-size: 1em !important;
 	}
 }

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -190,11 +190,13 @@ domReady( () => {
 										'after_success_behavior',
 										'after_success_url',
 										'after_success_button_label',
-									].forEach( afterSuccessParam => {
+										'newsletter_subscription_lists',
+										'newsletter_subscription_force_subscribe',
+									].forEach( customParam => {
 										const input = document.createElement( 'input' );
 										input.type = 'hidden';
-										input.name = afterSuccessParam;
-										input.value = formData.get( afterSuccessParam );
+										input.name = customParam;
+										input.value = formData.get( customParam );
 										singleVariationForm.appendChild( input );
 									} );
 								} );

--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -27,13 +27,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * existing customer account.
  */
 function newspack_blocks_replace_login_with_order_summary() {
-	$order      = isset( $_GET['order_id'] ) ? \wc_get_order( \absint( \wp_unslash( $_GET['order_id'] ) ) ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	$key        = isset( $_GET['key'] ) ? \wc_clean( \sanitize_text_field( \wp_unslash( $_GET['key'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	$is_valid   = $order && is_a( $order, 'WC_Order' ) && hash_equals( $order->get_order_key(), $key ); // Validate order key to prevent CSRF.
-
-	if ( ! $is_valid ) {
-		return;
-	}
+	$order = isset( $_GET['order_id'] ) ? \wc_get_order( \absint( \wp_unslash( $_GET['order_id'] ) ) ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$key   = isset( $_GET['key'] ) ? \wc_clean( \sanitize_text_field( \wp_unslash( $_GET['key'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 	// Render the newsletter confirmation if it was submitted.
 	$newsletter_confirmation = \Newspack_Blocks\Modal_Checkout::confirm_newsletter_signup();
@@ -45,6 +40,11 @@ function newspack_blocks_replace_login_with_order_summary() {
 		return;
 	} elseif ( $is_error ) {
 		echo esc_html( $newsletter_confirmation->get_error_message() );
+		return;
+	}
+
+	$is_valid = $order && is_a( $order, 'WC_Order' ) && hash_equals( $order->get_order_key(), $key ); // Validate order key to prevent CSRF.
+	if ( ! $is_valid ) {
 		return;
 	}
 

--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -30,17 +30,19 @@ function newspack_blocks_replace_login_with_order_summary() {
 	$order = isset( $_GET['order_id'] ) ? \wc_get_order( \absint( \wp_unslash( $_GET['order_id'] ) ) ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	$key   = isset( $_GET['key'] ) ? \wc_clean( \sanitize_text_field( \wp_unslash( $_GET['key'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-	// Render the newsletter confirmation if it was submitted.
-	$newsletter_confirmation = \Newspack_Blocks\Modal_Checkout::confirm_newsletter_signup();
-	$is_error                = \is_wp_error( $newsletter_confirmation );
-	$no_selected_lists       = $is_error && 'newspack_no_lists_selected' === $newsletter_confirmation->get_error_code();
+	if ( class_exists( 'Newspack_Newsletters_Subscription' ) ) {
+		// Render the newsletter confirmation if it was submitted.
+		$newsletter_confirmation = \Newspack_Blocks\Modal_Checkout::confirm_newsletter_signup();
+		$is_error                = \is_wp_error( $newsletter_confirmation );
+		$no_selected_lists       = $is_error && 'newspack_no_lists_selected' === $newsletter_confirmation->get_error_code();
 
-	if ( true === $newsletter_confirmation || $no_selected_lists ) {
-		echo \Newspack_Blocks\Modal_Checkout::render_newsletter_confirmation( $no_selected_lists ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		return;
-	} elseif ( $is_error ) {
-		echo esc_html( $newsletter_confirmation->get_error_message() );
-		return;
+		if ( true === $newsletter_confirmation || $no_selected_lists ) {
+			echo \Newspack_Blocks\Modal_Checkout::render_newsletter_confirmation( $no_selected_lists ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			return;
+		} elseif ( $is_error ) {
+			echo esc_html( $newsletter_confirmation->get_error_message() );
+			return;
+		}
 	}
 
 	$is_valid = $order && is_a( $order, 'WC_Order' ) && hash_equals( $order->get_order_key(), $key ); // Validate order key to prevent CSRF.

--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -35,25 +35,23 @@ function newspack_blocks_replace_login_with_order_summary() {
 		return;
 	}
 
-	// Handle the newsletter signup form.
-	$force_subscribe = isset( $_POST['newsletter_subscription_force_subscribe'] ) ? \sanitize_text_field( \wp_unslash( $_POST['newsletter_subscription_force_subscribe'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
-	$lists = explode( ',', isset( $_POST['newsletter_subscription_lists'] ) ? \sanitize_text_field( \wp_unslash( $_POST['newsletter_subscription_lists'] ) ) : '' ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+	// Render the newsletter confirmation if it was submitted.
+	$newsletter_confirmation = \Newspack_Blocks\Modal_Checkout::confirm_newsletter_signup();
+	$is_error                = \is_wp_error( $newsletter_confirmation );
+	$no_selected_lists       = $is_error && 'newspack_no_lists_selected' === $newsletter_confirmation->get_error_code();
 
-	if ( $force_subscribe && ! empty( $lists ) ) {
-		$newsletter_confirmation = \Newspack_Blocks\Modal_Checkout::confirm_newsletter_signup( $lists );
-		$is_error                = \is_wp_error( $newsletter_confirmation );
-		$no_selected_lists       = $is_error && 'newspack_no_lists_selected' === $newsletter_confirmation->get_error_code();
-
-		if ( true === $newsletter_confirmation || $no_selected_lists ) {
-			echo \Newspack_Blocks\Modal_Checkout::render_newsletter_confirmation( $no_selected_lists ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			return;
-		} elseif ( $is_error ) {
-			echo esc_html( $newsletter_confirmation->get_error_message() );
-			return;
-		}
+	if ( true === $newsletter_confirmation || $no_selected_lists ) {
+		echo \Newspack_Blocks\Modal_Checkout::render_newsletter_confirmation( $no_selected_lists ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		return;
+	} elseif ( $is_error ) {
+		echo esc_html( $newsletter_confirmation->get_error_message() );
+		return;
 	}
 
-	$is_success = ! $order->has_status( 'failed' );
+	$is_success      = ! $order->has_status( 'failed' );
+	$force_subscribe = isset( $_GET['newsletter_subscription_force_subscribe'] ) ? \sanitize_text_field( \wp_unslash( $_GET['newsletter_subscription_force_subscribe'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$lists           = isset( $_GET['newsletter_subscription_lists'] ) ? \sanitize_text_field( \wp_unslash( $_GET['newsletter_subscription_lists'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$lists           = empty( $lists ) ? [] : \explode( ',', $lists );
 	?>
 	<div class="woocommerce-order">
 	<?php if ( $is_success ) : ?>

--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -49,9 +49,16 @@ function newspack_blocks_replace_login_with_order_summary() {
 	}
 
 	$is_success      = ! $order->has_status( 'failed' );
+	$email_address   = $order->get_billing_email();
 	$force_subscribe = isset( $_GET['newsletter_subscription_force_subscribe'] ) ? \sanitize_text_field( \wp_unslash( $_GET['newsletter_subscription_force_subscribe'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	$lists           = isset( $_GET['newsletter_subscription_lists'] ) ? \sanitize_text_field( \wp_unslash( $_GET['newsletter_subscription_lists'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	$lists           = empty( $lists ) ? [] : \explode( ',', $lists );
+
+	if ( $force_subscribe && $email_address ) {
+		\Newspack_Blocks\Modal_Checkout::subscribe_newsletter_contact( $email_address, $lists );
+		// Reset $lists to prevent the newsletter confirmation from showing again.
+		$lists = [];
+	}
 	?>
 	<div class="woocommerce-order">
 	<?php if ( $is_success ) : ?>
@@ -73,7 +80,7 @@ function newspack_blocks_replace_login_with_order_summary() {
 				</strong>
 			</p>
 		</div>
-		<?php echo \Newspack_Blocks\Modal_Checkout::render_checkout_after_success_markup( $order, $force_subscribe ? [] : $lists ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+		<?php echo \Newspack_Blocks\Modal_Checkout::render_checkout_after_success_markup( $order, $lists ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	<?php else : ?>
 		<div class="newspack-ui__box newspack-ui__box__error newspack-ui__box--text-center">
 			<p>

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -11,6 +11,7 @@ declare global {
 			post_subtitle: boolean;
 			can_use_name_your_price: boolean;
 			tier_amounts_template: string;
+			has_newsletters: boolean;
 		};
 		grecaptcha: any;
 		newspackReaderActivation: {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1206810965479792/1205992141743582

This PR adds a newsletter subscription option to the donate and checkout button blocks. When enabled, the selected list will be presented to readers when checking out via the blocks. There is also an additional option to hide the subscription form and automatically subscribe the reader:

Block editor:
![Screenshot 2024-04-15 at 16 18 00](https://github.com/Automattic/newspack-blocks/assets/17905991/aa2a9f34-71e1-49a5-a774-41d5ce72380d)

Frontend:
![Screenshot 2024-04-12 at 18 03 44](https://github.com/Automattic/newspack-blocks/assets/17905991/1c9ecd29-9328-45a5-b363-d3802c7d53fa)

### How to test the changes in this Pull Request:

Before testing, make sure you also have `newspack-plugin` checked out to the `epic/ras-acc` branch.

First, we will test the blocks in the editor:
1. Go to any page or post and add a checkout button block.
2. In the block settings look for a new newsletter subscription section (pictured above)
3. Confirm each of the toggles can be toggled and updated to persist state:
4. Repeat the above steps with the donate block

Next, we will test the frontend functionality:
1. Visit the page or post where you added the blocks in the above steps.
2. Select either one and go through the full checkout process.
3. Depending on the settings you selected when setting up the block, confirm a newsletter signup form either appears or doesn't appear:
    - Enable newsletter subscription: Enables newsletter subscription during the checkout process for the block. Will cause the subscription form to appear UNLESS the next option is set.
    - Hide newsletter selection and always subscribe: Hides the subscription form but automatically subscribes the customer to the selected list
    - Lists: The selected lists will appear on the newsletter subscription form. If the form is hidden via the hide option, the customer will automatically be subscribed to the selected lists.
4. Test out the checkout flow with various newsletter subscription setting configurations (disable subscriptions, and ensure the form doesn't appear. Enable the form but select the hide option and confirm the contact is added to the esp, etc.)
5. Repeat the above steps for the donation block
6. Ensure you have a contact that has already been subscribed in the ESP. Go through the checkout flow for either block and confirm the form doesn't appear regardless of newsletter subscription settings

Finally, we will test the blocks still function when newsletters is inactive
1. Deactivate the newsletters plugin
2. Repeat the above steps, but make sure the option to set newsletter subscription settings is not present in block editors AND no subscription form appears during the checkout flow on the frontend.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
