### PR TITLE
fix(ras-acc): handle modal checkout cart errors

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -249,13 +249,9 @@ final class Modal_Checkout {
 			$cart_item_data = apply_filters( 'newspack_blocks_modal_checkout_cart_item_data', $cart_item_data );
 
 			\WC()->cart->empty_cart();
-			$is_added_to_cart = \WC()->cart->add_to_cart( $product_id, 1, 0, [], $cart_item_data );
+			\WC()->cart->add_to_cart( $product_id, 1, 0, [], $cart_item_data );
 
 			$query_args = [];
-			if ( ! $is_added_to_cart ) {
-				// If the product cannot be added to the cart, add error state query arg.
-				$query_args['cart_error'] = 1;
-			}
 			if ( ! empty( $referer_tags ) ) {
 				$query_args['referer_tags'] = implode( ',', $referer_tags );
 			}
@@ -537,7 +533,11 @@ final class Modal_Checkout {
 	 * Enqueue scripts for the checkout page rendered in a modal.
 	 */
 	public static function enqueue_scripts() {
-		if ( ( ! function_exists( 'is_checkout' ) || ! is_checkout() ) && ( ! function_exists( 'is_order_received_page' ) || ! is_order_received_page() ) ) {
+		if (
+			( ! function_exists( 'is_checkout' ) || ! is_checkout() ) &&
+			( ! function_exists( 'is_cart' ) || ! is_cart() ) &&
+			( ! function_exists( 'is_order_received_page' ) || ! is_order_received_page() )
+		) {
 			return;
 		}
 
@@ -646,6 +646,7 @@ final class Modal_Checkout {
 			return $template;
 		}
 		$class_prefix = self::get_class_prefix();
+		$wc_errors    = wc_get_notices( 'error' );
 		ob_start();
 		?>
 		<!doctype html>
@@ -658,8 +659,16 @@ final class Modal_Checkout {
 		</head>
 			<body class="<?php echo esc_attr( "$class_prefix {$class_prefix}__modal__content" ); ?>" id="newspack_modal_checkout_container">
 			<?php
-				echo do_shortcode( '[woocommerce_checkout]' );
-				wp_footer();
+			echo do_shortcode( '[woocommerce_checkout]' );
+			wp_footer();
+			// Trigger checkout error event if there are cart errors.
+			if ( is_cart() && ! empty( $wc_errors ) ) :
+				?>
+				<script>
+					jQuery( document.body ).trigger( 'checkout_error' );
+				</script>
+				<?php
+			endif;
 			?>
 		</body>
 		</html>

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -249,9 +249,13 @@ final class Modal_Checkout {
 			$cart_item_data = apply_filters( 'newspack_blocks_modal_checkout_cart_item_data', $cart_item_data );
 
 			\WC()->cart->empty_cart();
-			\WC()->cart->add_to_cart( $product_id, 1, 0, [], $cart_item_data );
+			$is_added_to_cart = \WC()->cart->add_to_cart( $product_id, 1, 0, [], $cart_item_data );
 
 			$query_args = [];
+			if ( ! $is_added_to_cart ) {
+				// If the product cannot be added to the cart, add error state query arg.
+				$query_args['cart_error'] = 1;
+			}
 			if ( ! empty( $referer_tags ) ) {
 				$query_args['referer_tags'] = implode( ',', $referer_tags );
 			}
@@ -656,12 +660,6 @@ final class Modal_Checkout {
 			<?php
 				echo do_shortcode( '[woocommerce_checkout]' );
 				wp_footer();
-			?>
-
-			<?php
-			if ( is_cart() ) {
-				self::render_close_button();
-			}
 			?>
 		</body>
 		</html>

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -529,7 +529,8 @@
 		margin-top: 0;
 	}
 
-	form.checkout .woocommerce-NoticeGroup {
+	form.checkout .woocommerce-NoticeGroup,
+	.woocommerce .woocommerce-notices-wrapper {
 		li div {
 			display: block; // Overrides display: flex from theme with listed errors.
 		}
@@ -545,6 +546,10 @@
 			margin: 0;
 			padding: 0;
 		}
+	}
+
+	.woocommerce .woocommerce-notices-wrapper {
+		margin-bottom: var(--newspack-ui-spacer-5, 24px);
 	}
 
 	.processing {

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -31,8 +31,17 @@ domReady(
 
 		function clearNotices() {
 			$(
-				`.woocommerce-NoticeGroup-checkout, .${ CLASS_PREFIX }__inline-error, .woocommerce-error, .woocommerce-message, .wc-block-components-notice-banner`
+				`.woocommerce-NoticeGroup-checkout, .${ CLASS_PREFIX }__inline-error, .woocommerce-error, .woocommerce-message, .wc-block-components-notice-banner, .woocommerce-notices-wrapper`
 			).remove();
+		}
+
+		/**
+		 * Set the checkout as ready so the modal can resolve the loading state.
+		 */
+		function setReady() {
+			const container = document.querySelector( '#newspack_modal_checkout_container' );
+			container.checkoutReady = true;
+			container.dispatchEvent( readyEvent );
 		}
 
 		if ( newspackBlocksModalCheckout.is_checkout_complete ) {
@@ -108,16 +117,6 @@ domReady(
 						$el.addClass( 'hidden' );
 					} else {
 						$el.removeClass( 'hidden' );
-					}
-				} );
-
-				/**
-				 * Apply newspack styling to default Woo checkout errors.
-				 */
-				$( document ).on( 'checkout_error', function () {
-					const $error = $( '.woocommerce-NoticeGroup-checkout' );
-					if ( $error ) {
-						$error.addClass( `${ CLASS_PREFIX }__notice ${ CLASS_PREFIX }__notice--error` );
 					}
 				} );
 
@@ -228,15 +227,6 @@ domReady(
 
 					$( document.body ).trigger( 'update_checkout' );
 					$( document.body ).trigger( 'checkout_error', [ error_message ] );
-				}
-
-				/**
-				 * Set the checkout as ready so the modal can resolve the loading state.
-				 */
-				function setReady() {
-					const container = document.querySelector( '#newspack_modal_checkout_container' );
-					container.checkoutReady = true;
-					container.dispatchEvent( readyEvent );
 				}
 
 				/**
@@ -656,12 +646,24 @@ domReady(
 			} );
 		}
 
+		/**
+		 * Apply newspack styling to default Woo checkout errors.
+		 */
+		$( document.body ).on( 'checkout_error', function () {
+			const $errors = $( '.woocommerce-NoticeGroup-checkout, .woocommerce-notices-wrapper' );
+			if ( $errors.length ) {
+				$errors.each(
+					( _, error ) => $( error ).addClass(`${ CLASS_PREFIX }__notice ${ CLASS_PREFIX }__notice--error` )
+				);
+			}
+			setReady();
+		} );
+
 		// Close modal when 'Esc' key is pressed and focus is inside of the iframe.
 		document.addEventListener( 'keydown', function ( ev ) {
 			if ( ev.key === 'Escape' ) {
 				parent.newspackCloseModalCheckout();
 			}
 		} );
-
 	} )( jQuery )
 );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207878733150171/f

This PR allows modal checkout to progress past the loading state, whenever there are errors adding items to cart. This also applies our newspack ui styles to the cart error:

Before:
![Screenshot 2024-08-21 at 16 06 42](https://github.com/user-attachments/assets/bf25fcbf-10e3-4e17-b5de-5f1b465dc9ed)


After:
![Screenshot 2024-08-21 at 15 59 11](https://github.com/user-attachments/assets/05d8a681-772d-4cea-a899-9cc0a5d2fa80)

I'm not sure if we should add any more information to the modal in these cases. This should be pretty rare though, so hopefully just presenting the error and allowing the reader to close the modal should be enough. Happy to take any suggestions.

### How to test the changes in this Pull Request:

**As Admin**
- Set up a limited subscription product where only one is available per account
- Set up a checkout button block on any page or post for this subscription product

**As Reader**
- Purchase a subscription via the checkout button, making sure to trigger some checkout errors by submitting a declined card first (`4000000000000002` `01/26` `123` for Stripe payment gateway for example)
- Confirm there are no regressions with the normal checkout errors
- Complete checkout for the subscription product with valid payment details
- Attempt to purchase the same subscription. This should trigger a cart error since the subscription is limited to 1 per reader
- Confirm checkout renders with the styled error

Note: I will be working on a fix to allow checkout to load for limited subscriptions when gifting is enabled. However, we won't be able to reliably test cart errors once that is fixed, so this should be tested and merged first.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
