### PR TITLE
fix(ras-acc): dont skip first step of modal checkout when gifting enabled

### DIFF
--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -136,19 +136,12 @@ domReady(
 				 */
 				if ( $checkout_continue.length ) {
 					setEditingDetails( true );
-					// Perform initial validation so it can skip 1st step if possible.
-					validateForm( true, () => {
-						// Attach handler to "Back" button.
-						$form.on( 'click', '#checkout_back', function ( ev ) {
-							ev.preventDefault();
-							setEditingDetails( true );
-						} );
-						// Remain on 1st step if subscriptions gift options are present.
-						if ( $gift_options.length ) {
-							setEditingDetails( true );
-						}
+					if ( ! $gift_options.length ) {
+						// Perform initial validation so it can skip 1st step if possible.
+						validateForm( true, setReady );
+					} else {
 						setReady();
-					} );
+					}
 				} else {
 					setReady();
 				}
@@ -584,6 +577,17 @@ domReady(
 							const success = ! result.messages;
 							if ( success ) {
 								setEditingDetails( false );
+								// If click #checkout_back event handler doesn't already exist add it to the form.
+								if (
+									! $._data( $form[ 0 ], 'events' )?.click?.some(
+										handler => handler.selector === '#checkout_back'
+									)
+								) {
+									$form.on( 'click', '#checkout_back', function ( ev ) {
+										ev.preventDefault();
+										setEditingDetails( true );
+									} );
+								}
 							} else if ( ! silent ) {
 								if ( result.messages ) {
 									handleFormError( result.messages );

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -143,6 +143,10 @@ domReady(
 							ev.preventDefault();
 							setEditingDetails( true );
 						} );
+						// Remain on 1st step if subscriptions gift options are present.
+						if ( $gift_options.length ) {
+							setEditingDetails( true );
+						}
 						setReady();
 					} );
 				} else {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1205234045751551/1207872481635256/f

This PR forces modal checkout to remain on step 1 whenever subscriptions gifting is present. This is because our modal checkout can skip ahead to step 2 when payment details are already saved, however step 2 of the modal does not have the option for gifting.

### How to test the changes in this Pull Request:

1. Set up a checkout button block for a subscription product with gifting enabled as well as a second button with a non-subscription product
2. As a reader with a saved payment method, go through checkout for the non-subscription product. Confirm the modal opens and immediately validates into the payment method step of modal checkout
3. Complete checkout being sure to test going back and re-editing details in the form.
4. As a reader with a saved payment method, go through checkout for the subscription product with gifting enabled. Confirm the modal opens into the billing details step of modal checkout
5. Complete checkout being sure to test going back and re-editing details in the form.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
