### PR TITLE
fix(ras-acc): check for checkout button inputs before appending

### DIFF
--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -210,7 +210,10 @@ domReady( () => {
 					if ( productData ) {
 						const data = JSON.parse( productData );
 						Object.keys( data ).forEach( key => {
-							form.appendChild( createHiddenInput( key, data[ key ] ) );
+							const existingInputs = form.querySelectorAll( 'input[name="' +  key + '"]' );
+							if ( 0 === existingInputs.length ) {
+								form.appendChild( createHiddenInput( key, data[ key ] ) );
+							}
 						} );
 					}
 					const formData = new FormData( form );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When you open a checkout button, it appends some hidden inputs to the button's form; if you keep opening it over and over, it will keep appending those fields. This PR adds a check to avoid duplicates (open to suggestions for making it more elegant! I just checked for existing inputs with the same name before appending). 

### How to test the changes in this Pull Request:

1. On epic/ras-acc, add a Checkout Button block to a page. 
2. With the element inspector open, click the Checkout Button block a couple times. Note that it appends hidden inputs each time:

![Screen Recording 2024-08-15 at 3 05 16 PM 2024-08-15 15_09_25](https://github.com/user-attachments/assets/94717daa-3643-4a26-aff9-4b724c5c498d)

3. Apply this PR and run `npm run build`.
4. Click the Checkout Button block once. Confirm that one set of the hidden inputs are added.
5. Click the Checkout Button block a few more times. Confirm that duplicates aren't added. 
6. Confirm that this works with multiple Checkout Buttons on the same page. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
