### PR TITLE
fix(ras-acc): undo bad merge updates

### DIFF
--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -366,11 +366,6 @@ domReady(
 				 */
 				function setEditingDetails( isEditingDetails ) {
 					const newspack_grecaptcha = window.newspack_grecaptcha || {};
-
-					// Scroll to top.
-					window.scroll( { top: 0, left: 0, behavior: 'smooth' } );
-					// Update checkout.
-					$( document.body ).trigger( 'update_checkout' );
 					clearNotices();
 					// Clear checkout details.
 					$( '#checkout_details' ).remove();


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR undoes a small change that occured during a bad merge on my part.

Specifically, a few lines that were removed in https://github.com/Automattic/newspack-blocks/pull/1823 were left in the merge.

### How to test the changes in this Pull Request:

Visually verify the code. You can also see https://github.com/Automattic/newspack-blocks/pull/1823 for testing instructions if you'd like to test more thoroughly.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
