### PR TITLE
fix(ras-acc): only trigger update_checkout event on validation

### DIFF
--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -340,7 +340,7 @@ domReady(
 								$nyp.find( 'input[name="price"]' ).focus();
 								$nyp.find( 'h3, input[name="price"]' ).addClass( 'newspack-ui__field-error' );
 							}
-							$( document.body ).trigger( 'update_checkout' );
+							$( document.body ).trigger( 'update_checkout', { update_shipping_method: false } );
 						},
 						complete: () => {
 							unblockForm( $nyp );
@@ -369,10 +369,6 @@ domReady(
 				 * @param {boolean} isEditingDetails
 				 */
 				function setEditingDetails( isEditingDetails ) {
-					// Scroll to top.
-					window.scroll( { top: 0, left: 0, behavior: 'smooth' } );
-					// Update checkout.
-					$( document.body ).trigger( 'update_checkout' );
 					clearNotices();
 					// Clear checkout details.
 					$( '#checkout_details' ).remove();
@@ -409,6 +405,8 @@ domReady(
 						} );
 					}
 					$form.triggerHandler( 'editing_details', [ isEditingDetails ] );
+					// Scroll to top.
+					window.scroll( { top: 0, left: 0, behavior: 'smooth' } );
 				}
 
 				/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207944985845149/f

This PR resolves an issue where the `update_checkout` woo event causes the order review table to end up in a blocked state. This looks to be happening because we are hiding the original order review table, cloning it, and rendering it in a non-standard part of the checkout. This seems to be happening at the same time as Woo attempts to block the table, perform some Woo logic, and then finally unblock the table and as a result the cloned table ends up in a blocked state.

We fix this by removing the call to trigger `update_checkout` event from the `setEditingDetails` method as well as from the cover fees script in https://github.com/Automattic/newspack-plugin/pull/3330 to allow updating checkout to be managed entirely within the `validateForm` function.

Before:
![Screenshot 2024-08-02 at 14 17 23](https://github.com/user-attachments/assets/b6c4c3de-9e24-43d8-bb89-62674ea42878)

After:
![Screenshot 2024-08-02 at 14 14 42](https://github.com/user-attachments/assets/d22523bd-98d0-49c2-bb4a-c4f62a90e277)

### How to test the changes in this Pull Request:

You will need to also checkout the following Plugin PR before testing: https://github.com/Automattic/newspack-plugin/pull/3330

1. As a new reader with no saved billing details/payment information, trigger modal checkout via any donation block (recurring donation to guarantee the transaction details table appears)
2. Proceed through the checkout flow until you get to the payment information step. Scroll down to see the Transactions details table.
3. On `epic/ras-acc` this will be "blocked" (grayed out). On this branch it will not.
4. Smoke test the checkout modal in various other contexts (checkout buttons with tax/shipping/coupons/nyp/etc. setup, one-time donations, etc.)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
