### PR TITLE
fix(ras-acc): remove woo generated errors from modal checkout

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -455,4 +455,9 @@
 	#checkout_back {
 		margin-top: 0;
 	}
+
+	// Hide woocommerce errors since we are rendering errors inline.
+	form.checkout .woocommerce-NoticeGroup {
+		display: none;
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Awaiting design feedback here: https://app.asana.com/0/0/1207546771559780/1207687937493923/f

Closes https://app.asana.com/0/1207385073694413/1207546771559780/f

This PR removes the standard woo notices from modal checkout:

![Screenshot 2024-06-28 at 15 14 53](https://github.com/Automattic/newspack-blocks/assets/17905991/436893e9-ab3d-42d6-8d98-71bca6476388)

This shouldn't be needed anymore since we are rendering errors inline below each input.

### How to test the changes in this Pull Request:

1. Set up WCPay on a test site (https://woocommerce.com/document/woopayments/testing-and-troubleshooting/sandbox-mode/)
2. Go through the modal checkout flow via any donation or checkout button
3. Enter billing details and proceed to next step (payment)
4. Select WCPay as the payment method and enter invalid data
5. On `epic/ras-acc` a woo error will appear in the billing form (pictured above). On this branch it will not.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
