### PR TITLE
fix(ras-acc): Update checkout modal title on successful transaction

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -576,6 +576,7 @@ final class Modal_Checkout {
 					'auth_modal_title'     => self::get_modal_checkout_labels( 'auth_modal_title' ),
 					'signin_modal_title'   => self::get_modal_checkout_labels( 'signin_modal_title' ),
 					'register_modal_title' => self::get_modal_checkout_labels( 'register_modal_title' ),
+					'thankyou_modal_title' => self::get_modal_checkout_labels( 'checkout_success' ),
 				],
 			]
 		);
@@ -1364,6 +1365,7 @@ final class Modal_Checkout {
 				'checkout_confirm'           => __( 'Complete transaction', 'newspack-blocks' ),
 				'checkout_confirm_variation' => __( 'Purchase', 'newspack-blocks' ),
 				'checkout_back'              => __( 'Back', 'newspack-blocks' ),
+				'checkout_success'           => __( 'Transaction successful', 'newspack-blocks' ),
 				'thankyou'                   => sprintf(
 					// Translators: %s is the site name.
 					__( 'Thank you for supporting %s. Your transaction was successful.', 'newspack-blocks' ),

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -574,8 +574,9 @@ final class Modal_Checkout {
 				'newspack_class_prefix' => self::get_class_prefix(),
 				'labels'                => [
 					'auth_modal_title'     => self::get_modal_checkout_labels( 'auth_modal_title' ),
-					'signin_modal_title'   => self::get_modal_checkout_labels( 'signin_modal_title' ),
+					'checkout_modal_title' => self::get_modal_checkout_labels( 'checkout_modal_title' ),
 					'register_modal_title' => self::get_modal_checkout_labels( 'register_modal_title' ),
+					'signin_modal_title'   => self::get_modal_checkout_labels( 'signin_modal_title' ),
 					'thankyou_modal_title' => self::get_modal_checkout_labels( 'checkout_success' ),
 				],
 			]

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -95,6 +95,8 @@ domReady( () => {
 			} else {
 				handleCheckoutComplete();
 			}
+			// Ensure we always reset the modal title once the modal closes.
+			setModalTitle( newspackBlocksModal.labels.checkout_modal_title );
 		}
 	};
 
@@ -358,6 +360,9 @@ domReady( () => {
 			if ( container.checkoutComplete ) {
 				// Update the modal title to reflect successful transaction.
 				setModalTitle( newspackBlocksModal.labels.thankyou_modal_title );
+			} else {
+				// Revert modal title default value.
+				setModalTitle( newspackBlocksModal.labels.checkout_modal_title );
 			}
 			if ( container.checkoutReady ) {
 				spinner.style.display = 'none';

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -124,6 +124,20 @@ domReady( () => {
 		document.body.style.overflow = 'hidden';
 	};
 
+	/**
+	 * Set the modal title.
+	 *
+	 * @param {string} title The title to set.
+	 */
+	const setModalTitle = title => {
+		const modalTitle = modalCheckout.querySelector( `.${ MODAL_CLASS_PREFIX }__header h2` );
+		if ( ! modalTitle ) {
+			return;
+		}
+
+		modalTitle.innerText = title;
+	};
+
 	window.newspackCloseModalCheckout = closeCheckout;
 
 	/**
@@ -341,6 +355,10 @@ domReady( () => {
 		const container = iframe?.contentDocument?.querySelector( `#${ IFRAME_CONTAINER_ID }` );
 		if ( container ) {
 			iframeResizeObserver.observe( container );
+			if ( container.checkoutComplete ) {
+				// Update the modal title to reflect successful transaction.
+				setModalTitle( newspackBlocksModal.labels.thankyou_modal_title );
+			}
 			if ( container.checkoutReady ) {
 				spinner.style.display = 'none';
 			} else {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207385073694413/1207603000223330/f

This PR updates the thank you modal title during the modal checkout flow:

![Screenshot 2024-06-26 at 16 45 23](https://github.com/Automattic/newspack-blocks/assets/17905991/c5d572e1-0a11-4364-b8ec-f81f4960206e)

### How to test the changes in this Pull Request:

1. As a reader, go through the modal checkout flow via any donate or checkout button.
2. After completing the order, confirm the thank you modal title has updated to 'Transaction successful' as pictured above.
3. Without reloading the page, trigger another modal checkout flow via any donate or checkout button (can be the same one as in step 1)
4. Confirm the title of the checkout modal is back to 'Complete your transaction'
5. Repeat the above steps with other donation or checkout buttons with other product types

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
