### PR TITLE
fix: correct font family

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -528,6 +528,7 @@
 		.woocommerce-info {
 			background: none;
 			color: inherit;
+			font-family: var(--newspack-ui-font-family, system-ui);
 			font-size: var(--newspack-ui-font-size-xs, 14px);
 			list-style-type: none;
 			margin: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a tiny error I noticed while testing https://github.com/Automattic/newspack-blocks/pull/1847, but that wasn't introduced in it: the WooCommerce errors are not picking up the right font family.

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Typography, and set the Heading font to something noticeably different than the system UI font used by Newspack UI (I used Chalkboard). 
2. Start a modal checkout using the Donate Block or Checkout Button block.
3. For the credit card number, use a number that will fail like `4000000000000002`.
4. Note the font family used by the error:

![CleanShot 2024-08-22 at 17 07 18](https://github.com/user-attachments/assets/d19595d1-a397-4211-8293-0b66c49c0383)

5. Apply this PR and run `npm run build`.
6. Repeat steps 2-4 and confirm the error uses the right sans-serif font:

![CleanShot 2024-08-22 at 17 04 04](https://github.com/user-attachments/assets/daeb7453-67fa-40b2-abe5-3c967dbd8557)
 
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
