### PR TITLE
fix (ras-acc): add styles for terms and conditions

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -508,6 +508,29 @@
 		color: var(--newspack-ui-color-neutral-60, colors.$newspack-ui-color-neutral-60);
 	}
 
+	// Terms and Conditions section
+	.woocommerce-terms-and-conditions {
+		background: var(--newspack-ui-color-neutral-5, #f7f7f7);
+		border-color: var(--newspack-ui-color-border, #ddd);
+		box-shadow: none;
+		margin-top: var(--newspack-ui-spacer-5, 24px);
+		padding: var(--newspack-ui-spacer-5, 24px);
+
+		+ p.form-row {
+			margin-top: var(--newspack-ui-spacer-5, 24px);
+
+			label {
+				display: flex;
+				gap: 0; // We can't use the default label gap because there are multiple elements.
+				margin: 0;
+			}
+
+			input {
+				margin: 2px var(--newspack-ui-spacer-base, 8px) 0 0;
+			}
+		}
+	}
+
 	// Buttons - adjust spacing
 	#place-order {
 		margin-bottom: 0;

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -520,13 +520,16 @@
 			margin-top: var(--newspack-ui-spacer-5, 24px);
 
 			label {
-				display: flex;
-				gap: 0; // We can't use the default label gap because there are multiple elements.
+				display: block;
 				margin: 0;
+				padding: 0 0 0 calc(var(--newspack-ui-spacer-4, 20px) + var(--newspack-ui-spacer-base, 8px)); // This is hacky but lets us pair the checkbox width + gap of normal checkboxes.
+				position: relative;
 			}
 
 			input {
+				inset: 0 auto auto 0;
 				margin: 2px var(--newspack-ui-spacer-base, 8px) 0 0;
+				position: absolute;
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds some styles for WooCommerce's built in terms and conditions checkbox, which appears on the second screen of the modal checkout.

See: 1207817176293825-as-1208279455320432

### How to test the changes in this Pull Request:

1. Create a page and title it "Terms and Conditions" or something similar. Give it some text content.
2. Under WP Admin > WooCommerce > Advanced, under the Page Settings header, use the Terms and conditions dropdown to find your page:

![CleanShot 2024-09-11 at 18 42 26](https://github.com/user-attachments/assets/83cb878a-c283-47c3-bfed-b26c32e9e9dc)

3. Run through a checkout; note the appearance of the Terms and Conditions checkbox at the bottom of the second screen.

![CleanShot 2024-09-11 at 18 45 34](https://github.com/user-attachments/assets/cf531bf2-24b7-4716-8307-8db2d22ac912)

4. Click the Terms and Conditions text to open the terms details and note the appearance.

![CleanShot 2024-09-11 at 18 46 05](https://github.com/user-attachments/assets/376ee88d-710e-4783-968a-21c4ca3acd84)

5. Apply this PR and run `npm run build`.
6. Repeat steps 3 and 4 and confirm that the Terms checkbox and details look better:

![CleanShot 2024-09-11 at 18 44 18](https://github.com/user-attachments/assets/6e5ba8d3-0ee2-4e14-bdfb-cb51c7e0258c)

![CleanShot 2024-09-11 at 18 44 34](https://github.com/user-attachments/assets/dc1d9612-3db7-48bc-8ece-3aa844531796)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
