### PR TITLE
fix: update error styles for coupons, NYP

### DIFF
--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -262,10 +262,22 @@ domReady(
 							if ( code ) {
 								const isError = code.includes( 'error' );
 								$coupon.append(
-									`<p class="result ${ CLASS_PREFIX }__helper-text">` + $( code ).text() + '</p>'
+									`<p class="result ${ CLASS_PREFIX }__helper-text ${
+										isError ? CLASS_PREFIX + '__inline-error' : ''
+									}">` +
+										$( code ).text() +
+										'</p>'
 								);
 								if ( isError ) {
 									$coupon.find( 'input[name="coupon_code"]' ).focus();
+									$coupon
+										.find( 'h3, input[name="coupon_code"]' )
+										.addClass( 'newspack-ui__field-error' );
+								} else {
+									$coupon.find( 'input[name="coupon_code"]' ).focus();
+									$coupon
+										.find( 'h3, input[name="coupon_code"]' )
+										.removeClass( 'newspack-ui__field-error' );
 								}
 								$( document.body ).trigger( 'applied_coupon_in_checkout', [ data.coupon_code ] );
 								$( document.body ).trigger( 'update_checkout', { update_shipping_method: false } );
@@ -315,16 +327,18 @@ domReady(
 							clearNotices();
 							$nyp.find( '.result' ).remove();
 							$nyp.append(
-								`<p class="result ${ CLASS_PREFIX }__${
-									success ? 'helper-text' : 'inline-error'
+								`<p class="result ${ CLASS_PREFIX }__helper-text ${
+									! success ? CLASS_PREFIX + '__inline-error' : ''
 								}">` +
 									res.message +
 									'</p>'
 							);
 							if ( success ) {
 								$( '.woocommerce-Price-amount' ).replaceWith( res.price );
+								$nyp.find( 'h3, input[name="price"]' ).removeClass( 'newspack-ui__field-error' );
 							} else {
 								$nyp.find( 'input[name="price"]' ).focus();
+								$nyp.find( 'h3, input[name="price"]' ).addClass( 'newspack-ui__field-error' );
 							}
 							$( document.body ).trigger( 'update_checkout' );
 						},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR restores some error styles to the coupon, Name Your Price fields in the modal checkout.

See 1207817176293825-as-1207912217241367

### How to test the changes in this Pull Request:

1. Start on a test site with coupons set up, and NYP enabled.
2. Set up a checkout button block attached to a simple product.
3. Run through the modal checkout.
4. When you get to the second screen, trigger errors for both the coupon and NYP fields (eg. enter a random code or no info for the former, enter a low number or no number for the latter).
5. Note the error styles -- the Coupon field remains black, and only the NYP error message is red:

![image](https://github.com/user-attachments/assets/3976b506-e782-48ab-9673-1466b38f62c6)

6. Apply this PR and run `npm run build`.
7. Repeat step 4, and confirm you get these error styles:

![image](https://github.com/user-attachments/assets/b14fe004-7f1e-4c6d-8a4f-65b50c893ae5)

8. Correct the information (add a real coupon code and a real NYP value), and resubmit the forms; confirm that the error styles go away.
9. Smoke test entering the correct info right off the bat, and confirm that things look/act correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
