### PR TITLE
fix: potential fatal with invalid attribute combo

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -322,7 +322,7 @@ final class Modal_Checkout {
 		$products = array_keys( self::$products );
 		foreach ( $products as $product_id ) {
 			$product = wc_get_product( $product_id );
-			if ( ! $product->is_type( 'variable' ) ) {
+			if ( ! $product || ! $product->is_type( 'variable' ) ) {
 				continue;
 			}
 			?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an obscure edge case that we've nevertheless seen out in the wild, which can potentially cause a fatal error.

### How to test the changes in this Pull Request:

1. On `trunk`, add a Checkout Button block to a post or page and set it to a variable product.
2. Enter Code Editing mode and replace the `variation` attribute and the `value` in the hidden input for `variation_id` with an empty space, like so (you can also replace it with a gibberish string):

```html
<!-- wp:newspack-blocks/checkout-button {"product":"662","variation":" ","is_variable":true,"price":"","text":"Invalid Checkout Button"} -->
<div class="wp-block-newspack-blocks-checkout-button wp-block-button"><form><button class="wp-block-button__link">Invalid Checkout Button</button><input type="hidden" name="product_id" value="662"/><input type="hidden" name="newspack_checkout" value="1"/><input type="hidden" name="variation_id" value=" "/><input type="hidden" name="is_variable" value="1"/><input type="hidden" name="after_success_button_label" value="Continue browsing"/></form></div>
<!-- /wp:newspack-blocks/checkout-button -->
```

3. Exit Code Editing mode and observe that the block attribute are now in this strange invalid state (no variation selected, but the "Allow the reader to select the variation before checkout" option also unchecked):

<img width="277" alt="Screenshot 2024-10-09 at 10 17 37 AM" src="https://github.com/user-attachments/assets/948f6a1f-051e-4f82-9584-696480ab0a10">

4. View the block on the front-end and observe that it results in a critical error.
5. Check out this branch, refresh the front-end, and confirm that there's no fatal and that clicking the block brings up the modal checkout with the first/default variation.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
