### PR TITLE
feat(homepage-posts): add a show-full-content attribute

### DIFF
--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -296,6 +296,7 @@ class Newspack_Blocks_API {
 				'excerpt'             => [
 					'rendered' => post_password_required( $post ) ? '' : $excerpt,
 				],
+				'full_content'        => get_the_content( $post->ID ),
 				'featured_media'      => (int) get_post_thumbnail_id( $post->ID ),
 				'id'                  => $post->ID,
 				'meta'                => $meta->get_value( $post->ID, $request ),

--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -10,6 +10,10 @@
 			"type": "boolean",
 			"default": true
 		},
+		"showFullContent": {
+			"type": "boolean",
+			"default": false
+		},
 		"excerptLength": {
 			"type": "number",
 			"default": 55
@@ -214,9 +218,7 @@
 		},
 		"postType": {
 			"type": "array",
-			"default": [
-				"post"
-			],
+			"default": ["post"],
 			"items": {
 				"type": "string"
 			}
@@ -227,9 +229,7 @@
 		},
 		"includedPostStatuses": {
 			"type": "array",
-			"default": [
-				"publish"
-			],
+			"default": ["publish"],
 			"items": {
 				"type": "string"
 			}

--- a/src/blocks/homepage-articles/edit.tsx
+++ b/src/blocks/homepage-articles/edit.tsx
@@ -111,6 +111,7 @@ class Edit extends Component< HomepageArticlesProps > {
 			showCaption,
 			showCredit,
 			showExcerpt,
+			showFullContent,
 			showReadMore,
 			readMoreLabel,
 			showSubtitle,
@@ -206,9 +207,14 @@ class Edit extends Component< HomepageArticlesProps > {
 							{ post.meta.newspack_post_subtitle || '' }
 						</RawHTML>
 					) }
-					{ showExcerpt && (
+					{ showExcerpt && ! showFullContent && (
 						<RawHTML key="excerpt" className="excerpt-contain">
 							{ post.excerpt.rendered }
+						</RawHTML>
+					) }
+					{ ! showExcerpt && showFullContent && (
+						<RawHTML key="full-content" className="excerpt-contain">
+							{ post.full_content }
 						</RawHTML>
 					) }
 					{ showReadMore && post.post_link && (
@@ -281,6 +287,7 @@ class Edit extends Component< HomepageArticlesProps > {
 			minHeight,
 			moreButton,
 			showExcerpt,
+			showFullContent,
 			showReadMore,
 			readMoreLabel,
 			excerptLength,
@@ -547,23 +554,44 @@ class Edit extends Component< HomepageArticlesProps > {
 						<ToggleControl
 							label={ __( 'Show Excerpt', 'newspack-blocks' ) }
 							checked={ showExcerpt }
-							onChange={ () => setAttributes( { showExcerpt: ! showExcerpt } ) }
+							onChange={ () => {
+								setAttributes({
+									showExcerpt: !showExcerpt,
+									showFullContent: showFullContent ? false : showFullContent
+								})
+							} }
 						/>
 					</PanelRow>
 					{ showExcerpt && (
-						<RangeControl
-							label={ __( 'Max number of words in excerpt', 'newspack-blocks' ) }
-							value={ excerptLength }
-							onChange={ ( value: number ) => setAttributes( { excerptLength: value } ) }
-							min={ 10 }
-							max={ 100 }
-						/>
+						<PanelRow>
+							<RangeControl
+								label={ __( 'Max number of words in excerpt', 'newspack-blocks' ) }
+								value={ excerptLength }
+								onChange={ ( value: number ) => setAttributes( { excerptLength: value } ) }
+								min={ 10 }
+								max={ 100 }
+							/>
+						</PanelRow>
 					) }
-					<ToggleControl
-						label={ __( 'Add a "Read More" link', 'newspack-blocks' ) }
-						checked={ showReadMore }
-						onChange={ () => setAttributes( { showReadMore: ! showReadMore } ) }
-					/>
+					<PanelRow>
+						<ToggleControl
+							label={ __( 'Show Full Content', 'newspack-blocks' ) }
+							checked={ showFullContent }
+							onChange={ () => {
+								setAttributes({
+									showFullContent: !showFullContent,
+									showExcerpt: showExcerpt ? false : showExcerpt
+								})
+							} }
+						/>
+					</PanelRow>
+					<PanelRow>
+						<ToggleControl
+							label={ __( 'Add a "Read More" link', 'newspack-blocks' ) }
+							checked={ showReadMore }
+							onChange={ () => setAttributes( { showReadMore: ! showReadMore } ) }
+						/>
+					</PanelRow>
 					{ showReadMore && (
 						<TextControl
 							label={ __( '"Read More" link text', 'newspack-blocks' ) }

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -147,8 +147,11 @@ call_user_func(
 				</div>
 			<?php endif; ?>
 			<?php
-			if ( $attributes['showExcerpt'] ) :
+			if ( $attributes['showExcerpt'] && ! $attributes['showFullContent'] ) :
 				the_excerpt();
+			endif;
+			if ( $attributes['showFullContent'] && ! $attributes['showExcerpt'] ) :
+				the_content();
 			endif;
 			if ( $post_link && ( $attributes['showReadMore'] ) ) :
 				?>

--- a/src/blocks/homepage-articles/utils.ts
+++ b/src/blocks/homepage-articles/utils.ts
@@ -161,6 +161,7 @@ const generatePreviewPost = ( id: PostId ) => {
 		excerpt: {
 			rendered: '<p>' + __( 'The post excerpt.', 'newspack-blocks' ) + '</p>',
 		},
+		full_content: __('Full post content.', 'newspack-blocks'),
 		post_link: '/',
 		featured_media: '1',
 		id,

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -65,6 +65,7 @@ declare global {
 		excerpt: {
 			rendered: string;
 		};
+		full_content: string;
 		meta: {
 			newspack_post_subtitle: string;
 		};
@@ -104,6 +105,7 @@ declare global {
 		postType: PostType[];
 		showImage: boolean;
 		showExcerpt: boolean;
+		showFullContent: boolean;
 		tags: TagId[];
 		customTaxonomies: Taxonomy[];
 		specificPosts: string[];
@@ -112,7 +114,6 @@ declare global {
 		categoryExclusions: CategoryId[];
 		customTaxonomyExclusions: Taxonomy[];
 		className: string;
-		showExcerpt: boolean;
 		excerptLength: number;
 		showReadMore: boolean;
 		readMoreLabel: string;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a "show full content" attribute on the Hompage Posts Block.

### How to test the changes in this Pull Request:

1. Insert a HPB on a page
2. Observe there's a new setting in "Post Control Settings" sidebar panel
3. Toggle on "Show Full Content" and observe full post content is displayed
4. Publish the page, observe the full post content is displayed 
5. Toggle it off, observe it's mutually exclusive with the "Show Excerpt" attribute

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208326151910219