### PR TITLE
fix (ras-acc): make processing class unique to avoid clashes

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -253,7 +253,7 @@
 	// Processing styles
 	.modal_checkout_nyp,
 	.modal_checkout_coupon {
-		&.processing {
+		&.modal-processing {
 			opacity: 0.5;
 		}
 	}
@@ -558,7 +558,7 @@
 		margin-top: 0;
 	}
 
-	.processing {
+	.modal-processing {
 		opacity: 0.5;
 	}
 }

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -635,14 +635,14 @@ domReady(
 				 * @return {boolean} Whether the form was blocked or not.
 				 */
 				function blockForm( form ) {
-					if ( form.is( '.processing' ) ) {
+					if ( form.is( '.modal-processing' ) ) {
 						return false;
 					}
 					const buttons = form.find( 'button[type=submit]' );
 					buttons.each( ( i, el ) => {
 						$( el ).attr( 'disabled', true );
 					} );
-					form.addClass( 'processing' );
+					form.addClass( 'modal-processing' );
 					return true;
 				}
 
@@ -654,14 +654,14 @@ domReady(
 				 * @return {boolean} Whether the form was unblocked or not.
 				 */
 				function unblockForm( form ) {
-					if ( ! form.is( '.processing' ) ) {
+					if ( ! form.is( '.modal-processing' ) ) {
 						return false;
 					}
 					const buttons = form.find( 'button[type=submit]' );
 					buttons.each( ( i, el ) => {
 						$( el ).attr( 'disabled', false );
 					} );
-					form.removeClass( 'processing' );
+					form.removeClass( 'modal-processing' );
 					return true;
 				}
 			} );

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -232,7 +232,7 @@ domReady( () => {
 				form.appendChild( modalCheckoutHiddenInput.cloneNode() );
 				form.target = IFRAME_NAME;
 				form.addEventListener( 'submit', ev => {
-					form.classList.add( 'processing' );
+					form.classList.add( 'modal-processing' );
 
 					const productData = form.dataset.product;
 					if ( productData ) {
@@ -288,14 +288,14 @@ domReady( () => {
 
 							// Open the variations modal.
 							ev.preventDefault();
-							form.classList.remove( 'processing' );
+							form.classList.remove( 'modal-processing' );
 							openModal( variationModal );
 							a11y.trapFocus( variationModal, false );
 							return;
 						}
 					}
 
-					form.classList.remove( 'processing' );
+					form.classList.remove( 'modal-processing' );
 
 					// Set reader activation checkout data if available.
 					let data = {};

--- a/src/modal-checkout/modal.scss
+++ b/src/modal-checkout/modal.scss
@@ -238,6 +238,6 @@
 	}
 }
 
-.processing {
+.modal-processing {
 	opacity: 0.5;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR attempts to fix an issue where a subscription product with a free trial won't let you advance to the second screen of the modal checkout, because the 'Continue' button is greyed out. 

My best guess is that something else (WooCommerce?) is removing the `processing` class before [this check](https://github.com/Automattic/newspack-blocks/blob/epic/ras-acc/src/modal-checkout/index.js#L657), causing it to fail and not finish the "unblock" process -- it's only happening with a very specific product setting, though, so there may be more to it than that. 

See 1207817176293825-as-1208214895993707

### How to test the changes in this Pull Request:

1. Set up a few different checkout button blocks, plus a donate block for comparison. Make sure one of the checkout button blocks links to a subscription product with a free trial. 
2. On epic/ras-acc, run through a few trial checkouts with your buttons; for the subscription with a trial, note that the 'Continue' button is greyed out:

![CleanShot 2024-09-04 at 14 20 31](https://github.com/user-attachments/assets/f50756ac-37d5-409b-9a55-d2fae9ccf941)

3. Apply this PR and run `npm run build`.
4. Confirm that the subscription product with a free trial can be purchased, and that you can make it past the first screen.
5. Smoke test the other checkouts (including using the NYP and coupon forms) and confirm the "processing" behaviour still works as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
