### PR TITLE
fix(ras-acc): copy over modal-specific styles

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -415,7 +415,7 @@ final class Modal_Checkout {
 			}
 			?>
 			<div
-				class="<?php echo esc_attr( "$class_prefix {$class_prefix}__modal-container {$class_prefix}__modal-variation" ); ?>"
+				class="<?php echo esc_attr( "$class_prefix {$class_prefix}__modal-container newspack-blocks__modal-variation" ); ?>"
 				data-product-id="<?php echo esc_attr( $product_id ); ?>"
 			>
 				<div class="<?php echo esc_attr( "{$class_prefix}__modal-container__overlay" ); ?>"></div>
@@ -430,17 +430,17 @@ final class Modal_Checkout {
 						</button>
 					</header>
 					<section class="<?php echo esc_attr( "{$class_prefix}__modal__content" ); ?>">
-						<div class="<?php echo esc_attr( "{$class_prefix}__selection" ); ?>" data-product-id="<?php echo esc_attr( $product_id ); ?>">
+						<div class="newspack-blocks__selection" data-product-id="<?php echo esc_attr( $product_id ); ?>">
 							<h3><?php echo esc_html( $product->get_name() ); ?></h3>
 							<p><?php esc_html_e( 'Select an option to continue:', 'newspack-blocks' ); ?></p>
-							<ul class="<?php echo esc_attr( "{$class_prefix}__options" ); ?>">
+							<ul class="newspack-blocks__options"">
 								<?php
 								$variations = $product->get_available_variations( 'objects' );
 								foreach ( $variations as $variation ) :
 									$name  = wc_get_formatted_variation( $variation, true );
 									$price = $variation->get_price_html();
 									?>
-									<li class="<?php echo esc_attr( "{$class_prefix}__options__item" ); ?>">
+									<li class="newspack-blocks__options__item"">
 										<div class="summary">
 											<span class="price"><?php echo $price; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
 										</div>

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -215,10 +215,20 @@
 	}
 
 	// Override checkout payment method box.
-	.wc_payment_method {
 
+	.wc_payment_methods {
+		margin: 0 0 var( --newspack-ui-spacer-5, 24px );
+
+		label[for="payment_method_stripe"] {
+			&.newspack-ui__input-card {
+				padding: var( --newspack-ui-spacer-3, 16px ) !important;
+			}
+		}
+	}
+
+	.wc_payment_method {
 		+ .wc_payment_method {
-			margin-top: calc( var( --newspack-ui-spacer-5, 24px ) / -2 );
+			margin-top: var( --newspack-ui-spacer-2, 12px );
 		}
 
 		span {
@@ -357,16 +367,6 @@
 				font-size: var( --newspack-ui-font-size-xs, 14px );
 				line-height: var( --newspack-ui-line-height-xs, 1.4286 );
 				padding: 0;
-			}
-		}
-	}
-
-	.wc_payment_methods {
-		margin: 0;
-
-		label[for="payment_method_stripe"] {
-			&.newspack-ui__input-card {
-				padding: var( --newspack-ui-spacer-3, 16px ) !important;
 			}
 		}
 	}

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -1,25 +1,116 @@
-/* stylelint-disable-next-line */
-#newspack_modal_checkout_container { /* stylelint-disable-line */
-	padding: 24px;
+@use '../shared/sass/colors';
+
+// stylelint-disable-next-line selector-id-pattern
+#newspack_modal_checkout_container {
+	padding: var( --newspack-ui-spacer-5, 24px );
+
+	form p {
+		margin: 0 0 var( --newspack-ui-spacer-5, 24px );
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
 
 	.order-review-wrapper.hidden {
 		display: none;
 	}
-	/* Remove support for "Allow customers to log into an existing account during checkout" */
+
+	// Remove support for "Allow customers to log into an existing account during checkout"
 	.woocommerce-form-login-toggle {
 		display: none;
 	}
-	/* Hide reCAPTCHA badge */
+
+	// Hide reCAPTCHA badge
 	.grecaptcha-badge {
 		visibility: hidden !important;
 	}
 
-	/* Custom Gift Subscriptions form elements */
+	// Required fields.
+	.woocommerce form .form-row .required {
+		color: var( --newspack-ui-color-error-50, colors.$color__error );
+	}
+
+	// Billing & Shipping fields
+	.woocommerce-checkout {
+		h3 {
+			font-size: var( --newspack-ui-font-size-s, 16px );
+			line-height: var( --newspack-ui-line-height-s, 1.5 );
+			margin: 0 0 var( --newspack-ui-spacer-5, 24px );
+		}
+
+		.woocommerce-billing-fields h3 {
+			margin: 0 0 var( --newspack-ui-spacer-5, 24px );
+		}
+
+		// After Customer Details
+		// stylelint-disable-next-line selector-id-pattern
+		#after_customer_details {
+			h3 {
+				margin-bottom: var( --newspack-ui-spacer-2, 12px );
+			}
+		}
+
+		// Override label styles from theme
+		.woocommerce-billing-fields,
+		.woocommerce-account-fields,
+		.woocommerce-shipping-fields,
+		.woocommerce-additional-fields {
+			label {
+				font-size: var( --newspack-ui-font-size-s, 16px );
+				line-height: var( --newspack-ui-line-height-s, 1.5 );
+			}
+
+		}
+	}
+
+	// Override billing details spacing.
+	// stylelint-disable-next-line selector-id-pattern
+	#checkout_details {
+		margin-bottom: var( --newspack-ui-spacer-5, 24px );
+
+		h3 {
+			margin: 0 0 var( --newspack-ui-spacer-base, 8px );
+		}
+	}
+
+	.billing-details,
+	.shipping-details {
+		&:not(:last-child ) {
+			margin-bottom: var( --newspack-ui-spacer-5, 24px );
+		}
+
+		p {
+			margin: 0;
+		}
+	}
+
+	// Different shipping address toggle
+	#ship-to-different-address {
+		margin-bottom: 0;
+
+		&,
+		label {
+			display: block;
+		}
+	}
+
+	.shipping_address {
+		margin-top: var( --newspack-ui-spacer-5, 24px );
+	}
+
+
+	// Gift Subscriptions
 	.newspack-wcsg {
 		&--gift-toggle {
 			align-items: center;
 			display: flex;
 			font-weight: 700;
+			margin-bottom: 0;
+
+			label {
+				display: flex !important;
+			}
 
 			.woocommerce-input-wrapper {
 				line-height: 0.5;
@@ -40,14 +131,15 @@
 		}
 	}
 
+	// Name Your Price styles
 	.name-your-price {
-		margin-bottom: var( --newspack-ui-spacer-5, 20px );
+		margin-bottom: var( --newspack-ui-spacer-5, 24px );
 	}
 
 	.modal_checkout_nyp {
 		h3 {
 			color: var( --newspack-ui-label-color, inherit );
-			margin-bottom: var(--newspack-ui-spacer-base);
+			margin-bottom: var(--newspack-ui-spacer-base, 8px);
 		}
 
 		.input-price {
@@ -81,10 +173,275 @@
 		}
 	}
 
+	// Coupon Styles
+	.woocommerce-form-coupon {
+		margin-bottom: var( --newspack-ui-spacer-5, 24px );
+
+		h3 {
+			color: var( --newspack-ui-label-color, inherit );
+			margin-bottom: var( --newspack-ui-spacer-base, 8px );
+		}
+
+		p:first-of-type {
+			align-items: center;
+			display: flex;
+			gap: var( --newspack-ui-spacer-base, colors.$newspack-ui-color-neutral-90 );
+
+			input,
+			button {
+				margin: 0 !important;
+			}
+
+			+ .newspack-ui__helper-text {
+				margin-top: calc( var( --newspack-ui-spacer-3, 16px ) * -1 );
+			}
+		}
+	}
+
+	// Processing styles
 	.modal_checkout_nyp,
 	.modal_checkout_coupon {
 		&.processing {
 			opacity: 0.5;
 		}
+	}
+
+	// Checkout form heading.
+	.woocommerce .order-details-summary {
+		// Top margin not needed in newspack ui modal.
+		h2 {
+			margin-top: 0;
+		}
+	}
+
+	// Override checkout payment method box.
+	.wc_payment_method {
+
+		+ .wc_payment_method {
+			margin-top: calc( var( --newspack-ui-spacer-5, 24px ) / -2 );
+		}
+
+		span {
+			font-weight: var( --newspack-ui-font-weight-strong, 600 );
+		}
+
+		> label:first-of-type {
+			margin: unset;
+		}
+
+		.payment_box {
+			background: transparent;
+			font-weight: normal;
+			padding: 0;
+
+			p {
+				color: var( --newspack-ui-color-neutral-60, colors.$newspack-ui-color-neutral-60 );
+				font-size: var( --newspack-ui-font-size-xs, 14px );
+				line-height: var( --newspack-ui-line-height-xs, 1.4286 );
+			}
+
+			ul.wc-saved-payment-methods {
+				padding: 0;
+
+				li {
+					margin-bottom: var( --newspack-ui-spacer-3, 16px );
+
+					label {
+						font-size: var( --newspack-ui-font-size-xs, 14px );
+						font-weight: normal;
+						line-height: var( --newspack-ui-line-height-xs, 1.4286 );
+					}
+
+					input {
+						margin-right: var( --newspack-ui-spacer-base, 8px );
+					}
+				}
+			}
+
+			fieldset {
+				margin: 0 0 var( --newspack-ui-spacer-2, 12px );
+				padding: 0 !important; // To override inline styles.
+
+				&:last-child {
+					margin-bottom: 0;
+				}
+
+				p {
+					font-size: var(--newspack-ui-font-size-xs, 14px );
+					line-height: var( --newspack-ui-line-height-xs, 1.4286 );
+					margin-bottom: 0;
+
+					&.form-row {
+						display: flex;
+						gap: var( --newspack-ui-spacer-2, 12px );
+						align-items: flex-start;
+
+						input {
+							margin: 0;
+						}
+
+						label {
+							margin-bottom: 0;
+							font-weight: normal;
+						}
+					}
+				}
+			}
+
+			.newspack-cover-fees,
+			.woocommerce-SavedPaymentMethods-saveNew {
+				label {
+					font-size: var( --newspack-ui-font-size-xs, 14px );
+					line-height: var( --newspack-ui-line-height-xs, 1.4286 );
+				}
+
+				&::before {
+					display: none;
+				}
+			}
+		}
+
+		// Override a style coming from the theme to hide the radio -- we need this when there's more than one option.
+		input.input-radio[name="payment_method"] {
+			display: inherit;
+		}
+
+		// If the only payment option, we're hiding the radio selection so we don't need a grid.
+		&:first-child:last-child .newspack-ui__input-card {
+			grid-template-columns: none;
+			gap: 0;
+
+			input.input-radio[name="payment_method"] {
+				display: none;
+			}
+		}
+	}
+
+	// WooCommerce Payments
+	#payment {
+		.payment_method_woocommerce_payments .testmode-info {
+			margin-bottom: 0;
+		}
+	}
+
+	// Stripe inputs
+	.wc-credit-card-form {
+		.form-row-wide {
+			margin-bottom: var( --newspack-ui-spacer-base, 8px );
+		}
+		.wc-stripe-elements-field,
+		.wc-stripe-iban-element-field {
+			border: 1px solid var( --newspack-ui-color-input-border, colors.$newspack-ui-color-neutral-30 );
+			border-radius: var( --newspack-ui-border-radius-m, 6px );
+			display: block;
+			font-family: var( --newspack-ui-font-family, system-ui );
+			font-size: var( --newspack-ui-font-size-s, 16px );
+			line-height: var( --newspack-ui-line-height-s, 1.5 );
+			padding: calc( var( --newspack-ui-spacer-2, 12px ) - 1px ) calc( var( --newspack-ui-spacer-3, 16px ) - 1px );
+		}
+
+		&:has( div.stripe-source-errors[role="alert"]:not( :empty ) ) {
+			.wc-stripe-elements-field,
+			.wc-stripe-iban-element-field {
+				border-color: var( --newspack-ui-color-error-50, colors.$color__error );
+			}
+
+			label {
+				color: var( --newspack-ui-color-error-50, colors.$color__error );
+			}
+
+			.woocommerce_error {
+				background: transparent;
+				color: var( --newspack-ui-color-error-50, colors.$color__error );
+				font-family: var( --newspack-ui-font-family, system-ui );
+				font-size: var( --newspack-ui-font-size-xs, 14px );
+				line-height: var( --newspack-ui-line-height-xs, 1.4286 );
+				padding: 0;
+			}
+		}
+	}
+
+	.wc_payment_methods {
+		margin: 0;
+
+		label[for="payment_method_stripe"] {
+			&.newspack-ui__input-card {
+				padding: var( --newspack-ui-spacer-3, 16px ) !important;
+			}
+		}
+	}
+
+	// Woo Payments inputs
+	#wcpay-upe-element,
+	.wcpay-upe-element {
+		margin: var( --newspack-ui-spacer-3, 16px ) 0;
+		padding: 0;
+	}
+
+	// Order review table.
+	.woocommerce-checkout-review-order-table {
+		th,
+		td,
+		label,
+		small {
+			font-size: var( --newspack-ui-font-size-xs, 14px ) !important;
+			line-height: var( --newspack-ui-line-height-xs, 1.4286 ) !important;
+		}
+
+		thead th,
+		.recurring-totals th {
+			background: transparent;
+		}
+
+		// stylelint-disable-next-line selector-id-pattern
+		.woocommerce-shipping-totals #shipping_method {
+			li,
+			label {
+				margin: 0;
+			}
+		}
+	}
+
+	.woocommerce .first-payment-date {
+		font-family: var( --newspack-ui-font-family, system-ui );
+	}
+
+	// Override checkout form terms and condition text.
+	.woocommerce-terms-and-conditions-wrapper {
+		font-size: var( --newspack-ui-font-size-xs, 14px );
+		line-height: var( --newspack-ui-line-height-xs, 1.4286 );
+		margin-bottom: 0;
+	}
+
+	// Errors
+	.woocommerce-invalid {
+		input,
+		textarea,
+		.select2-container--default .select2-selection--single {
+			border-color: var( --newspack-ui-color-error-50, colors.$color__error );
+
+			&:focus {
+				outline-color: var( --newspack-ui-color-error-50, colors.$color__error );
+			}
+		}
+
+		label {
+			color: var( --newspack-ui-color-error-50, colors.$color__error );
+		}
+	}
+
+	// Privacy Policy
+	.woocommerce-privacy-policy-text {
+		color: var( --newspack-ui-color-neutral-60, colors.$newspack-ui-color-neutral-60 );
+	}
+
+	// Buttons - adjust spacing
+	#place-order {
+		margin-bottom: 0;
+	}
+
+	// stylelint-disable-next-line selector-id-pattern
+	#checkout_back {
+		margin-top: 0;
 	}
 }

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -129,7 +129,7 @@ domReady( () => {
 	/**
 	 * Handle variations modal close button.
 	 */
-	document.querySelectorAll( `.${ MODAL_CLASS_PREFIX }-variation` ).forEach( variationModal => {
+	document.querySelectorAll( '.newspack-blocks__modal-variation' ).forEach( variationModal => {
 		variationModal.addEventListener( 'click', ev => {
 			if ( ev.target === variationModal ) {
 				closeCheckout();
@@ -148,7 +148,7 @@ domReady( () => {
 	 */
 	document
 		.querySelectorAll(
-			`.wpbnbd.wpbnbd--platform-wc,.wp-block-newspack-blocks-checkout-button,.${ MODAL_CLASS_PREFIX }-variation`
+			'.wpbnbd.wpbnbd--platform-wc, .wp-block-newspack-blocks-checkout-button, .newspack-blocks__modal-variation'
 		)
 		.forEach( element => {
 			const forms = element.querySelectorAll( 'form' );
@@ -171,7 +171,7 @@ domReady( () => {
 
 				form.addEventListener( 'submit', ev => {
 					const formData = new FormData( form );
-					const variationModals = document.querySelectorAll( `.${ MODAL_CLASS_PREFIX }-variation` );
+					const variationModals = document.querySelectorAll( '.newspack-blocks__modal-variation' );
 
 					// Clear any open variation modal.
 					variationModals.forEach( variationModal => {

--- a/src/modal-checkout/modal.scss
+++ b/src/modal-checkout/modal.scss
@@ -129,7 +129,7 @@
 		}
 	}
 
-	// Replace with the stuff from the plugin directly.
+	// Product variations styles
 	&__modal-variation {
 		.newspack-blocks {
 			&__selection {
@@ -162,7 +162,7 @@
 					flex: 1 1 100%;
 					text-align: center;
 
-					@media ( min-width: 600px ) {
+					@media ( min-width: variables.$mobile_width ) {
 						flex: 1 1 30%;
 						max-width: calc( 33.3333% - 10px );
 						&:first-child:nth-last-child( 2 ),

--- a/src/modal-checkout/modal.scss
+++ b/src/modal-checkout/modal.scss
@@ -129,19 +129,19 @@
 		}
 	}
 
+	// Replace with the stuff from the plugin directly.
 	&__modal-variation {
 		.newspack-blocks {
-			&__modal {
-				&__content {
-					padding: 24px;
-					overflow: auto;
-					border-radius: 5px;
-					h3 {
-						font-size: 16px;
-						margin: 0;
-					}
-					p {
-						font-size: 0.8em;
+			&__selection {
+				> *:first-child {
+					margin-top: 0;
+				}
+
+				h3 {
+					margin: 0;
+
+					+ p {
+						margin-top: calc( var( --newspack-ui-spacer-base, 8px ) / 2);
 					}
 				}
 			}
@@ -150,15 +150,18 @@
 				list-style: none;
 				display: flex;
 				flex-wrap: wrap;
-				gap: 16px;
-				margin: 0;
+				gap: var( --newspack-ui-spacer-2, 12px );
+				margin: var( --newspack-ui-spacer-5, 24px ) 0 0;
 				padding: 0;
 
 				&__item {
-					border: 1px solid #ddd;
-					border-radius: 6px;
-					text-align: center;
+					border: 1px solid var(--newspack-ui-color-border, colors.$newspack-ui-color-neutral-30 );
+					border-radius: var( --newspack-ui-border-radius-m, 6px );
+					display: flex;
+					flex-direction: column;
 					flex: 1 1 100%;
+					text-align: center;
+
 					@media ( min-width: 600px ) {
 						flex: 1 1 30%;
 						max-width: calc( 33.3333% - 10px );
@@ -168,29 +171,49 @@
 							max-width: calc( 50% - 10px );
 						}
 					}
+
 					.summary {
-						font-size: 14px;
-						padding: 12px;
-						border-bottom: 1px solid #ddd;
-						bdi {
-							display: block;
-							font-weight: 600;
-							font-size: 32px;
+						font-size: var( --newspack-ui-font-size-xs, 14px );
+						line-height: var( --newspack-ui-line-height-xs, 1.4286 );
+						padding: var( --newspack-ui-spacer-5, 24px ) var( --newspack-ui-spacer-2, 12px );
+						position: relative;
+
+						.price {
+							// Scale up just the primary price for a product, not the other fees:
+							> .amount > bdi,
+							> ins > .amount > bdi {
+								display: block;
+								font-weight: 600;
+								font-size: var( --newspack-ui-font-size-xl, clamp( 1.375rem, 0.394rem + 2.008vw, 2rem ) );
+								line-height: var( --newspack-ui-line-height-xl, 1.375 );
+							}
+
+							del {
+								color: var( --newspack-ui-color-neutral-60, colors.$newspack-ui-color-neutral-60 );
+								left: 0;
+								position: absolute;
+								top: calc( var( --newspack-ui-spacer-base, 8px ) * 0.75 );
+								width: 100%;
+							}
 						}
 					}
+
 					.variation {
-						padding: 12px;
-						font-size: 14px;
-						line-height: 1.5;
-						border-bottom: 1px solid #ddd;
+						border-top: 1px solid var(--newspack-ui-color-border, colors.$newspack-ui-color-neutral-30 );
+						font-size: var( --newspack-ui-font-size-xs, 14px );
 						font-weight: 600;
+						line-height: var( --newspack-ui-line-height-xs, 1.4286 );
+						margin-top: auto;
+						padding: var( --newspack-ui-spacer-2, 12px );
 					}
+
 					form {
-						padding: 12px;
+						border-top: 1px solid var(--newspack-ui-color-border, colors.$newspack-ui-color-neutral-30 );
+						padding: var( --newspack-ui-spacer-2, 12px ) var( --newspack-ui-spacer-2, 12px ) 0;
 						button {
 							display: block;
+							margin-top: 0 !important;
 							width: 100%;
-							font-size: 14px;
 						}
 					}
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR, along with https://github.com/Automattic/newspack-plugin/pull/3158, moves some checkout-specific styles from the Newspack Plugin over to the Newspack Blocks, since they're only used in this plugin.

See 1205234045751551-as-1207417754699774

### How to test the changes in this Pull Request:

1. Apply this PR and https://github.com/Automattic/newspack-plugin/pull/3158, and run `npm run build` for each.
2. Run a couple checkouts and just make sure things look okay -- you want to make sure to test things like product variations, coupons and NYP to make sure everything looks okay.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
