### PR TITLE
fix(ras-acc): adjust nyp suggested price variation modal markup

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -466,6 +466,10 @@ final class Modal_Checkout {
 										'variation_id' => $variation_id,
 									];
 
+									// Remove colon for nyp variations.
+									if ( class_exists( '\WC_Name_Your_Price_Helpers' ) && \WC_Name_Your_Price_Helpers::is_nyp( $variation->get_id() ) ) {
+										$price = str_replace( ':', '', $price );
+									}
 									?>
 									<li class="newspack-blocks__options__item"">
 										<div class="summary">

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -466,9 +466,11 @@ final class Modal_Checkout {
 										'variation_id' => $variation_id,
 									];
 
-									// Remove colon for nyp variations.
+									// Replace nyp price html for variations.
 									if ( class_exists( '\WC_Name_Your_Price_Helpers' ) && \WC_Name_Your_Price_Helpers::is_nyp( $variation->get_id() ) ) {
-										$price = str_replace( ':', '', $price );
+										$price_html = str_replace( ':', '', $price_html );
+										$price_html = str_replace( '<span class="suggested-text">', '<span class="suggested-text"><span class="suggested-prefix">', $price_html );
+										$price_html = str_replace( '<span class="woocommerce-Price-amount amount">', '</span><span class="woocommerce-Price-amount amount">', $price_html );
 									}
 									?>
 									<li class="newspack-blocks__options__item"">

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -15,6 +15,7 @@ const IFRAME_NAME = 'newspack_modal_checkout_iframe';
 const IFRAME_CONTAINER_ID = 'newspack_modal_checkout_container';
 const MODAL_CHECKOUT_ID = 'newspack_modal_checkout';
 const MODAL_CLASS_PREFIX = `${ CLASS_PREFIX }__modal`;
+const VARIATON_MODAL_CLASS_PREFIX = 'newspack-blocks__modal-variation';
 
 domReady( () => {
 	const modalCheckout = document.querySelector( `#${ MODAL_CHECKOUT_ID }` );
@@ -175,7 +176,7 @@ domReady( () => {
 						} );
 					}
 					const formData = new FormData( form );
-					const variationModals = document.querySelectorAll( `.${ MODAL_CLASS_PREFIX }-variation` );
+					const variationModals = document.querySelectorAll( `.${ VARIATON_MODAL_CLASS_PREFIX }` );
 					// Clear any open variation modal.
 					variationModals.forEach( variationModal => {
 						closeModal( variationModal );

--- a/src/modal-checkout/modal.scss
+++ b/src/modal-checkout/modal.scss
@@ -180,7 +180,6 @@
 						position: relative;
 
 						.price {
-							.suggested-text,
 							del {
 								color: var( --newspack-ui-color-neutral-60, colors.$newspack-ui-color-neutral-60 );
 								left: 0;
@@ -188,6 +187,12 @@
 								top: calc( var( --newspack-ui-spacer-base, 8px ) * 0.75 );
 								width: 100%;
 							}
+
+							.suggested-text {
+							  display: block;
+							  color: var( --newspack-ui-color-neutral-60, colors.$newspack-ui-color-neutral-60 );
+							  margin-top: calc( ( var( --newspack-ui-spacer-base, 8px ) * 0.75 ) - var( --newspack-ui-spacer-5, 24px ) );
+                            }
 
 							// Scale up just the primary price for a product, not the other fees:
 							> .amount > bdi,
@@ -198,13 +203,6 @@
 								font-weight: 600;
 								font-size: var( --newspack-ui-font-size-xl, clamp( 1.375rem, 0.394rem + 2.008vw, 2rem ) );
 								line-height: var( --newspack-ui-line-height-xl, 1.375 );
-							}
-
-							.subscription-details {
-								left: 0;
-								position: absolute;
-								bottom: calc( var( --newspack-ui-spacer-base, 8px ) * 0.75 );
-								width: 100%;
 							}
 						}
 					}

--- a/src/modal-checkout/modal.scss
+++ b/src/modal-checkout/modal.scss
@@ -179,21 +179,24 @@
 						position: relative;
 
 						.price {
-							// Scale up just the primary price for a product, not the other fees:
-							> .amount > bdi,
-							> ins > .amount > bdi {
-								display: block;
-								font-weight: 600;
-								font-size: var( --newspack-ui-font-size-xl, clamp( 1.375rem, 0.394rem + 2.008vw, 2rem ) );
-								line-height: var( --newspack-ui-line-height-xl, 1.375 );
-							}
-
+							.suggested-text,
 							del {
 								color: var( --newspack-ui-color-neutral-60, colors.$newspack-ui-color-neutral-60 );
 								left: 0;
 								position: absolute;
 								top: calc( var( --newspack-ui-spacer-base, 8px ) * 0.75 );
 								width: 100%;
+							}
+
+							// Scale up just the primary price for a product, not the other fees:
+							.suggested-text > .amount > bdi,
+							> .amount > bdi,
+							> ins > .amount > bdi {
+								color: initial;
+								display: block;
+								font-weight: 600;
+								font-size: var( --newspack-ui-font-size-xl, clamp( 1.375rem, 0.394rem + 2.008vw, 2rem ) );
+								line-height: var( --newspack-ui-line-height-xl, 1.375 );
 							}
 						}
 					}

--- a/src/modal-checkout/modal.scss
+++ b/src/modal-checkout/modal.scss
@@ -180,19 +180,14 @@
 						position: relative;
 
 						.price {
-							del {
+							del,
+							.suggested-prefix {
 								color: var( --newspack-ui-color-neutral-60, colors.$newspack-ui-color-neutral-60 );
 								left: 0;
 								position: absolute;
 								top: calc( var( --newspack-ui-spacer-base, 8px ) * 0.75 );
 								width: 100%;
 							}
-
-							.suggested-text {
-							  display: block;
-							  color: var( --newspack-ui-color-neutral-60, colors.$newspack-ui-color-neutral-60 );
-							  margin-top: calc( ( var( --newspack-ui-spacer-base, 8px ) * 0.75 ) - var( --newspack-ui-spacer-5, 24px ) );
-                            }
 
 							// Scale up just the primary price for a product, not the other fees:
 							> .amount > bdi,

--- a/src/modal-checkout/modal.scss
+++ b/src/modal-checkout/modal.scss
@@ -176,6 +176,7 @@
 						font-size: var( --newspack-ui-font-size-xs, 14px );
 						line-height: var( --newspack-ui-line-height-xs, 1.4286 );
 						padding: var( --newspack-ui-spacer-5, 24px ) var( --newspack-ui-spacer-2, 12px );
+						height: 100%;
 						position: relative;
 
 						.price {
@@ -189,14 +190,21 @@
 							}
 
 							// Scale up just the primary price for a product, not the other fees:
-							.suggested-text > .amount > bdi,
 							> .amount > bdi,
-							> ins > .amount > bdi {
+							> ins > .amount > bdi,
+							> .suggested-text > .amount > bdi {
 								color: initial;
 								display: block;
 								font-weight: 600;
 								font-size: var( --newspack-ui-font-size-xl, clamp( 1.375rem, 0.394rem + 2.008vw, 2rem ) );
 								line-height: var( --newspack-ui-line-height-xl, 1.375 );
+							}
+
+							.subscription-details {
+								left: 0;
+								position: absolute;
+								bottom: calc( var( --newspack-ui-spacer-base, 8px ) * 0.75 );
+								width: 100%;
 							}
 						}
 					}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1205234045751551/1207428738079159/f

Adjusts nyp price summary styles in variation modal to match other price summary formats:

![Screenshot 2024-06-11 at 13 17 54](https://github.com/Automattic/newspack-blocks/assets/17905991/f638b3b1-0c77-4a22-96c7-fe840d7b1071)


### How to test the changes in this Pull Request:

- Add a checkout button for a variable product to any page. Ensure the `Allow the reader to select the variation before checkout.` option is checked in block settings.
- Add a second checkout button for a variable subscription to any page. Again, ensure the `Allow the reader to select the variation before checkout.` option is checked in block settings.
- Enable NYP, and set at least one of the variations (but not all) to use nyp. Do this for both the variable product AND the variable subscription
- As a reader, select the variable product checkout button and confirm the variable modal appears. Confirm the alignment of the prices match up, and the suggested price text appears above the price as pictured above
- Do the same for the variable subscription checkout button. Confirm the alignment of the suggested price text, the price, and the "per month" does not appear strange.
- Play with the various subscription variation options (i.e. trial period, sign up fee, etc.) and repeat the previous step

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
