### PR TITLE
fix(ras-acc): address design feedback

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1135,7 +1135,14 @@ final class Modal_Checkout {
 		if ( ! $cart || $cart->is_empty() ) {
 			return $text;
 		}
-		return self::get_modal_checkout_labels( 'checkout_confirm' );
+		$total = \wp_strip_all_tags( \wc_price( $cart->total ) );
+
+		return sprintf(
+			/* translators: 1: Checkout button confirmation text. 2: Order total. */
+			__( '%1$s: %2$s', 'newspack-blocks' ),
+			self::get_modal_checkout_labels( 'checkout_confirm' ),
+			$total
+		);
 	}
 
 	/**

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -106,10 +106,12 @@ domReady( () => {
 
 	const closeModal = el => {
 		el.setAttribute( 'data-state', 'closed' );
+		document.body.style.overflow = 'auto';
 	};
 
 	const openModal = el => {
 		el.setAttribute( 'data-state', 'open' );
+		document.body.style.overflow = 'hidden';
 	};
 
 	window.newspackCloseModalCheckout = closeCheckout;


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1206943664367857/1207328906416559/f

- Removes scroll from main body while the checkout modal is open.
- Adds the price to the checkout modal payment button for the checkout button block

![Screenshot 2024-05-24 at 15 36 27](https://github.com/Automattic/newspack-blocks/assets/17905991/a2d3523a-decc-4a65-81a5-941b35704b6e)

### How to test the changes in this Pull Request:

- Trigger modal checkout via a donate or checkout button on any page
- Move your mouse outside of the modal and scroll
- On `epic/ras-acc` the main content will continue to scroll while the modal is open. On this branch it should not.
- Go through the modal checkout process until you are on the last step, where the `Complete transaction` button is.
- Confirm you also see the price in the button as pictured above

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
