### PR TITLE
fix: respect subscriptions limiter, and handle cart errors in modal

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -72,6 +72,15 @@ final class Modal_Checkout {
 		add_filter( 'googlesitekit_adsense_tag_blocked', [ __CLASS__, 'is_modal_checkout' ] );
 		add_filter( 'googlesitekit_tagmanager_tag_blocked', [ __CLASS__, 'is_modal_checkout' ] );
 		add_filter( 'jetpack_active_modules', [ __CLASS__, 'jetpack_active_modules' ] );
+
+		// Ensure that options to limit the number of subscriptions per product are respected.
+		if ( self::is_modal_checkout() && class_exists( 'WCS_Limiter' ) ) {
+			add_filter( 'woocommerce_subscription_is_purchasable', [ 'WCS_Limiter', 'is_purchasable_switch' ], 12, 2 );
+			add_filter( 'woocommerce_subscription_variation_is_purchasable', [ 'WCS_Limiter', 'is_purchasable_switch' ], 12, 2 );
+			add_filter( 'woocommerce_subscription_is_purchasable', [ 'WCS_Limiter', 'is_purchasable_renewal' ], 12, 2 );
+			add_filter( 'woocommerce_subscription_variation_is_purchasable', [ 'WCS_Limiter', 'is_purchasable_renewal' ], 12, 2 );
+			add_filter( 'woocommerce_valid_order_statuses_for_order_again', [ 'WCS_Limiter', 'filter_order_again_statuses_for_limited_subscriptions' ] );
+		}
 	}
 
 	/**

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -32,6 +32,8 @@ final class Modal_Checkout {
 	 */
 	public static function init() {
 		add_action( 'wp_loaded', [ __CLASS__, 'process_checkout_request' ], 5 );
+		add_filter( 'wp_redirect', [ __CLASS__, 'pass_url_param_on_redirect' ] );
+		add_filter( 'woocommerce_cart_product_cannot_be_purchased_message', [ __CLASS__, 'woocommerce_cart_product_cannot_be_purchased_message' ], 10, 2 );
 		add_action( 'wp_footer', [ __CLASS__, 'render_modal_markup' ], 100 );
 		add_action( 'wp_footer', [ __CLASS__, 'render_variation_selection' ], 100 );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
@@ -364,9 +366,6 @@ final class Modal_Checkout {
 	 * Enqueue scripts for the checkout page rendered in a modal.
 	 */
 	public static function enqueue_scripts() {
-		if ( ! function_exists( 'is_checkout' ) || ! is_checkout() ) {
-			return;
-		}
 		if ( ! self::is_modal_checkout() ) {
 			return;
 		}
@@ -430,14 +429,24 @@ final class Modal_Checkout {
 	 * @return string
 	 */
 	public static function get_checkout_template( $template ) {
-		if ( ! function_exists( 'is_checkout' ) || ! function_exists( 'is_order_received_page' ) ) {
+		if ( ! function_exists( 'is_checkout' ) || ! function_exists( 'is_order_received_page' ) || ! function_exists( 'is_cart' ) ) {
 			return $template;
 		}
-		if ( ! is_checkout() && ! is_order_received_page() ) {
+		if ( ! is_checkout() && ! is_order_received_page() && ! is_cart() ) {
 			return $template;
 		}
 		if ( ! self::is_modal_checkout() ) {
 			return $template;
+		}
+		$body_classes = [ 'newspack-modal-checkout' ];
+		if ( is_checkout() ) {
+			$body_classes[] = 'checkout';
+		}
+		if ( is_order_received_page() ) {
+			$body_classes[] = 'order-received';
+		}
+		if ( is_cart() ) {
+			$body_classes[] = 'cart';
 		}
 		ob_start();
 		?>
@@ -449,10 +458,16 @@ final class Modal_Checkout {
 			<link rel="profile" href="https://gmpg.org/xfn/11" />
 			<?php wp_head(); ?>
 		</head>
-		<body id="newspack_modal_checkout">
+		<body id="newspack_modal_checkout" class="<?php echo esc_attr( implode( ' ', $body_classes ) ); ?>">
 			<?php
 			echo do_shortcode( '[woocommerce_checkout]' );
 			wp_footer();
+			?>
+
+			<?php
+			if ( is_cart() ) {
+				self::render_close_button();
+			}
 			?>
 		</body>
 		</html>
@@ -785,6 +800,27 @@ final class Modal_Checkout {
 	}
 
 	/**
+	 * Render a generic button to close the modal.
+	 *
+	 * @param string $button_label The button label.
+	 */
+	private static function render_close_button( $button_label = '' ) {
+		if ( ! $button_label ) {
+			$button_label = __( 'Close window', 'newspack-blocks' );
+		}
+		?>
+			<div class="button-container">
+				<a
+					onclick="parent.newspackCloseModalCheckout(this);"
+					class="button close-button"
+				>
+					<?php echo esc_html( $button_label ); ?>
+				</a>
+			</div>
+		<?php
+	}
+
+	/**
 	 * Renders newsletter signup form.
 	 *
 	 * @param WC_Order $order The order related to the transaction.
@@ -970,9 +1006,44 @@ final class Modal_Checkout {
 	}
 
 	/**
+	 * Ensure that the modal_checkout param is passed if we get redirected while inside the modal.
+	 * This is so that we can continue hiding site elements that we don't want to show inside the modal.
+	 *
+	 * @param string $location The path or URL to redirect to.
+	 *
+	 * @return string
+	 */
+	public static function pass_url_param_on_redirect( $location ) {
+		if ( self::is_modal_checkout() ) {
+			$location = \add_query_arg( [ 'modal_checkout' => 1 ], $location );
+		}
+		return $location;
+	}
+
+	/**
+	 * Filters the error message shown when a product can't be added to the cart.
+	 *
+	 * @param string     $message Message.
+	 * @param WC_Product $product_data Product data.
+	 *
+	 * @return string
+	 */
+	public static function woocommerce_cart_product_cannot_be_purchased_message( $message, $product_data ) {
+		if ( method_exists( 'WCS_Limiter', 'is_purchasable' ) ) {
+			$product = \wc_get_product( $product_data->get_id() );
+			if ( ! \WCS_Limiter::is_purchasable( false, $product ) ) {
+				$message .= ' ' . __( 'You may only have one subscription of this product at a time.', 'newspack-blocks' );
+			}
+		}
+
+		return $message;
+	}
+
+	/**
 	 * Is this request using the modal checkout?
 	 */
 	public static function is_modal_checkout() {
+
 		$is_modal_checkout = isset( $_REQUEST['modal_checkout'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! $is_modal_checkout && isset( $_REQUEST['post_data'] ) && is_string( $_REQUEST['post_data'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$is_modal_checkout = strpos( $_REQUEST['post_data'], 'modal_checkout=1' ) !== false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -75,7 +75,13 @@ final class Modal_Checkout {
 		add_filter( 'googlesitekit_tagmanager_tag_blocked', [ __CLASS__, 'is_modal_checkout' ] );
 		add_filter( 'jetpack_active_modules', [ __CLASS__, 'jetpack_active_modules' ] );
 
-		// Ensure that options to limit the number of subscriptions per product are respected.
+		/**
+		 * Ensure that options to limit the number of subscriptions per product are respected.
+		 * Note: This is normally called only for regular checkout pages and REST API requests,
+		 * so we need to add the filters for modal checkout.
+		 *
+		 * See: https://github.com/Automattic/woocommerce-subscriptions-core/blob/trunk/includes/class-wcs-limiter.php#L23
+		*/
 		if ( self::is_modal_checkout() && class_exists( 'WCS_Limiter' ) ) {
 			add_filter( 'woocommerce_subscription_is_purchasable', [ 'WCS_Limiter', 'is_purchasable_switch' ], 12, 2 );
 			add_filter( 'woocommerce_subscription_variation_is_purchasable', [ 'WCS_Limiter', 'is_purchasable_switch' ], 12, 2 );

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -1,9 +1,19 @@
 @use '../shared/sass/colors';
 
 /* stylelint-disable-next-line */
-#newspack_modal_checkout {
+.newspack-modal-checkout {
 	padding: 32px;
 	font-size: 1rem;
+	&.cart {
+		.button-container {
+			text-align: center;
+		}
+		.woocommerce-error {
+			background: none;
+			color: colors.$color__error;
+			padding: 0;
+		}
+	}
 	.order-details-summary {
 		border: 2px solid;
 		border-radius: 3px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Respects the "Limit subscription" option in Woo products. Also implements some styles so that the modal checkout window is still usable if the `add_to_cart` method fails and redirects to the cart page inside the modal.

Closes `1200550061930446/1207095202849399`.

### How to test the changes in this Pull Request:

1. Ensure you have two subscription products published: a simple subscription and a variable one (see the [Woo documentation](https://href.li/?https://woocommerce.com/document/subscriptions/store-manager-guide/#creating-a-subscription-product) for details on how to set up).
2. For each product, in Product data > Advanced, set the "Limit subscription" option to "Limit to one active subscription".

<img width="808" alt="Screenshot 2024-05-09 at 4 53 19 PM" src="https://github.com/Automattic/newspack-blocks/assets/2230142/8e65f469-4236-4df5-b485-fef5db62280d">

3. Publish a page or post with Checkout Button blocks for each product.
4. As a reader, purchase a subscription for each product using the Checkout Button blocks.
5. After purchasing, while still logged in as the reader, attempt to purchase each product again.
6. On `trunk`, observe that the modal checkout window displays the full Cart page with site header + footer, locked behind a loading animation that never resolves.

<img width="1005" alt="Screenshot 2024-05-09 at 5 02 15 PM" src="https://github.com/Automattic/newspack-blocks/assets/2230142/a69a4efb-7df9-4ef6-92de-ee3e4f12cf08">

7. Check out this branch. Repeat step 6 and confirm that you now see a more graceful error message in the modal, along with a button that closes the modal when clicked.

<img width="657" alt="Screenshot 2024-05-09 at 4 50 33 PM" src="https://github.com/Automattic/newspack-blocks/assets/2230142/67863c7a-b658-408e-8a17-16090a8d3b6d">

8. As an admin, cancel the reader's subscriptions for both products.
9. Repeat step 7 and confirm that you can now repurchase those products.
10. As an admin, for each product, change the "Limit subscription" option to "Limit to one of any status". 
11. Repeat step 7 and confirm that you still see the same error message as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207095202849399