### PR TITLE
fix (ras-acc): prevent NYP, coupon submission from clearing credit card fields

### DIFF
--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -334,7 +334,6 @@ domReady(
 						},
 					} );
 				}
-
 				if ( $coupon.length ) {
 					$coupon.on( 'submit', handleCouponSubmit );
 					$( document.body ).on( 'removed_coupon_in_checkout', () => {
@@ -388,7 +387,6 @@ domReady(
 								$nyp.find( 'h3, input[name="price"]' ).addClass( 'newspack-ui__field-error' );
 							}
 							$( document.body ).trigger( 'update_checkout', { update_shipping_method: false } );
-
 						},
 						complete: () => {
 							unblockForm( $nyp );

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -129,6 +129,48 @@ domReady(
 				} );
 
 				/**
+				 * Get updated cart total to update the "Place Order" button.
+				 */
+				function returnUpdatedCartTotal() {
+					let cartTotal;
+					$.ajax({
+						url: newspackBlocksModalCheckout.ajax_url,
+						method: 'POST',
+						async: false,
+						data: {
+							action: 'get_cart_total',
+						},
+						success: (response)=>{
+							cartTotal = response;
+						}
+					});
+					if ( cartTotal ) {
+						return cartTotal;
+					}
+				}
+
+				$( document ).on( 'updated_checkout', function() {
+					// Update "Place Order" button to include current price.
+					let processOrderText = newspackBlocksModalCheckout.labels.complete_button;
+					if ( ! processOrderText ) {
+						return;
+					}
+					if ( $( '#place_order' ).hasClass( 'button-label-updated' ) ) {
+						// Modify button text to include updated price.
+						const tree = $( '<div>' + processOrderText + '</div>' );
+						// Update the HTML in the .cart-price span with the new price, and return.
+						tree.find('.cart-price').html( returnUpdatedCartTotal, function() {
+							return this.childNodes;
+						} );
+						processOrderText = tree.html();
+						$( '#place_order' ).html( processOrderText );
+					} else {
+						// Set default button label passed from PHP.
+						$( '#place_order' ).addClass( 'button-label-updated' ).html( processOrderText );
+					}
+				} );
+
+				/**
 				 * Handle gift options.
 				 */
 				if ( $gift_options.length ) {
@@ -292,6 +334,7 @@ domReady(
 						},
 					} );
 				}
+
 				if ( $coupon.length ) {
 					$coupon.on( 'submit', handleCouponSubmit );
 					$( document.body ).on( 'removed_coupon_in_checkout', () => {
@@ -345,6 +388,7 @@ domReady(
 								$nyp.find( 'h3, input[name="price"]' ).addClass( 'newspack-ui__field-error' );
 							}
 							$( document.body ).trigger( 'update_checkout', { update_shipping_method: false } );
+
 						},
 						complete: () => {
 							unblockForm( $nyp );

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -131,7 +131,7 @@ domReady(
 				/**
 				 * Get updated cart total to update the "Place Order" button.
 				 */
-				function returnUpdatedCartTotal() {
+				function getUpdatedCartTotal() {
 					let cartTotal;
 					$.ajax({
 						url: newspackBlocksModalCheckout.ajax_url,
@@ -159,7 +159,7 @@ domReady(
 						// Modify button text to include updated price.
 						const tree = $( '<div>' + processOrderText + '</div>' );
 						// Update the HTML in the .cart-price span with the new price, and return.
-						tree.find('.cart-price').html( returnUpdatedCartTotal, function() {
+						tree.find('.cart-price').html( getUpdatedCartTotal, function() {
 							return this.childNodes;
 						} );
 						processOrderText = tree.html();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR moves setting and updating the 'Complete Transaction' button price from PHP to JS. This is to prevent an issue where submitting a coupon or NYP after filling in the credit card fields would cause the credit card fields to be cleared.

See: 1207817176293825-as-1208255803261156.

### How to test the changes in this Pull Request:

1. Start on epic/ras-acc.
2. Enable coupons, and set up at least one regular coupon.
3. Set up Checkout button blocks for a simple product and a NYP product, plus a donate block.
4. Set up Stripe Gateway and WooPayments as your payment options.
5. As a reader, run through a transaction using the simple product.
6. On the second screen, fill out your payment information first. 
7. Fill in your coupon, and Apply.
8. Note that the credit card fields reset.
9. Repeat steps 5-8 with the NYP product, and with both payment gateways.
10. Apply this PR and run `npm run build`.
11. Repeat steps 5-8 with both your simple and NYP products, and both payment processors. When you do this, confirm that the credit card values remain in place, and also confirm that the Confirm Transaction button at the bottom updates with the correct price. 
12. Try applying your coupon, then removing it, and checking the price in the Confirm Transaction button each time. 
13. Run a transaction with the Donate Button block, and confirm the button on the second screen just says "Donate Now". 
14. Smoke test a few other product options, like a subscription product or variable product, and make sure the Confirm Transaction button displays the correct initial payment amount.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
