### PR TITLE
fix(ras-acc): replace express payment 'or' styles

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -557,6 +557,7 @@ final class Modal_Checkout {
 				'nyp_nonce'             => wp_create_nonce( 'newspack_checkout_name_your_price' ),
 				'newspack_class_prefix' => self::get_class_prefix(),
 				'is_checkout_complete'  => function_exists( 'is_order_received_page' ) && is_order_received_page(),
+				'divider_text'          => esc_html__( 'Or', 'newspack-blocks' ),
 				'labels'                => [
 					'billing_details'  => self::get_modal_checkout_labels( 'billing_details' ),
 					'shipping_details' => self::get_modal_checkout_labels( 'shipping_details' ),

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -513,6 +513,13 @@
 		margin-bottom: 0;
 	}
 
+	// Express checkout dividers.
+	// This is being replaced with JavaScript so it can be styled correctly.
+	#wcpay-express-checkout-button-separator,
+	#wc-stripe-payment-request-button-separator {
+		display: none !important; // !important needed to override inline styles.
+	}
+
 	// stylelint-disable-next-line selector-id-pattern
 	#checkout_back {
 		margin-top: 0;

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -518,6 +518,10 @@
 	#wcpay-express-checkout-button-separator,
 	#wc-stripe-payment-request-button-separator {
 		display: none !important; // !important needed to override inline styles.
+
+		&[style*="display:none"] + .newspack-ui__word-divider {
+			display: none;
+		}
 	}
 
 	// stylelint-disable-next-line selector-id-pattern

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -45,6 +45,12 @@ domReady(
 			}
 		} else {
 			$( document.body ).on( 'init_checkout', function () {
+
+				// If present, update the markup used for the WooPayments express checkout divider.
+				$( '#wcpay-express-checkout-button-separator, #wc-stripe-payment-request-button-separator' ).after(
+					'<div class="newspack-ui__word-divider">' + newspackBlocksModalCheckout.divider_text + '</div>'
+				);
+
 				let originalFormHandlers = [];
 
 				const $form = $( 'form.checkout' );
@@ -106,7 +112,7 @@ domReady(
 				} );
 
 				/**
-				 * Apply newspack styling to default Woo chekcout errors.
+				 * Apply newspack styling to default Woo checkout errors.
 				 */
 				$( document ).on( 'checkout_error', function () {
 					const $error = $( '.woocommerce-NoticeGroup-checkout' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes some minor improvements to the Express Payment styles coming from the Stripe Gateway and WooPayments plugins (Google, Apple Pay) to make the `-- OR --` divider match the styles used in the Newspack UI.

See 1207817176293825-as-1207991235341036

### How to test the changes in this Pull Request:

1. Enable WooPayments, and under WooCommerce > Settings > Payments > WooPayments, enable Apple and Google as payment options under Express Checkouts.
2. View on the front end and run through a checkout; note the appearance of the `-- OR --` text. (You may need to open the modal checkout in Safari to see Apple Pay).

![CleanShot 2024-08-22 at 15 34 55](https://github.com/user-attachments/assets/bb39bea0-41c9-42b6-88cc-7adef5007ba7)

![CleanShot 2024-08-22 at 15 35 25](https://github.com/user-attachments/assets/9a3816ef-057f-4082-b597-cbc68fe41036)


3. Apply the PR and run `npm run build`.
4. Repeat step 2 and confirm the `Or` looks more like it does in the Reader Registration modal.

![CleanShot 2024-08-22 at 13 54 06](https://github.com/user-attachments/assets/73ecd258-c22c-49e9-9f82-6459085f67de)

![CleanShot 2024-08-22 at 13 54 55](https://github.com/user-attachments/assets/8a5e5c5c-1353-40e5-beaf-c497e9ef0b0c)

5. Disable WooPayments and enable Stripe Gateway as a payment option. 
6. Repeat step 2 in Safari; it should (in theory!) just show the Apple Pay button. Confirm the `Or` looks okay.

![CleanShot 2024-08-22 at 13 52 24](https://github.com/user-attachments/assets/e617b8e9-732a-446e-9adb-25f6f6b454c9)

7. Repeat step 2 in Chrome/Firefox; in my testing, no express payment button loaded but hopefully that consistently the case. In that case, confirm there isn't a weird orphan `Or` without a button.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
