### PR TITLE
fix(modal-checkout): tweak HTML to satisfy Woo Payments field validation

### DIFF
--- a/src/modal-checkout/templates/checkout-form.php
+++ b/src/modal-checkout/templates/checkout-form.php
@@ -128,7 +128,10 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 					</select>
 					<span id="select2-billing_state-container" style="display:none;"></span>
 				<?php else : ?>
-					<input type="hidden" id="<?php echo esc_attr( 'billing_' . $key ); ?>" name="<?php echo esc_attr( 'billing_' . $key ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+					<?php // Satisfy HTML structure for Woo Payments field validation. ?>
+					<span class="form-row" style="display:none;">
+						<input type="hidden" id="<?php echo esc_attr( 'billing_' . $key ); ?>" name="<?php echo esc_attr( 'billing_' . $key ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+					</span>
 				<?php endif; ?>
 			<?php endforeach; ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1200530782742699-as-1208317393051728/f

Since [this change](https://github.com/Automattic/woocommerce-payments/pull/8502) in WooCommerce Payments our modal checkout crashes when attempting to submit a payment. Our 2-step approach generates hidden inputs containing the billing information from the 1st step. These inputs are not in the HTML structure WooCommerce Payments expects for front-end field validation.

This PR tweaks the HTML so the hidden inputs are inside `.form-row` nodes, satisfying the WooComerce Payments js.

### How to test the changes in this Pull Request:

1. Setup WooCommerce Payments in sandbox mode (read more here: https://woocommerce.com/document/woopayments/testing-and-troubleshooting/sandbox-mode/)
2. While in the release branch, attempt to donate via Donate block
3. Confirm the modal checkout page refreshes after a trying to submit the payment with an error notice
4. Check out this branch
5. Donate and confirm the payment goes through

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
