### PR TITLE
fix(newspack-blocks): prevent fatal error on iframe blocks without attributes

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -84,6 +84,7 @@ class Newspack_Blocks {
 
 			foreach ( $blocks as $block ) {
 				if ( 'newspack-blocks/iframe' === $block['blockName']
+					&& is_array( $block['attrs'] )
 					&& array_key_exists( 'isFullScreen', $block['attrs'] )
 					&& $block['attrs']['isFullScreen']
 					) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixing this fatal error I saw in the logs:
```
Fatal error: Uncaught TypeError: array_key_exists(): Argument #2 ($array) must be of type array, null given in ./wp-content/plugins/editing-toolkit-plugin/prod/newspack-blocks/synced-newspack-blocks/class-newspack-blocks.php:88
Stack trace:
#0 ./wp-includes/class-wp-hook.php(324): Newspack_Blocks::hide_post_content_when_iframe_block_is_fullscreen('<p>Redacted...')
```
Line 88 is `					&& array_key_exists( 'isFullScreen', $block['attrs'] )`.  It looks like it's happening when there's an iframe block with no attributes, therefore `$block['attrs']` is null instead of an array.  Solution: Add an additional check that it's an array.

### How to test the changes in this Pull Request:

Manual inspection.


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
