### PR TITLE
fix(ras-acc): update max-height for modals

### DIFF
--- a/src/modal-checkout/modal.scss
+++ b/src/modal-checkout/modal.scss
@@ -58,7 +58,7 @@
 				border-radius: 6px;
 				background: colors.$color__background-body;
 				max-width: 600px;
-				max-height: 90vh;
+				max-height: 90%;
 				min-height: 300px;
 				display: flex;
 				flex-direction: column;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR needs to be tested with https://github.com/Automattic/newspack-plugin/pull/3316.

Some mobile versions of Chrome and Safari (in my testing, on iPhone 13+) aren't interpreting our modal's max-height of `90vh` correctly -- in Chrome, the modal is getting cut off a bit, and in Safari, it's acting like it's `100vh`.

This PR switches the modal's max-height from `90vh` to `90%`, which seems to be more consistently respected.

### How to test the changes in this Pull Request:

1. Ideally test in an iPhone 13 or higher (my own iPhone 11 doesn't show the original issue)****
2. Try running the modal checkout in Safari and Chrome. Note the height of the modal:

<img src="https://github.com/user-attachments/assets/1d1d418e-747b-40e6-bc89-859c55ac6040" width="350">

3. Apply this PR and https://github.com/Automattic/newspack-plugin/pull/3316, and run `npm run build` for each.
4. Retest on your mobile device and confirm that the modal is now ~90% of the window height at the most. 

<img src="https://github.com/user-attachments/assets/1024a026-26ae-43c4-b393-831b1bd0bdd2" width="350">

5. Test in desktop and try adjusting the browser window size, making it shorter and narrower. Confirm that the modal respects the 90% max-height.

**** I'm testing in Browserstack; if you don't have access to the right devices but are testing, please let me know!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
