### PR TITLE
fix(ras-acc): don't show phone field when it's not enabled

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -746,6 +746,7 @@ final class Modal_Checkout {
 		 * at the Checkout Button Block level.
 		 */
 		$billing_fields = apply_filters( 'newspack_blocks_donate_billing_fields_keys', [] );
+
 		if ( empty( $billing_fields ) ) {
 			return $fields;
 		}
@@ -760,7 +761,9 @@ final class Modal_Checkout {
 		/**
 		 * Add the form-row-last CSS class to billing phone field.
 		 */
-		$fields['billing']['billing_phone']['class'] = 'form-row-last';
+		if ( in_array( 'billing_phone', $billing_fields, true ) ) {
+			$fields['billing']['billing_phone']['class'] = 'form-row-last';
+		}
 
 		return $fields;
 	}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -746,7 +746,6 @@ final class Modal_Checkout {
 		 * at the Checkout Button Block level.
 		 */
 		$billing_fields = apply_filters( 'newspack_blocks_donate_billing_fields_keys', [] );
-
 		if ( empty( $billing_fields ) ) {
 			return $fields;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In https://github.com/Automattic/newspack-blocks/pull/1762, I tried adding an extra class to the phone billing field to help even out the checkout form, without realizing that this made the phone field always show, even when not enabled.

This PR adds a check to make sure the phone field should be showing before adding the CSS class.

### How to test the changes in this Pull Request:

1. On epic/ras-acc, navigate to WP Admin > Newspack > Reader Revenue > Donations, and turn off the 'Phone' field in the billing field settings.
2. Run a checkout with the modal checkout; note that you get a label-less field at the bottom of the billing details. If you inspect the form, you'll see it's the phone field:

![image](https://github.com/Automattic/newspack-blocks/assets/177561/fc2c66a6-3c1b-489c-b017-c9a06236e750)

3. Apply this PR. 
4. Repeat step 2; confirm that you don't get the random field at the bottom anymore. 
5. Navigate back to the Reader Revenue > Donation settings, and enable the phone field.
6. Repeat step 2; confirm that the phone field shows, and that it still has `form-row-last` CSS class.

![image](https://github.com/Automattic/newspack-blocks/assets/177561/aed8314f-8fc5-466c-95b8-58184fa58735)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
