### PR TITLE
fix: add styles for the test CC number

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -456,6 +456,9 @@
 		.js-woopayments-copy-test-number {
 			font-size: inherit;
 			font-weight: normal;
+			line-height: var(--newspack-ui-line-height-xs, 1.4286);
+			padding: 0;
+			vertical-align: unset;
 
 			&:hover,
 			&:focus {

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -444,11 +444,34 @@
 		}
 	}
 
-	// Woo Payments inputs
+	// WooPayments inputs
 	#wcpay-upe-element,
 	.wcpay-upe-element {
 		margin: 0 0 var(--newspack-ui-spacer-3, 16px);
 		padding: 0;
+	}
+
+	.payment_method_woocommerce_payments {
+		// WooPayments test credit card number
+		.js-woopayments-copy-test-number {
+			font-size: inherit;
+			font-weight: normal;
+
+			&:hover,
+			&:focus {
+				color: inherit;
+				filter: none;
+			}
+
+			i {
+				height: 1em;
+				width: 1em;
+			}
+		}
+
+		.testmode-info a {
+			text-decoration: underline;
+		}
 	}
 
 	// Order review table.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR tweaks the "copy" styles newly added to the test credit card number for WooPayments to make it line up better with the rest of the text number message.

See 1207817176293825-as-1208279455320445

### How to test the changes in this Pull Request:

1. Start on a test site running epic/ras-acc, and has WooPayments set to test mode as one of the payment options.
2. Start a transaction; on the second modal checkout screen, note the appearance of the test credit card number. You can also see this on the [test site](https://ras-acc.newspackstaging.com/):

![CleanShot 2024-09-11 at 17 37 16](https://github.com/user-attachments/assets/f8e318fc-0d0c-424a-b545-af7c46ca2a8e)

3. Apply this PR and run `npm run build`.
4. Confirm that the number looks like it fits in more.

![CleanShot 2024-09-12 at 08 40 40](https://github.com/user-attachments/assets/02b21e02-6143-46bf-8398-cc3cc4fa8d9d)

5. Try hovering over and clicking the number to copy it; confirm that the styles look good (the checkmark icon seems like it's a good scale, and the text remains light grey).

![CleanShot 2024-09-12 at 08 40 54](https://github.com/user-attachments/assets/2e1ff094-1cce-4248-902a-5bc62a4405d9)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
