### PR TITLE
fix(ras-acc): apply wp-block-button class to checkout buttons

### DIFF
--- a/src/blocks/checkout-button/view.php
+++ b/src/blocks/checkout-button/view.php
@@ -176,6 +176,7 @@ function render_callback( $attributes ) {
 		'checkout-button',
 		$attributes,
 		[
+			'wp-block-button',
 			( $font_size || isset( $style['typography']['fontSize'] ) ) ? 'has-custom-font-size' : '',
 			$width ? ' has-custom-width wp-block-button__width-' . esc_attr( $width ) : '',
 		]


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1208327956169310/f

This PR fixes an issue where checkout button blocks were losing the `wp-block-button` class when upgrading to `epic/ras-acc`.

![Screenshot 2024-09-19 at 12 32 26](https://github.com/user-attachments/assets/ea537cf8-4b5a-4ef0-9c6d-75bcfd437962)


### How to test the changes in this Pull Request:

1. Make sure `trunk` is checked out and compiled
2. Add a checkout button to any post or page
3. As a reader view the post or page and verify the checkout button has the `wp-block-button` class as pictured above.
4. Checkout `epic/ras-acc` and build
5. Once again as a reader view the post or page with the checkout button. The `wp-block-button` class should be missing.
6. Repeat the above steps, but instead of `epic/ras-acc` checkout this branch on step 4. This time the `wp-block-button` class should not be missing.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
