### PR TITLE
fix(ras-acc): tweak billing, shipping columns styles

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -50,7 +50,6 @@ final class Modal_Checkout {
 		add_filter( 'woocommerce_get_checkout_order_received_url', [ __CLASS__, 'woocommerce_get_return_url' ], 10, 2 );
 		add_filter( 'wc_get_template', [ __CLASS__, 'wc_get_template' ], 10, 2 );
 		add_filter( 'woocommerce_checkout_fields', [ __CLASS__, 'woocommerce_checkout_fields' ] );
-		add_filter( 'woocommerce_checkout_fields', [ __CLASS__, 'change_phone_css_class' ] );
 		add_filter( 'woocommerce_update_order_review_fragments', [ __CLASS__, 'order_review_fragments' ] );
 		add_filter( 'newspack_recaptcha_verify_captcha', [ __CLASS__, 'recaptcha_verify_captcha' ], 10, 2 );
 		add_filter( 'woocommerce_enqueue_styles', [ __CLASS__, 'dequeue_woocommerce_styles' ] );
@@ -757,18 +756,12 @@ final class Modal_Checkout {
 			}
 			unset( $fields['billing'][ $key ] );
 		}
-		return $fields;
-	}
 
-	/**
-	 * Add the form-row-last CSS class to billing phone field.
-	 *
-	 * @param array $fields Checkout fields.
-	 *
-	 * @return array
-	 */
-	public static function change_phone_css_class( $fields ) {
+		/**
+		 * Add the form-row-last CSS class to billing phone field.
+		 */
 		$fields['billing']['billing_phone']['class'] = 'form-row-last';
+
 		return $fields;
 	}
 

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -50,6 +50,7 @@ final class Modal_Checkout {
 		add_filter( 'woocommerce_get_checkout_order_received_url', [ __CLASS__, 'woocommerce_get_return_url' ], 10, 2 );
 		add_filter( 'wc_get_template', [ __CLASS__, 'wc_get_template' ], 10, 2 );
 		add_filter( 'woocommerce_checkout_fields', [ __CLASS__, 'woocommerce_checkout_fields' ] );
+		add_filter( 'woocommerce_checkout_fields', [ __CLASS__, 'change_phone_css_class' ] );
 		add_filter( 'woocommerce_update_order_review_fragments', [ __CLASS__, 'order_review_fragments' ] );
 		add_filter( 'newspack_recaptcha_verify_captcha', [ __CLASS__, 'recaptcha_verify_captcha' ], 10, 2 );
 		add_filter( 'woocommerce_enqueue_styles', [ __CLASS__, 'dequeue_woocommerce_styles' ] );
@@ -750,6 +751,18 @@ final class Modal_Checkout {
 			}
 			unset( $fields['billing'][ $key ] );
 		}
+		return $fields;
+	}
+
+	/**
+	 * Add the form-row-last CSS class to billing phone field.
+	 *
+	 * @param array $fields Checkout fields.
+	 *
+	 * @return array
+	 */
+	public static function change_phone_css_class( $fields ) {
+		$fields['billing']['billing_phone']['class'] = 'form-row-last';
 		return $fields;
 	}
 

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -17,13 +17,11 @@
 	// Billing and Shipping fields - make sure there's not a small orphan row
 	.woocommerce form {
 		.form-row-first:not( :has( + .form-row-last ) ),
-		.form-row-last,
-		.form-row-wide {
-			+ .form-row-last {
-				clear: both;
-				float: none;
-				width: 100%;
-			}
+		.form-row-last + .form-row-last,
+		.form-row-wide + .form-row-last {
+			clear: both;
+			float: none;
+			width: 100%;
 		}
 	}
 

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -14,6 +14,19 @@
 		visibility: hidden !important;
 	}
 
+	// Billing and Shipping fields - make sure there's not a small orphan row
+	.woocommerce form {
+		.form-row-first:not( :has( + .form-row-last ) ),
+		.form-row-last,
+		.form-row-wide {
+			+ .form-row-last {
+				clear: both;
+				float: none;
+				width: 100%;
+			}
+		}
+	}
+
 	/* Custom Gift Subscriptions form elements */
 	.newspack-wcsg {
 		&--gift-toggle {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes some minor tweaks to the billing/shipping field styles in the modal checkout, to make sure they sit in even columns. 

Rather than doing a bigger overhaul of the CSS, I tried to leverage the existing classes and a bit of hacky CSS to make fields full width when they'd otherwise be filling half the space.

See 1205234045751551-as-1207477278860637

### How to test the changes in this Pull Request:

1. Start on `epic/ras-acc` and set up at least two modal checkout situations: the donate block, and a checkout button for a regular product. 
2. Run through a checkout for each; with the default settings, you'll likely have a little orphan field, like this:

![image](https://github.com/Automattic/newspack-blocks/assets/177561/3aa09656-565a-4759-b888-4029d85167b0)

3. Apply the PR and run `npm run build`.
4. Confirm that the checkout with regular settings now doesn't have a lonely field:

![image](https://github.com/Automattic/newspack-blocks/assets/177561/5c74f500-70b0-4388-98fd-cc625bf817ff)

5. Navigate to WP Admin > Newspack > Reader Revenue, and toggle off some of the billing fields in the Donate tab, then run through the Donate checkout to make sure there are no gaps.
6. Repeat step 5 a couple times to make sure there aren't weird combinations that will leave a gap. Basically anytime a field that's normally floated left or right is alone on their row, they should become full-width.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
