### PR TITLE
fix(ras-acc): adjust font size of important order review table entries

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -12,6 +12,17 @@
 		}
 	}
 
+	table.woocommerce-checkout-review-order-table {
+		thead > tr > th {
+			font-weight: var( --newspack-ui-font-weight-strong, 600 );
+		}
+
+		tfoot > tr.order-total > th,
+		tfoot > tr.recurring-totals > th {
+			font-weight: var( --newspack-ui-font-weight-strong, 600 );
+		}
+	}
+
 	.order-review-wrapper.hidden {
 		display: none;
 	}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207878733150157/f

This PR adjusts the font weight for some of the entries in the order review table:

![Screenshot 2024-07-31 at 17 03 11](https://github.com/user-attachments/assets/e6791cf7-ffc2-4ba6-9faf-ca8b2b55c568)

The following should have a font-weight of 600 in the order review table:

- Table headings
- Total heading
- Total price
- Recurring totals heading
- Recurring total heading
- Recurring total price

### How to test the changes in this Pull Request:

1. As a reader trigger modal checkout via any donate block. Be sure to select a recurring option
2. At the payment method step, scroll down to the order review table (pictured above)
3. Confirm the above bits are bolded at 600 font weight

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
