### PR TITLE
fix(ras-acc): re-adds missing newsletters form styles

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -1,3 +1,5 @@
+@use '../shared/sass/colors';
+
 /* stylelint-disable-next-line */
 #newspack_modal_checkout_container { /* stylelint-disable-line */
 	padding: 24px;
@@ -38,5 +40,45 @@
 				visibility: visible;
 			}
 		}
+	}
+}
+
+.newspack-modal-newsletters {
+	margin-top: 20px;
+	padding-top: 22px;
+	border-top: 1px solid colors.$color__border;
+	&__info {
+		margin-bottom: 35px;
+		span {
+			color: colors.$color__text-light;
+		}
+	}
+	&__list-item {
+		display: flex;
+		align-items: center;
+		margin-bottom: 18px;
+		padding: 12px;
+		border: 1px solid colors.$color__border;
+		border-radius: 6px;
+		b {
+			display: block;
+			margin-bottom: 2px;
+		}
+	}
+	label {
+		flex: 1;
+		cursor: pointer;
+		margin-bottom: 0;
+	}
+	input[type='checkbox'] {
+		padding: 10px;
+		margin-right: 10px !important;
+	}
+	input[type='submit'],
+	&__button {
+		margin-top: 25px;
+		width: 100%;
+		padding: 22px !important;
+		font-size: 1em !important;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This just re-adds some newsletters form styles that seem to have been removed from the checkout block.

Before:
![Screenshot 2024-05-07 at 16 24 23](https://github.com/Automattic/newspack-blocks/assets/17905991/7b324fda-fcad-49ee-ac9e-d78259336853)

After:
![Screenshot 2024-05-07 at 16 11 00](https://github.com/Automattic/newspack-blocks/assets/17905991/ac51ead4-a71c-462f-88d4-6db1fb2ec6d2)

### How to test the changes in this Pull Request:

1. Enable the post checkout newsletter signup flag in `wp-config.php`: `define( 'NEWSPACK_ENABLE_POST_CHECKOUT_NEWSLETTER_SIGNUP', true );`
2. Logged in as a reader, go through the checkout flow
3. On the thank you page, on `trunk` you should see a newsletters signup form with no styles. On this branch you should see the styled form as pictured above.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
