### PR TITLE
fix(ras-acc): minor spacing tweaks in credit card options, gift receipient 

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -261,6 +261,7 @@
 				color: var( --newspack-ui-color-neutral-60, colors.$newspack-ui-color-neutral-60 );
 				font-size: var( --newspack-ui-font-size-xs, 14px );
 				line-height: var( --newspack-ui-line-height-xs, 1.4286 );
+				margin: 0;
 			}
 
 			ul.wc-saved-payment-methods {
@@ -340,16 +341,16 @@
 		}
 	}
 
+	.wc-saved-payment-methods {
+		margin-top: var( --newspack-ui-spacer-3, 16px );
+	}
+
 	// WooCommerce Payments
 	#payment {
 		.payment_method_woocommerce_payments {
 
 			.testmode-info {
 				margin-bottom: 0;
-
-				+ .wc-saved-payment-methods {
-					margin-top: var( --newspack-ui-spacer-5, 24px );
-				}
 			}
 		}
 	}
@@ -394,7 +395,7 @@
 	// Woo Payments inputs
 	#wcpay-upe-element,
 	.wcpay-upe-element {
-		margin: var( --newspack-ui-spacer-5, 24px ) 0 var( --newspack-ui-spacer-3, 16px ) 0;
+		margin: 0 0 var( --newspack-ui-spacer-3, 16px );
 		padding: 0;
 	}
 

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -352,6 +352,11 @@
 			.testmode-info {
 				margin-bottom: 0;
 			}
+
+			// stylelint-disable-next-line selector-id-pattern
+			#wc-woocommerce_payments-upe-form {
+				margin-top: var( --newspack-ui-spacer-3, 16px );
+			}
 		}
 	}
 

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -394,7 +394,7 @@
 	// Woo Payments inputs
 	#wcpay-upe-element,
 	.wcpay-upe-element {
-		margin: var( --newspack-ui-spacer-3, 16px ) 0;
+		margin: var( --newspack-ui-spacer-5, 24px ) 0 var( --newspack-ui-spacer-3, 16px ) 0;
 		padding: 0;
 	}
 

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -81,7 +81,8 @@
 	}
 
 	.billing-details,
-	.shipping-details {
+	.shipping-details,
+	.gift-details {
 		&:not(:last-child ) {
 			margin-bottom: var( --newspack-ui-spacer-5, 24px );
 		}
@@ -341,8 +342,15 @@
 
 	// WooCommerce Payments
 	#payment {
-		.payment_method_woocommerce_payments .testmode-info {
-			margin-bottom: 0;
+		.payment_method_woocommerce_payments {
+
+			.testmode-info {
+				margin-bottom: 0;
+
+				+ .wc-saved-payment-methods {
+					margin-top: var( --newspack-ui-spacer-5, 24px );
+				}
+			}
 		}
 	}
 

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -494,7 +494,7 @@ domReady(
 					) {
 						if ( !! data.newspack_wcsg_is_gift && !! data.wcsg_gift_recipients_email ) {
 							html.push( '<div class="gift-details">' );
-							html.push( '<h2>' + newspackBlocksModalCheckout.labels.gift_recipient + '</h2>' );
+							html.push( '<h3>' + newspackBlocksModalCheckout.labels.gift_recipient + '</h3>' );
 							html.push( `<p class="${ classname }">` + data.wcsg_gift_recipients_email + '</p>' );
 						}
 					}


### PR DESCRIPTION
### All Submissions: 

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes some minor spacing adjustments to the checkout:

See 1207817176293825-as-1207912217241384

### How to test the changes in this Pull Request:

1. Start on a test site with gift subscriptions enabled, and with WooPayments as one of the payment methods (ideally that plus Stripe for comparison).
2. Run through a couple transactions as a reader to save payment information in each payment platform. 
3. Run through a subscription transaction, and opt to gift it. On the second screen, compare the spacing between the Billing and Gifting headings and the content after, and of the test payment text and saved payment options (this is obviously minor since it wouldn't be on a live site, but it was bugging me!). 

![image](https://github.com/user-attachments/assets/f362b2d1-2ba4-4a3f-a13d-def708675656)

![image](https://github.com/user-attachments/assets/25679e09-39de-4752-9132-4762d4b8daab)

![image](https://github.com/user-attachments/assets/b4eb92bf-ac19-472f-affa-924c5f1b08b3)


4. Apply this PR and run `npm run build`.
5. Repeat step 3; confirm the spacing looks better.

![image](https://github.com/user-attachments/assets/36837dd5-98cd-42b8-ad02-49c3196eedcf)

![image](https://github.com/user-attachments/assets/9690cf65-c3b9-4590-825c-6c14dd607441)

![image](https://github.com/user-attachments/assets/d7513f44-c3ad-4d88-9ec8-0cb92de9fac2)

6. Run through one more payment as a different user (no saved payment options) and confirm there are no issues.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
