### PR TITLE
fix(ras-acc): don't close modal when redirecting

### DIFF
--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -57,18 +57,9 @@ domReady( () => {
 		const hasNewsletterPopup = document?.querySelector( '.newspack-newsletters-signup-modal' );
 
 		// We want to block closing the modal if redirecting elsewhere:
-		let shouldCloseModal = true;
+		const shouldCloseModal = ! afterSuccessUrlInput || ! afterSuccessBehaviorInput || ! container?.checkoutComplete;
 
-		if (
-			afterSuccessUrlInput &&
-			afterSuccessBehaviorInput &&
-			container?.checkoutComplete &&
-			! hasNewsletterPopup
-		) {
-			shouldCloseModal = false;
-		}
-
-		if ( shouldCloseModal ) {
+		if ( shouldCloseModal || hasNewsletterPopup ) {
 			spinner.style.display = 'flex';
 			if ( iframe && modalContent.contains( iframe ) ) {
 				// Reset iframe and modal content heights.
@@ -112,7 +103,7 @@ domReady( () => {
 			if ( window?.newspackReaderActivation?.openNewslettersSignupModal ) {
 				window.newspackReaderActivation.openNewslettersSignupModal( {
 					callback: handleCheckoutComplete,
-					skipClose: ( afterSuccessUrlInput && afterSuccessBehaviorInput ) ? true : false,
+					closeOnSuccess: shouldCloseModal,
 				} );
 			} else {
 				handleCheckoutComplete();

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -54,14 +54,16 @@ domReady( () => {
 		const afterSuccessBehaviorInput = container.querySelector(
 			'input[name="after_success_behavior"]'
 		);
+		const hasNewsletterPopup = document?.querySelector( '.newspack-newsletters-signup-modal' );
 
 		// We want to block closing the modal if redirecting elsewhere:
 		let shouldCloseModal = true;
+
 		if (
 			afterSuccessUrlInput &&
 			afterSuccessBehaviorInput &&
 			container?.checkoutComplete &&
-			! window?.newspackReaderActivation?._openNewslettersSignupModal
+			! hasNewsletterPopup
 		) {
 			shouldCloseModal = false;
 		}

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -49,40 +49,51 @@ domReady( () => {
 
 	const initialHeight = modalContent.clientHeight + spinner.clientHeight + 'px';
 	const closeCheckout = () => {
-		spinner.style.display = 'flex';
-
 		const container = iframe?.contentDocument?.querySelector( `#${ IFRAME_CONTAINER_ID }` );
+		const afterSuccessUrlInput = container.querySelector( 'input[name="after_success_url"]' );
+		const afterSuccessBehaviorInput = container.querySelector(
+			'input[name="after_success_behavior"]'
+		);
 
-		if ( iframe && modalContent.contains( iframe ) ) {
-			// Reset iframe and modal content heights.
-			iframe.src = 'about:blank';
-			iframe.style.height = '0';
-			modalContent.removeChild( iframe );
-			modalContent.style.height = initialHeight;
+		// We want to block closing the modal if redirecting elsewhere:
+		let shouldCloseModal = true;
+		if (
+			afterSuccessUrlInput &&
+			afterSuccessBehaviorInput &&
+			container?.checkoutComplete &&
+			! window?.newspackReaderActivation?._openNewslettersSignupModal
+		) {
+			shouldCloseModal = false;
 		}
 
-		if ( iframeResizeObserver ) {
-			iframeResizeObserver.disconnect();
-		}
-
-		document.querySelectorAll( `.${ MODAL_CLASS_PREFIX }-container` ).forEach( el => {
-			closeModal( el );
-			if ( el.overlayId && window.newspackReaderActivation?.overlays ) {
-				window.newspackReaderActivation?.overlays.remove( el.overlayId );
+		if ( shouldCloseModal ) {
+			spinner.style.display = 'flex';
+			if ( iframe && modalContent.contains( iframe ) ) {
+				// Reset iframe and modal content heights.
+				iframe.src = 'about:blank';
+				iframe.style.height = '0';
+				modalContent.removeChild( iframe );
+				modalContent.style.height = initialHeight;
 			}
-		} );
 
-		if ( modalTrigger ) {
-			modalTrigger.focus();
+			if ( iframeResizeObserver ) {
+				iframeResizeObserver.disconnect();
+			}
+
+			document.querySelectorAll( `.${ MODAL_CLASS_PREFIX }-container` ).forEach( el => {
+				closeModal( el );
+				if ( el.overlayId && window.newspackReaderActivation?.overlays ) {
+					window.newspackReaderActivation?.overlays.remove( el.overlayId );
+				}
+			} );
+
+			if ( modalTrigger ) {
+				modalTrigger.focus();
+			}
 		}
 
 		if ( container?.checkoutComplete ) {
 			const handleCheckoutComplete = () => {
-				const afterSuccessUrlInput = container.querySelector( 'input[name="after_success_url"]' );
-				const afterSuccessBehaviorInput = container.querySelector(
-					'input[name="after_success_behavior"]'
-				);
-
 				if ( afterSuccessUrlInput && afterSuccessBehaviorInput ) {
 					const afterSuccessUrl = afterSuccessUrlInput.getAttribute( 'value' );
 					const afterSuccessBehavior = afterSuccessBehaviorInput.getAttribute( 'value' );
@@ -95,16 +106,21 @@ domReady( () => {
 				}
 				window?.newspackReaderActivation?.resetCheckoutData?.();
 			};
+
 			if ( window?.newspackReaderActivation?.openNewslettersSignupModal ) {
 				window.newspackReaderActivation.openNewslettersSignupModal( {
 					callback: handleCheckoutComplete,
+					skipClose: ( afterSuccessUrlInput && afterSuccessBehaviorInput ) ? true : false,
 				} );
 			} else {
 				handleCheckoutComplete();
 			}
+
 			// Ensure we always reset the modal title and width once the modal closes.
-			setModalWidth();
-			setModalTitle( newspackBlocksModal.labels.checkout_modal_title );
+			if ( shouldCloseModal ) {
+				setModalWidth();
+				setModalTitle( newspackBlocksModal.labels.checkout_modal_title );
+			}
 		} else {
 			window?.newspackReaderActivation?.resetCheckoutData?.();
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR, along with https://github.com/Automattic/newspack-plugin/pull/3369, prevent the last step of the modal checkout from closing if the next step is redirecting to a new page/previous page. This will hopefully reduce confusion/make the transition a little smoother.

Note: It's entirely possible there's a more elegant way to handle all or parts of this; I'd love some feedback on that front if you have any! 

See 1207817176293825-as-1207817176293828

### How to test the changes in this Pull Request:

1. Start with a test site running epic/ras-acc, and with "Present newsletter signup after checkout and registration" disabled under Engagement > Reader Activation > Advanced Settings.
2. Set up at least the following blocks:
     * A checkout button block with no after checkout behaviour set.
     * A checkout button block with a redirect to a different page after checkout.
     * A checkout button block that goes back to the previous page after checkout.
     * A donate block with no after checkout behaviour set.
     * A donate block with a redirect to a different page after checkout.
     * A donate block that goes back to the previous page after checkout.
3. Test running checkouts with each, for the blocks with the redirect, note that the modal closes before the redirect happens.
4. Apply this PR and https://github.com/Automattic/newspack-plugin/pull/3369, and run `npm run build` for each.
5. Repeat step 2; confirm that the modal stays open while the redirect happens, but closes as expected when not.
6. Navigate to Engagement > Reader Activation > Advanced Settings and enable "Present newsletter signup after checkout and registration".
7. Repeat step 2, and confirm the modal stays open while the redirect happens, but closes as expected when not.
8. Repeat step 2 on at least one block, but sign up for all newsletters on one of the block.
9. Repeat step 2 again and confirm that the newsletter modal isn't shown, and the thank you modal stays open while the redirect happens. 
10. Smoke test other screens, like triggering the newsletter sign up when you Sign Up to the site, and running checkouts as a new reader, and confirm there aren't any issues.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
