### PR TITLE
fix(ras-acc): update shipping details header

### DIFF
--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -461,7 +461,7 @@ domReady(
 					// Shipping details.
 					if ( data.hasOwnProperty( 'shipping_address_1' ) ) {
 						html.push( '<div class="shipping-details">' );
-						html.push( '<h2>' + newspackBlocksModalCheckout.labels.shipping_details + '</h2>' );
+						html.push( '<h3>' + newspackBlocksModalCheckout.labels.shipping_details + '</h3>' );
 						let shippingAddress = '';
 						if ( ! data.ship_to_different_address ) {
 							shippingAddress = billingAddress;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This teeny PR switches the Shipping Details header from `h2` to `h3`, both to match the hierarchy level of the Billing Details header, but also so it picks up the spacing styles.

### How to test the changes in this Pull Request:

1. On epic/ras-acc, set up a product that requires shipping, assign it to a Checkout Button block, and run a checkout.
2. When you hit the second screen, note the spacing between the Billing Details heading and info, and the Shipping Details heading and info:

![image](https://github.com/Automattic/newspack-blocks/assets/177561/3b2032b0-d5de-4c8c-907c-8ca1791bd335)

3. Apply this PR and run `npm run build`.
4. Run the checkout again and confirm that the spacing looks the same:

![image](https://github.com/Automattic/newspack-blocks/assets/177561/c06ccfa6-044b-4d2e-99bf-d5bc44745299)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
