### PR TITLE
fix (ras-acc): improve error styles

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -483,18 +483,19 @@
 	}
 
 	form.checkout .woocommerce-NoticeGroup {
-		ul.woocommerce-error {
-			background: none;
-			color: inherit;
-			list-style-type: none;
-			padding-left: 0;
-			padding-right: 0;
+		li div {
+			display: block; // Overrides display: flex from theme with listed errors.
 		}
 
 		.woocommerce-message,
 		.woocommerce-error,
 		.woocommerce-info {
+			background: none;
+			color: inherit;
 			font-size: var( --newspack-ui-font-size-xs, 14px );
+			list-style-type: none;
+			margin: 0;
+			padding: 0;
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes some error styling in the modal checkout. It's a little strange because I haven't been able to consistently recreate the error -- it seems to do with multiple back-to-back transactions, but I'm not 100% sure. In the meantime, I've included testing steps that involve copy-pasting the HTML for the error into the checkout form to test the styles.

If it'd make more sense to test with the actual error, I can go back to hammering it to see if I can get better steps to recreate!

See: 1207817176293825-as-1207922679399315

### How to test the changes in this Pull Request:

1. Purchase a product or donation product using the modal checkout.
2. On the first screen (Billing Details), use the element inspector to edit the HTML, and add this HTML after the opening form tag:

```
<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout newspack-ui__notice newspack-ui__notice--error">
<ul class="woocommerce-error" role="alert">
<li>
<div class="woocommerce-error">There was an error processing your order. Please check for any charges in your payment method and review your <a href="#">order history</a> before placing the order again.</div></li></ul></div>
```

4. Note the appearance of the error -- it looks like two errors nested in one, and there's an odd line break after the link (this is due to `display: flex` being used in these messages outside of the modal checkout to help position a button):

![image](https://github.com/user-attachments/assets/8c03d217-7304-4f19-909d-b1dfd7d5c8f6)

5. Apply this PR and run `npm run build`.
6. Repeat step 2 and confirm that the styles look okay:

![image](https://github.com/user-attachments/assets/06c05fc8-0e3d-4751-82b9-a112e48aef69)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
