### PR TITLE
fix(modal-checkout): optimize iframe load and refactor anonymous cart generation

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -160,9 +160,8 @@ final class Modal_Checkout {
 		}
 
 		$is_newspack_checkout = filter_input( INPUT_GET, 'newspack_checkout', FILTER_SANITIZE_NUMBER_INT );
-		$is_newspack_donate   = filter_input( INPUT_GET, 'newspack_donate', FILTER_SANITIZE_NUMBER_INT );
 
-		if ( ! $is_newspack_checkout && ! $is_newspack_donate ) {
+		if ( ! $is_newspack_checkout ) {
 			return;
 		}
 
@@ -292,9 +291,14 @@ final class Modal_Checkout {
 			 */
 			\do_action( 'newspack_blocks_checkout_button_modal', $checkout_button_metadata );
 
-			if ( ! defined( 'DOING_AJAX' ) ) {
+			$checkout_url = apply_filters( 'newspack_blocks_checkout_url', $checkout_url );
+
+			if ( defined( 'DOING_AJAX' ) ) {
+				echo wp_json_encode( [ 'url' => $checkout_url ] );
+				exit;
+			} else {
 				// Redirect to checkout.
-			\wp_safe_redirect( apply_filters( 'newspack_blocks_checkout_url', $checkout_url ) );
+				\wp_safe_redirect( $checkout_url );
 				exit;
 			}
 		}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -167,6 +167,7 @@ final class Modal_Checkout {
 		}
 
 		// Flag the checkout as a registration for both newspack checkout and donate flows.
+		$is_checkout_registration = filter_input( INPUT_GET, self::CHECKOUT_REGISTRATION_FLAG, FILTER_SANITIZE_NUMBER_INT );
 		if ( $is_checkout_registration ) {
 			\WC()->session->set( self::CHECKOUT_REGISTRATION_FLAG, true );
 		}
@@ -180,7 +181,6 @@ final class Modal_Checkout {
 		$after_success_behavior     = filter_input( INPUT_GET, 'after_success_behavior', FILTER_SANITIZE_SPECIAL_CHARS );
 		$after_success_url          = filter_input( INPUT_GET, 'after_success_url', FILTER_SANITIZE_URL );
 		$after_success_button_label = filter_input( INPUT_GET, 'after_success_button_label', FILTER_SANITIZE_SPECIAL_CHARS );
-		$is_checkout_registration   = filter_input( INPUT_GET, self::CHECKOUT_REGISTRATION_FLAG, FILTER_SANITIZE_NUMBER_INT );
 
 		if ( ! $product_id ) {
 			return;

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -163,7 +163,6 @@ final class Modal_Checkout {
 		}
 	}
 
-
 	/**
 	 * Process checkout request for modal.
 	 */

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -627,6 +627,7 @@ final class Modal_Checkout {
 			// WP.
 			'jquery',
 			// Newspack.
+			'newspack-newsletters-',
 			'newspack-blocks-modal',
 			'newspack-blocks-modal-checkout',
 			'newspack-wc',

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -57,6 +57,7 @@ final class Modal_Checkout {
 		add_action( 'wp_ajax_nopriv_modal_checkout_request', [ __CLASS__, 'process_checkout_request' ] );
 		add_action( 'wp', [ __CLASS__, 'process_checkout_request' ] );
 
+		add_action( 'wp_loaded', [ __CLASS__, 'set_checkout_registration_flag' ] );
 		add_filter( 'wp_redirect', [ __CLASS__, 'pass_url_param_on_redirect' ] );
 		add_filter( 'woocommerce_cart_product_cannot_be_purchased_message', [ __CLASS__, 'woocommerce_cart_product_cannot_be_purchased_message' ], 10, 2 );
 		add_filter( 'woocommerce_add_error', [ __CLASS__, 'hide_expiry_message_shop_link' ] );
@@ -152,6 +153,18 @@ final class Modal_Checkout {
 	}
 
 	/**
+	 * Set the checkout registration flag to WC session.
+	 */
+	public static function set_checkout_registration_flag() {
+		// Flag the checkout as a registration.
+		$is_checkout_registration = filter_input( INPUT_GET, self::CHECKOUT_REGISTRATION_FLAG, FILTER_SANITIZE_NUMBER_INT );
+		if ( $is_checkout_registration ) {
+			\WC()->session->set( self::CHECKOUT_REGISTRATION_FLAG, true );
+		}
+	}
+
+
+	/**
 	 * Process checkout request for modal.
 	 */
 	public static function process_checkout_request() {
@@ -160,17 +173,6 @@ final class Modal_Checkout {
 		}
 
 		$is_newspack_checkout = filter_input( INPUT_GET, 'newspack_checkout', FILTER_SANITIZE_NUMBER_INT );
-		$is_newspack_donate   = filter_input( INPUT_GET, 'newspack_donate', FILTER_SANITIZE_NUMBER_INT );
-
-		if ( ! $is_newspack_checkout && ! $is_newspack_donate ) {
-			return;
-		}
-
-		// Flag the checkout as a registration for both newspack checkout and donate flows.
-		$is_checkout_registration = filter_input( INPUT_GET, self::CHECKOUT_REGISTRATION_FLAG, FILTER_SANITIZE_NUMBER_INT );
-		if ( $is_checkout_registration ) {
-			\WC()->session->set( self::CHECKOUT_REGISTRATION_FLAG, true );
-		}
 
 		if ( ! $is_newspack_checkout ) {
 			return;

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -703,7 +703,7 @@ final class Modal_Checkout {
 			'newspack-blocks-modal',
 			'newspackBlocksModal',
 			[
-				'ajax_url'									 => admin_url( 'admin-ajax.php' ),
+				'ajax_url'                   => admin_url( 'admin-ajax.php' ),
 				'checkout_registration_flag' => self::CHECKOUT_REGISTRATION_FLAG,
 				'newspack_class_prefix'      => self::get_class_prefix(),
 				'labels'                     => [

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -655,6 +655,13 @@ final class Modal_Checkout {
 			'stripe',
 		];
 
+		/**
+		 * Filters the allowed assets to render in the modal checkout
+		 *
+		 * @param string[] $allowed_assets Array of allowed assets handles.
+		 */
+		$allowed_assets = apply_filters( 'newspack_blocks_modal_checkout_allowed_assets', $allowed_assets );
+
 		global $wp_scripts, $wp_styles;
 
 		foreach ( $wp_scripts->queue as $handle ) {

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -574,7 +574,7 @@ final class Modal_Checkout {
 			return;
 		}
 
-		$dependencies = [ 'jquery' ];
+		$dependencies = [ 'jquery', 'wc-checkout' ];
 		// Add support reCAPTCHA dependencies, if connected.
 		if ( class_exists( 'Newspack\Recaptcha' ) && \Newspack\Recaptcha::can_use_captcha() ) {
 			$dependencies[] = \Newspack\Recaptcha::SCRIPT_HANDLE;

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -13,6 +13,7 @@ import { domReady } from './utils';
 domReady(
 	( $ => {
 		if ( ! $ ) {
+			console.warn( 'jQuery is not available.' ); // eslint-disable-line no-console
 			return;
 		}
 
@@ -587,6 +588,7 @@ domReady(
 				function validateForm( silent = false, cb = () => {} ) {
 					const blocked = blockForm( $form );
 					if ( ! blocked ) {
+						cb();
 						return false;
 					}
 					clearNotices();

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -59,8 +59,7 @@ domReady(
 				container.checkoutComplete = true;
 			}
 		} else {
-			$( document.body ).on( 'init_checkout', function () {
-
+			function init() {
 				// If present, update the markup used for the WooPayments express checkout divider.
 				$( '#wcpay-express-checkout-button-separator, #wc-stripe-payment-request-button-separator' ).after(
 					'<div class="newspack-ui__word-divider">' + newspackBlocksModalCheckout.divider_text + '</div>'
@@ -71,6 +70,7 @@ domReady(
 				const $form = $( 'form.checkout' );
 
 				if ( ! $form.length ) {
+					console.warn( 'Form is not available' ); // eslint-disable-line no-console
 					return;
 				}
 				const $coupon = $( 'form.modal_checkout_coupon' );
@@ -718,7 +718,8 @@ domReady(
 					form.removeClass( 'modal-processing' );
 					return true;
 				}
-			} );
+			}
+			init();
 		}
 
 		/**

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -10,8 +10,8 @@ import './checkout.scss';
 import { manageCheckoutAttempt, manageLoaded, managePagination } from './analytics';
 import { domReady } from './utils';
 
-domReady(
-	( $ => {
+( $ => {
+	domReady( () => {
 		if ( ! $ ) {
 			console.warn( 'jQuery is not available.' ); // eslint-disable-line no-console
 			return;
@@ -748,5 +748,5 @@ domReady(
 				parent.newspackCloseModalCheckout();
 			}
 		} );
-	} )( jQuery )
-);
+	} )
+} )( jQuery );

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -588,6 +588,7 @@ domReady(
 				function validateForm( silent = false, cb = () => {} ) {
 					const blocked = blockForm( $form );
 					if ( ! blocked ) {
+						console.warn( 'Unable to block the form' ); // eslint-disable-line no-console
 						cb();
 						return false;
 					}

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -374,13 +374,11 @@ domReady( () => {
 				title: newspackBlocksModal.labels.auth_modal_title,
 				callback: ( message, authData ) => {
 					cartReq.then( url => {
-						const checkoutForm = generateCheckoutPageForm( url );
-						// Signal checkout registration.
+						// If registered, append the registration flag query param to the url.
 						if ( authData?.registered ) {
-							checkoutForm.appendChild(
-								createHiddenInput( newspackBlocksModal.checkout_registration_flag, '1' )
-							);
+							url += `&${ newspackBlocksModal.checkout_registration_flag }=1`;
 						}
+						const checkoutForm = generateCheckoutPageForm( url );
 						triggerCheckout( checkoutForm );
 					} )
 					.catch( error => {

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -562,6 +562,13 @@ domReady( () => {
 						}
 						window.newspackReaderActivation?.setCheckoutData?.( data );
 
+						// Add to cart asynchroneously.
+						const urlParams = new URLSearchParams( formData );
+						urlParams.append( 'action', 'modal_checkout_request' );
+						fetch( newspackBlocksModal.ajax_url + '?' + urlParams.toString() ).catch( error => {
+							console.warn( 'Unable to generate cart:', error ); // eslint-disable-line no-console
+						} );
+
 						// Initialize auth flow if reader is not authenticated.
 						window.newspackReaderActivation.openAuthModal( {
 							title: newspackBlocksModal.labels.auth_modal_title,

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -130,7 +130,11 @@ domReady( () => {
 	iframe.addEventListener( 'load', handleIframeReady );
 
 	/**
-	 * Generate cart.
+	 * Generate cart via ajax.
+	 *
+	 * This strategy, used for anonymous users, addresses an edge case in which
+	 * the session for a newly registered reader fails to carry the cart over to
+	 * the checkout.
 	 *
 	 * @return {Promise} The promise that resolves with the checkout URL.
 	 */

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -40,13 +40,15 @@ domReady( () => {
 	iframe.style.visibility = 'hidden';
 
 	function iframeReady( cb ) {
-		let timer;
+		if ( iframe._readyTimer ) {
+			clearTimeout( iframe._readyTimer );
+		}
 		let fired = false;
 
 		function ready() {
 			if ( ! fired ) {
 				fired = true;
-				clearTimeout( timer );
+				clearTimeout( iframe._readyTimer );
 				cb.call( this );
 			}
 		}
@@ -73,7 +75,7 @@ domReady( () => {
 					addEvent( doc, 'readystatechange', readyState );
 				}
 			} else {
-				timer = setTimeout( checkLoaded, 10 );
+				iframe._readyTimer = setTimeout( checkLoaded, 10 );
 			}
 		}
 		checkLoaded();

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -498,7 +498,7 @@ domReady( () => {
 						window.history.back();
 					}
 				}
-				window?.newspackReaderActivation?.resetCheckoutData?.();
+				window?.newspackReaderActivation?.setPendingCheckout?.();
 			};
 
 			if ( window?.newspackReaderActivation?.openNewslettersSignupModal ) {
@@ -516,7 +516,7 @@ domReady( () => {
 				setModalTitle( newspackBlocksModal.labels.checkout_modal_title );
 			}
 		} else {
-			window?.newspackReaderActivation?.resetCheckoutData?.();
+			window?.newspackReaderActivation?.setPendingCheckout?.();
 
 			// Track a dismissal event (modal has been manually closed without completing the checkout).
 			manageDismissed();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR addresses a few different issues:

Introduces a new strategy to detect iframe load so it can be ready sooner. The `load` event dispatch waits for render-blocking assets to load before firing. The new strategy watches for the iframe content document to trigger when the DOM is ready.

The dequeuing strategy is now reversed so that only whitelisted assets can be enqueued. This prevents unnecessary assets from loading.

#### Cart generation via ajax

To handle an edge case in which carts are getting wiped between an account registration and the modal checkout render, this PR changes the strategy for anonymous readers.

Carts should now be generated in parallel to the auth/account creation flow. This allows for the cart session to be created before the authentication, which, once authenticated, Woo should handle the transition without issues.

Because of this new strategy, readers signing in via link should also be able to restore the checkout flow with the existing cart. The pending checkout logic has been simplified here and in https://github.com/Automattic/newspack-plugin/pull/3471.

### How to test the changes in this Pull Request:

1. Checkout this branch and https://github.com/Automattic/newspack-plugin/pull/3471
2. In a fresh session, start the checkout button flow with a subscription product
3. Register a new reader and confirm you are able to purchase without issues
4. In another fresh session, start the checkout button flow with the same product
5. This time, enter an existing email and click to sign in via link
6. Paste the link in your session and confirm you are authenticated and able to proceed with the checkout
7. Repeat steps 2-6 but through the Donate block

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
