### PR TITLE
fix(ras-acc): smoother modal transitions

### DIFF
--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -29,10 +29,11 @@ domReady( () => {
 	const modalCheckoutHiddenInput = createHiddenInput( 'modal_checkout', '1' );
 	const spinner = modalContent.querySelector( `.${ CLASS_PREFIX }__spinner` );
 	let modalTrigger = document.querySelector( '.newspack-reader__account-link' )?.[0];
-
 	// Initialize empty iframe.
+	const initialHeight = '600px'; // Fixed initial height to avoid too much layout shift.
 	const iframe = document.createElement( 'iframe' );
 	iframe.name = IFRAME_NAME;
+	iframe.style.height = initialHeight;
 
 	const iframeResizeObserver = new ResizeObserver( entries => {
 		if ( ! entries || ! entries.length ) {
@@ -46,8 +47,6 @@ domReady( () => {
 			iframe.style.height = iframeHeight;
 		}
 	} );
-
-	const initialHeight = modalContent.clientHeight + spinner.clientHeight + 'px';
 	const closeCheckout = () => {
 		const container = iframe?.contentDocument?.querySelector( `#${ IFRAME_CONTAINER_ID }` );
 		const afterSuccessUrlInput = container?.querySelector( 'input[name="after_success_url"]' );
@@ -64,9 +63,9 @@ domReady( () => {
 			if ( iframe && modalContent.contains( iframe ) ) {
 				// Reset iframe and modal content heights.
 				iframe.src = 'about:blank';
-				iframe.style.height = '0';
-				modalContent.removeChild( iframe );
+				iframe.style.height = initialHeight;
 				modalContent.style.height = initialHeight;
+				modalContent.removeChild( iframe );
 			}
 
 			if ( iframeResizeObserver ) {

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -34,6 +34,7 @@ domReady( () => {
 	const iframe = document.createElement( 'iframe' );
 	iframe.name = IFRAME_NAME;
 	iframe.style.height = initialHeight;
+	iframe.style.visibility = 'hidden';
 
 	const iframeResizeObserver = new ResizeObserver( entries => {
 		if ( ! entries || ! entries.length ) {
@@ -41,10 +42,15 @@ domReady( () => {
 		}
 		const contentRect = entries[ 0 ].contentRect;
 		if ( contentRect ) {
-			const iframeHeight = contentRect.top + contentRect.bottom + 'px';
+			const iframeHeight = contentRect.top + contentRect.bottom;
+			if ( iframeHeight === 0 ) {
+				// If height is 0, hide iframe content instead of resizing to avoid layout shift.
+				iframe.style.visibility = 'hidden';
+				return;
+			}
 			// Match iframe and modal content heights to avoid inner iframe scollbar.
-			modalContent.style.height = iframeHeight;
-			iframe.style.height = iframeHeight;
+			modalContent.style.height = iframeHeight + 'px';
+			iframe.style.height = iframeHeight + 'px';
 		}
 	} );
 	const closeCheckout = () => {
@@ -64,6 +70,7 @@ domReady( () => {
 				// Reset iframe and modal content heights.
 				iframe.src = 'about:blank';
 				iframe.style.height = initialHeight;
+				iframe.style.visibility = 'hidden';
 				modalContent.style.height = initialHeight;
 				modalContent.removeChild( iframe );
 			}
@@ -105,7 +112,7 @@ domReady( () => {
 
 			// Ensure we always reset the modal title and width once the modal closes.
 			if ( shouldCloseModal ) {
-				setModalWidth();
+				setModalSize();
 				setModalTitle( newspackBlocksModal.labels.checkout_modal_title );
 			}
 		} else {
@@ -157,11 +164,11 @@ domReady( () => {
 	};
 
 	/**
-	 * Sets the width of the modal.
+	 * Sets the size of the modal.
 	 *
 	 * @param {string} size Options are 'small' or 'default'. Default is 'default'.
 	 */
-	const setModalWidth = ( size = 'default' ) => {
+	const setModalSize = ( size = 'default' ) => {
 		const modal = modalCheckout.querySelector( `.${ MODAL_CLASS_PREFIX }` );
 		if ( ! modal ) {
 			return;
@@ -446,29 +453,36 @@ domReady( () => {
 			}
 		}
 		const container = iframe?.contentDocument?.querySelector( `#${ IFRAME_CONTAINER_ID }` );
-		if ( container ) {
+		const setModalReady = () => {
 			iframeResizeObserver.observe( container );
+			if ( spinner.style.display !== 'none' ) {
+				spinner.style.display = 'none';
+			}
+			if ( iframe.style.visibility !== 'visible' ) {
+				iframe.style.visibility = 'visible';
+			}
+		}
+		if ( container ) {
 			if ( container.checkoutComplete ) {
 				// Update the modal title and width to reflect successful transaction.
-				setModalWidth( 'small' );
+				setModalSize( 'small' );
 				setModalTitle( newspackBlocksModal.labels.thankyou_modal_title );
+				setModalReady();
 				a11y.trapFocus( modalCheckout.querySelector( `.${ MODAL_CLASS_PREFIX }` ) );
 			} else {
 				// Revert modal title and width default value.
-				setModalWidth();
+				setModalSize();
 				setModalTitle( newspackBlocksModal.labels.checkout_modal_title );
 			}
 			if ( container.checkoutReady ) {
-				spinner.style.display = 'none';
+				setModalReady();
 			} else {
-				container.addEventListener( 'checkout-ready', () => {
-					spinner.style.display = 'none';
-				} );
+				container.addEventListener( 'checkout-ready', () => setModalReady() );
 			}
+		// Make sure the iframe has actually loaded something, even if not the expected container.
+		// This check prevents an issue in Chrome where the 'load' event fired twice and the spinner was hidden too soon.
 		} else if ( 'about:blank' !== location.href ) {
-			// Make sure the iframe has actually loaded something, even if not the expected container.
-			// This check prevents an issue in Chrome where the 'load' event fired twice and the spinner was hidden too soon.
-			spinner.style.display = 'none';
+			setModalReady();
 		}
 	} );
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207944985845153/f

This PR attempts to make the auth + checkout flows less jarring and "flashy" by:

Setting a fixed loading modal checkout height:

![Screenshot 2024-09-03 at 09 53 00](https://github.com/user-attachments/assets/bb7554ff-f80a-4f4c-8c96-496ba8461d2a)

Preventing the iframe content from being visible until checkout is actually ready:

https://github.com/user-attachments/assets/32b7dc4d-c2a0-4286-a635-b5788f807087

Preventing the iframe from resizing to 0px (which happens after checkout is successful but before the thank you modal renders):

https://github.com/user-attachments/assets/10727cc1-3a08-457d-aa90-07be25b69e27

### How to test the changes in this Pull Request:

1. As a logged out reader, trigger any checkout modal via any donation or checkout button.
2. Log in with an account that has a saved payment method and continue with checkout. Confirm checkout loads with a spinner, and nothing is visible until after the spinner disappears.
3. Complete checkout. Confirm the checkout modal does not shrink before transitioning to the smaller thank you modal.
5. Repeat the above steps with a new reader with no saved payment method. The only difference should be modal checkout loads into the billing details step, but there should still be nothing visible until the spinner disappears
6. Do some more smoke tests for the auth and checkout flows

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
