### PR TITLE
fix(ras-acc): ensure variable modal added to ras overlays

### DIFF
--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -50,8 +50,8 @@ domReady( () => {
 	const initialHeight = modalContent.clientHeight + spinner.clientHeight + 'px';
 	const closeCheckout = () => {
 		const container = iframe?.contentDocument?.querySelector( `#${ IFRAME_CONTAINER_ID }` );
-		const afterSuccessUrlInput = container.querySelector( 'input[name="after_success_url"]' );
-		const afterSuccessBehaviorInput = container.querySelector(
+		const afterSuccessUrlInput = container?.querySelector( 'input[name="after_success_url"]' );
+		const afterSuccessBehaviorInput = container?.querySelector(
 			'input[name="after_success_behavior"]'
 		);
 		const hasNewsletterPopup = document?.querySelector( '.newspack-newsletters-signup-modal' );
@@ -73,12 +73,7 @@ domReady( () => {
 				iframeResizeObserver.disconnect();
 			}
 
-			document.querySelectorAll( `.${ MODAL_CLASS_PREFIX }-container` ).forEach( el => {
-				closeModal( el );
-				if ( el.overlayId && window.newspackReaderActivation?.overlays ) {
-					window.newspackReaderActivation?.overlays.remove( el.overlayId );
-				}
-			} );
+			document.querySelectorAll( `.${ MODAL_CLASS_PREFIX }-container` ).forEach( el => closeModal( el ) );
 
 			if ( modalTrigger ) {
 				modalTrigger.focus();
@@ -122,11 +117,6 @@ domReady( () => {
 	const openCheckout = () => {
 		spinner.style.display = 'flex';
 		openModal( modalCheckout );
-
-		if ( window.newspackReaderActivation?.overlays ) {
-			modalCheckout.overlayId = window.newspackReaderActivation?.overlays.add();
-		}
-
 		modalContent.appendChild( iframe );
 		modalCheckout.addEventListener( 'click', ev => {
 			if ( ev.target === modalCheckout ) {
@@ -138,11 +128,17 @@ domReady( () => {
 	};
 
 	const closeModal = el => {
+		if ( el.overlayId && window.newspackReaderActivation?.overlays ) {
+			window.newspackReaderActivation?.overlays.remove( el.overlayId );
+		}
 		el.setAttribute( 'data-state', 'closed' );
 		document.body.style.overflow = 'auto';
 	};
 
 	const openModal = el => {
+		if ( window.newspackReaderActivation?.overlays ) {
+			modalCheckout.overlayId = window.newspackReaderActivation?.overlays.add();
+		}
 		el.setAttribute( 'data-state', 'open' );
 		document.body.style.overflow = 'hidden';
 	};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207922674964414/f

This PR adds variation modals to ras overlays to ensure there aren't any overlapping popups:

![Screenshot 2024-08-29 at 10 54 41](https://github.com/user-attachments/assets/7aa6dc35-944e-424d-9515-aa32e6174f2e)

Note: I accidentally pushed these changes directly to `epic/ras-acc`, but have reverted in https://github.com/Automattic/newspack-blocks/commit/2f16c9711ef764912045e68d01114c1d4a4ce42f 🤦 

### How to test the changes in this Pull Request:

1. Set up a delayed overlay campaign for any segment of user
2. On a post or page the campaign targets add a checkout button for a variable product, allowing the reader to select variation
3. As a reader targeted by the campaign, visit the page or post and click the checkout button to bring up the variation modal. Don't make a selection.
4. On `epic/ras-acc`, the prompt will appear below the variation modal as pictured above. On this branch it wont.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
