### PR TITLE
fix(ras-acc): show suggested nyp prices donation block

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1438,6 +1438,8 @@ final class Modal_Checkout {
 	 * @param string $name      The name.
 	 * @param string $price     The price. Optional. If not provided, the price string will contain 0.
 	 * @param string $frequency The frequency. Optional. If not provided, the price will be treated as a one-time payment.
+	 *
+	 * @return string The price string.
 	 */
 	public static function get_summary_card_price_string( $name, $price = '', $frequency = '' ) {
 		if ( ! $price ) {

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-frequency-based.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-frequency-based.php
@@ -139,10 +139,15 @@ class Newspack_Blocks_Donate_Renderer_Frequency_Based extends Newspack_Blocks_Do
 
 						<?php foreach ( $configuration['frequencies'] as $frequency_slug => $frequency_name ) : ?>
 							<?php
-								$formatted_amount = Newspack_Blocks::can_use_name_your_price() ? '' : $configuration['amounts'][ $frequency_slug ][3];
-								$product_data     = wp_json_encode(
+								$amount                = $configuration['amounts'][ $frequency_slug ][3];
+								$product_price_summary = Modal_Checkout::get_summary_card_price_string(
+									__( 'Donate', 'newspack-blocks' ),
+									'',
+									$frequency_slug
+								);
+								$product_data = wp_json_encode(
 									[
-										'donation_price_summary_' . $frequency_slug => Modal_Checkout::get_summary_card_price_string( __( 'Donate', 'newspack-blocks' ), $formatted_amount, $frequency_slug ),
+										'donation_price_summary_' . $frequency_slug => $product_price_summary,
 									]
 								);
 							?>
@@ -171,7 +176,7 @@ class Newspack_Blocks_Donate_Renderer_Frequency_Based extends Newspack_Blocks_Do
 											type='number'
 											min='<?php echo esc_attr( $configuration['minimumDonation'] ); ?>'
 											name='donation_value_<?php echo esc_attr( $frequency_slug ); ?>_untiered'
-											value='<?php echo esc_attr( $formatted_amount ); ?>'
+											value='<?php echo esc_attr( $amount ); ?>'
 											id='newspack-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-untiered-input'
 										/>
 									</div>
@@ -179,7 +184,7 @@ class Newspack_Blocks_Donate_Renderer_Frequency_Based extends Newspack_Blocks_Do
 									<input
 										type='radio'
 										name='donation_value_<?php echo esc_attr( $frequency_slug ); ?>'
-										value='<?php echo esc_attr( $formatted_amount ); ?>'
+										value='<?php echo esc_attr( $amount ); ?>'
 										id='newspack-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-untiered-input'
 										checked
 									/>
@@ -187,7 +192,7 @@ class Newspack_Blocks_Donate_Renderer_Frequency_Based extends Newspack_Blocks_Do
 										class='tier-select-label tier-label'
 										for='newspack-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-untiered-input'
 									>
-										<?php echo wp_kses_post( Newspack_Blocks::get_formatted_amount( $formatted_amount, $frequency_slug ) ); ?>
+										<?php echo wp_kses_post( Newspack_Blocks::get_formatted_amount( $amount, $frequency_slug ) ); ?>
 									</label>
 									<?php endif; ?>
 								</div>


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1205234045751551/1207835507085627/f

This fixes an issue where the nyp suggested prices were not populating on the frontend for the donation block:

![Screenshot 2024-07-19 at 14 09 24](https://github.com/user-attachments/assets/f15525b2-5d61-4b98-8446-1f2b5f6369b2)

### How to test the changes in this Pull Request:

1. Add a donation block to any page or post with the following settings:
  - Using NYP
  - 'Tiered' donations turned off under the Suggested Donations section, so you only have the price field for each frequency. 
![Screenshot 2024-07-19 at 14 11 10](https://github.com/user-attachments/assets/b040064e-184e-4fde-a71d-3d454d753b18)
2. Visit the page or post on the front-end and confirm the input fields within the donate block are pre-populated with suggested prices from first step.
3. Smoke test some other donation block layouts and settings to confirm nothing else has been broken

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
