### PR TITLE
fix(ras-acc): add check to prevent JS error in variation modal

### DIFF
--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -50,8 +50,8 @@ domReady( () => {
 	const initialHeight = modalContent.clientHeight + spinner.clientHeight + 'px';
 	const closeCheckout = () => {
 		const container = iframe?.contentDocument?.querySelector( `#${ IFRAME_CONTAINER_ID }` );
-		const afterSuccessUrlInput = container.querySelector( 'input[name="after_success_url"]' );
-		const afterSuccessBehaviorInput = container.querySelector(
+		const afterSuccessUrlInput = container?.querySelector( 'input[name="after_success_url"]' );
+		const afterSuccessBehaviorInput = container?.querySelector(
 			'input[name="after_success_behavior"]'
 		);
 		const hasNewsletterPopup = document?.querySelector( '.newspack-newsletters-signup-modal' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I noticed this randomly while testing another PR: the changes I made to keep modals open while redirecting broke the ability to close the variation modal.

### How to test the changes in this Pull Request:

1. On epic/ras-acc, set up a Checkout Button block with a variable product where the reader can pick the variation.
2. On the front end, click the Checkout Button block to open the variation picker.
3. Click the close button; note it doesn't close and throws a JS error.
4. Apply this PR and run `npm run build`. 
5. Repeat steps 2-3 and confirm that the modal closes as expected.
6. Repeat a couple of the tests from https://github.com/Automattic/newspack-blocks/pull/1855 and confirm that the modal-not-closing-when-redirecting behaviour still works as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
