### PR TITLE
feat(ras-acc): make checkout modal UI text filterable

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -242,7 +242,7 @@ final class Modal_Checkout {
 		*
 		* @param string $title The title.
 		*/
-		$title        = self::get_modal_checkout_labels( 'auth_modal_title' );
+		$title        = self::get_modal_checkout_labels( 'checkout_modal_title' );
 		$class_prefix = self::get_class_prefix();
 		?>
 		<div id="newspack_modal_checkout" class="<?php echo esc_attr( "$class_prefix {$class_prefix}__modal-container" ); ?>">
@@ -300,7 +300,7 @@ final class Modal_Checkout {
 		*
 		* @param string $title The title.
 		*/
-		$title        = self::get_modal_checkout_labels( 'title' );
+		$title        = self::get_modal_checkout_labels( 'variation_modal_title' );
 		$products     = array_keys( self::$products );
 		$class_prefix = self::get_class_prefix();
 
@@ -1264,62 +1264,66 @@ final class Modal_Checkout {
 	 * @return string[]|string The label string or an array of labels keyed by string.
 	 */
 	public static function get_modal_checkout_labels( $key = null ) {
-		$default_labels = [
-			'title'                      => __( 'Complete your transaction', 'newspack-blocks' ),
-			'billing_details'            => __( 'Billing details', 'newspack-blocks' ),
-			'shipping_details'           => __( 'Shipping details', 'newspack-blocks' ),
-			'gift_recipient'             => __( 'Gift recipient', 'newspack-blocks' ),
-			'auth_modal_title'           => __( 'Complete your transaction', 'newspack-blocks' ),
-			'signin_modal_title'         => _x(
-				'Sign in to complete transaction',
-				'Login modal title when logged out user attempts to checkout.',
-				'newspack-blocks'
-			),
-			'register_modal_title'       => _x(
-				'Register to complete transaction',
-				'Login modal title when unregistered user attempts to checkout',
-				'newspack-blocks'
-			),
-			'after_success'              => __( 'Continue browsing', 'newspack-blocks' ),
-			'donation_gift_details'      => __( 'This donation is a gift', 'newspack-blocks' ),
-			'purchase_gift_details'      => __( 'This purchase is a gift', 'newspack-blocks' ),
-			'newsletter_confirmation'    => sprintf(
-				// Translators: %s is the site name.
-				__( 'Thanks for supporting %s.', 'newspack-blocks' ),
-				get_option( 'blogname' )
-			),
-			'newsletter_details'         => sprintf(
-				// Translators: %s is the site name.
-				__( 'Get the best of %s directly in your email inbox.', 'newspack-blocks' ),
-				get_bloginfo( 'name' )
-			),
-			'newsletter_signup'          => __( 'Continue', 'newspack-blocks' ),
-			'newsletter_success'         => __( 'Signup successful!', 'newspack-blocks' ),
-			'newsletter_title'           => __( 'Sign up for newsletters', 'newspack-blocks' ),
-			'checkout_confirm'           => __( 'Complete transaction', 'newspack-blocks' ),
-			'checkout_confirm_variation' => __( 'Purchase', 'newspack-blocks' ),
-			'checkout_back'              => __( 'Back', 'newspack-blocks' ),
-			'thankyou'                   => sprintf(
-				// Translators: %s is the site name.
-				__( 'Thank you for supporting %s. Your transaction was successful.', 'newspack-blocks' ),
-				get_option( 'blogname' )
-			),
-		];
-
 		if ( empty( self::$modal_checkout_labels ) ) {
+			$default_labels = [
+				'billing_details'            => __( 'Billing details', 'newspack-blocks' ),
+				'shipping_details'           => __( 'Shipping details', 'newspack-blocks' ),
+				'gift_recipient'             => __( 'Gift recipient', 'newspack-blocks' ),
+				'checkout_modal_title'       => __( 'Complete your transaction', 'newspack-blocks' ),
+				'variation_modal_title'      => __( 'Complete your transaction', 'newspack-blocks' ),
+				'auth_modal_title'           => __( 'Complete your transaction', 'newspack-blocks' ),
+				'signin_modal_title'         => _x(
+					'Sign in to complete transaction',
+					'Login modal title when logged out user attempts to checkout.',
+					'newspack-blocks'
+				),
+				'register_modal_title'       => _x(
+					'Register to complete transaction',
+					'Login modal title when unregistered user attempts to checkout',
+					'newspack-blocks'
+				),
+				'after_success'              => __( 'Continue browsing', 'newspack-blocks' ),
+				'donation_gift_details'      => __( 'This donation is a gift', 'newspack-blocks' ),
+				'purchase_gift_details'      => __( 'This purchase is a gift', 'newspack-blocks' ),
+				'newsletter_confirmation'    => sprintf(
+					// Translators: %s is the site name.
+					__( 'Thanks for supporting %s.', 'newspack-blocks' ),
+					get_option( 'blogname' )
+				),
+				'newsletter_details'         => sprintf(
+					// Translators: %s is the site name.
+					__( 'Get the best of %s directly in your email inbox.', 'newspack-blocks' ),
+					get_bloginfo( 'name' )
+				),
+				'newsletter_signup'          => __( 'Continue', 'newspack-blocks' ),
+				'newsletter_success'         => __( 'Signup successful!', 'newspack-blocks' ),
+				'newsletter_title'           => __( 'Sign up for newsletters', 'newspack-blocks' ),
+				'checkout_confirm'           => __( 'Complete transaction', 'newspack-blocks' ),
+				'checkout_confirm_variation' => __( 'Purchase', 'newspack-blocks' ),
+				'checkout_back'              => __( 'Back', 'newspack-blocks' ),
+				'thankyou'                   => sprintf(
+					// Translators: %s is the site name.
+					__( 'Thank you for supporting %s. Your transaction was successful.', 'newspack-blocks' ),
+					get_option( 'blogname' )
+				),
+			];
+
 			/**
 			* Filters the global labels for modal checkout flow.
 			*
 			* @param mixed[] $labels Labels keyed by name.
 			*/
-			self::$modal_checkout_labels = apply_filters( 'newspack_blocks_modal_checkout_labels', $default_labels );
+			$filtered_labels = apply_filters( 'newspack_blocks_modal_checkout_labels', $default_labels );
+
+			// Merge the default and filtered labels to ensure there are no missing labels.
+			self::$modal_checkout_labels = array_merge( $default_labels, $filtered_labels );
 		}
 
 		if ( ! $key ) {
-			return array_merge( $default_labels, self::$modal_checkout_labels );
+			return self::$modal_checkout_labels;
 		}
 
-		return self::$modal_checkout_labels[ $key ] ?? $default_labels[ $key ] ?? '';
+		return self::$modal_checkout_labels[ $key ] ?? '';
 	}
 }
 Modal_Checkout::init();

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -28,6 +28,13 @@ final class Modal_Checkout {
 	private static $products = [];
 
 	/**
+	 * Labels for the modal checkout UI.
+	 *
+	 * @var mixed[]
+	 */
+	private static $modal_checkout_labels = [];
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
@@ -235,7 +242,7 @@ final class Modal_Checkout {
 		*
 		* @param string $title The title.
 		*/
-		$title        = self::get_modal_title();
+		$title        = self::get_modal_checkout_labels( 'auth_modal_title' );
 		$class_prefix = self::get_class_prefix();
 		?>
 		<div id="newspack_modal_checkout" class="<?php echo esc_attr( "$class_prefix {$class_prefix}__modal-container" ); ?>">
@@ -293,7 +300,7 @@ final class Modal_Checkout {
 		*
 		* @param string $title The title.
 		*/
-		$title        = apply_filters( 'newspack_blocks_modal_checkout_title', __( 'Complete your transaction', 'newspack-blocks' ) );
+		$title        = self::get_modal_checkout_labels( 'title' );
 		$products     = array_keys( self::$products );
 		$class_prefix = self::get_class_prefix();
 
@@ -338,7 +345,7 @@ final class Modal_Checkout {
 										<form>
 											<input type="hidden" name="newspack_checkout" value="1" />
 											<input type="hidden" name="product_id" value="<?php echo esc_attr( $variation->get_id() ); ?>" />
-											<button type="submit" class="<?php echo esc_attr( "{$class_prefix}__button {$class_prefix}__button--primary" ); ?>"><?php esc_html_e( 'Purchase', 'newspack-blocks' ); ?></button>
+											<button type="submit" class="<?php echo esc_attr( "{$class_prefix}__button {$class_prefix}__button--primary" ); ?>"><?php echo esc_html( self::get_modal_checkout_labels( 'place_order_variation' ) ); ?></button>
 										</form>
 									</li>
 								<?php endforeach; ?>
@@ -375,9 +382,9 @@ final class Modal_Checkout {
 			[
 				'newspack_class_prefix' => self::get_class_prefix(),
 				'labels'                => [
-					'billing_details'  => __( 'Billing details', 'newspack-blocks' ),
-					'shipping_details' => __( 'Shipping details', 'newspack-blocks' ),
-					'gift_recipient'   => __( 'Gift recipient', 'newspack-blocks' ),
+					'billing_details'  => self::get_modal_checkout_labels( 'billing_details' ),
+					'shipping_details' => self::get_modal_checkout_labels( 'shipping_details' ),
+					'gift_recipient'   => self::get_modal_checkout_labels( 'gift_recipient' ),
 				],
 			]
 		);
@@ -424,17 +431,9 @@ final class Modal_Checkout {
 			[
 				'newspack_class_prefix' => self::get_class_prefix(),
 				'labels'                => [
-					'auth_modal_title'     => self::get_modal_title(),
-					'signin_modal_title'   => _x(
-						'Sign in to complete transaction',
-						'Login modal title when logged out user attempts to checkout.',
-						'newspack-blocks'
-					),
-					'register_modal_title' => _x(
-						'Register to complete transaction',
-						'Login modal title when unregistered user attempts to checkout',
-						'newspack-blocks'
-					),
+					'auth_modal_title'     => self::get_modal_checkout_labels( 'auth_modal_title' ),
+					'signin_modal_title'   => self::get_modal_checkout_labels( 'signin_modal_title' ),
+					'register_modal_title' => self::get_modal_checkout_labels( 'register_modal_title' ),
 				],
 			]
 		);
@@ -708,13 +707,13 @@ final class Modal_Checkout {
 				if ( $is_valid_email ) {
 					\WCS_Gifting::update_cart_item_key( $cart_item, $cart_item_key, $recipient_email );
 				} else {
+					$notice = $self_gifting
+						? __( 'Please enter someone else\' email address to receive this gift.', 'newspack-blocks' )
+						: __( 'Please enter a valid email address to receive this gift.', 'newspack-blocks' );
+
 					// Handle email validation errors.
 					\wc_add_notice(
-						sprintf(
-							// Translators: WCSG email validation error message.
-							__( 'Please enter %s email address to receive this gift.', 'newspack-blocks' ),
-							$self_gifting ? __( 'someone else’s', 'newspack-blocks' ) : __( 'a valid', 'newspack-blocks' )
-						),
+						$notice,
 						'error',
 						[ 'id' => 'wcsg_gift_recipients_email' ]
 					);
@@ -812,7 +811,7 @@ final class Modal_Checkout {
 			return;
 		}
 
-		$button_label = ! empty( $_REQUEST['after_success_button_label'] ) ? urldecode( wp_unslash( $_REQUEST['after_success_button_label'] ) ) : __( 'Continue browsing', 'newspack-blocks' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$button_label = ! empty( $_REQUEST['after_success_button_label'] ) ? urldecode( wp_unslash( $_REQUEST['after_success_button_label'] ) ) : self::get_modal_checkout_labels( 'after_success' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$url          = ! empty( $_REQUEST['after_success_url'] ) ? urldecode( wp_unslash( $_REQUEST['after_success_url'] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		?>
 			<button
@@ -854,16 +853,10 @@ final class Modal_Checkout {
 		}
 		?>
 			<div class="newspack-modal-newsletters">
-				<h4><?php esc_html_e( 'Sign up for newsletters', 'newspack-blocks' ); ?></h4>
+				<h4><?php echo esc_html( self::get_modal_checkout_labels( 'newsletter_title' ) ); ?></h4>
 				<div class="newspack-modal-newsletters__info">
 					<?php
-					echo esc_html(
-						sprintf(
-							// Translators: %s is the site name.
-							__( 'Get the best of %s directly in your email inbox.', 'newspack-blocks' ),
-							get_bloginfo( 'name' )
-						)
-					);
+					echo esc_html( self::get_modal_checkout_labels( 'newsletter_details' ) );
 					?>
 					<br>
 					<span>
@@ -908,7 +901,7 @@ final class Modal_Checkout {
 						<?php
 					}
 					?>
-					<input type="submit" value="<?php esc_html_e( 'Continue', 'newspack-blocks' ); ?>">
+					<input type="submit" value="<?php echo esc_html( self::get_modal_checkout_labels( 'newsletter_signup' ) ); ?>">
 				</form>
 			</div>
 		<?php
@@ -979,17 +972,11 @@ final class Modal_Checkout {
 	public static function render_newsletter_confirmation( $no_lists_selected = false ) {
 		?>
 			<?php if ( ! $no_lists_selected ) : ?>
-				<h4><?php esc_html_e( 'Signup successful!', 'newspack-blocks' ); ?></h4>
+				<h4><?php echo esc_html( self::get_modal_checkout_labels( 'newsletter_success' ) ); ?></h4>
 			<?php endif; ?>
 			<p>
 				<?php
-				echo esc_html(
-					sprintf(
-						// Translators: %s is the site name.
-						__( 'Thanks for supporting %s.', 'newspack-blocks' ),
-						get_option( 'blogname' )
-					)
-				);
+				echo esc_html( self::get_modal_checkout_labels( 'newsletter_confirmation' ) );
 				?>
 			</p>
 		<?php
@@ -1054,11 +1041,7 @@ final class Modal_Checkout {
 		if ( ! $cart || $cart->is_empty() ) {
 			return $text;
 		}
-		return sprintf(
-			// Translators: %s is the price.
-			__( 'Complete transaction: %s', 'newspack-blocks' ),
-			esc_html( wp_strip_all_tags( \WC()->cart->get_total() ) )
-		);
+		return self::get_modal_checkout_labels( 'place_order' );
 	}
 
 	/**
@@ -1221,12 +1204,7 @@ final class Modal_Checkout {
 	 */
 	public static function subscriptions_gifting_label() {
 		$is_donation = method_exists( 'Newspack\Donations', 'is_donation_cart' ) && \Newspack\Donations::is_donation_cart();
-		$label       = sprintf(
-			// Translators: Whether the transaction is a donation or a non-donation purchase.
-			__( 'This %s is a gift', 'newspack-blocks' ),
-			$is_donation ? __( 'donation', 'newspack-blocks' ) : __( 'purchase', 'newspack-blocks' )
-		);
-
+		$label       = $is_donation ? self::get_modal_checkout_labels( 'donation_gift_details' ) : self::get_modal_checkout_labels( 'purchase_gift_details' );
 		return \apply_filters( 'wcsg_enable_gifting_checkbox_label', $label ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WooCommerce hooks.
 	}
 
@@ -1255,18 +1233,6 @@ final class Modal_Checkout {
 	}
 
 	/**
-	 * Gets the modal header title.
-	 */
-	public static function get_modal_title() {
-		/**
-		* Filters the header title for the modal checkout.
-		*
-		* @param string $title The title.
-		*/
-		return apply_filters( 'newspack_blocks_modal_checkout_title', __( 'Complete your transaction', 'newspack-blocks' ) );
-	}
-
-	/**
 	 * Get the relevant class prefix (newspack-blocks or newspack-ui) depending on whether Newpack plugin is active.
 	 */
 	private static function get_class_prefix() {
@@ -1288,6 +1254,66 @@ final class Modal_Checkout {
 		$newspack_ui_html = preg_replace( '/class=".*?"/', "class='{$class_prefix}__button {$class_prefix}__button--primary {$class_prefix}__button--wide'", $html );
 
 		return $newspack_ui_html;
+	}
+
+	/**
+	 * Get modal checkout flow labels.
+	 *
+	 * @param string|null $key Key of the label to return (optional).
+	 *
+	 * @return string[]|string The label string or an array of labels keyed by string.
+	 */
+	private static function get_modal_checkout_labels( $key = null ) {
+		$default_labels = [
+			'title'                   => __( 'Complete your transaction', 'newspack-blocks' ),
+			'billing_details'         => __( 'Billing details', 'newspack-blocks' ),
+			'shipping_details'        => __( 'Shipping details', 'newspack-blocks' ),
+			'gift_recipient'          => __( 'Gift recipient', 'newspack-blocks' ),
+			'auth_modal_title'        => __( 'Complete your transaction', 'newspack-blocks' ),
+			'signin_modal_title'      => _x(
+				'Sign in to complete transaction',
+				'Login modal title when logged out user attempts to checkout.',
+				'newspack-blocks'
+			),
+			'register_modal_title'    => _x(
+				'Register to complete transaction',
+				'Login modal title when unregistered user attempts to checkout',
+				'newspack-blocks'
+			),
+			'after_success'           => __( 'Continue browsing', 'newspack-blocks' ),
+			'donation_gift_details'   => __( 'This donation is a gift', 'newspack-blocks' ),
+			'purchase_gift_details'   => __( 'This purchase is a gift', 'newspack-blocks' ),
+			'newsletter_confirmation' => sprintf(
+				// Translators: %s is the site name.
+				__( 'Thanks for supporting %s.', 'newspack-blocks' ),
+				get_option( 'blogname' )
+			),
+			'newsletter_details'      => sprintf(
+				// Translators: %s is the site name.
+				__( 'Get the best of %s directly in your email inbox.', 'newspack-blocks' ),
+				get_bloginfo( 'name' )
+			),
+			'newsletter_signup'       => __( 'Continue', 'newspack-blocks' ),
+			'newsletter_success'      => __( 'Signup successful!', 'newspack-blocks' ),
+			'newsletter_title'        => __( 'Sign up for newsletters', 'newspack-blocks' ),
+			'place_order'             => __( 'Complete transaction', 'newspack-blocks' ),
+			'place_order_variation'   => __( 'Purchase', 'newspack-blocks' ),
+		];
+
+		if ( empty( self::$modal_checkout_labels ) ) {
+			/**
+			* Filters the global labels for modal checkout flow.
+			*
+			* @param mixed[] $labels Labels keyed by name.
+			*/
+			self::$modal_checkout_labels = apply_filters( 'newspack_blocks_modal_checkout_labels', $default_labels );
+		}
+
+		if ( ! $key ) {
+			return array_merge( $default_labels, self::$modal_checkout_labels );
+		}
+
+		return self::$modal_checkout_labels[ $key ] ?? $default_labels[ $key ] ?? '';
 	}
 }
 Modal_Checkout::init();

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -345,7 +345,7 @@ final class Modal_Checkout {
 										<form>
 											<input type="hidden" name="newspack_checkout" value="1" />
 											<input type="hidden" name="product_id" value="<?php echo esc_attr( $variation->get_id() ); ?>" />
-											<button type="submit" class="<?php echo esc_attr( "{$class_prefix}__button {$class_prefix}__button--primary" ); ?>"><?php echo esc_html( self::get_modal_checkout_labels( 'place_order_variation' ) ); ?></button>
+											<button type="submit" class="<?php echo esc_attr( "{$class_prefix}__button {$class_prefix}__button--primary" ); ?>"><?php echo esc_html( self::get_modal_checkout_labels( 'checkout_confirm_variation' ) ); ?></button>
 										</form>
 									</li>
 								<?php endforeach; ?>
@@ -1041,7 +1041,7 @@ final class Modal_Checkout {
 		if ( ! $cart || $cart->is_empty() ) {
 			return $text;
 		}
-		return self::get_modal_checkout_labels( 'place_order' );
+		return self::get_modal_checkout_labels( 'checkout_confirm' );
 	}
 
 	/**
@@ -1263,41 +1263,47 @@ final class Modal_Checkout {
 	 *
 	 * @return string[]|string The label string or an array of labels keyed by string.
 	 */
-	private static function get_modal_checkout_labels( $key = null ) {
+	public static function get_modal_checkout_labels( $key = null ) {
 		$default_labels = [
-			'title'                   => __( 'Complete your transaction', 'newspack-blocks' ),
-			'billing_details'         => __( 'Billing details', 'newspack-blocks' ),
-			'shipping_details'        => __( 'Shipping details', 'newspack-blocks' ),
-			'gift_recipient'          => __( 'Gift recipient', 'newspack-blocks' ),
-			'auth_modal_title'        => __( 'Complete your transaction', 'newspack-blocks' ),
-			'signin_modal_title'      => _x(
+			'title'                      => __( 'Complete your transaction', 'newspack-blocks' ),
+			'billing_details'            => __( 'Billing details', 'newspack-blocks' ),
+			'shipping_details'           => __( 'Shipping details', 'newspack-blocks' ),
+			'gift_recipient'             => __( 'Gift recipient', 'newspack-blocks' ),
+			'auth_modal_title'           => __( 'Complete your transaction', 'newspack-blocks' ),
+			'signin_modal_title'         => _x(
 				'Sign in to complete transaction',
 				'Login modal title when logged out user attempts to checkout.',
 				'newspack-blocks'
 			),
-			'register_modal_title'    => _x(
+			'register_modal_title'       => _x(
 				'Register to complete transaction',
 				'Login modal title when unregistered user attempts to checkout',
 				'newspack-blocks'
 			),
-			'after_success'           => __( 'Continue browsing', 'newspack-blocks' ),
-			'donation_gift_details'   => __( 'This donation is a gift', 'newspack-blocks' ),
-			'purchase_gift_details'   => __( 'This purchase is a gift', 'newspack-blocks' ),
-			'newsletter_confirmation' => sprintf(
+			'after_success'              => __( 'Continue browsing', 'newspack-blocks' ),
+			'donation_gift_details'      => __( 'This donation is a gift', 'newspack-blocks' ),
+			'purchase_gift_details'      => __( 'This purchase is a gift', 'newspack-blocks' ),
+			'newsletter_confirmation'    => sprintf(
 				// Translators: %s is the site name.
 				__( 'Thanks for supporting %s.', 'newspack-blocks' ),
 				get_option( 'blogname' )
 			),
-			'newsletter_details'      => sprintf(
+			'newsletter_details'         => sprintf(
 				// Translators: %s is the site name.
 				__( 'Get the best of %s directly in your email inbox.', 'newspack-blocks' ),
 				get_bloginfo( 'name' )
 			),
-			'newsletter_signup'       => __( 'Continue', 'newspack-blocks' ),
-			'newsletter_success'      => __( 'Signup successful!', 'newspack-blocks' ),
-			'newsletter_title'        => __( 'Sign up for newsletters', 'newspack-blocks' ),
-			'place_order'             => __( 'Complete transaction', 'newspack-blocks' ),
-			'place_order_variation'   => __( 'Purchase', 'newspack-blocks' ),
+			'newsletter_signup'          => __( 'Continue', 'newspack-blocks' ),
+			'newsletter_success'         => __( 'Signup successful!', 'newspack-blocks' ),
+			'newsletter_title'           => __( 'Sign up for newsletters', 'newspack-blocks' ),
+			'checkout_confirm'           => __( 'Complete transaction', 'newspack-blocks' ),
+			'checkout_confirm_variation' => __( 'Purchase', 'newspack-blocks' ),
+			'checkout_back'              => __( 'Back', 'newspack-blocks' ),
+			'thankyou'                   => sprintf(
+				// Translators: %s is the site name.
+				__( 'Thank you for supporting %s. Your transaction was successful.', 'newspack-blocks' ),
+				get_option( 'blogname' )
+			),
 		];
 
 		if ( empty( self::$modal_checkout_labels ) ) {

--- a/src/modal-checkout/templates/form-checkout.php
+++ b/src/modal-checkout/templates/form-checkout.php
@@ -6,6 +6,8 @@
  * @package Newspack_Blocks
  */
 
+namespace Newspack_Blocks;
+
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WooCommerce hooks.
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template variables.
 
@@ -42,7 +44,7 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 				<?php do_action( 'woocommerce_checkout_after_order_review' ); ?>
 			</div>
 			<?php do_action( 'woocommerce_checkout_after_customer_details' ); ?>
-			<button class="newspack-ui__button newspack-ui__button--tertiary newspack-ui__button--wide" id="checkout_back" type="button"><?php esc_html_e( 'Back', 'newspack-blocks' ); ?></button>
+			<button class="newspack-ui__button newspack-ui__button--tertiary newspack-ui__button--wide" id="checkout_back" type="button"><?php echo esc_html( Modal_Checkout::get_modal_checkout_labels( 'checkout_back' ) ); ?></button>
 		</div>
 	<?php endif; ?>
 </form>

--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -9,6 +9,8 @@
  * @var WC_Order $order
  */
 
+namespace Newspack_Blocks;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -61,10 +63,7 @@ function newspack_blocks_replace_login_with_order_summary() {
 			<p>
 				<strong>
 					<?php
-						esc_html_e(
-							'Thank you for supporting The News Paper! Your transaction was successful.',
-							'newspack-blocks'
-						);
+						echo esc_html( Modal_Checkout::get_modal_checkout_labels( 'thankyou' ) );
 					?>
 				</strong>
 			</p>


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1206943664367847/1205669646691019/f

This PR makes the previously hard-coded modal checkout flow custom text filterable:

![Screenshot 2024-04-17 at 16 21 53](https://github.com/Automattic/newspack-blocks/assets/17905991/f47c4c53-20cb-421f-9f75-cbefc15e9929)

Note: I have not made any of the errors or default WC checkout form text filterable. Only the additional custom text added by the blocks plugin. Let me know if you think any of these should be added.

### How to test the changes in this Pull Request:

1. Go through the modal checkout flow by purchasing a donation or checkout block product and confirm none of the text is broken
2. Add the following filter and test modal checkout again. Confirm all of the text has been replaced as expected:

```
add_filter( 'newspack_blocks_modal_checkout_labels', function( $labels ) {
	return [
		'title'                      => 'banana',
		'billing_details'            => 'banana',
		'shipping_details'           => 'banana',
		'gift_recipient'             => 'banana',
		'auth_modal_title'           => 'banana',
		'signin_modal_title'         => 'banana',
		'register_modal_title'       => 'banana',
		'after_success'              => 'banana',
		'donation_gift_details'      => 'banana',
		'purchase_gift_details'      => 'banana',
		'newsletter_confirmation'    => 'banana',
		'newsletter_details'         => 'banana',
		'newsletter_success'         => 'banana',
		'newsletter_title'           => 'banana',
		'newsletter_signup'          => 'banana',
		'checkout_confirm'           => 'banana',
		'checkout_confirm_variation' => 'banana',
		'checkout_back'              => 'banana',
		'thankyou'                   => 'banana',
	];
} );
```
3. Replace the above filter with the following and test modal checkout one more time. This time confirm all of the default text appears as expected:

```
add_filter( 'newspack_blocks_modal_checkout_labels', function( $labels ) {
	return [];
} );
```

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
