### PR TITLE
fix (ras-acc): update spacing, breaks for credit card info

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -276,9 +276,11 @@
 			}
 
 			ul.wc-saved-payment-methods {
+				margin-top: var( --newspack-ui-spacer-3, 16px );
 				padding: 0;
 
 				li {
+					display: flex;
 					margin-bottom: var( --newspack-ui-spacer-3, 16px );
 
 					label {
@@ -352,10 +354,6 @@
 		}
 	}
 
-	.wc-saved-payment-methods {
-		margin-top: var( --newspack-ui-spacer-3, 16px );
-	}
-
 	// WooCommerce Payments
 	#payment {
 		.payment_method_woocommerce_payments {
@@ -404,6 +402,16 @@
 				font-size: var( --newspack-ui-font-size-xs, 14px );
 				line-height: var( --newspack-ui-line-height-xs, 1.4286 );
 				padding: 0;
+			}
+		}
+
+		@media ( max-width: 440px ) {
+			&#wc-stripe-cc-form {
+				.form-row-first,
+				.form-row-last {
+					float: none;
+					width: 100%;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a couple spacing/styling issues for the modal checkout on mobile.

See 1207817176293825-as-1207944985845233

### How to test the changes in this Pull Request:

1. Set up your test site so it has more than one payment option (ideally credit card, like Woo Payments and Stripe Gateway).
2. Run a test checkout with either and save the payment information on a mobile-sized screen (a narrow browser window will be easier, since we need to futz with the width a bit).
3. Run a second test checkout in the same session; pick the same payment gateway and note the appearance of the two radio buttons. The labels wrap, but they should fully remain to the right (you may need to adjust the screen width to get this, it happens for me ~390px):

![image](https://github.com/user-attachments/assets/70e42058-e760-4d9f-a245-8caf28de3ba9)

4. If you haven't already, run a third checkout and save payment information specifically for the Stripe Gateway.
5. Run another checkout, picking Stripe Gateway again, and opting to use a new form of payment. On smaller screen sizes (440px and narrower, or iPhone 12 and smaller), note the appearance of the Card Code (CVC):

![image](https://github.com/user-attachments/assets/e808b6dc-d4df-48ea-bfb6-06f5f9945db0)

6. Apply this PR and run `npm run build`.
7. Repeat step 3 and confirm that the radio button and label alignment is such that the labels no longer wrap:

![image](https://github.com/user-attachments/assets/bf3c29f1-2741-4e7d-8097-b89ca224d122)

8. Repeat step 5, and confirm that the Card Code field in the Stripe Gateway wraps when the screen is less than 440px wide, but will sit side by side on screens larger than that:

![image](https://github.com/user-attachments/assets/be97f036-74f3-4178-a415-3f35e95f327d)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
