### PR TITLE
fix: add `woocommerce_after_order_notes` action for integrations that need it

### DIFF
--- a/src/modal-checkout/templates/checkout-form.php
+++ b/src/modal-checkout/templates/checkout-form.php
@@ -161,6 +161,11 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 				</div>
 			<?php endif; ?>
 
+			<?php
+			if ( ! has_action( 'woocommerce_after_order_notes' ) ) {
+				do_action( 'woocommerce_after_order_notes', $checkout );
+			}
+			?>
 			<div class="after-customer-details">
 				<?php do_action( 'woocommerce_checkout_after_customer_details' ); ?>
 			</div>

--- a/src/modal-checkout/templates/checkout-form.php
+++ b/src/modal-checkout/templates/checkout-form.php
@@ -162,7 +162,8 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 			<?php endif; ?>
 
 			<?php
-			if ( ! has_action( 'woocommerce_after_order_notes' ) ) {
+			global $wp_actions;
+			if ( ! isset( $wp_actions['woocommerce_after_order_notes'] ) ) {
 				do_action( 'woocommerce_after_order_notes', $checkout );
 			}
 			?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Currently our custom checkout form doesn't include Woo's shipping form template, which is where the `woocommerce_after_order_notes` action lives. This PR adds it right before the `woocommerce_checkout_after_customer_details` action, which is roughly where it should appear in relation to the checkout fields. Only registers the action hook if it hasn't already been registered.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Create a custom action callback to execute on the `woocommerce_after_order_notes` hook, e.g.

```php
add_action(
	'woocommerce_after_order_notes',
	function( $checkout ) {
		error_log( 'woocommerce_after_order_notes action!!!' );
		error_log( print_r( $checkout, true ) );
	}
);
```

3. Start a purchase of a product via the Checkout Button block. On the second screen (with payment details) confirm that your action callback is executed and that the `$checkout` argument is an instance of `WC_Checkout`.
4. Go to your `/shop` page and start a purchase via the standard Woo checkout flow. Confirm that your action callback is executed here, too.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207083368446933