### PR TITLE
fix: deprecate video playlist block

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -241,6 +241,7 @@ class Newspack_Blocks {
 				'custom_taxonomies'          => self::get_custom_taxonomies(),
 				'can_use_name_your_price'    => self::can_use_name_your_price(),
 				'tier_amounts_template'      => self::get_formatted_amount(),
+				'can_use_video_playlist'     => self::can_use_video_playlist_block(),
 			];
 
 			if ( class_exists( 'WP_REST_Newspack_Author_List_Controller' ) ) {
@@ -1642,6 +1643,30 @@ class Newspack_Blocks {
 		);
 
 		return $combined_caption;
+	}
+
+	/**
+	 * Check if the current site can use the Video Playlist block.
+	 * If the block doesn't already exist in site content, it won't be registered.
+	 */
+	public static function can_use_video_playlist_block() {
+		// Check if the block exists in any content on the site.
+		$existing_blocks = new WP_Query(
+			[
+				'fields'         => 'ids',
+				'post_type'      => 'any',
+				'post_status'    => 'publish',
+				's'              => 'newspack-blocks/youtube-video-playlist',
+				'posts_per_page' => 1,
+			]
+		);
+
+		// Don't register the block if it's not already on the site.
+		if ( 0 < $existing_blocks->found_posts ) {
+			return true;
+		}
+
+		return false;
 	}
 }
 Newspack_Blocks::init();

--- a/src/blocks/video-playlist/edit.js
+++ b/src/blocks/video-playlist/edit.js
@@ -1,18 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { Component, Fragment } from '@wordpress/element';
-import { Placeholder, Spinner, PanelBody, RangeControl } from '@wordpress/components';
+import { Notice, Placeholder, Spinner, PanelBody } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
 import { addQueryArgs } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
-
-/**
- * Internal dependencies.
- */
-import AutocompleteTokenField from '../../components/autocomplete-tokenfield';
 
 class Edit extends Component {
 	constructor( props ) {
@@ -176,54 +171,45 @@ class Edit extends Component {
 	};
 
 	/**
-	 * Hide the overlay so users can play the videos.
-	 */
-	hideOverlay() {
-		this.setState( { interactive: true } );
-	}
-
-	/**
 	 * Render.
 	 */
 	render() {
-		const { attributes, setAttributes } = this.props;
-		const { categories, videosToShow } = attributes;
-		const { embed, isLoading, interactive } = this.state;
+		const { embed, isLoading } = this.state;
+
+		const Warning = () => (
+			<>
+				<h2>{ __( 'The YouTube Video Playlist block is deprecated', 'newspack-plugin' ) }</h2>
+				<p dangerouslySetInnerHTML={ {
+					__html: sprintf(
+						// translators: %1$s is the link to Google's help doc on creating YouTube playlists. %2$s is the link to the help doc on embedding playlists.
+						__( 'Consider using <a href="%1$s">YouTube Playlists</a> instead, which can be <a href="%2$s">embedded</a> into post or page content.', 'newspack-blocks' ),
+						'https://support.google.com/youtube/answer/57792',
+						'https://support.google.com/youtube/answer/171780'
+					),
+				} } />
+			</>
+		)
 
 		return (
 			<Fragment>
-				{ ( isLoading || '' === embed ) && this.renderPlaceholder() }
-				{ ! ( isLoading || '' === embed ) && (
-					<div className="wpbnbvp-preview">
-						<div dangerouslySetInnerHTML={ { __html: embed } } />
-						{ ! interactive && (
-							// eslint-disable-next-line jsx-a11y/no-static-element-interactions
-							<div className="wpbnbvp__overlay" onMouseUp={ () => this.hideOverlay() } />
-						) }
-					</div>
-				) }
+				<div>
+					{ ( isLoading || '' === embed ) && this.renderPlaceholder() }
+					{ ! ( isLoading || '' === embed ) && (
+						<div className="wpbnbvp-preview">
+							<div dangerouslySetInnerHTML={ { __html: embed } } />
+						</div>
+					) }
+					{ ! isLoading && (
+						<div className="wpbnbvp__overlay">
+							<Warning />
+						</div>
+					) }
+				</div>
 				<InspectorControls>
 					<PanelBody title={ __( 'Settings', 'newspack-blocks' ) } initialOpen={ true }>
-						<Fragment>
-							<RangeControl
-								className="videosToShow"
-								label={ __( 'Videos', 'newspack-blocks' ) }
-								help={ __( 'The maximum number of videos to pull from posts.', 'newspack-blocks' ) }
-								value={ videosToShow }
-								onChange={ _videosToShow => setAttributes( { videosToShow: _videosToShow } ) }
-								min={ 1 }
-								max={ 30 }
-								required
-							/>
-							<AutocompleteTokenField
-								key="categories"
-								tokens={ categories || [] }
-								onChange={ _categories => setAttributes( { categories: _categories } ) }
-								fetchSuggestions={ this.fetchCategorySuggestions }
-								fetchSavedInfo={ this.fetchSavedCategories }
-								label={ __( 'Categories', 'newspack-blocks' ) }
-							/>
-						</Fragment>
+						<Notice status="warning" isDismissible={ false }>
+							<Warning />
+						</Notice>
 					</PanelBody>
 				</InspectorControls>
 			</Fragment>

--- a/src/blocks/video-playlist/editor.js
+++ b/src/blocks/video-playlist/editor.js
@@ -4,4 +4,6 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { name, settings } from '.';
 
-registerBlockType( `newspack-blocks/${ name }`, settings );
+if ( window.newspack_blocks_data?.can_use_video_playlist ) {
+	registerBlockType( `newspack-blocks/${ name }`, settings );
+}

--- a/src/blocks/video-playlist/editor.scss
+++ b/src/blocks/video-playlist/editor.scss
@@ -5,8 +5,17 @@
  * Prevents interaction with the player until the block is focused.
  */
 .wpbnbvp__overlay {
+	align-content: center;
+	background-color: rgba(255, 255, 255, 0.9);
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	left: 0;
+	height: 100%;
 	position: absolute;
-	inset: 0;
+	text-align: center;
+	top: 0;
+	width: 100%;
 }
 
 .wpbnbvp-preview {

--- a/src/blocks/video-playlist/index.js
+++ b/src/blocks/video-playlist/index.js
@@ -15,7 +15,7 @@ import edit from './edit';
 import './editor.scss';
 
 export const name = 'youtube-video-playlist';
-export const title = __( 'YouTube Video Playlist', 'newspack-blocks' );
+export const title = __( 'YouTube Video Playlist (DEPRECATED)', 'newspack-blocks' );
 
 export const icon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">

--- a/src/blocks/video-playlist/view.php
+++ b/src/blocks/video-playlist/view.php
@@ -23,6 +23,10 @@ function newspack_blocks_render_block_video_playlist( $attributes ) {
  * Registers the `newspack-blocks/donate` block on server.
  */
 function newspack_blocks_register_video_playlist() {
+	if ( ! Newspack_Blocks::can_use_video_playlist_block() ) {
+		return;
+	}
+
 	register_block_type(
 		'newspack-blocks/youtube-video-playlist',
 		array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Deprecates the YouTube Video Playlist block, as this functionality is now a core feature of YouTube itself.

If the block already exists in any site content, the block will continue to render on the front-end, but editor instances will no longer be editable and will display a deprecation warning.

If the block doesn't exist in any site content, it won't be registered and therefore can't be added to any post content.

At a future date, we can consider removing all block assets from this repo.

### How to test the changes in this Pull Request:

1. On `trunk`, add some YouTube video embeds to post content. Make sure to embed using full, unshortened YouTube URLs to embed or they won't be recognized by the Video Playlist block.
2. Add a YouTube Video Playlist block to another post or page. Confirm that it renders a preview in the editor and renders videos on the front-end.
3. Check out this branch. Confirm that the block continues to render without changes on the front-end.
4. Confirm that in the editor, the block shows a deprecation warning both in the block preview and in the sidebar, and that there's no longer UI to edit block attributes. Confirm that the links in the warning message link out to Google help docs explaining how to create/manage and embed YouTube playlists.

<img width="1145" alt="Screenshot 2024-10-11 at 4 47 09 PM" src="https://github.com/user-attachments/assets/547a3f2d-2bd5-48ec-8f53-8da259eb53fa">

5. Remove the YouTube Video Playlist block from the post (and any other posts/pages it might exist in`*`), save, then refresh the editor. Confirm that the YouTube Video Playlist block can no longer be found in the block inserter.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208493279061517