### PR TITLE
fix(ras-acc): update woocommerce checkout payment error styles

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -464,22 +464,11 @@
 		margin-top: 0;
 	}
 
-	form.checkout .woocommerce-NoticeGroup {
-		align-items: center;
-		background: color.adjust( wp-colors.$alert-red, $lightness: 51% );
-		display: flex;
-		justify-content: flex-start;
-		margin: 32px 0;
-		padding: 6px 8px;
-		border-radius: 2px;
-		box-shadow: 0 0 8px 4px rgba( black, 0.08 );
-		border-left: 3px solid wp-colors.$alert-red;
-		box-sizing: border-box;
-
-		ul.woocommerce-error {
-			background: none;
-			color: wp-colors.$gray-900;
-			margin: 0 !important;
-		}
+	form.checkout .woocommerce-NoticeGroup ul.woocommerce-error {
+		background: none;
+		color: inherit;
+		list-style-type: none;
+		padding-left: 0;
+		padding-right: 0;
 	}
 }

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+@use '~@wordpress/base-styles/colors' as wp-colors;
 @use '../shared/sass/colors';
 
 // stylelint-disable-next-line selector-id-pattern
@@ -460,5 +462,24 @@
 	// stylelint-disable-next-line selector-id-pattern
 	#checkout_back {
 		margin-top: 0;
+	}
+
+	form.checkout .woocommerce-NoticeGroup {
+		align-items: center;
+		background: color.adjust( wp-colors.$alert-red, $lightness: 51% );
+		display: flex;
+		justify-content: flex-start;
+		margin: 32px 0;
+		padding: 6px 8px;
+		border-radius: 2px;
+		box-shadow: 0 0 8px 4px rgba( black, 0.08 );
+		border-left: 3px solid wp-colors.$alert-red;
+		box-sizing: border-box;
+
+		ul.woocommerce-error {
+			background: none;
+			color: wp-colors.$gray-900;
+			margin: 0 !important;
+		}
 	}
 }

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -1,5 +1,3 @@
-@use 'sass:color';
-@use '~@wordpress/base-styles/colors' as wp-colors;
 @use '../shared/sass/colors';
 
 // stylelint-disable-next-line selector-id-pattern

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -462,11 +462,19 @@
 		margin-top: 0;
 	}
 
-	form.checkout .woocommerce-NoticeGroup ul.woocommerce-error {
-		background: none;
-		color: inherit;
-		list-style-type: none;
-		padding-left: 0;
-		padding-right: 0;
+	form.checkout .woocommerce-NoticeGroup {
+		ul.woocommerce-error {
+			background: none;
+			color: inherit;
+			list-style-type: none;
+			padding-left: 0;
+			padding-right: 0;
+		}
+
+		.woocommerce-message,
+		.woocommerce-error,
+		.woocommerce-info {
+			font-size: var( --newspack-ui-font-size-xs, 14px );
+		}
 	}
 }

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -15,6 +15,7 @@ domReady(
 			return;
 		}
 
+		const CLASS_PREFIX = newspackBlocksModalCheckout.newspack_class_prefix;
 		const readyEvent = new CustomEvent( 'checkout-ready' );
 
 		function getEventHandlers( element, event ) {
@@ -30,7 +31,7 @@ domReady(
 
 		function clearNotices() {
 			$(
-				`.woocommerce-NoticeGroup-checkout, .${ newspackBlocksModalCheckout.newspack_class_prefix }__inline-error, .woocommerce-error, .woocommerce-message, .wc-block-components-notice-banner`
+				`.woocommerce-NoticeGroup-checkout, .${ CLASS_PREFIX }__inline-error, .woocommerce-error, .woocommerce-message, .wc-block-components-notice-banner`
 			).remove();
 		}
 
@@ -106,6 +107,16 @@ domReady(
 				} );
 
 				/**
+				 * Apply newspack styling to default Woo chekcout errors.
+				 */
+				$( document ).on( 'checkout_error', function () {
+					const $error = $( '.woocommerce-NoticeGroup-checkout' );
+					if ( $error ) {
+						$error.addClass( `${ CLASS_PREFIX }__notice ${ CLASS_PREFIX }__notice--error` );
+					}
+				} );
+
+				/**
 				 * Handle gift options.
 				 */
 				if ( $gift_options.length ) {
@@ -173,9 +184,7 @@ domReady(
 							}
 							$field.addClass( 'woocommerce-invalid' ).removeClass( 'woocommerce-valid' );
 							$field.append(
-								`<span class="${ newspackBlocksModalCheckout.newspack_class_prefix }__inline-error">` +
-									$error.text() +
-									'</span>'
+								`<span class="${ CLASS_PREFIX }__inline-error">` + $error.text() + '</span>'
 							);
 							$error.remove();
 						} else {
@@ -263,9 +272,7 @@ domReady(
 							if ( code ) {
 								const isError = code.includes( 'error' );
 								$coupon.append(
-									`<p class="result ${ newspackBlocksModalCheckout.newspack_class_prefix }__helper-text">` +
-										$( code ).text() +
-										'</p>'
+									`<p class="result ${ CLASS_PREFIX }__helper-text">` + $( code ).text() + '</p>'
 								);
 								if ( isError ) {
 									$coupon.find( 'input[name="coupon_code"]' ).focus();
@@ -319,7 +326,7 @@ domReady(
 							clearNotices();
 							$nyp.find( '.result' ).remove();
 							$nyp.append(
-								`<p class="result ${ newspackBlocksModalCheckout.newspack_class_prefix }__${
+								`<p class="result ${ CLASS_PREFIX }__${
 									success ? 'helper-text' : 'inline-error'
 								}">` +
 									res.message +
@@ -413,7 +420,7 @@ domReady(
 						data[ item.name ] = item.value;
 					} );
 
-					const classname = `${ newspackBlocksModalCheckout.newspack_class_prefix }__font--xs`;
+					const classname = `${ CLASS_PREFIX }__font--xs`;
 					const html = [];
 					html.push( '<div class="billing-details">' );
 					html.push( '<h3>' + newspackBlocksModalCheckout.labels.billing_details + '</h3>' );
@@ -578,7 +585,7 @@ domReady(
 									handleFormError( result.messages );
 								} else {
 									handleFormError(
-										`<div class="${ newspackBlocksModalCheckout.newspack_class_prefix }__inline-error">` +
+										`<div class="${ CLASS_PREFIX }__inline-error">` +
 											wc_checkout_params.i18n_checkout_error +
 											'</div>'
 									);


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**Important: This PR relies on updates to newspack ui which will be added in https://github.com/Automattic/newspack-plugin/pull/3235. DO NOT MERGE until that PR has been merged.**

Closes https://app.asana.com/0/1207720049982626/1207546771559780/f

This PR updates the styles for the generic woocommerce payment errors that appear for invalid payment attempts:

![Screenshot 2024-07-10 at 12 57 30](https://github.com/Automattic/newspack-blocks/assets/17905991/49b7fa26-f60c-4452-be28-875de150e45a)

### How to test the changes in this Pull Request:

1. Make sure to have `epic/ras-acc` checked out in `newspack-plugin`
2. Initiate modal checkout via any donate or checkout button
3. Enter all checkout info and proceed to the payment portion of modal checkout
4. Enter any invalid payment details (for stripe based payment gateways, you can use the following test card with any expiration date and any cvv which will trigger a failure: 4000 0000 0000 0002)
5. On `epic/ras-acc` the error will have default woo styles and clash a bit with our newspack ui styles. On this branch the styles will match that of our newspack notices as pictured above

Bonus: Test some other payment gateways and try to generate other errors in the payment form (some payment gateways will trigger this error when attempting to submit empty fields while others will not)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
