### PR TITLE
fix(homepage-articles): author URL

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -478,19 +478,13 @@ function newspack_blocks_format_byline( $author_info ) {
 			function ( $accumulator, $author ) use ( $author_info, &$index ) {
 				$index++;
 				$penultimate = count( $author_info ) - 2;
-
-				$get_author_posts_url = get_author_posts_url( $author->ID );
-				if ( function_exists( 'coauthors_posts_links' ) ) {
-					$get_author_posts_url = get_author_posts_url( $author->ID, $author->user_nicename );
-				}
-
 				return array_merge(
 					$accumulator,
 					[
 						sprintf(
 							/* translators: 1: author link. 2: author name. 3. variable seperator (comma, 'and', or empty) */
 							'<span class="author vcard"><a class="url fn n" href="%1$s">%2$s</a></span>',
-							esc_url( $get_author_posts_url ),
+							esc_url( $author->url ),
 							esc_html( $author->display_name )
 						),
 						( $index < $penultimate ) ? ', ' : '',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adjusts the author URL in the Homepage Posts block, so the same one is used for the author image and name links. The code removed only doubles what's already done in the [`prepare_authors` method](https://github.com/Automattic/newspack-blocks/blob/5cbb2fd75866818e11f42966341156b48d347d09/includes/class-newspack-blocks.php#L835). 

### How to test the changes in this Pull Request:

1. Insert a Homepage Posts block
2. On the frontend, observe both author links – the one in the avatar and the author's name – are the same

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->