### PR TITLE
fix(homepage-posts): exclude current post only on posts and pages

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -622,10 +622,11 @@ class Newspack_Blocks {
 				if ( count( $newspack_blocks_all_specific_posts_ids ) ) {
 					$args['post__not_in'] = $newspack_blocks_all_specific_posts_ids; // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_post__not_in
 				}
+				$current_post_id = get_the_ID();
 				$args['post__not_in'] = array_merge( // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_post__not_in
 					$args['post__not_in'] ?? [],
 					array_keys( $newspack_blocks_post_id ),
-					get_the_ID() ? [ get_the_ID() ] : []
+					is_singular() && $current_post_id ? [ $current_post_id ] : []
 				);
 			}
 			if ( $categories && count( $categories ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adjusts handling of the posts query in the Homepage Posts & Carousel blocks to accommodate block themes.

Fixes https://github.com/Automattic/wp-calypso/issues/69306, https://github.com/Automattic/wp-calypso/issues/73171

Solution by @dsas, thanks !

### How to test the changes in this Pull Request:

1. On `trunk`, activate an FSE theme
2. Set the homepage to display latest posts
3. Open the Site Editor to edit the homepage, insert a Query Loop block and a Homepage Posts block below
4. Observe the Query Loop block displays the latest posts, while the HP block displays posts excluding the most recent one
5. Switch to this branch & reload the page
6. Observe both blocks displaying the same set of posts (three first posts, by default)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->