### PR TITLE
fix(ras-acc): intermittent auth + checkout flow error

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -702,16 +702,16 @@ final class Modal_Checkout {
 		<body class="<?php echo esc_attr( "$class_prefix {$class_prefix}__modal__content" ); ?>" id="newspack_modal_checkout_container">
 			<?php
 			echo do_shortcode( '[woocommerce_checkout]' );
-			wp_footer();
-			// Trigger checkout error event if there are cart errors.
 			if ( is_cart() && ! empty( $wc_errors ) ) :
 				?>
 				<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide" id="checkout_error_back" type="submit"><?php esc_html_e( 'Go back', 'newspack-blocks' ); ?></button>
 				<script>
+					// Trigger checkout error event if there are cart errors.
 					jQuery( document.body ).trigger( 'checkout_error' );
 				</script>
 				<?php
 			endif;
+			wp_footer();
 			?>
 		</body>
 		</html>

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -719,15 +719,17 @@ domReady(
 		}
 
 		/**
-		 * Apply newspack styling to default Woo checkout errors.
+		 * Handle modal checkout error events.
 		 */
 		$( document.body ).on( 'checkout_error', function () {
+			// Apply newspack styling to default Woo checkout errors.
 			const $errors = $( '.woocommerce-NoticeGroup-checkout, .woocommerce-notices-wrapper' );
 			if ( $errors.length ) {
 				$errors.each(
 					( _, error ) => $( error ).addClass(`${ CLASS_PREFIX }__notice ${ CLASS_PREFIX }__notice--error` )
 				);
 			}
+			// Handle "Back" button click.
 			const $checkout_error_back = $( '#checkout_error_back' );
 			if ( $checkout_error_back.length ) {
 				$checkout_error_back.on( 'click', ev => {
@@ -735,6 +737,7 @@ domReady(
 					parent.newspackCloseModalCheckout()
 				} );
 			}
+			// Trigger ready state.
 			setReady( false );
 		} );
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1208379852549374

Fixes an issue where when modal checkout renders the cart with no errors, the modal is left in a loading state infinitely:
![Screenshot 2024-10-10 at 13 14 43](https://github.com/user-attachments/assets/90d9d983-32c1-463a-8161-2c9edf370be9)

### How to test the changes in this Pull Request:

This is very difficult to reproduce since the case of modal checkout rendering the cart page with no errors seems to only happen on the Hyperallergic beta test site, but we can mimic this by commenting out the following line of code: https://github.com/Automattic/newspack-blocks/blob/4bb284340a70750f9e2f65587510678424aeff93/includes/class-modal-checkout.php#L253

1. With the above line of code commented out, initiate the checkout modal via a checkout button.
2. Confirm you see a generic error with a back button appear in the modal:
![Screenshot 2024-10-10 at 13 17 40](https://github.com/user-attachments/assets/eebcf8f7-3f1c-4718-9076-eb43e8faeb89)
3. Uncomment the code above back in, and smoke test the checkout modal to confirm nothing has broken

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
