### PR TITLE
fix: account for patterns when rendering hpp in editor

### DIFF
--- a/src/blocks/homepage-articles/utils.ts
+++ b/src/blocks/homepage-articles/utils.ts
@@ -222,12 +222,25 @@ export const postsBlockSelector = (
 		attributes,
 	}: { clientId: Block[ 'clientId' ]; attributes: HomepageArticlesAttributes }
 ): HomepageArticlesPropsFromDataSelector => {
-	const { getEditedPostAttribute } = select( 'core/editor' );
-	const editorBlocks = getEditedPostAttribute( 'blocks' ) || [];
 	const { getBlocks } = select( 'core/block-editor' );
-	const editorBlocksIds = getEditorBlocksIds( editorBlocks );
+	const { getEditedPostAttribute } = select( 'core/editor' );
+
+	const editorBlocks = getEditedPostAttribute( 'blocks' ) || [];
+	const allEditorBlocks = [];
+
+	for ( const block of editorBlocks ) {
+		// Get pattern blocks as well.
+		if ( block.name === 'core/block' ) {
+			allEditorBlocks.push( ...getBlocks( block.clientId ) );
+		} else {
+			allEditorBlocks.push( block );
+		}
+	}
+
+	const editorBlocksIds = getEditorBlocksIds( allEditorBlocks );
 	const blocks = getBlocks();
 	const isWidgetEditor = blocks.some( block => block.name === 'core/widget-area' );
+
 	// The block might be rendered in the block styles preview, not in the editor.
 	const isEditorBlock =
 		editorBlocksIds.length === 0 || editorBlocksIds.indexOf( clientId ) >= 0 || isWidgetEditor;

--- a/src/blocks/homepage-articles/utils.ts
+++ b/src/blocks/homepage-articles/utils.ts
@@ -201,7 +201,7 @@ const getPreviewPosts = ( attributes: HomepageArticlesAttributes ) =>
 
 type Select = ( namespace: string ) => {
 	// core/blocks-editor
-	getBlocks: () => Block[];
+	getBlocks: ( clientId?: string ) => Block[];
 	// core/editor
 	getEditedPostAttribute: ( attribute: string ) => Block[];
 	// core


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207720049982626/1207721228317933/f

This PR fixes an issue introduced when updating WP to 6.6 where the HPP block rendered within a synced pattern causes the hpp block to render defaults in the editor after a post is edited.

Before:

![Screenshot 2024-07-08 at 17 11 48](https://github.com/Automattic/newspack-blocks/assets/17905991/16308c5c-7131-4d25-a2b6-0c6630957bf9)

After:

![Screenshot 2024-07-08 at 17 11 23](https://github.com/Automattic/newspack-blocks/assets/17905991/7beb41e2-91eb-49e7-b62a-5ea487762e73)


### How to test the changes in this Pull Request:

1. Start on a site running WP 6.6 RC
2. Add the HPP block to any page or post, convert to a saved patter, and save
3. Reload the post editor. The HPP block should be rendering real post data
4. Now edit anything in the post aside from the HPP synced pattern. On `release` this will cause the real post data to revert to placeholder data. On this branch, it will not.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
