### PR TITLE
fix: support new is_my_account() method from main plugin

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -130,13 +130,7 @@ final class Modal_Checkout {
 		$order_id           = $result['order_id'];
 		$order              = \wc_get_order( $order_id );
 		$modal_checkout_url = $order->get_meta( '_newspack_modal_checkout_url' );
-		if (
-			empty( $modal_checkout_url ) ||
-			(
-				// Until we use the modal checkout flow from My Account, we don't want to show the modal checkout thank you template for checkouts originating from My Account.
-				method_exists( 'Newspack\WooCommerce_My_Account', 'is_from_my_account' ) && \Newspack\WooCommerce_My_Account::is_from_my_account()
-			)
-		) {
+		if ( empty( $modal_checkout_url ) ) {
 			return $result;
 		}
 
@@ -1080,6 +1074,10 @@ final class Modal_Checkout {
 	 * Is this request using the modal checkout?
 	 */
 	public static function is_modal_checkout() {
+		// Until we use the modal checkout flow from My Account, we don't want to show the modal checkout thank you template for checkouts originating from My Account.
+		if ( method_exists( 'Newspack\WooCommerce_My_Account', 'is_from_my_account' ) && \Newspack\WooCommerce_My_Account::is_from_my_account() ) {
+			return false;
+		}
 
 		$is_modal_checkout = isset( $_REQUEST['modal_checkout'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! $is_modal_checkout && isset( $_REQUEST['post_data'] ) && is_string( $_REQUEST['post_data'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer.php
@@ -14,12 +14,6 @@ require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'src/blocks/donate/frontend/class-new
  * Server-side rendering of the `newspack-blocks/donate` block.
  */
 class Newspack_Blocks_Donate_Renderer {
-	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		add_filter( 'woocommerce_checkout_fields', [ __CLASS__, 'woocommerce_checkout_fields' ] );
-	}
 
 	/**
 	 * Get the keys of the billing fields to render for logged out users.
@@ -38,34 +32,6 @@ class Newspack_Blocks_Donate_Renderer {
 		 * @param array $fields Billing fields.
 		 */
 		return apply_filters( 'newspack_blocks_donate_billing_fields_keys', $fields );
-	}
-
-	/**
-	 * Modify fields for modal checkout.
-	 *
-	 * @param array $fields Checkout fields.
-	 *
-	 * @return array
-	 */
-	public static function woocommerce_checkout_fields( $fields ) {
-		if ( ! class_exists( 'Newspack\Donations' ) || ! method_exists( 'Newspack\Donations', 'is_donation_cart' ) ) {
-			return $fields;
-		}
-		if ( ! \Newspack\Donations::is_donation_cart() ) {
-			return $fields;
-		}
-		$billing_fields = self::get_billing_fields_keys();
-		if ( empty( $billing_fields ) ) {
-			return $fields;
-		}
-		$billing_keys = array_keys( $fields['billing'] );
-		foreach ( $billing_keys as $key ) {
-			if ( in_array( $key, $billing_fields, true ) ) {
-				continue;
-			}
-			unset( $fields['billing'][ $key ] );
-		}
-		return $fields;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Currently, transactions completed from the "My Account" dashboard are not using the modal checkout flow. However, due to a fix in #1573 for express checkout flows, when completing a transaction from My Account that's also related to a subscription that originated with a modal checkout flow, these transactions are flagged as My Account transactions and show the modal checkout thank you template, but in a non-modal context, trapping the user in a dead-end.

This fix relies on a new method in https://github.com/Automattic/newspack-plugin/pull/3389 that lets us determine if a checkout flow originated from My Account, and show the correct non-modal thank you template if so.

The better solution would be to use the modal checkout flow for My Account transactions too, but this is a bigger change than is appropriate for a hotfix.

### How to test the changes in this Pull Request:

See testing instructions in https://github.com/Automattic/newspack-plugin/pull/3389.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
