### PR TITLE
fix: make sure image scale CSS class is applied in editor

### DIFF
--- a/src/blocks/homepage-articles/edit.tsx
+++ b/src/blocks/homepage-articles/edit.tsx
@@ -678,7 +678,7 @@ class Edit extends Component< HomepageArticlesProps > {
 			[ `colgap-${ colGap }` ]: postLayout === 'grid',
 			[ `ts-${ typeScale }` ]: typeScale !== 5,
 			[ `image-align${ mediaPosition }` ]: showImage,
-			[ `is-${ imageScale }` ]: imageScale !== 1 && showImage,
+			[ `is-${ imageScale }` ]: showImage,
 			'mobile-stack': mobileStack,
 			[ `is-${ imageShape }` ]: showImage,
 			'has-text-color': textColor.color !== '',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Similar to https://github.com/Automattic/newspack-blocks/pull/1706, this PR fixes an issue where the image scale S wasn't previewing in the editor. 

I think both of these were kind of introduced [here](https://github.com/Automattic/newspack-blocks/commit/d09772c5ed430681c648b403581d2695a2df50e2#diff-99666cd1ffb5a73c1179234f9386da2da6a77c983828fd30ad2a25b6bcf556edL680-L682), but I can't, for the life of me, remember why those two sizes were excluded from the classes to begin with. 

### How to test the changes in this Pull Request:

1. Add a HPB to the editor, and align the images left or right.
2. Change the image size using the option in the sidebar, from L to XL, M, then S. Note that M and S are the same.
3. Apply this PR and run `npm run build`.
4. Rerun step 2 and confirm that S now previews correctly (should be ~25% of the available space).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
