### PR TITLE
fix(ras-acc): remove use of jquery blockUI

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -472,4 +472,8 @@
 			font-size: var( --newspack-ui-font-size-xs, 14px );
 		}
 	}
+
+	.processing {
+		opacity: 0.5;
+	}
 }

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -57,7 +57,6 @@ domReady(
 				const $checkout_continue = $( '#checkout_continue' );
 				const $customer_details = $( '#customer_details' );
 				const $after_customer_details = $( '#after_customer_details' );
-				const $place_order_button = $( '#place_order' );
 				const $gift_options = $( '.newspack-wcsg--wrapper' );
 
 				/**
@@ -334,6 +333,7 @@ domReady(
 						},
 						complete: () => {
 							unblockForm( $nyp );
+							input.attr( 'disabled', false );
 							input.focus();
 						},
 					} );
@@ -601,9 +601,10 @@ domReady(
 					if ( form.is( '.processing' ) ) {
 						return false;
 					}
-
-					$checkout_continue.attr( 'disabled', 'disabled' );
-					$place_order_button.attr( 'disabled', 'disabled' );
+					const buttons = form.find( 'button[type=submit]' );
+					buttons.each( ( i, el ) => {
+						$( el ).attr( 'disabled', true );
+					} );
 					form.addClass( 'processing' );
 					return true;
 				}
@@ -619,9 +620,10 @@ domReady(
 					if ( ! form.is( '.processing' ) ) {
 						return false;
 					}
-
-					$checkout_continue.removeAttr( 'disabled' );
-					$place_order_button.removeAttr( 'disabled' );
+					const buttons = form.find( 'button[type=submit]' );
+					buttons.each( ( i, el ) => {
+						$( el ).attr( 'disabled', false );
+					} );
 					form.removeClass( 'processing' );
 					return true;
 				}

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -155,7 +155,7 @@ domReady(
 				 * @param {string} error_message
 				 */
 				function handleFormError( error_message ) {
-					$form.removeClass( 'processing' ).unblock();
+					unblockForm( $form );
 					$form
 						.find( '.input-text, select, input:checkbox' )
 						.trigger( 'validate' )
@@ -244,16 +244,10 @@ domReady(
 				 */
 				function handleCouponSubmit( ev ) {
 					ev.preventDefault();
-					if ( $coupon.is( '.processing' ) ) {
+					const blocked = blockForm( $coupon );
+					if ( ! blocked ) {
 						return false;
 					}
-					$coupon.addClass( 'processing' ).block( {
-						message: null,
-						overlayCSS: {
-							background: '#fff',
-							opacity: 0.6,
-						},
-					} );
 					const data = {
 						security: wc_checkout_params.apply_coupon_nonce,
 						coupon_code: $coupon.find( 'input[name="coupon_code"]' ).val(),
@@ -282,8 +276,7 @@ domReady(
 							}
 						},
 						complete: () => {
-							// Unblock form.
-							$coupon.removeClass( 'processing' ).unblock();
+							unblockForm( $coupon );
 						},
 					} );
 				}
@@ -303,10 +296,10 @@ domReady(
 				 */
 				function handleNYPFormSubmit( ev ) {
 					ev.preventDefault();
-					if ( $nyp.is( '.processing' ) ) {
+					const blocked = blockForm( $nyp );
+					if ( ! blocked ) {
 						return false;
 					}
-					$nyp.addClass( 'processing' );
 					const input = $nyp.find( 'input[name="price"]' );
 					input.attr( 'disabled', true );
 					const data = {
@@ -340,9 +333,8 @@ domReady(
 							$( document.body ).trigger( 'update_checkout' );
 						},
 						complete: () => {
-							input.attr( 'disabled', false );
+							unblockForm( $nyp );
 							input.focus();
-							$nyp.removeClass( 'processing' );
 						},
 					} );
 				}
@@ -382,7 +374,6 @@ domReady(
 						}
 						$customer_details.show();
 						$after_customer_details.hide();
-						$place_order_button.attr( 'disabled', 'disabled' );
 						$customer_details.find( 'input' ).first().focus();
 						// Remove default form event handlers.
 						originalFormHandlers = getEventHandlers( $form[ 0 ], 'submit' ).slice( 0 );
@@ -399,7 +390,6 @@ domReady(
 						}
 						$customer_details.hide();
 						$after_customer_details.show();
-						$place_order_button.removeAttr( 'disabled' );
 						renderCheckoutDetails();
 						// Store event handlers.
 						$form.off( 'submit', handleFormSubmit );
@@ -524,17 +514,11 @@ domReady(
 				 * @param {Function} cb     Callback function.
 				 */
 				function validateForm( silent = false, cb = () => {} ) {
-					if ( $form.is( '.processing' ) ) {
+					const blocked = blockForm( $form );
+					if ( ! blocked ) {
 						return false;
 					}
 					clearNotices();
-					$form.addClass( 'processing' ).block( {
-						message: null,
-						overlayCSS: {
-							background: '#fff',
-							opacity: 0.6,
-						},
-					} );
 
 					// Remove generic errors.
 					const $genericErrors = $form.find(
@@ -572,8 +556,7 @@ domReady(
 								return;
 							}
 
-							// Unblock form.
-							$form.removeClass( 'processing' ).unblock();
+							unblockForm( $form );
 
 							// Result will always be 'failure' from the server. We'll check for
 							// 'messages' in the response to see if it was successful.
@@ -605,6 +588,42 @@ domReady(
 							cb( { messages } );
 						},
 					} );
+				}
+
+				/**
+				 * Blocks provided form.
+				 *
+				 * @param {jQuery} form
+				 *
+				 * @return {boolean} Whether the form was blocked or not.
+				 */
+				function blockForm( form ) {
+					if ( form.is( '.processing' ) ) {
+						return false;
+					}
+
+					$checkout_continue.attr( 'disabled', 'disabled' );
+					$place_order_button.attr( 'disabled', 'disabled' );
+					form.addClass( 'processing' );
+					return true;
+				}
+
+				/**
+				 * Unblocks provided form.
+				 *
+				 * @param {jQuery} form
+				 *
+				 * @return {boolean} Whether the form was unblocked or not.
+				 */
+				function unblockForm( form ) {
+					if ( ! form.is( '.processing' ) ) {
+						return false;
+					}
+
+					$checkout_continue.removeAttr( 'disabled' );
+					$place_order_button.removeAttr( 'disabled' );
+					form.removeClass( 'processing' );
+					return true;
 				}
 			} );
 		}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207836897783913/f

Jquery's block UI can cause some strange behavior sometimes, like form jumpiness, or in this case not overlaying the complete form. This PR removes jquery block UI calls from modal checkout in favor of some custom blocking logic and styling:

Before:
![Screenshot 2024-07-29 at 15 29 04](https://github.com/user-attachments/assets/ac84c3c7-7804-42ff-8738-ad23f87c720d)

After:
![Screenshot 2024-07-29 at 15 29 53](https://github.com/user-attachments/assets/98dbf2ae-7858-48bf-9ae4-d529366439cb)

### How to test the changes in this Pull Request:

1. As a reader trigger modal checkout via any donation button
2. Go through the checkout flow, paying attention to processing states (any time the form is validating)
3. Confirm the form appears to be in a "loading state" whenever it is processing
4. Repeat the above steps for the checkout button. Make sure to test the coupon and nyp fields as well (coupons and the nyp extension will need to be active and set up for the products for these)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
