### PR TITLE
fix: fix wrapping issue happening in Firefox

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -81,24 +81,24 @@
 		// width of column - ( column gap / number of columns * number of gaps )
 		&.columns-3 article,
 		&.columns-6 article {
-			flex-basis: calc( 33.33% - ( var( --wpnbha-col-gap ) / 3 * 2 ) );
+			flex-basis: calc( 33.33% - ( var( --wpnbha-col-gap ) / 3 * 2 ) - 0.1px );
 		}
 
 		&.is-style-borders.columns-3 article,
 		&.is-style-borders.columns-6 article {
-			flex-basis: calc( 33.33% - ( 2 * var( --wpnbha-col-gap ) / 3 * 2 ) - 1px );
+			flex-basis: calc( 33.33% - ( 2 * var( --wpnbha-col-gap ) / 3 * 2 ) - 1.1px );
 		}
 
 		&.columns-2 article,
 		&.columns-4 article,
 		&.columns-5 article {
-			flex-basis: calc( 50% - ( var( --wpnbha-col-gap ) / 2 ) );
+			flex-basis: calc( 50% - ( var( --wpnbha-col-gap ) / 2 ) - 0.1px );
 		}
 
 		&.is-style-borders.columns-2 article,
 		&.is-style-borders.columns-4 article,
 		&.is-style-borders.columns-5 article {
-			flex-basis: calc( 50% - ( 2 * var( --wpnbha-col-gap ) / 2 ) - 1px );
+			flex-basis: calc( 50% - ( 2 * var( --wpnbha-col-gap ) / 2 ) - 1.1px );
 		}
 
 		&.columns-5 article:last-of-type,
@@ -109,29 +109,29 @@
 
 	@include mixins.media( tablet ) {
 		&.columns-4 article {
-			flex-basis: calc( 25% - ( var( --wpnbha-col-gap ) / 4 * 3 ) );
+			flex-basis: calc( 25% - ( var( --wpnbha-col-gap ) / 4 * 3 ) - 0.1px );
 		}
 
 		&.is-style-borders.columns-4 article {
-			flex-basis: calc( 25% - ( 2 * var( --wpnbha-col-gap ) / 4 * 3 ) - 1px );
+			flex-basis: calc( 25% - ( 2 * var( --wpnbha-col-gap ) / 4 * 3 ) - 1.1px );
 		}
 
 		&.columns-5 article,
 		&.columns-5 article:last-of-type {
-			flex-basis: calc( 20% - ( var( --wpnbha-col-gap ) / 5 * 4 ) );
+			flex-basis: calc( 20% - ( var( --wpnbha-col-gap ) / 5 * 4 ) - 0.1px );
 		}
 
 		&.is-style-borders.columns-5 article,
 		&.is-style-borders.columns-5 article:last-of-type {
-			flex-basis: calc( 20% - ( 2 * var( --wpnbha-col-gap ) / 5 * 4 ) - 1px );
+			flex-basis: calc( 20% - ( 2 * var( --wpnbha-col-gap ) / 5 * 4 ) - 1.1px );
 		}
 
 		&.columns-6 article {
-			flex-basis: calc( 16.6666% - ( var( --wpnbha-col-gap ) / 6 * 5 ) );
+			flex-basis: calc( 16.6666% - ( var( --wpnbha-col-gap ) / 6 * 5 ) - 0.1px );
 		}
 
 		&.is-style-borders.columns-6 article {
-			flex-basis: calc( 16.6666% - ( 2 * var( --wpnbha-col-gap ) / 6 * 5 ) - 1px );
+			flex-basis: calc( 16.6666% - ( 2 * var( --wpnbha-col-gap ) / 6 * 5 ) - 1.1px );
 		}
 	}
 
@@ -345,7 +345,7 @@
 			text-align: right;
 			text-overflow: ellipsis;
 			z-index: 3;
-			
+
 			a,
 			a:visited {
 			    color: #fff;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a odd pixel rounding issue that's happening in FF 125.0.1. It's not an elegant fix by any means, but hopefully works as a stopgap until we find something better.

### How to test the changes in this Pull Request:

1. Make sure you're running Firefox 125.0.1.
2. Add a columns block to the editor, and add a series of grid-layout homepage post blocks inside - 2 across, 3-across, 4-across, etc.
3. Adjust the width of the column up and down by 0.1% increments.
4. Note that most of the blocks (all but the three across) will wrap one article to the next line at random points. You can also publish the post, and do the same on the front-end using the element inspector (unfortunately when it wraps in the editor, it doesn't always wrap on the front end, and vis versa.
5. Apply this PR and run `npm run build`.
6. Repeat step 4 in the editor & on the front-end and confirm the blocks no longer wrap. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
