### PR TITLE
Fix homepage-articles block not parsing nested inner blocks

### DIFF
--- a/src/blocks/homepage-articles/store.js
+++ b/src/blocks/homepage-articles/store.js
@@ -17,7 +17,7 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import metadata from './block.json';
-import { getBlockQueries, sanitizePostList } from './utils';
+import { getBlockQueries, sanitizePostList, recursivelyGetBlocks } from './utils';
 
 const { name } = metadata;
 export const STORE_NAMESPACE = `newspack-blocks/${ name }`;
@@ -138,15 +138,7 @@ const createFetchPostsSaga = blockNames => {
 
 		yield put( { type: 'DISABLE_UI' } );
 
-		// Ensure innerBlocks are populated for widget area blocks.
-		// See https://github.com/WordPress/gutenberg/issues/32607#issuecomment-890728216.
-		const blocks = getBlocks().map( block => {
-			const innerBlocks = select( 'core/block-editor' ).getBlocks( block.clientId );
-			return {
-				...block,
-				innerBlocks,
-			};
-		} );
+		const blocks = recursivelyGetBlocks( getBlocks );
 
 		const blockQueries = getBlockQueries( blocks, blockNames );
 

--- a/src/blocks/homepage-articles/utils.ts
+++ b/src/blocks/homepage-articles/utils.ts
@@ -271,3 +271,23 @@ export const postsBlockDispatch = (
 		triggerReflow: isEditorBlock ? dispatch( STORE_NAMESPACE ).reflow : () => undefined,
 	};
 };
+
+// Ensure innerBlocks are populated for some blocks (e.g. `widget-area` and `post-content`).
+// See https://github.com/WordPress/gutenberg/issues/32607#issuecomment-890728216.
+// See https://github.com/Automattic/wp-calypso/issues/91839.
+export const recursivelyGetBlocks = (
+	getBlocks: ( clientId?: string ) => Block[],
+	blocks: Block[] = getBlocks()
+) => {
+	return blocks.map( ( block ) => {
+		let innerBlocks =
+			block.innerBlocks.length === 0
+				? getBlocks( block.clientId )
+				: block.innerBlocks;
+		innerBlocks = recursivelyGetBlocks( getBlocks, innerBlocks );
+		return {
+			...block,
+			innerBlocks,
+		};
+	});
+};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Related to https://github.com/Automattic/wp-calypso/issues/91839. This will also need a sync to https://github.com/Automattic/jetpack.

The `Homepage Posts` block (or the `Blog Posts` block in calypso and jetpack) won't load in the site editor. This is because the block fails to discover itself with `getBlocks`. This was partially fixed in https://github.com/Automattic/newspack-blocks/pull/1066 but didn't take nested inner blocks into accounts. Since the `core/post-content` block is similar, this PR recursively calls `getBlocks` on all nested inner blocks.

### How to test the changes in this Pull Request:

Test with `wp-now` locally:

1. Switch to this branch and run `npm install`.
2. Run `npm start` to build the blocks locally.
3. Run `npx @wp-now/wp-now start`, it should open a webpage.
4. Go to Pages -> Sample Page.
5. Add a `Homepage Posts` block at the end of the page and expect it to display correctly.
6. Save the page. Then, go to Appearance -> Editor -> Pages -> Sample Page to open the same page in the site editor.
7. Expect the block to display correctly in the site editor as well.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
