### PR TITLE
fix(ras-acc): update limited subscription cart error and modal layout

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -670,6 +670,7 @@ final class Modal_Checkout {
 			// Trigger checkout error event if there are cart errors.
 			if ( is_cart() && ! empty( $wc_errors ) ) :
 				?>
+				<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide" id="checkout_error_back" type="submit"><?php esc_html_e( 'Go back', 'newspack-blocks' ); ?></button>
 				<script>
 					jQuery( document.body ).trigger( 'checkout_error' );
 				</script>

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1064,7 +1064,11 @@ final class Modal_Checkout {
 	 * @return string
 	 */
 	public static function get_subscription_limited_message() {
-		return __( 'You may only have one subscription of this product at a time.', 'newspack-blocks' );
+		return sprintf(
+			// translators: %s: Site name.
+			__( "You're already a subscriber! You can only have one active subscription at a time. Thank you for supporting %s.", 'newspack-blocks' ),
+			get_bloginfo( 'name' )
+		);
 	}
 
 	/**
@@ -1079,7 +1083,7 @@ final class Modal_Checkout {
 		if ( method_exists( 'WCS_Limiter', 'is_purchasable' ) ) {
 			$product = \wc_get_product( $product_data->get_id() );
 			if ( ! \WCS_Limiter::is_purchasable( false, $product ) ) {
-				$message .= ' ' . self::get_subscription_limited_message();
+				$message = self::get_subscription_limited_message();
 			}
 		}
 

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -529,6 +529,11 @@
 		margin-top: 0;
 	}
 
+	// stylelint-disable-next-line selector-id-pattern
+	#checkout_error_back {
+		margin-bottom: 0;
+	}
+
 	form.checkout .woocommerce-NoticeGroup,
 	.woocommerce .woocommerce-notices-wrapper {
 		li div {
@@ -550,6 +555,7 @@
 
 	.woocommerce .woocommerce-notices-wrapper {
 		margin-bottom: var(--newspack-ui-spacer-5, 24px);
+		margin-top: 0;
 	}
 
 	.processing {

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -677,6 +677,13 @@ domReady(
 					( _, error ) => $( error ).addClass(`${ CLASS_PREFIX }__notice ${ CLASS_PREFIX }__notice--error` )
 				);
 			}
+			const $checkout_error_back = $( '#checkout_error_back' );
+			if ( $checkout_error_back.length ) {
+				$checkout_error_back.on( 'click', ev => {
+					ev.preventDefault();
+					parent.newspackCloseModalCheckout()
+				} );
+			}
 			setReady();
 		} );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207878733150171/f

This PR updates the limited subscription checkout error message and adds a back button to the modal when an error is present:

![Screenshot 2024-08-27 at 17 07 47](https://github.com/user-attachments/assets/cd0d4c7f-612f-4ba9-9c22-0d96e1b86d7b)

### How to test the changes in this Pull Request:

1. Set up a limited subscription product
2. Add a checkout button for the limited subscription to any page or post
3. As a reader that does not have a subscription for this product, purchase the limited subscription. Confirm you can checkout with no issues and there is no additional Go back button present in the checkout modal.
4. As the same reader, attempt to purchase the limited subscription once more. Confirm an error appears in the modal and a Go back button is present as pictured above
5. Confirm the Go back button closes the modal
6. Repeat step 4 and this time confirm the X also closes the modal

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
