### PR TITLE
fix(ras-acc): adjust thankyou modal sizing

### DIFF
--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -16,6 +16,7 @@ domReady(
 		}
 
 		const readyEvent = new CustomEvent( 'checkout-ready' );
+		const completeEvent = new CustomEvent( 'checkout-complete' );
 
 		function getEventHandlers( element, event ) {
 			const events = $._data( element, 'events' );
@@ -36,11 +37,19 @@ domReady(
 
 		if ( newspackBlocksModalCheckout.is_checkout_complete ) {
 			/**
+			 * Set the checkout as complete so the modal can resolve post checkout state.
+			 */
+			function setComplete() {
+				container.checkoutComplete = true;
+				container.dispatchEvent( completeEvent );
+			}
+
+			/**
 			 * Set the checkout as complete so the modal can resolve post checkout flows.
 			 */
 			const container = document.querySelector( '#newspack_modal_checkout_container' );
 			if ( container ) {
-				container.checkoutComplete = true;
+				setComplete();
 			}
 		} else {
 			$( document.body ).on( 'init_checkout', function () {

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -16,7 +16,6 @@ domReady(
 		}
 
 		const readyEvent = new CustomEvent( 'checkout-ready' );
-		const completeEvent = new CustomEvent( 'checkout-complete' );
 
 		function getEventHandlers( element, event ) {
 			const events = $._data( element, 'events' );
@@ -37,19 +36,11 @@ domReady(
 
 		if ( newspackBlocksModalCheckout.is_checkout_complete ) {
 			/**
-			 * Set the checkout as complete so the modal can resolve post checkout state.
-			 */
-			function setComplete() {
-				container.checkoutComplete = true;
-				container.dispatchEvent( completeEvent );
-			}
-
-			/**
 			 * Set the checkout as complete so the modal can resolve post checkout flows.
 			 */
 			const container = document.querySelector( '#newspack_modal_checkout_container' );
 			if ( container ) {
-				setComplete();
+				container.checkoutComplete = true;
 			}
 		} else {
 			$( document.body ).on( 'init_checkout', function () {

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -95,7 +95,8 @@ domReady( () => {
 			} else {
 				handleCheckoutComplete();
 			}
-			// Ensure we always reset the modal title once the modal closes.
+			// Ensure we always reset the modal title and width once the modal closes.
+			setModalWidth();
 			setModalTitle( newspackBlocksModal.labels.checkout_modal_title );
 		}
 	};
@@ -138,6 +139,24 @@ domReady( () => {
 		}
 
 		modalTitle.innerText = title;
+	};
+
+	/**
+	 * Sets the width of the modal.
+	 *
+	 * @param {string} size Options are 'small' or 'default'. Default is 'default'.
+	 */
+	const setModalWidth = ( size = 'default' ) => {
+		const modal = modalCheckout.querySelector( `.${ MODAL_CLASS_PREFIX }` );
+		if ( ! modal ) {
+			return;
+		}
+
+		if ( size === 'small' ) {
+			modal.classList.add( `${ MODAL_CLASS_PREFIX }--small` );
+		} else {
+			modal.classList.remove( `${ MODAL_CLASS_PREFIX }--small` );
+		}
 	};
 
 	window.newspackCloseModalCheckout = closeCheckout;
@@ -363,10 +382,12 @@ domReady( () => {
 		if ( container ) {
 			iframeResizeObserver.observe( container );
 			if ( container.checkoutComplete ) {
-				// Update the modal title to reflect successful transaction.
+				// Update the modal title and width to reflect successful transaction.
+				setModalWidth( 'small' );
 				setModalTitle( newspackBlocksModal.labels.thankyou_modal_title );
 			} else {
-				// Revert modal title default value.
+				// Revert modal title and width default value.
+				setModalWidth();
 				setModalTitle( newspackBlocksModal.labels.checkout_modal_title );
 			}
 			if ( container.checkoutReady ) {
@@ -374,13 +395,6 @@ domReady( () => {
 			} else {
 				container.addEventListener( 'checkout-ready', () => {
 					spinner.style.display = 'none';
-				} );
-
-				container.addEventListener( 'checkout-complete', () => {
-					const modalContainer = modalCheckout.querySelector( `.${ MODAL_CLASS_PREFIX }` );
-					if ( modalContainer ) {
-						modalContainer.classList.add( `${ MODAL_CLASS_PREFIX }--small` );
-					}
 				} );
 			}
 		} else if ( 'about:blank' !== location.href ) {

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -375,6 +375,13 @@ domReady( () => {
 				container.addEventListener( 'checkout-ready', () => {
 					spinner.style.display = 'none';
 				} );
+
+				container.addEventListener( 'checkout-complete', () => {
+					const modalContainer = modalCheckout.querySelector( `.${ MODAL_CLASS_PREFIX }` );
+					if ( modalContainer ) {
+						modalContainer.classList.add( `${ MODAL_CLASS_PREFIX }--small` );
+					}
+				} );
 			}
 		} else if ( 'about:blank' !== location.href ) {
 			// Make sure the iframe has actually loaded something, even if not the expected container.


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207385073694413/1207603000223323/f

This PR adjusts the checkout thankyou modal width to use the `newspack-ui__modal--small` sizing:

![Screenshot 2024-06-26 at 16 14 33](https://github.com/Automattic/newspack-blocks/assets/17905991/b627dd8a-c5cc-43e7-bb19-657e255468f7)

### How to test the changes in this Pull Request:

1. As a reader, go through the modal checkout flow via any donate or checkout button.
2. After completing the order, confirm the thank you modal resizes to small automatically
3. Without reloading the page, trigger another modal checkout flow via any donate or checkout button (can be the same one as in step 1)
4. Confirm the size of the checkout form is large again
5. Repeat the above steps with other donation or checkout buttons with other product types

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
