### PR TITLE
hotfix: re-add block caching

### DIFF
--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -20,6 +20,7 @@ define( 'NEWSPACK_BLOCKS__VERSION', '4.2.0' );
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'includes/class-newspack-blocks.php';
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'includes/class-newspack-blocks-api.php';
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'includes/class-newspack-blocks-patterns.php';
+require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'includes/class-newspack-blocks-caching.php';
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'includes/class-modal-checkout.php';
 
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'includes/plugins/class-the-events-calendar.php';


### PR DESCRIPTION
Block caching file loading was accidentally removed in 0b0b02c8dc0257b076f7f6925445ab0eddda561e. This hotfix adds it back there. 