### PR TITLE
fix(ras-acc): always show order review table for subscription products

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -956,6 +956,9 @@ final class Modal_Checkout {
 				return true;
 			}
 		}
+		if ( class_exists( 'WC_Subscriptions_Cart' ) && \WC_Subscriptions_Cart::cart_contains_subscription() ) {
+			return true;
+		}
 		return false;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207878733150157/f

This PR ensures we always show the transaction order review table in modal checkout when a subscription product is being checked out. Even in the case of simple subscriptions with no tax, shipping, fees, etc.

![Screenshot 2024-07-25 at 17 30 22](https://github.com/user-attachments/assets/0c30b5a6-8aba-49cc-9a56-c8d3ba6ce21f)

### How to test the changes in this Pull Request:

1. As admin, Check the `Allow donors to cover transaction fees` checkbox via the Newspack > Reader Revenue > Stripe Settings menu
2. As a reader visit any page with a donate block set up
3. Select a monthly donation option and go through checkout
4. Confirm the transaction order review table appears as pictured above
5. Now select a one-time donation option and go through checkout until you get to the payment method step
6. Selecting Stripe as the payment gateway, ensure the checkbox to cover fees is NOT checked
![Screenshot 2024-07-25 at 17 34 49](https://github.com/user-attachments/assets/c906e2a0-a521-4f58-9101-6601348bc7a8)
7. Confirm no transaction order review table is present
8. Now check the cover fees box
9. Confirm the transaction order review table appears

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
