### PR TITLE
fix(ras-acc): make sure checkout modal fires when logged in

### DIFF
--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -1,5 +1,4 @@
-/* globals newspack_ras_config, newspackBlocksModal */
-window.newspack_ras_config = window.newspack_ras_config || {};
+/* globals newspackBlocksModal, newspack_ras_config */
 
 /**
  * Style dependencies

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -1,4 +1,5 @@
-/* globals newspackBlocksModal */
+/* globals newspack_ras_config, newspackBlocksModal */
+window.newspack_ras_config = window.newspack_ras_config || {};
 
 /**
  * Style dependencies
@@ -43,7 +44,6 @@ domReady( () => {
 	const modalContent = modalCheckout.querySelector( `.${ MODAL_CLASS_PREFIX }__content` );
 	const modalCheckoutHiddenInput = document.createElement( 'input' );
 	const spinner = modalContent.querySelector( `.${ CLASS_PREFIX }__spinner` );
-	const loggedIn = document.querySelector( 'body' ).classList.contains( 'logged-in' );
 	modalCheckoutHiddenInput.type = 'hidden';
 	modalCheckoutHiddenInput.name = 'modal_checkout';
 	modalCheckoutHiddenInput.value = '1';
@@ -209,7 +209,7 @@ domReady( () => {
 					if (
 						window?.newspackReaderActivation?.openAuthModal &&
 						! window?.newspackReaderActivation?.getReader?.()?.authenticated &&
-						! loggedIn
+						! newspack_ras_config.is_logged_in
 					) {
 						ev.preventDefault();
 						// Initialize auth flow if reader is not authenticated.

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -43,6 +43,7 @@ domReady( () => {
 	const modalContent = modalCheckout.querySelector( `.${ MODAL_CLASS_PREFIX }__content` );
 	const modalCheckoutHiddenInput = document.createElement( 'input' );
 	const spinner = modalContent.querySelector( `.${ CLASS_PREFIX }__spinner` );
+	const loggedIn = document.querySelector( 'body' ).classList.contains( 'logged-in' );
 	modalCheckoutHiddenInput.type = 'hidden';
 	modalCheckoutHiddenInput.name = 'modal_checkout';
 	modalCheckoutHiddenInput.value = '1';
@@ -207,7 +208,8 @@ domReady( () => {
 
 					if (
 						window?.newspackReaderActivation?.openAuthModal &&
-						! window?.newspackReaderActivation?.getReader?.()?.authenticated
+						! window?.newspackReaderActivation?.getReader?.()?.authenticated &&
+						! loggedIn
 					) {
 						ev.preventDefault();
 						// Initialize auth flow if reader is not authenticated.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a small issue I noticed when working on the components, but didn't really investigate: when you're logged in as a WordPress User (and not a Reader), the checkout modal didn't open. The variable modal did open, but then when you picked a variation, it would close the modal and not move to the checkout.

My fix is just to check for the `logged-in` CSS class, but there's probably a more elegant way that ties into the existing code!

### How to test the changes in this Pull Request:

1. On the epic/ras-acc branch, set up a donate block and a checkout button block that loads a product with variations.
2. In a window when you're logged into WordPress, try to run the checkout from each block. Note that it doesn't work (either doesn't open a modal, or closes the variation modal when you pick a variation).
3. In an incognito window, repeat step 2 and note the modals do work (it will open the registration modal first before the checkout modal). 
4. Apply this PR and run `npm run build`.
5. Repeat steps 2 and 3 and confirm the checkout modal can be reached in both cases.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
