### PR TITLE
fix: make sure font scale 5 previews in editor

### DIFF
--- a/src/blocks/homepage-articles/edit.tsx
+++ b/src/blocks/homepage-articles/edit.tsx
@@ -676,7 +676,7 @@ class Edit extends Component< HomepageArticlesProps > {
 			'show-image': showImage,
 			[ `columns-${ columns }` ]: postLayout === 'grid',
 			[ `colgap-${ colGap }` ]: postLayout === 'grid',
-			[ `ts-${ typeScale }` ]: typeScale !== 5,
+			[ `ts-${ typeScale }` ]: typeScale,
 			[ `image-align${ mediaPosition }` ]: showImage,
 			[ `is-${ imageScale }` ]: imageScale !== 1 && showImage,
 			'mobile-stack': mobileStack,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I'm not sure why I'm just noticing this, since it seems to have been the behaviour for a while, but type scale 5 wasn't previewing the correct font size in the editor because the `ts-5` CSS class wasn't being applied to the block when that font size was used. 

### How to test the changes in this Pull Request:

1. Add three homepage post blocks to a page; to make them easier to compare, make them layout grid. 
2. Give them the type scales 6, 5, and 4. 
3. Note that font scale 5 is smaller than 4.
4. Apply this PR and run `npm run build`.
5. Confirm that font scale 5 previews a size that's more logical relative to the two type scales that bookend it (larger than 4, but smaller than 6).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
