### PR TITLE
feat(ras-acc): add name your price support to checkout button

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1391,6 +1391,8 @@ final class Modal_Checkout {
 					__( 'Thank you for supporting %s. Your transaction was successful.', 'newspack-blocks' ),
 					get_option( 'blogname' )
 				),
+				'checkout_nyp'               => __( "Your contribution directly funds our work. If you're moved to do so, you can opt to pay more than the standard rate.", 'newspack-blocks' ),
+				'checkout_nyp_thankyou'      => __( "Thank you for your generosity! We couldn't do this without you!", 'newspack-blocks' ),
 			];
 
 			/**

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1286,7 +1286,7 @@ final class Modal_Checkout {
 						<p class="input-price" >
 							<label for="price">
 								<span class="currency"><?php echo esc_html( $currency_symbol ); ?></span>
-								<input type="number" step=".01" name="price" placeholder="<?php echo esc_attr( $price ); ?>" />
+								<input type="number" min="0" step=".01" name="price" placeholder="<?php echo esc_attr( $price ); ?>" />
 							</label>
 							<button type="submit" class="<?php echo esc_attr( "{$class_prefix}__button {$class_prefix}__button--outline" ); ?>">
 								<?php echo esc_html( self::get_modal_checkout_labels( 'checkout_nyp_apply' ) ); ?>

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1264,17 +1264,17 @@ final class Modal_Checkout {
 					$_product = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
 					if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && \WC_Name_Your_Price_Helpers::is_nyp( $_product ) && apply_filters( 'woocommerce_checkout_cart_item_visible', true, $cart_item, $cart_item_key ) ) :
 						?>
-						<h3><?php echo esc_html( self::get_modal_checkout_labels( 'checkout_nyp_title' ) ); ?></h3>
 						<form class="modal_checkout_nyp">
+							<h3><?php echo esc_html( self::get_modal_checkout_labels( 'checkout_nyp_title' ) ); ?></h3>
 							<input type="hidden" name="newspack_checkout_name_your_price" value="1" />
 							<input type="hidden" name="product_id" value="<?php echo esc_attr( $_product->get_id() ); ?>" />
-							<div class="modal_checkout_nyp_input">
+							<p class="input-price" >
 								<label for="price">
 									<span><?php echo esc_html( \get_woocommerce_currency_symbol() ); ?></span>
-									<input type="number" step="any" min="<?php echo esc_attr( \WC_Name_Your_Price_Helpers::get_minimum_price( $_product->get_id() ) ); ?>" name="price" placeholder="<?php echo esc_attr( \WC_Name_Your_Price_Helpers::get_suggested_price( $_product->get_id() ) ); ?>" />
+									<input type="number" step="any" min="<?php echo esc_attr( \WC_Name_Your_Price_Helpers::get_minimum_price( $_product->get_id() ) ); ?>" class="input-text" name="price" placeholder="<?php echo esc_attr( \WC_Name_Your_Price_Helpers::get_suggested_price( $_product->get_id() ) ); ?>" />
 								</label>
 								<button type="submit" class="<?php echo esc_attr( "{$class_prefix}__button {$class_prefix}__button--outline" ); ?>"><?php echo esc_html( self::get_modal_checkout_labels( 'checkout_nyp_apply' ) ); ?></button>
-							</div>
+							</p>
 							<p class="result <?php echo esc_attr( "{$class_prefix}__inline-info" ); ?>"><?php echo esc_attr( self::get_modal_checkout_labels( 'checkout_nyp' ) ); ?></p>
 						</form>
 						<?php

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -270,8 +270,6 @@ final class Modal_Checkout {
 			return;
 		}
 
-		\WC()->cart->empty_cart();
-
 		$price     = filter_input( INPUT_POST, 'amount', FILTER_SANITIZE_NUMBER_INT );
 		$min_price = \WC_Name_Your_Price_Helpers::get_minimum_price( $product_id );
 		$max_price = \WC_Name_Your_Price_Helpers::get_maximum_price( $product_id );
@@ -304,9 +302,13 @@ final class Modal_Checkout {
 			wp_die();
 		}
 
-		$cart_item_data['nyp'] = (float) \WC_Name_Your_Price_Helpers::standardize_number( $price );
+		foreach ( \WC()->cart->get_cart() as $cart_item_key => $cart_item ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			if ( $cart_item['product_id'] !== $product_id ) {
+				continue;
+			}
 
-		\WC()->cart->add_to_cart( $product_id, 1, 0, [], $cart_item_data );
+			$cart_item['data']->set_price( $price );
+		}
 
 		wp_send_json_success(
 			[

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1251,6 +1251,13 @@ final class Modal_Checkout {
 		if ( ! self::is_modal_checkout() || ! function_exists( 'WC' ) || ! method_exists( '\WC_Name_Your_Price_Helpers', 'is_nyp' ) ) {
 			return;
 		}
+
+		// Only show for checkout button modal checkout.
+		$is_donation = method_exists( 'Newspack\Donations', 'is_donation_cart' ) && \Newspack\Donations::is_donation_cart();
+		if ( $is_donation ) {
+			return;
+		}
+
 		$cart = \WC()->cart;
 		if ( 1 !== $cart->get_cart_contents_count() ) {
 			return;

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -287,17 +287,17 @@ final class Modal_Checkout {
 			wp_die();
 		}
 
-		$cart_item_data = self::amend_cart_item_data( [ 'referer' => $referer ] );
+		$cart_item_data = self::amend_cart_item_data( [ 'referer' => wp_get_referer() ] );
 
 		foreach ( \WC()->cart->get_cart() as $cart_item_key => $cart_item ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-			if ( $cart_item['product_id'] !== (int) $product_id ) {
+			if ( $cart_item['product_id'] !== (int) $product_id && $cart_item['variation_id'] !== (int) $product_id ) {
 				continue;
 			}
 
 			$cart_item_data['nyp'] = $price;
 			$cart_item_data['base_price'] = isset( $cart_item['base_price'] ) ? $cart_item['base_price'] : $cart_item['nyp'];
 
-			if ( $price <= $cart_item_data['base_price'] ) {
+			if ( $price < $cart_item_data['base_price'] ) {
 				wp_send_json_error(
 					[
 						'message' => sprintf(

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1172,7 +1172,7 @@ final class Modal_Checkout {
 	 * Render name your price form if nyp is active and available.
 	 */
 	public static function render_name_your_price_form() {
-		if ( ! self::is_modal_checkout() || ! \Newspack_Blocks::can_use_name_your_price() ) {
+		if ( ! self::is_modal_checkout() || ! class_exists( '\WC' ) || ! method_exists( '\WC_Name_Your_Price_Helpers', 'is_nyp' ) ) {
 			return;
 		}
 		$cart = \WC()->cart;

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -261,6 +261,8 @@ final class Modal_Checkout {
 			return;
 		}
 
+		check_ajax_referer( 'newspack_checkout_name_your_price' );
+
 		$is_newspack_checkout_nyp = filter_input( INPUT_POST, 'newspack_checkout_name_your_price', FILTER_SANITIZE_NUMBER_INT );
 		$product_id               = filter_input( INPUT_POST, 'product_id', FILTER_SANITIZE_NUMBER_INT );
 
@@ -464,6 +466,7 @@ final class Modal_Checkout {
 			'newspackBlocksModalCheckout',
 			[
 				'ajax_url'              => admin_url( 'admin-ajax.php' ),
+				'nyp_nonce'             => wp_create_nonce( 'newspack_checkout_name_your_price' ),
 				'newspack_class_prefix' => self::get_class_prefix(),
 				'labels'                => [
 					'billing_details'  => self::get_modal_checkout_labels( 'billing_details' ),

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -257,7 +257,7 @@ final class Modal_Checkout {
 			return;
 		}
 
-		if ( ! \Newspack_Blocks::can_use_name_your_price() || ! method_exists( '\WC_Name_Your_Price_Helpers', 'is_nyp' ) ) {
+		if ( ! function_exists( 'WC' ) || ! \Newspack_Blocks::can_use_name_your_price() || ! method_exists( '\WC_Name_Your_Price_Helpers', 'is_nyp' ) ) {
 			return;
 		}
 
@@ -270,7 +270,7 @@ final class Modal_Checkout {
 			return;
 		}
 
-		$price     = filter_input( INPUT_POST, 'amount', FILTER_SANITIZE_NUMBER_INT );
+		$price     = filter_input( INPUT_POST, 'amount', FILTER_SANITIZE_NUMBER_FLOAT );
 		$min_price = \WC_Name_Your_Price_Helpers::get_minimum_price( $product_id );
 		$max_price = \WC_Name_Your_Price_Helpers::get_maximum_price( $product_id );
 
@@ -310,10 +310,12 @@ final class Modal_Checkout {
 			$cart_item['data']->set_price( $price );
 		}
 
+		\WC()->cart->calculate_totals();
+
 		wp_send_json_success(
 			[
 				'message' => self::get_modal_checkout_labels( 'checkout_nyp_thankyou' ),
-				'price'   => $price,
+				'price'   => \wc_price( $price ),
 			]
 		);
 
@@ -1246,7 +1248,7 @@ final class Modal_Checkout {
 	 * Render name your price form if nyp is active and available.
 	 */
 	public static function render_name_your_price_form() {
-		if ( ! self::is_modal_checkout() || ! method_exists( '\WC_Name_Your_Price_Helpers', 'is_nyp' ) ) {
+		if ( ! self::is_modal_checkout() || ! function_exists( 'WC' ) || ! method_exists( '\WC_Name_Your_Price_Helpers', 'is_nyp' ) ) {
 			return;
 		}
 		$cart = \WC()->cart;

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1269,9 +1269,13 @@ final class Modal_Checkout {
 							<input type="hidden" name="newspack_checkout_name_your_price" value="1" />
 							<input type="hidden" name="product_id" value="<?php echo esc_attr( $_product->get_id() ); ?>" />
 							<div class="modal_checkout_nyp_input">
-								<input type="number" step="any" min="<?php echo esc_attr( \WC_Name_Your_Price_Helpers::get_minimum_price( $_product->get_id() ) ); ?>" name="price" placeholder="<?php echo esc_attr( \WC_Name_Your_Price_Helpers::get_suggested_price( $_product->get_id() ) ); ?>" />
+								<label for="price">
+									<span><?php echo esc_html( \get_woocommerce_currency_symbol() ); ?></span>
+									<input type="number" step="any" min="<?php echo esc_attr( \WC_Name_Your_Price_Helpers::get_minimum_price( $_product->get_id() ) ); ?>" name="price" placeholder="<?php echo esc_attr( \WC_Name_Your_Price_Helpers::get_suggested_price( $_product->get_id() ) ); ?>" />
+								</label>
 								<button type="submit" class="<?php echo esc_attr( "{$class_prefix}__button {$class_prefix}__button--outline" ); ?>"><?php echo esc_html( self::get_modal_checkout_labels( 'checkout_nyp_apply' ) ); ?></button>
 							</div>
+							<p class="result <?php echo esc_attr( "{$class_prefix}__inline-info" ); ?>"><?php echo esc_attr( self::get_modal_checkout_labels( 'checkout_nyp' ) ); ?></p>
 						</form>
 						<?php
 					endif;

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1286,7 +1286,7 @@ final class Modal_Checkout {
 						<p class="input-price" >
 							<label for="price">
 								<span class="currency"><?php echo esc_html( $currency_symbol ); ?></span>
-								<input type="number" min="0" step=".01" name="price" placeholder="<?php echo esc_attr( $price ); ?>" />
+								<input type="number" min="0" step=".01" name="price" placeholder="<?php echo esc_attr( $price ); ?>" onwheel="return false" />
 							</label>
 							<button type="submit" class="<?php echo esc_attr( "{$class_prefix}__button {$class_prefix}__button--outline" ); ?>">
 								<?php echo esc_html( self::get_modal_checkout_labels( 'checkout_nyp_apply' ) ); ?>

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1292,7 +1292,7 @@ final class Modal_Checkout {
 								<?php echo esc_html( self::get_modal_checkout_labels( 'checkout_nyp_apply' ) ); ?>
 							</button>
 						</p>
-						<p class="result <?php echo esc_attr( "{$class_prefix}__inline-info" ); ?>">
+						<p class="result <?php echo esc_attr( "{$class_prefix}__helper-text" ); ?>">
 							<?php echo esc_attr( self::get_modal_checkout_labels( 'checkout_nyp' ) ); ?>
 						</p>
 					</form>

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -270,7 +270,7 @@ final class Modal_Checkout {
 			return;
 		}
 
-		$price     = filter_input( INPUT_POST, 'amount', FILTER_SANITIZE_NUMBER_FLOAT );
+		$price     = \WC_Name_Your_Price_Helpers::standardize_number( filter_input( INPUT_POST, 'price', FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION ) );
 		$min_price = \WC_Name_Your_Price_Helpers::get_minimum_price( $product_id );
 		$max_price = \WC_Name_Your_Price_Helpers::get_maximum_price( $product_id );
 
@@ -279,7 +279,7 @@ final class Modal_Checkout {
 				[
 					'message' => sprintf(
 						// Translators: %s is the minimum price.
-						__( 'Adjusted amount must exceed the minimum price of %s.', 'newspack-blocks' ),
+						__( 'Adjusted amount must be greater than the minimum of %s.', 'newspack-blocks' ),
 						\wc_price( $min_price )
 					),
 				]
@@ -293,7 +293,7 @@ final class Modal_Checkout {
 				[
 					'message' => sprintf(
 						// Translators: %s is the maximum price.
-						__( 'Adjusted amount must not exceed the maximum price of %s.', 'newspack-blocks' ),
+						__( 'Adjusted price must be less than the maximum of %s.', 'newspack-blocks' ),
 						\wc_price( $max_price )
 					),
 				]
@@ -303,7 +303,7 @@ final class Modal_Checkout {
 		}
 
 		foreach ( \WC()->cart->get_cart() as $cart_item_key => $cart_item ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-			if ( $cart_item['product_id'] !== $product_id ) {
+			if ( $cart_item['product_id'] !== (int) $product_id ) {
 				continue;
 			}
 
@@ -1268,9 +1268,9 @@ final class Modal_Checkout {
 						<form class="modal_checkout_nyp">
 							<input type="hidden" name="newspack_checkout_name_your_price" value="1" />
 							<input type="hidden" name="product_id" value="<?php echo esc_attr( $_product->get_id() ); ?>" />
-							<div>
-								<input name="amount" placeholder="<?php echo esc_attr( \WC_Name_Your_Price_Helpers::get_suggested_price( $_product->get_id() ) ); ?>" />
-								<button type="submit" class="<?php echo esc_attr( "{$class_prefix}__button {$class_prefix}__button--primary" ); ?>"><?php echo esc_html( self::get_modal_checkout_labels( 'checkout_nyp_apply' ) ); ?></button>
+							<div class="modal_checkout_nyp_input">
+								<input type="number" step="any" min="<?php echo esc_attr( \WC_Name_Your_Price_Helpers::get_minimum_price( $_product->get_id() ) ); ?>" name="price" placeholder="<?php echo esc_attr( \WC_Name_Your_Price_Helpers::get_suggested_price( $_product->get_id() ) ); ?>" />
+								<button type="submit" class="<?php echo esc_attr( "{$class_prefix}__button {$class_prefix}__button--outline" ); ?>"><?php echo esc_html( self::get_modal_checkout_labels( 'checkout_nyp_apply' ) ); ?></button>
 							</div>
 						</form>
 						<?php

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -44,5 +44,23 @@
 		display: flex;
 		flex-wrap: nowrap;
 		gap: 8px;
+
+		label {
+			display: flex;
+			align-items: center;
+			margin: 0;
+			position: relative;
+			width: 100%;
+
+			span {
+				padding-left: 0.5em;
+				position: absolute;
+				left: 0;
+			}
+
+			input {
+				padding-left: 1.5em;
+			}
+		}
 	}
 }

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -55,7 +55,7 @@
 				position: relative;
 				width: 100%;
 
-				span {
+				span.currency {
 					padding-left: 0.5em;
 					position: absolute;
 					left: 0;

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -56,13 +56,13 @@
 				width: 100%;
 
 				span.currency {
-					padding-left: 0.5em;
+					padding-left: 16px;
 					position: absolute;
 					left: 0;
 				}
 
 				input {
-					padding-left: 1.5em;
+					padding-left: 32px;
 				}
 			}
 		}

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -40,26 +40,30 @@
 		}
 	}
 
-	.modal_checkout_nyp_input {
-		display: flex;
-		flex-wrap: nowrap;
-		gap: 8px;
-
-		label {
+	.modal_checkout_nyp {
+		.input-price {
 			display: flex;
 			align-items: center;
+			flex-wrap: nowrap;
+			gap: 0.5em;
 			margin: 0;
-			position: relative;
-			width: 100%;
 
-			span {
-				padding-left: 0.5em;
-				position: absolute;
-				left: 0;
-			}
+			label {
+				display: flex;
+				align-items: center;
+				margin: 0;
+				position: relative;
+				width: 100%;
 
-			input {
-				padding-left: 1.5em;
+				span {
+					padding-left: 0.5em;
+					position: absolute;
+					left: 0;
+				}
+
+				input {
+					padding-left: 1.5em;
+				}
 			}
 		}
 	}

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -39,4 +39,10 @@
 			}
 		}
 	}
+
+	.modal_checkout_nyp_input {
+		display: flex;
+		flex-wrap: nowrap;
+		gap: 8px;
+	}
 }

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -46,7 +46,7 @@
 			align-items: center;
 			flex-wrap: nowrap;
 			gap: 0.5em;
-			margin: 0;
+			margin: 0 0 8px;
 
 			label {
 				display: flex;
@@ -64,6 +64,10 @@
 				input {
 					padding-left: 32px;
 				}
+			}
+
+			button {
+				margin-top: 0;
 			}
 		}
 	}

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -70,5 +70,9 @@
 				margin-top: 0;
 			}
 		}
+
+		&.processing {
+			opacity: 0.5;
+		}
 	}
 }

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -290,7 +290,7 @@ import './checkout.scss';
 			const data = {
 				_ajax_nonce: newspackBlocksModalCheckout.nyp_nonce,
 				action: 'process_name_your_price_request',
-				amount: $nyp.find( 'input[name="amount"]' ).val(),
+				price: $nyp.find( 'input[name="price"]' ).val(),
 				product_id: $nyp.find( 'input[name="product_id"]' ).val(),
 				newspack_checkout_name_your_price: $nyp
 					.find( 'input[name="newspack_checkout_name_your_price"]' )
@@ -313,7 +313,7 @@ import './checkout.scss';
 					if ( success ) {
 						$( '.woocommerce-Price-amount' ).replaceWith( res.price );
 					} else {
-						$nyp.find( 'input[name="amount"]' ).focus();
+						$nyp.find( 'input[name="price"]' ).focus();
 					}
 				},
 				complete: () => {

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -289,9 +289,8 @@ import './checkout.scss';
 			} );
 			$nyp.find( '.result' ).remove();
 			const data = {
+				_ajax_nonce: newspackBlocksModalCheckout.nyp_nonce,
 				action: 'process_name_your_price_request',
-				// TODO: Add nonce.
-				// security: 'name-your-price',
 				amount: $nyp.find( 'input[name="amount"]' ).val(),
 				product_id: $nyp.find( 'input[name="product_id"]' ).val(),
 				newspack_checkout_name_your_price: $nyp

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -304,8 +304,8 @@ import './checkout.scss';
 					clearNotices();
 					$nyp.find( '.result' ).remove();
 					$nyp.append(
-						`<p class="result ${ newspackBlocksModalCheckout.newspack_class_prefix }__inline-${
-							success ? 'info' : 'error'
+						`<p class="result ${ newspackBlocksModalCheckout.newspack_class_prefix }__${
+							success ? 'helper-text' : 'inline-error'
 						}">` +
 							res.message +
 							'</p>'

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -38,6 +38,7 @@ import './checkout.scss';
 		}
 
 		const $coupon = $( 'form.modal_checkout_coupon' );
+		const $nyp = $( 'form.modal_checkout_nyp' );
 		const $checkout_continue = $( '#checkout_continue' );
 		const $customer_details = $( '#customer_details' );
 		const $after_customer_details = $( '#after_customer_details' );
@@ -267,6 +268,58 @@ import './checkout.scss';
 				$coupon.find( '.result' ).remove();
 				$coupon.find( 'input[name="coupon_code"]' ).val( '' ).focus();
 			} );
+		}
+
+		/**
+		 * Handle name your price submission.
+		 *
+		 * @param {Event} ev
+		 */
+		function handleNYPFormSubmit( ev ) {
+			ev.preventDefault();
+			if ( $nyp.is( '.processing' ) ) {
+				return false;
+			}
+			$nyp.addClass( 'processing' ).block( {
+				message: null,
+				overlayCSS: {
+					background: '#fff',
+					opacity: 0.6,
+				},
+			} );
+			$nyp.find( '.result' ).remove();
+			const data = {
+				action: 'process_name_your_price_request',
+				// TODO: Add nonce.
+				// security: 'name-your-price',
+				amount: $nyp.find( 'input[name="amount"]' ).val(),
+				product_id: $nyp.find( 'input[name="product_id"]' ).val(),
+				newspack_checkout_name_your_price: $nyp
+					.find( 'input[name="newspack_checkout_name_your_price"]' )
+					.val(),
+			};
+			// Ajax request.
+			$.ajax( {
+				type: 'POST',
+				url: newspackBlocksModalCheckout.ajax_url,
+				data,
+				success: ( { success, data: res } ) => {
+					$nyp.append(
+						`<p class="result ${ newspackBlocksModalCheckout.newspack_class_prefix }__inline-${
+							success ? 'info' : 'error'
+						}">` +
+							res.message +
+							'</p>'
+					);
+					// TODO: Update price in the checkout if successful.
+				},
+				complete: () => {
+					$nyp.removeClass( 'processing' ).unblock();
+				},
+			} );
+		}
+		if ( $nyp.length ) {
+			$nyp.on( 'submit', handleNYPFormSubmit );
 		}
 
 		/**

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -296,7 +296,6 @@ import './checkout.scss';
 					.find( 'input[name="newspack_checkout_name_your_price"]' )
 					.val(),
 			};
-			// Ajax request.
 			$.ajax( {
 				type: 'POST',
 				url: newspackBlocksModalCheckout.ajax_url,
@@ -312,7 +311,7 @@ import './checkout.scss';
 							'</p>'
 					);
 					if ( success ) {
-						// TODO: Update price in the checkout if successful.
+						$( '.woocommerce-Price-amount' ).replaceWith( res.price );
 					} else {
 						$nyp.find( 'input[name="amount"]' ).focus();
 					}

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -352,6 +352,9 @@ import './checkout.scss';
 				if ( $coupon.length ) {
 					$coupon.hide();
 				}
+				if ( $nyp.length ) {
+					$nyp.hide();
+				}
 				$customer_details.show();
 				$after_customer_details.hide();
 				$place_order_button.attr( 'disabled', 'disabled' );
@@ -365,6 +368,9 @@ import './checkout.scss';
 			} else {
 				if ( $coupon.length ) {
 					$coupon.show();
+				}
+				if ( $nyp.length ) {
+					$nyp.show();
 				}
 				$customer_details.hide();
 				$after_customer_details.show();

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -287,7 +287,6 @@ import './checkout.scss';
 					opacity: 0.6,
 				},
 			} );
-			$nyp.find( '.result' ).remove();
 			const data = {
 				_ajax_nonce: newspackBlocksModalCheckout.nyp_nonce,
 				action: 'process_name_your_price_request',
@@ -303,6 +302,8 @@ import './checkout.scss';
 				url: newspackBlocksModalCheckout.ajax_url,
 				data,
 				success: ( { success, data: res } ) => {
+					clearNotices();
+					$nyp.find( '.result' ).remove();
 					$nyp.append(
 						`<p class="result ${ newspackBlocksModalCheckout.newspack_class_prefix }__inline-${
 							success ? 'info' : 'error'
@@ -310,7 +311,11 @@ import './checkout.scss';
 							res.message +
 							'</p>'
 					);
-					// TODO: Update price in the checkout if successful.
+					if ( success ) {
+						// TODO: Update price in the checkout if successful.
+					} else {
+						$nyp.find( 'input[name="amount"]' ).focus();
+					}
 				},
 				complete: () => {
 					$nyp.removeClass( 'processing' ).unblock();

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -280,13 +280,9 @@ import './checkout.scss';
 			if ( $nyp.is( '.processing' ) ) {
 				return false;
 			}
-			$nyp.addClass( 'processing' ).block( {
-				message: null,
-				overlayCSS: {
-					background: '#fff',
-					opacity: 0.6,
-				},
-			} );
+			$nyp.addClass( 'processing' );
+			const input = $nyp.find( 'input[name="price"]' );
+			input.attr( 'disabled', true );
 			const data = {
 				_ajax_nonce: newspackBlocksModalCheckout.nyp_nonce,
 				action: 'process_name_your_price_request',
@@ -317,7 +313,9 @@ import './checkout.scss';
 					}
 				},
 				complete: () => {
-					$nyp.removeClass( 'processing' ).unblock();
+					input.attr( 'disabled', false );
+					input.focus();
+					$nyp.removeClass( 'processing' );
 				},
 			} );
 		}

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -425,9 +425,7 @@ import './checkout.scss';
 				}
 			}
 
-			$( '.order-details-summary' ).after(
-				'<div id="checkout_details">' + html.join( '' ) + '</div>'
-			);
+			$( 'form.checkout' ).before( '<div id="checkout_details">' + html.join( '' ) + '</div>' );
 		}
 
 		/**

--- a/src/modal-checkout/templates/form-coupon.php
+++ b/src/modal-checkout/templates/form-coupon.php
@@ -17,7 +17,7 @@ if ( ! wc_coupons_enabled() ) { // @codingStandardsIgnoreLine.
 	<h3><?php esc_html_e( 'Apply a coupon code', 'newspack-blocks' ); ?></h3>
 	<p>
 		<input type="text" name="coupon_code" class="input-text" placeholder="<?php esc_attr_e( 'Coupon code', 'newspack-blocks' ); ?>" id="coupon_code" value="" />
-		<button type="submit" class="<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?> newspack-ui__button newspack-ui__button--secondary" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'newspack-blocks' ); ?>"><?php esc_html_e( 'Apply', 'newspack-blocks' ); ?></button>
+		<button type="submit" class="<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?> newspack-ui__button newspack-ui__button--outline" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'newspack-blocks' ); ?>"><?php esc_html_e( 'Apply', 'newspack-blocks' ); ?></button>
 	</p>
 	<div class="clear"></div>
 </form>


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1206943664367857/1206041522383357/f

This PR adds support for name your price to the checkout button block:

![Screenshot 2024-05-14 at 18 04 22](https://github.com/Automattic/newspack-blocks/assets/17905991/c8164dd4-8af5-433a-9796-e064fd3af8dd)

### How to test the changes in this Pull Request:

Note: Be sure the to checkout `epic/ras-acc` in the main newspack plugin before testing.

1. Ensure Name Your Price is installed and active
2. Create a simple product, a subscription product, and a variable product, all with name your price set, as well as any type of product with NYP NOT setup.
  - For at least one product set a maximum price 
3. Add a checkout button block for each of these products to any page
  - For at least one button set a custom price that is above the minimum price via the name your price block settings
4. Logged in as a reader, select the simple product button
5. Go through the edit billing details section (first step) of checkout and proceed to the payment section (second step)
6. Confirm you see a **Increase your support** section with a form to enter a new price for the product (pictured above)
7. Enter a price that is below the minimum price and submit. Confirm an error appears asking you to input an amount greater than the base price
8. If this is the product with a custom price set via block settings, enter a price that is below the set price listed at the top of the checkout modal, but above the minimum price and submit. Confirm an error appears asking you to input an amount greater than the base price
9. If this is the product with a maximum price set product settings, enter a price that is above the max price and submit. Confirm an error appears asking you to input a price that is less than the max price.
10. Enter a valid price and submit. Confirm the price updates at the top of the checkout modal.
11. Complete checkout and confirm the correct price was charged in WP-Admin WooCommerce Orders menu as well as in the customer receipt sent by Woo.
12. Repeat the above steps for the variable and subscription products and confirm the NYP form is present and functions as expected.
13. Repeat the above steps for the product that does not have NYP active. Confirm the NYP form does NOT appear during the checkout flow.
14. On any page, add a donation block
15. As a reader, make a donation via the donation block. Confirm the **Increase your support** field is not present during the checkout field

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
