### PR TITLE
fix(ras-acc): respect cart coupons on nyp submit

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -356,8 +356,16 @@ final class Modal_Checkout {
 			}
 		}
 
+		$coupons = \WC()->cart->get_applied_coupons();
+
 		\WC()->cart->empty_cart();
 		\WC()->cart->add_to_cart( $product_id, 1, 0, [], $cart_item_data );
+
+		if ( ! empty( $coupons ) ) {
+			foreach ( $coupons as $coupon ) {
+				\WC()->cart->apply_coupon( $coupon );
+			}
+		}
 
 		wp_send_json_success(
 			[

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -380,7 +380,6 @@ domReady(
 									'</p>'
 							);
 							if ( success ) {
-								$( '.woocommerce-Price-amount' ).replaceWith( res.price );
 								$nyp.find( 'h3, input[name="price"]' ).removeClass( 'newspack-ui__field-error' );
 							} else {
 								$nyp.find( 'input[name="price"]' ).focus();


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1208344897866336/f

This PR fixes an issue where the checkout button nyp input would remove any applied coupons on submit.

![Screenshot 2024-09-18 at 16 36 53](https://github.com/user-attachments/assets/f3bd0589-6f78-4f94-a681-a0a2e013dfff)

### How to test the changes in this Pull Request:

1. Set up a checkout button block for a product that has both coupons AND nyp enabled
2. As a reader trigger the checkout modal via the checkout button and go through checkout until you get to the payment method section
3. Input a valid coupon and submit. Verify the order review table and submit button update with the correct values
4. Now input a valid NYP amount and submit. On `epic/ras-acc` the coupon will be removed. On this branch, it should not and everything should update correctly.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
