### PR TITLE
fix(ras-acc): ensure order review table is always unblocked when visible

### DIFF
--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -109,15 +109,18 @@ domReady(
 					const $el = $wrapper.clone();
 					// Remove existing table from inside the payment methods.
 					$( '#payment .order-review-wrapper' ).remove();
-					// Move new order review table to the payment methods.
-					$( '.payment_methods' ).after( $el );
-					// Toggle visibility according to table content.
 					const $table = $el.find( 'table' );
+					// Toggle visibility according to table content.
 					if ( $table.is( '.empty' ) ) {
 						$el.addClass( 'hidden' );
 					} else {
+						// WooCommerce blocks the order review table while updating.
+						// We need to make sure the cloned table is always unblocked.
+						$table.unblock();
 						$el.removeClass( 'hidden' );
 					}
+					// Move new order review table to the payment methods.
+					$( '.payment_methods' ).after( $el );
 				} );
 
 				/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1208232700780037/f

Modal checkout clones the Woo order review table and sticks it at the bottom of the modal whenever WC checkout updates. However, in some cases it's possible for Woo to block the form before our cloning takes place, resulting in a blocked order review table:

![Screenshot 2024-09-09 at 13 52 54](https://github.com/user-attachments/assets/a24d866a-f08b-4b04-b334-b1503f0c325a)

This PR forces the cloned order review table to unblock prior to rendering it so this doesn't happen anymore:

![Screenshot 2024-09-09 at 14 00 08](https://github.com/user-attachments/assets/d7e7877d-2632-41de-b6d9-3e487c6c405d)

### How to test the changes in this Pull Request:

1. As an admin enable taxes or shipping and create a product that has these applied
2. Add a checkout button block to any page or post for the product in step 1
3. As a logged out reader, trigger modal checkout via the checkout button added in step 2
4. Register an account, and proceed to the checkout modal
5. Add billing details and select next
6. In the payment method step, confirm the order review table is not blocked

Bonus: Smoke test the order review table in other scenarios, such as updating the price via NYP, adding a coupon, etc.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
