### PR TITLE
feat(checkout-button): add wp-block-button to the wrapperclasses

### DIFF
--- a/src/blocks/checkout-button/save.js
+++ b/src/blocks/checkout-button/save.js
@@ -43,7 +43,7 @@ export default function save( { attributes, className } ) {
 		...spacingProps.style,
 	};
 
-	const wrapperClasses = classnames( className, {
+	const wrapperClasses = classnames( className, 'wp-block-button', {
 		[ `has-custom-font-size` ]: fontSize || style?.typography?.fontSize,
 		[ `has-custom-width wp-block-button__width-${ width }` ]: width,
 	} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The themes (Classic && Block) are missing some `:hover` styles because the wrapper doesn't have the `wp-block-button` class. This PR adds the class (on save).

Note: The issue is even more visible with the Block Theme because the outline style variation simply doesn't work.

![error](https://github.com/Automattic/newspack-blocks/assets/177929/2cf16d87-d0e0-4406-91e2-024ed399468e)
![fix](https://github.com/Automattic/newspack-blocks/assets/177929/3265726c-41d6-4004-bfe3-826e71a7d99a)

### How to test the changes in this Pull Request:

1. Add a checkout button block
2. Change the style to outline
3. Publish page and check front-end
4. No hover
5. Switch to this branch
6. Refresh editor (note: for some reason it breaks the block -- probably because it adds the class on save -- I could use some help here!)
7. Save the block again
8. Refresh front-end

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
