### PR TITLE
fix(ras-acc): add extra check for iframe for spinner visibility

### DIFF
--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -261,7 +261,9 @@ domReady( () => {
 					spinner.style.display = 'none';
 				} );
 			}
-		} else {
+		} else if ( 'about:blank' !== location.href ) {
+			// Make sure the iframe has actually loaded something, even if not the expected container.
+			// This check prevents an issue in Chrome where the 'load' event fired twice and the spinner was hidden too soon.
 			spinner.style.display = 'none';
 		}
 	} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue where the iframe load event is getting fired twice in Chrome and Safari -- one too early -- and it ended up hiding the spinner too soon so it was never visible in the modal checkout. 

I'm not sure of the issue the original `else` statement was fixing or how to recreate it -- [it was added](https://github.com/Automattic/newspack-blocks/commit/bbc9946df37f47972e1d653e9c7db70ae1298a6e) as part of [this PR](https://github.com/Automattic/newspack-blocks/pull/1602), so the commit doesn't go into too much depth. This seemed like a relatively safe approach -- if the iframe hasn't loaded anything, it's probably safe to keep showing the spinner -- but I'm definitely good with going another way! 

See 1205234045751551-1207426203801787

### How to test the changes in this Pull Request:

1. On the `epic/ras-acc` branch, set up a checkout button, and run a checkout in Chrome or Safari. Note when the modal is trying to load the checkout, it doesn't show a loader. Compare with Firefox, which will show a loader on the epic branch.

![image](https://github.com/Automattic/newspack-blocks/assets/177561/f6820714-0a7d-4da4-874c-ecd614ae75ef)

2. Apply this PR and run `npm run build`.
3. Confirm that the loader now shows in Chrome, and is removed when the checkout finishes loading:

![image](https://github.com/Automattic/newspack-blocks/assets/177561/f8098067-db51-441e-9faf-9f75f9a38f30)

4. Confirm that the loader still works in Firefox.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
