### PR TITLE
fix(ras-acc): prevent JS error when trying to close variable modal

### DIFF
--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -51,8 +51,6 @@ domReady( () => {
 	const closeCheckout = () => {
 		spinner.style.display = 'flex';
 
-		const container = iframe.contentDocument.querySelector( `#${ IFRAME_CONTAINER_ID }` );
-
 		if ( iframe && modalContent.contains( iframe ) ) {
 			// Reset iframe and modal content heights.
 			iframe.src = 'about:blank';
@@ -72,30 +70,34 @@ domReady( () => {
 			}
 		} );
 
-		if ( container.checkoutComplete ) {
-			const handleCheckoutComplete = () => {
-				const afterSuccessUrlInput = container.querySelector( 'input[name="after_success_url"]' );
-				const afterSuccessBehaviorInput = container.querySelector(
-					'input[name="after_success_behavior"]'
-				);
+		if ( iframe.contentDocument ) {
+			const container = iframe.contentDocument.querySelector( `#${ IFRAME_CONTAINER_ID }` );
 
-				if ( afterSuccessUrlInput && afterSuccessBehaviorInput ) {
-					const afterSuccessUrl = afterSuccessUrlInput.getAttribute( 'value' );
-					const afterSuccessBehavior = afterSuccessBehaviorInput.getAttribute( 'value' );
+			if ( container.checkoutComplete ) {
+				const handleCheckoutComplete = () => {
+					const afterSuccessUrlInput = container.querySelector( 'input[name="after_success_url"]' );
+					const afterSuccessBehaviorInput = container.querySelector(
+						'input[name="after_success_behavior"]'
+					);
 
-					if ( 'custom' === afterSuccessBehavior ) {
-						window.location.href = afterSuccessUrl;
-					} else if ( 'referrer' === afterSuccessBehavior ) {
-						window.history.back();
+					if ( afterSuccessUrlInput && afterSuccessBehaviorInput ) {
+						const afterSuccessUrl = afterSuccessUrlInput.getAttribute( 'value' );
+						const afterSuccessBehavior = afterSuccessBehaviorInput.getAttribute( 'value' );
+
+						if ( 'custom' === afterSuccessBehavior ) {
+							window.location.href = afterSuccessUrl;
+						} else if ( 'referrer' === afterSuccessBehavior ) {
+							window.history.back();
+						}
 					}
+				};
+				if ( window?.newspackReaderActivation?.openNewslettersSignupModal ) {
+					window.newspackReaderActivation.openNewslettersSignupModal( {
+						callback: handleCheckoutComplete,
+					} );
+				} else {
+					handleCheckoutComplete();
 				}
-			};
-			if ( window?.newspackReaderActivation?.openNewslettersSignupModal ) {
-				window.newspackReaderActivation.openNewslettersSignupModal( {
-					callback: handleCheckoutComplete,
-				} );
-			} else {
-				handleCheckoutComplete();
 			}
 		}
 	};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I noticed when testing that the Close button stopped working on the product variable checkout modal, and it was throwing a JS error. I reordered things a bit to fix the error, but there might be a nicer way to do this! 

### How to test the changes in this Pull Request:

1. On the epic/ras-acc branch, set up a product with variations, and assign it to a Checkout Button block.
2. Click the checkout button, and then try to close it with the close button. Note it doesn't work, and that you get the following error in the console:

```
TypeError: Cannot read properties of null (reading 'querySelector')
```

3. Apply this PR and run `npm run build`.
4. Repeat testing step 2; confirm that the modal closes without error.
5. Set up a Checkout Button block with a regular product.
6. Start the checkout from the regular product checkout, and try to close it; confirm it closes without JS errors.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
