### PR TITLE
fix(block-styles): columns shouldn't enforce gap for block themes

### DIFF
--- a/src/block-styles/core/columns/editor.scss
+++ b/src/block-styles/core/columns/editor.scss
@@ -1,7 +1,7 @@
 @use '../../../shared/sass/variables';
 @use '../../../shared/sass/mixins';
 
-.editor-styles-wrapper div.wp-block-columns {
+body:not( [class*="block-theme"] ) .editor-styles-wrapper div.wp-block-columns {
 	gap: 32px;
 
 	&.is-style-borders {
@@ -34,11 +34,11 @@
 
 				&::after {
 					border-right: 1px solid variables.$color__border;
-					bottom: 12px;
+					bottom: 0;
 					content: '';
 					position: absolute;
 					right: -32px;
-					top: 12px;
+					top: 0;
 				}
 
 				&:nth-child( odd )::after {

--- a/src/block-styles/core/columns/view.scss
+++ b/src/block-styles/core/columns/view.scss
@@ -1,7 +1,7 @@
 @use '../../../shared/sass/variables';
 @use '../../../shared/sass/mixins';
 
-div.wp-block-columns {
+body:not( [class*="block-theme"] ) div.wp-block-columns {
 	gap: 32px;
 
 	&.is-style-borders {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If we're using Newspack Blocks with a block theme, like Newspack Block Theme, we shouldn't enforce the gap between columns to be 32px since this can be modified in the editor.

This PR excludes the newspack-block-theme so a publisher can enjoy full control of the Block Spacing setting whilst using our Block Theme.

![Setting](https://github.com/Automattic/newspack-blocks/assets/177929/aa5fddd5-6bde-4e5e-a065-ce750f3d72c4)

### How to test the changes in this Pull Request:

1. Activate NP Block Theme
2. In a page, add a columns block.
3. Try to update the block spacing -- nothing happens
4. Switch to this branch
5. Try again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
