### PR TITLE
fix: modal checkout continue button

### DIFF
--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -29,7 +29,7 @@ domReady( () => {
 	const continueButton = document.querySelector( '.modal-continue' );
 	if ( continueButton ) {
 		continueButton.addEventListener( 'click', () => {
-			const form = document.querySelector( '.checkout' );
+			const form = document.querySelector( 'form.checkout' );
 			form.submit();
 		} );
 	}

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -200,7 +200,7 @@ domReady( () => {
 					innerButtons.forEach( innerButton => {
 						innerButton.addEventListener( 'click', () => ( spinner.style.display = 'flex' ) );
 					} );
-					const innerForm = iframe.contentDocument.querySelector( '.checkout' );
+					const innerForm = iframe.contentDocument.querySelector( 'form.checkout' );
 					if ( innerForm ) {
 						const innerBillingFields = [
 							...innerForm.querySelectorAll( '.woocommerce-billing-fields input' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1728 introduced a regression. This fixes it.

### How to test the changes in this Pull Request:

1. On `trunk`, start a product purchase via Checkout Button block. Observe that a JS error is thrown upon clicking "Continue" from the first modal screen:

```
Uncaught TypeError: innerForm.submit is not a function
    at HTMLInputElement.eval (modal.js:231:29)
```

2. Checkout this branch, repeat, and confirm that you're able to complete the purchase.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
