### PR TITLE
fix(donate-block): fix typo in textdomain and color variables

### DIFF
--- a/src/blocks/donate/index.js
+++ b/src/blocks/donate/index.js
@@ -60,15 +60,15 @@ export const settings = {
  */
 registerBlockStyle( 'newspack-blocks/donate', {
 	name: 'alternate',
-	label: __( 'Alternate', 'newapack-blocks' ),
+	label: __( 'Alternate', 'newspack-blocks' ),
 } );
 
 registerBlockStyle( 'newspack-blocks/donate', {
 	name: 'minimal',
-	label: __( 'Minimal', 'newapack-blocks' ),
+	label: __( 'Minimal', 'newspack-blocks' ),
 } );
 
 registerBlockStyle( 'newspack-blocks/donate', {
 	name: 'modern',
-	label: __( 'Modern', 'newapack-blocks' ),
+	label: __( 'Modern', 'newspack-blocks' ),
 } );

--- a/src/blocks/donate/styles/style-variations.scss
+++ b/src/blocks/donate/styles/style-variations.scss
@@ -354,7 +354,7 @@
 		border: 1px solid var( --newspack-ui-color-neutral-30, colors.$newspack-ui-color-neutral-30 );
 		border-bottom: 0;
 		border-top: 0;
-		color: var( --newspack-ui-color-neutral-60, #6c6c6c );
+		color: var( --newspack-ui-color-neutral-60, colors.$newspack-ui-color-neutral-60 );
 		font-size: var( --newspack-ui-font-size-s, 16px );
 		line-height: var( --newspack-ui-line-height-s, 1.5 );
 		margin: 0;
@@ -489,7 +489,7 @@
 				border: 1px solid transparent;
 				background: transparent;
 				border-radius: var( --newspack-ui-border-radius-xs, 3px );
-				color: var( --newspack-ui-color-neutral-60, #6c6c6c );
+				color: var( --newspack-ui-color-neutral-60, colors.$newspack-ui-color-neutral-60 );
 				font-size: var( --newspack-ui-font-size-xs, 14px );
 				line-height: var( --newspack-ui-spacer-5, 24px );
 				padding: calc( var( --newspack-ui-spacer-base, 8px ) - 1px ) calc( var( --newspack-ui-spacer-3, 16px ) - 1px );
@@ -545,7 +545,7 @@
 			line-height: var( --newspack-ui-line-height-s, 1.5 );
 	
 			.tiers {
-				color: var( --newspack-ui-color-neutral-60, #6c6c6c );
+				color: var( --newspack-ui-color-neutral-60, colors.$newspack-ui-color-neutral-60 );
 				position: relative;
 	
 				.tier-label {
@@ -661,7 +661,7 @@
 
 				.wpbnbd__button {
 					border-radius: var( --newspack-ui-border-radius-xs, 3px );
-					color: var( --newspack-ui-color-neutral-60, #6c6c6c );
+					color: var( --newspack-ui-color-neutral-60, colors.$newspack-ui-color-neutral-60 );
 					font-size: var( --newspack-ui-font-size-xs, 14px );
 					font-weight: 600;
 					line-height: var( --newspack-ui-spacer-5, 24px );
@@ -746,7 +746,7 @@
 				margin-bottom: var( --newspack-ui-spacer-5, 24px );
 
 				&__value {
-					color: var( --newspack-ui-color-neutral-60, #6c6c6c );
+					color: var( --newspack-ui-color-neutral-60, colors.$newspack-ui-color-neutral-60 );
 					font-size: var( --newspack-ui-font-size-2xs, 12px );
 					line-height: var( --newspack-ui-line-height-2xs, 1.3333 );
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

There was a small typo in the text domain. Also, neutral-60 wasn't using color variables. This PR fixes these issues.

### How to test the changes in this Pull Request:

Make sure the style variations still work

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
