### PR TITLE
fix(ras-acc): hide NYP on billing screen

### DIFF
--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -369,6 +369,9 @@ domReady(
 						if ( $coupon.length ) {
 							$coupon.hide();
 						}
+						if ( $nyp.length ) {
+							$nyp.hide();
+						}
 						$customer_details.show();
 						$after_customer_details.hide();
 						$place_order_button.attr( 'disabled', 'disabled' );
@@ -382,6 +385,9 @@ domReady(
 					} else {
 						if ( $coupon.length ) {
 							$coupon.show();
+						}
+						if ( $nyp.length ) {
+							$nyp.show();
 						}
 						$customer_details.hide();
 						$after_customer_details.show();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR just re-adds a NYP show/hide code that I think was removed accidentally when different commits came together.

See: 1205234045751551-1207500552150790

### How to test the changes in this Pull Request:

1. On epic/ras-acc, set up a Checkout Button block with a NYP product.
2. Run through the checkout; note that the NYP input appears on both the Billing and Order Details screens:

![Screen Shot 2024-06-06 at 1 06 34 PM](https://github.com/Automattic/newspack-blocks/assets/177561/48921493-89c7-4263-990d-66380461def1)

3. Apply this PR and run `npm run build`.
4. Re-run the checkout, and confirm that the NYP field only shows on the second Order Details screen, and not on the Billing Details screen.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
