### PR TITLE
feat: additional component updates

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -853,23 +853,25 @@ final class Modal_Checkout {
 		}
 		?>
 			<div class="newspack-modal-newsletters">
-				<h4><?php echo esc_html( self::get_modal_checkout_labels( 'newsletter_title' ) ); ?></h4>
+				<h3><?php echo esc_html( self::get_modal_checkout_labels( 'newsletter_title' ) ); ?></h3>
 				<div class="newspack-modal-newsletters__info">
+					<p>
 					<?php
 					echo esc_html( self::get_modal_checkout_labels( 'newsletter_details' ) );
 					?>
-					<br>
-					<span>
-					<?php
-						echo esc_html(
-							sprintf(
-								// Translators: %s is the user's email address.
-								__( 'Sending to: %s', 'newspack-blocks' ),
-								$email_address
-							)
-						);
-					?>
-					</span>
+						<br>
+						<span class="newspack-ui__color-text-gray">
+						<?php
+							echo esc_html(
+								sprintf(
+									// Translators: %s is the user's email address.
+									__( 'Sending to: %s', 'newspack-blocks' ),
+									$email_address
+								)
+							);
+						?>
+						</span>
+					</p>
 				</div>
 				<form>
 					<input type="hidden" name="modal_checkout" value="1" />
@@ -879,7 +881,7 @@ final class Modal_Checkout {
 					foreach ( $newsletters_lists as $list ) {
 						$checkbox_id = sprintf( 'newspack-blocks-list-%s', $list['id'] );
 						?>
-							<div class="newspack-modal-newsletters__list-item">
+						<label class="newspack-ui__input-card">
 							<input
 								type="checkbox"
 								name="lists[]"
@@ -891,17 +893,15 @@ final class Modal_Checkout {
 								}
 								?>
 							>
-							<label for="<?php echo \esc_attr( $checkbox_id ); ?>">
-								<b><?php echo \esc_html( $list['title'] ); ?></b>
-								<?php if ( ! empty( $list['description'] ) ) : ?>
-									<span><?php echo \esc_html( $list['description'] ); ?></span>
-								<?php endif; ?>
-							</label>
-							</div>
+							<strong><?php echo \esc_html( $list['title'] ); ?></strong><br>
+							<?php if ( ! empty( $list['description'] ) ) : ?>
+								<span class="newspack-ui__helper-text"><?php echo \esc_html( $list['description'] ); ?></span>
+							<?php endif; ?>
+						</label>
 						<?php
 					}
 					?>
-					<input type="submit" value="<?php echo esc_html( self::get_modal_checkout_labels( 'newsletter_signup' ) ); ?>">
+					<input type="submit" class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide" value="<?php echo esc_html( self::get_modal_checkout_labels( 'newsletter_signup' ) ); ?>">
 				</form>
 			</div>
 		<?php

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -893,7 +893,7 @@ final class Modal_Checkout {
 								}
 								?>
 							>
-							<strong><?php echo \esc_html( $list['title'] ); ?></strong><br>
+							<strong><?php echo \esc_html( $list['title'] ); ?></strong>
 							<?php if ( ! empty( $list['description'] ) ) : ?>
 								<span class="newspack-ui__helper-text"><?php echo \esc_html( $list['description'] ); ?></span>
 							<?php endif; ?>

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -243,7 +243,7 @@ import './checkout.scss';
 					if ( code ) {
 						const isError = code.includes( 'error' );
 						$coupon.append(
-							`<p class="result ${ newspackBlocksModalCheckout.newspack_class_prefix }__inline-info">` +
+							`<p class="result ${ newspackBlocksModalCheckout.newspack_class_prefix }__helper-text">` +
 								$( code ).text() +
 								'</p>'
 						);
@@ -333,7 +333,7 @@ import './checkout.scss';
 				data[ item.name ] = item.value;
 			} );
 
-			const classname = `${ newspackBlocksModalCheckout.newspack_class_prefix }__inline-info`;
+			const classname = `${ newspackBlocksModalCheckout.newspack_class_prefix }__helper-text`;
 			const html = [];
 			html.push( '<div class="billing-details">' );
 			html.push( '<h3>' + newspackBlocksModalCheckout.labels.billing_details + '</h3>' );

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -333,7 +333,7 @@ import './checkout.scss';
 				data[ item.name ] = item.value;
 			} );
 
-			const classname = `${ newspackBlocksModalCheckout.newspack_class_prefix }__helper-text`;
+			const classname = `${ newspackBlocksModalCheckout.newspack_class_prefix }__font--xs`;
 			const html = [];
 			html.push( '<div class="billing-details">' );
 			html.push( '<h3>' + newspackBlocksModalCheckout.labels.billing_details + '</h3>' );

--- a/src/modal-checkout/templates/payment-method.php
+++ b/src/modal-checkout/templates/payment-method.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 
 <li class="wc_payment_method payment_method_<?php echo esc_attr( $gateway->id ); ?>">
-	<label class="newspack-ui__input-list" for="payment_method_<?php echo esc_attr( $gateway->id ); ?>">
+	<label class="newspack-ui__input-card" for="payment_method_<?php echo esc_attr( $gateway->id ); ?>">
 		<input id="payment_method_<?php echo esc_attr( $gateway->id ); ?>" type="radio" class="input-radio" name="payment_method" value="<?php echo esc_attr( $gateway->id ); ?>" <?php checked( $gateway->chosen, true ); ?> data-order_button_text="<?php echo esc_attr( $gateway->order_button_text ); ?>" />
 		<span>
 			<?php echo $gateway->get_title(); /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?> <?php echo $gateway->get_icon(); /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Updates the CSS classes used in Newspack Blocks, related to these changes: https://github.com/Automattic/newspack-plugin/pull/3091

Specifically:

* Replaced the `newspack-ui__inline-info` class with `newspack-ui__helper-text`, to line up with the Figma naming convention.
* Replaced the `newspack-ui__helper-text` class on the address with `newspack-ui__font--xs` to get the font size without picking up the lighter grey colour.
* Replaced the `newspack-ui__input-list` classname with `newspack-ui__input-card`.
* Edited to add: updated the newsletter coda styles.

### How to test the changes in this Pull Request:

1. See https://github.com/Automattic/newspack-plugin/pull/3091 for testing steps and test with it.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
