### PR TITLE
feat: homepage articles update loading animation

### DIFF
--- a/languages/newspack-blocks-de_DE.po
+++ b/languages/newspack-blocks-de_DE.po
@@ -549,18 +549,13 @@ msgstr ""
 msgid "Renews on"
 msgstr ""
 
-#: release/newspack-blocks/src/blocks/homepage-articles/view.php:387
+#: release/newspack-blocks/src/blocks/homepage-articles/view.php:393
 #: src/blocks/homepage-articles/view.php:389 dist/editor.js:41
 #: release/newspack-blocks/dist/editor.js:2816
 #: release/newspack-blocks/src/blocks/homepage-articles/edit.js:782
 #: src/blocks/homepage-articles/edit.js:785
 msgid "Load more posts"
 msgstr "Mehr Beiträge laden"
-
-#: release/newspack-blocks/src/blocks/homepage-articles/view.php:392
-#: src/blocks/homepage-articles/view.php:394
-msgid "Loading..."
-msgstr "Lade..."
 
 #: release/newspack-blocks/src/blocks/homepage-articles/view.php:395
 #: src/blocks/homepage-articles/view.php:397

--- a/languages/newspack-blocks-es_ES.po
+++ b/languages/newspack-blocks-es_ES.po
@@ -541,17 +541,12 @@ msgstr ""
 msgid "Renews on"
 msgstr ""
 
-#: release/newspack-blocks/src/blocks/homepage-articles/view.php:387
+#: release/newspack-blocks/src/blocks/homepage-articles/view.php:393
 #: src/blocks/homepage-articles/view.php:389 dist/editor.js:41
 #: release/newspack-blocks/dist/editor.js:2816
 #: release/newspack-blocks/src/blocks/homepage-articles/edit.js:782
 #: src/blocks/homepage-articles/edit.js:785
 msgid "Load more posts"
-msgstr ""
-
-#: release/newspack-blocks/src/blocks/homepage-articles/view.php:392
-#: src/blocks/homepage-articles/view.php:394
-msgid "Loading..."
 msgstr ""
 
 #: release/newspack-blocks/src/blocks/homepage-articles/view.php:395

--- a/languages/newspack-blocks-fr_BE.po
+++ b/languages/newspack-blocks-fr_BE.po
@@ -539,18 +539,13 @@ msgstr ""
 msgid "Renews on"
 msgstr ""
 
-#: release/newspack-blocks/src/blocks/homepage-articles/view.php:387
+#: release/newspack-blocks/src/blocks/homepage-articles/view.php:393
 #: src/blocks/homepage-articles/view.php:389 dist/editor.js:41
 #: release/newspack-blocks/dist/editor.js:2816
 #: release/newspack-blocks/src/blocks/homepage-articles/edit.js:782
 #: src/blocks/homepage-articles/edit.js:785
 msgid "Load more posts"
 msgstr "Charger plus d’articles"
-
-#: release/newspack-blocks/src/blocks/homepage-articles/view.php:392
-#: src/blocks/homepage-articles/view.php:394
-msgid "Loading..."
-msgstr "Chargement…"
 
 #: release/newspack-blocks/src/blocks/homepage-articles/view.php:395
 #: src/blocks/homepage-articles/view.php:397

--- a/languages/newspack-blocks-pt_PT.po
+++ b/languages/newspack-blocks-pt_PT.po
@@ -541,18 +541,13 @@ msgstr ""
 msgid "Renews on"
 msgstr ""
 
-#: release/newspack-blocks/src/blocks/homepage-articles/view.php:387
+#: release/newspack-blocks/src/blocks/homepage-articles/view.php:393
 #: src/blocks/homepage-articles/view.php:389 dist/editor.js:41
 #: release/newspack-blocks/dist/editor.js:2816
 #: release/newspack-blocks/src/blocks/homepage-articles/edit.js:782
 #: src/blocks/homepage-articles/edit.js:785
 msgid "Load more posts"
 msgstr "Carregar mais posts"
-
-#: release/newspack-blocks/src/blocks/homepage-articles/view.php:392
-#: src/blocks/homepage-articles/view.php:394
-msgid "Loading..."
-msgstr "Carregando..."
 
 #: release/newspack-blocks/src/blocks/homepage-articles/view.php:395
 #: src/blocks/homepage-articles/view.php:397

--- a/languages/newspack-blocks.pot
+++ b/languages/newspack-blocks.pot
@@ -550,18 +550,13 @@ msgstr ""
 msgid "Renews on"
 msgstr ""
 
-#: release/newspack-blocks/src/blocks/homepage-articles/view.php:387
+#: release/newspack-blocks/src/blocks/homepage-articles/view.php:393
 #: src/blocks/homepage-articles/view.php:389
 #: dist/editor.js:41
 #: release/newspack-blocks/dist/editor.js:2816
 #: release/newspack-blocks/src/blocks/homepage-articles/edit.js:782
 #: src/blocks/homepage-articles/edit.js:785
 msgid "Load more posts"
-msgstr ""
-
-#: release/newspack-blocks/src/blocks/homepage-articles/view.php:392
-#: src/blocks/homepage-articles/view.php:394
-msgid "Loading..."
 msgstr ""
 
 #: release/newspack-blocks/src/blocks/homepage-articles/view.php:395

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -385,17 +385,17 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 		if ( $has_more_button ) :
 			?>
 			<button type="button" class="wp-block-button__link" data-next="<?php echo esc_url( $articles_rest_url ); ?>">
-			<?php
-			if ( ! empty( $attributes['moreButtonText'] ) ) {
-				echo esc_html( $attributes['moreButtonText'] );
-			} else {
-				esc_html_e( 'Load more posts', 'newspack-blocks' );
-			}
-			?>
+				<span class="label">
+					<?php
+					if ( ! empty( $attributes['moreButtonText'] ) ) {
+						echo esc_html( $attributes['moreButtonText'] );
+					} else {
+						esc_html_e( 'Load more posts', 'newspack-blocks' );
+					}
+					?>
+				</span>
+				<span class="loading"></span>
 			</button>
-			<p class="loading">
-				<?php esc_html_e( 'Loading...', 'newspack-blocks' ); ?>
-			</p>
 			<p class="error">
 				<?php esc_html_e( 'Something went wrong. Please refresh the page and/or try again.', 'newspack-blocks' ); ?>
 			</p>

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -366,6 +366,7 @@
 
 	> button {
 		margin-top: 1em;
+		position: relative;
 	}
 
 	&.has-more-button {
@@ -376,11 +377,30 @@
 
 	&.has-more-button.is-loading {
 		button {
-			display: none;
+			pointer-events: none;
+		}
+		.label {
+			visibility: hidden;
 		}
 		.loading {
 			display: block;
 		}
+	}
+
+	.loading {
+		animation: linear 900ms infinite wpnbha-loading-animation;
+		border-color: currentcolor currentcolor transparent transparent;
+		border-radius: 50%;
+		border-style: solid;
+		border-width: 1.5px;
+		height: 18px;
+		left: 50%;
+		margin-left: -9px;
+		margin-top: -9px;
+		position: absolute;
+		top: 50%;
+		transform: rotate(0deg);
+		width: 18px;
 	}
 
 	&.has-more-button.is-error {
@@ -726,5 +746,14 @@
 			border: 0;
 			padding-right: 0;
 		}
+	}
+}
+
+@keyframes wpnbha-loading-animation {
+	from {
+		transform: rotate( 0deg );
+	}
+	to {
+		transform: rotate( 360deg );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR substitutes the "Loading..." message, which appears when the "Load more posts" button is clicked, with a spinner animation within the button itself.

This is done because the "Loading..." message does not have the same height/line-height as the button, resulting in a minor layout shift. By incorporating a spinner into the button, users will still receive visual feedback without any layout disruptions.

![spinner-animation](https://github.com/Automattic/newspack-blocks/assets/177929/6f5f2f91-3b4c-4a6d-a77e-19d5bd43766c)

### How to test the changes in this Pull Request:

1. Add a homepage post block to a page, make sure you toggle `Show "Load more posts" Button`
2. Save and visit the page, click on the button (the button should disappear and have a "Loading..." message instead)
3. Switch to this branch and refresh your page, click on the button (you should now see a spinner animation within the button).
4. In the editor, modify the label of the button. Save
5. Check the front-end to see if the button keeps the correct width

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
