### PR TITLE
fix(ras-acc): remove unneeded aria-label from checkout-button

### DIFF
--- a/src/blocks/checkout-button/view.php
+++ b/src/blocks/checkout-button/view.php
@@ -88,7 +88,7 @@ function render_callback( $attributes ) {
 	);
 
 	$button = sprintf(
-		'<button class="%1$s" style="%2$s" aria-label="%3$s" type="submit">%3$s</button>',
+		'<button class="%1$s" style="%2$s" type="submit">%3$s</button>',
 		$button_classes,
 		$button_styles,
 		$text


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes an unnecessary `aria-label` attribute from the Checkout Button block -- since the button displays a text label, and the `aria-label` and visible button label value are the same, they're kind of redundant. (More info about `aria-label [here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)).

It also has the nice side effect of fixing an issue where Checkout Button Blocks using inline highlight styles ended up kind of garbled.

See 1207817176293825-as-1208200566409339.

### How to test the changes in this Pull Request:

1. Starting on `trunk`, add some Checkout Button blocks to a page. Use the 'Highlight' style on the block toolbar to change the text colour of one of the blocks. 
2. Switch to the `epic/ras-acc` branch, and note how the button looks -- the `<mark>` tag and attributes added by the Highlight style end up inside of the `aria-label` attribute, mangling the HTML.

![CleanShot 2024-09-04 at 14 46 05](https://github.com/user-attachments/assets/9c206764-2057-445e-96a4-5a1f4cdd3a91)

3. Switch to this branch.
4. Confirm that the output of the button now looks correct:

![CleanShot 2024-09-04 at 14 46 38](https://github.com/user-attachments/assets/273b966a-2d68-4228-a499-4ef1cf9c7f3e)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
