### PR TITLE
feat: ensure regenerator-runtime is available (for WP 6.6)

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,19 +50,30 @@ const placeholderBlocksScript = path.join( __dirname, 'src', 'setup', 'placehold
 
 const blockStylesScript = [ path.join( __dirname, 'src', 'block-styles', 'view' ) ];
 
+const entry = {
+	placeholder_blocks: placeholderBlocksScript,
+	editor: editorScript,
+	block_styles: blockStylesScript,
+	modal: path.join( __dirname, 'src/modal-checkout/modal.js' ),
+	modalCheckout: path.join( __dirname, 'src/modal-checkout' ),
+	frequencyBased: path.join( __dirname, 'src/blocks/donate/frequency-based' ),
+	tiersBased: path.join( __dirname, 'src/blocks/donate/tiers-based' ),
+	...viewBlocksScripts,
+};
+
+Object.keys( entry ).forEach( key => {
+	const value = entry[ key ];
+	if ( Array.isArray( value ) ) {
+		entry[ key ] = [ 'regenerator-runtime/runtime', ...value ];
+	} else {
+		entry[ key ] = [ 'regenerator-runtime/runtime', value ];
+	}
+} );
+
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },
 	{
-		entry: {
-			placeholder_blocks: placeholderBlocksScript,
-			editor: editorScript,
-			block_styles: blockStylesScript,
-			modal: path.join( __dirname, 'src/modal-checkout/modal.js' ),
-			modalCheckout: path.join( __dirname, 'src/modal-checkout' ),
-			frequencyBased: path.join( __dirname, 'src/blocks/donate/frequency-based' ),
-			tiersBased: path.join( __dirname, 'src/blocks/donate/tiers-based' ),
-			...viewBlocksScripts,
-		},
+		entry,
 		'output-path': path.join( __dirname, 'dist' ),
 	}
 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

WP 6.6 changes some things and `regenerator-runtime` is not available anymore. This PR adds it to every entry file processed by webpack. 

### How to test the changes in this Pull Request:

1. On `trunk`, open a post editor with WordPress 6.6* installed 
1. Observe no block can be added 
2. Switch to this branch, rebuild, observe blocks can be inserted
3. Switch WP to 6.5, again observe the editor behaving as expected

\* `6.6-beta2` to be exact

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->