### PR TITLE
fix(ras-acc): remove extra spacing from variable product modal heading

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -459,9 +459,9 @@ final class Modal_Checkout {
 						</button>
 					</header>
 					<section class="<?php echo esc_attr( "{$class_prefix}__modal__content" ); ?>">
+						<h3><?php echo esc_html( $product_name ); ?></h3>
+						<p><?php esc_html_e( 'Select an option to continue:', 'newspack-blocks' ); ?></p>
 						<div class="<?php echo esc_attr( "{$class_prefix}__selection" ); ?>" data-product-id="<?php echo esc_attr( $product_id ); ?>">
-							<h3><?php echo esc_html( $product_name ); ?></h3>
-							<p><?php esc_html_e( 'Select an option to continue:', 'newspack-blocks' ); ?></p>
 							<ul class="newspack-blocks__options"">
 								<?php
 								$variations = $product->get_available_variations( 'objects' );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207878733150167/f

This PR rearranges the elements in the variable product modal to remove some extra spacing from the top of the modal:

Before:
![Screenshot 2024-07-25 at 16 07 54](https://github.com/user-attachments/assets/64d29a89-0102-43d4-bea6-d8047d64a643)

After:
![Screenshot 2024-07-25 at 16 08 22](https://github.com/user-attachments/assets/9236ec67-023c-4dba-a9cb-58cefeb60db6)

### How to test the changes in this Pull Request:

1. Set up a checkout button block for a variable product and allow variation selection
2. As a reader, select the checkout button and confirm the variable product modal appears
3. Verify there isn't extra spacing at the top as pictured above

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
