### PR TITLE
fix(block-styles): make sure columns style targets direct children

### DIFF
--- a/src/block-styles/core/columns/editor.scss
+++ b/src/block-styles/core/columns/editor.scss
@@ -11,9 +11,9 @@
 
 .wp-block-columns {
 	@include mixins.media( tablet ) {
-		&.is-style-first-col-to-second [data-type='core/column']:nth-child( 2 ),
-		&.is-style-first-col-to-third [data-type='core/column']:nth-child( 2 ),
-		&.is-style-first-col-to-third [data-type='core/column']:nth-child( 3 ) {
+		&.is-style-first-col-to-second > [data-type='core/column']:nth-child( 2 ),
+		&.is-style-first-col-to-third > [data-type='core/column']:nth-child( 2 ),
+		&.is-style-first-col-to-third > [data-type='core/column']:nth-child( 3 ) {
 			order: -1;
 		}
 	}

--- a/src/block-styles/core/columns/view.scss
+++ b/src/block-styles/core/columns/view.scss
@@ -21,13 +21,13 @@ div.wp-block-columns {
 
 .wp-block-columns {
 	@include mixins.media( tablet ) {
-		&.is-style-first-col-to-second .wp-block-column:nth-child( 2 ) {
+		&.is-style-first-col-to-second > .wp-block-column:nth-child( 2 ) {
 			order: -1;
 		}
 
 		&.is-style-first-col-to-third {
-			.wp-block-column:nth-child( 2 ),
-			.wp-block-column:nth-child( 3 ) {
+			> .wp-block-column:nth-child( 2 ),
+			> .wp-block-column:nth-child( 3 ) {
 				order: -1;
 			}
 		}
@@ -65,13 +65,13 @@ div.wp-block-columns {
 		@include mixins.media( tablet ) {
 			&.is-style-first-col-to-second,
 			&.is-style-first-col-to-third {
-				.wp-block-column:first-child::after {
+				> .wp-block-column:first-child::after {
 					display: none;
 				}
 			}
 
-			&.is-style-first-col-to-second .wp-block-column:nth-child( 2 )::after,
-			&.is-style-first-col-to-third .wp-block-column:nth-child( 3 )::after {
+			&.is-style-first-col-to-second > .wp-block-column:nth-child( 2 )::after,
+			&.is-style-first-col-to-third > .wp-block-column:nth-child( 3 )::after {
 				display: block;
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If you use a Columns Block inside a Columns Block that as one one the "Move first col..." styles it will also be affected. It's because at the moment the CSS targets ALL the Columns inside a Columns Block that has these specific styles. Instead, it should only target the direct Column Blocks.

__Before:__

![1-error](https://github.com/Automattic/newspack-blocks/assets/177929/36822e00-c3e4-49b5-acb8-5ff6afd047a5)

__After:__

![2-fixed](https://github.com/Automattic/newspack-blocks/assets/177929/cb196599-a77d-45af-85dd-ae6f77b0f13c)

### How to test the changes in this Pull Request:

1. Create a new page and add a Columns Block, change the style to "Move first col..." (test both styles)
2. Inside this Columns Block, add another Columns Block but keep the style to Default (or Border)
3. Notice the first column moves too.
4. Publish the page.
5. Switch to this branch and refresh the page (and editor)
6. The child Columns Block should render correctly now, with the Column un-moved.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
