### PR TITLE
fix(ras-acc): allow limited subscription gifting

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1542,6 +1542,9 @@ final class Modal_Checkout {
 	 * @param int            $user_id The user ID.
 	 */
 	public static function subscriptions_product_limited_for_user( $is_limited_for_user, $product, $user_id ) {
+		if ( method_exists( 'WCSG_Product', 'is_giftable' ) && \WCSG_Product::is_giftable( $product ) ) {
+			return false;
+		}
 		if ( $user_id !== 0 ) {
 			return $is_limited_for_user;
 		}

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -159,7 +159,7 @@
 			margin-bottom: 0;
 
 			label {
-				display: flex !important;
+				display: grid !important;
 				margin-bottom: 0;
 			}
 

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -64,6 +64,7 @@ domReady(
 				const $customer_details = $( '#customer_details' );
 				const $after_customer_details = $( '#after_customer_details' );
 				const $gift_options = $( '.newspack-wcsg--wrapper' );
+				const $is_forced_gifting = $gift_options?.find( '.newspack-wcsg--gift-toggle input' )?.is( ':checked' );
 
 				/**
 				 * Handle styling update for selected payment method.
@@ -127,13 +128,15 @@ domReady(
 				if ( $gift_options.length ) {
 					const $gift_toggle = $gift_options.find( '.newspack-wcsg--gift-toggle input' );
 					const $gift_email = $gift_options.find( '.newspack-wcsg--gift-email' );
-					$gift_toggle.on( 'change', function () {
+					const toggleGifting = () => {
 						if ( $gift_toggle.is( ':checked' ) ) {
 							$gift_email.addClass( 'visible' );
 						} else {
 							$gift_email.removeClass( 'visible' );
 						}
-					} );
+					}
+					$gift_toggle.on( 'change', toggleGifting );
+					toggleGifting();
 				}
 
 				/**
@@ -385,6 +388,10 @@ domReady(
 						if ( $nyp.length ) {
 							$nyp.hide();
 						}
+						if ( $gift_options.length && $is_forced_gifting ) {
+							// Ensure gifting is always disabled if forced.
+							$gift_options.find( '.newspack-wcsg--gift-toggle input' ).attr( 'disabled', true );
+						}
 						$customer_details.show();
 						$after_customer_details.hide();
 						$customer_details.find( 'input' ).first().focus();
@@ -543,9 +550,14 @@ domReady(
 						$genericErrors.remove();
 					}
 
+					if ( $is_forced_gifting ) {
+						// If gifting is forced, we need to remove the disabled attr before submitting.
+						$gift_options?.find( 'input' )?.attr( 'disabled', false );
+					}
 					const serializedForm = $form.serializeArray();
 					// Add 'update totals' parameter so it just performs validation.
 					serializedForm.push( { name: 'woocommerce_checkout_update_totals', value: '1' } );
+
 					// Ajax request.
 					$.ajax( {
 						type: 'POST',

--- a/src/modal-checkout/templates/form-gift-subscription.php
+++ b/src/modal-checkout/templates/form-gift-subscription.php
@@ -14,13 +14,19 @@ defined( 'ABSPATH' ) || exit;
 		<?php if ( ! $is_renewal ) : ?>
 		<p class="newspack-wcsg--gift-toggle form-row form-row-wide">
 			<label for="newspack_wcsg_is_gift">
-				<input type="checkbox" id="newspack_wcsg_is_gift" name="newspack_wcsg_is_gift" />
+				<input type="checkbox" id="newspack_wcsg_is_gift" name="newspack_wcsg_is_gift" <?php echo esc_attr( $is_limited ? 'checked disabled' : '' ); ?>/>
 				<?php echo \esc_html( \Newspack_Blocks\Modal_Checkout::subscriptions_gifting_label() ); ?>
+				<?php if ( $is_limited ) : ?>
+					<span class="newspack-ui__helper-text"><?php echo esc_html( __( 'This item is only purchasable as a gift.', 'newspack-blocks' ) ); ?></span>
+				<?php endif; ?>
 			</label>
 		</p>
-		<p id="wcsg_gift_recipients_email_field" class="newspack-wcsg--gift-email form-row form-row-wide">
+		<p id="wcsg_gift_recipients_email_field" class="newspack-wcsg--gift-email form-row form-row-wide  <?php echo esc_attr( $is_limited ? 'validate-required validate-email' : '' ); ?>">
 			<label for="wcsg_gift_recipients_email">
 				<?php esc_html_e( 'Recipient’s Email Address', 'newspack-blocks' ); ?>
+				<?php if ( $is_limited ) : ?>
+					<abbr class="required" title="required">*</abbr>
+				<?php endif; ?>
 			</label>
 			<input type="email" class="input-text" name="wcsg_gift_recipients_email" placeholder="<?php echo esc_attr( __( 'recipient@example.com', 'newspack-blocks' ) ); ?>" value="<?php echo esc_attr( $email ); ?>"/>
 		</p>


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207878733150171/f

This PR allows readers that have limited subscriptions to gift the same subscription via modal checkout. Previously the subscriptions limiter logic was preventing these readers from adding the limited subscriptions to cart, which made it impossible to gift. This resolves this by bypassing the limiter when gifting is enabled AND we are in modal checkout. We also:

- force the gifting toggle to be checked
- add helper text to notify the reader the subscription must be gifted
- make the gifting email required

![Screenshot 2024-08-22 at 18 00 42](https://github.com/user-attachments/assets/b6263909-aa9a-40ae-a175-19da1fd3fa3a)

### How to test the changes in this Pull Request:

TBA

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
