### PR TITLE
feat(donate): add setting to change the style of tiered donations

### DIFF
--- a/src/blocks/donate/block.json
+++ b/src/blocks/donate/block.json
@@ -52,6 +52,10 @@
 			"type": "string",
 			"default": "frequency"
 		},
+		"tierStyle": {
+			"type": "string",
+			"default": "grid"
+		},
 		"useModalCheckout": {
 			"type": "boolean",
 			"default": true

--- a/src/blocks/donate/edit/index.tsx
+++ b/src/blocks/donate/edit/index.tsx
@@ -18,12 +18,14 @@ import {
 	Spinner,
 	SelectControl,
 	ToggleControl,
+	Toolbar,
 	TextControl,
 	Button,
 	Notice,
 } from '@wordpress/components';
-import { InspectorControls, ColorPaletteControl } from '@wordpress/block-editor';
+import { BlockControls, ColorPaletteControl, InspectorControls } from '@wordpress/block-editor';
 import { isEmpty, pick } from 'lodash';
+import { Icon, formatListBullets, grid } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -145,6 +147,7 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 	const isManual = attributes.manual && canUseNameYourPrice;
 	const isTiered = isManual ? attributes.tiered : settings.tiered;
 	const isTierBasedLayoutEnabled = isTiered && attributes.layoutOption === 'tiers';
+	const tierLayoutStyle = attributes.tierStyle;
 
 	const amounts = isManual ? attributes.amounts : settings.amounts;
 
@@ -166,8 +169,24 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 			'wpbnbd',
 			`wpbnbd--${ isTierBasedLayoutEnabled ? 'tiers-based' : 'frequency-based' }`,
 			`wpbnbd--platform-${ settings.platform }`,
-			`wpbnbd-frequencies--${ availableFrequencies.length }`
+			`wpbnbd-frequencies--${ availableFrequencies.length }`,
+			isTierBasedLayoutEnabled && `wpbnbd--tier-style-${ tierLayoutStyle }`
 		);
+
+	const tiersLayoutControls = [
+		{
+			icon: <Icon icon={ grid } />,
+			title: __( 'Grid View', 'newspack-blocks' ),
+			onClick: () => setAttributes( { tierStyle: 'grid' } ),
+			isActive: attributes.tierStyle === 'grid',
+		},
+		{
+			icon: <Icon icon={ formatListBullets } />,
+			title: __( 'List View', 'newspack-blocks' ),
+			onClick: () => setAttributes( { tierStyle: 'list' } ),
+			isActive: attributes.tierStyle === 'list',
+		},
+	];
 
 	const minimumDonation = isManual ? attributes.minimumDonation : settings.minimumDonation;
 	const displayedAmounts = { ...amounts };
@@ -204,9 +223,14 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 	return (
 		<>
 			{ isTierBasedLayoutEnabled ? (
-				<div className={ getWrapperClassNames() }>
-					<TierBasedLayout { ...componentProps } amounts={ displayedAmounts } />
-				</div>
+				<>
+					<div className={ getWrapperClassNames() }>
+						<TierBasedLayout { ...componentProps } amounts={ displayedAmounts } />
+					</div>
+					<BlockControls>
+						<Toolbar controls={ tiersLayoutControls } />
+					</BlockControls>
+				</>
 			) : (
 				<div className={ getWrapperClassNames( [ isTiered ? 'tiered' : 'untiered' ] ) }>
 					<FrequencyBasedLayout

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
@@ -109,6 +109,7 @@ abstract class Newspack_Blocks_Donate_Renderer_Base {
 
 		$is_tiers_based                        = $configuration['tiered'] && 'tiers' === $attributes['layoutOption'];
 		$configuration['is_tier_based_layout'] = $is_tiers_based;
+		$tier_style                            = $attributes['tierStyle'];
 
 		$frequencies = [
 			'once'  => __( 'One-time', 'newspack-blocks' ),
@@ -137,6 +138,7 @@ abstract class Newspack_Blocks_Donate_Renderer_Base {
 			'wpbnbd--platform-' . $configuration['platform'],
 			$classname,
 			'wpbnbd-frequencies--' . count( $configuration['frequencies'] ),
+			$is_tiers_based ? 'wpbnbd--tier-style-' . $tier_style : null,
 		];
 
 		if ( ! Newspack_Blocks::can_use_name_your_price() ) {

--- a/src/blocks/donate/styles/style-variations.scss
+++ b/src/blocks/donate/styles/style-variations.scss
@@ -785,25 +785,5 @@
 				}
 			}
 		}
-
-		&.list {
-			.wpbnbd__tiers {
-				&__tier {
-					margin: 0;
-					width: 100%;
-				}
-				
-				&__options {
-					display: grid;
-					gap: var( --newspack-ui-spacer-2, 12px );
-					margin: 0;
-					overflow: hidden;
-	
-					&__dots {
-						display: none;
-					}
-				}
-			}
-		}
 	}
 }

--- a/src/blocks/donate/styles/view.scss
+++ b/src/blocks/donate/styles/view.scss
@@ -4,7 +4,7 @@
 @use './style-variations';
 
 .wpbnbd {
-	 &__button,
+	&__button,
 	.tab-container .freq-label {
 		border: 0 solid variables.$color__border;
 		background: colors.$color__background-body;

--- a/src/blocks/donate/tiers-based/style.scss
+++ b/src/blocks/donate/tiers-based/style.scss
@@ -162,4 +162,24 @@
 			}
 		}
 	}
+
+	&.wpbnbd--tier-style-list {
+		.wpbnbd__tiers {			
+			&__options {
+				display: grid;
+				gap: var( --newspack-ui-spacer-2, 12px );
+				margin: 0 !important;
+				overflow: hidden;
+
+				&__dots {
+					display: none;
+				}
+			}
+
+			&__tier {
+				margin: 0 !important;
+				width: 100%;
+			}
+		}
+	}
 }

--- a/src/blocks/donate/types.ts
+++ b/src/blocks/donate/types.ts
@@ -79,6 +79,7 @@ export type DonateBlockAttributes = OverridableConfiguration & {
 	layoutOption: 'frequency' | 'tiers';
 	// For tiers-based layout option.
 	tiersBasedOptions: [ TierBasedOptionValue, TierBasedOptionValue, TierBasedOptionValue ];
+	tierStyle: 'grid' | 'list';
 	// Manual mode enables block-level overrides of the global Donate settings.
 	manual: boolean;
 	// Post-checkout button option.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

_The Problem_

When using the Tiered layout, we end up with a 3-column layout. It's great when it's within the main content area but if a publisher wants to insert this block in a narrow column, it looks pretty bad...

![Screenshot 2024-05-31 at 14 06 49@2x](https://github.com/Automattic/newspack-blocks/assets/177929/76f5a8d3-37ac-41a7-b387-197e17e5304e)

_The Solution_

The idea is to be able to toggle between a Grid, and a List style.
This is something I originally introduced with the [Modern style variation](https://github.com/Automattic/newspack-blocks/pull/1734) as a custom CSS class and thought it would be better to just add this at the block level (props @dkoo!).

![Screenshot 2024-05-31 at 14 08 00@2x](https://github.com/Automattic/newspack-blocks/assets/177929/2499d418-5b6a-4dfb-a581-a117aa502ff5)

Instead of being a simple CSS class, this PR adds the buttons to the Toolbar, when the Tiers layout is selected. By default it's the Grid layout but now publishers are able to switch to a List if they want/need to.

![Screenshot 2024-05-31 at 14 07 17@2x](https://github.com/Automattic/newspack-blocks/assets/177929/03109df6-05e6-47f8-9898-3a2d53bbf7f1)

### How to test the changes in this Pull Request:

1. On a page, add a bunch of Donate blocks, including some in narrow columns (e.g. 33/33/33)
2. Have them Tiered based
3. Check the front-end
4. Switch to this branch
5. Refresh editor and check if you see the Tier style buttons
6. Play with the buttons and see if it toggles the correct styles in the editor and front-end

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
