### PR TITLE
fix(modal-checkout): move checkout_error trigger

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -614,6 +614,7 @@ final class Modal_Checkout {
 				'newspack_class_prefix' => self::get_class_prefix(),
 				'is_checkout_complete'  => function_exists( 'is_order_received_page' ) && is_order_received_page(),
 				'divider_text'          => esc_html__( 'Or', 'newspack-blocks' ),
+				'is_error'              => ! is_checkout() && ! is_order_received_page(),
 				'labels'                => [
 					'billing_details'  => self::get_modal_checkout_labels( 'billing_details' ),
 					'shipping_details' => self::get_modal_checkout_labels( 'shipping_details' ),
@@ -793,11 +794,6 @@ final class Modal_Checkout {
 					</div>
 				</div>
 				<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide" id="checkout_error_back" type="submit"><?php esc_html_e( 'Go back', 'newspack-blocks' ); ?></button>
-				<script>
-					document.addEventListener( 'DOMContentLoaded', function() {
-						jQuery( document.body ).trigger( 'checkout_error' );
-					});
-				</script>
 				<?php
 			}
 				wp_footer();

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -751,5 +751,9 @@ import { domReady } from './utils';
 				parent.newspackCloseModalCheckout();
 			}
 		} );
+
+		if ( newspackBlocksModalCheckout.is_error ) {
+			$( document.body ).trigger( 'checkout_error' );
+		}
 	} )
 } )( jQuery );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `checkout_error` may not always run because the script might end up running after the `DOMContentLoaded` event dispatch. This PR tweaks the approach so the trigger runs in the modal script, which runs inside `domReady()` and is ensured to always run.

### How to test the changes in this Pull Request:

1. While on the `epic/ras-acc` branch, use the checkout button to purchase a subscription you already own (make sure the subscription product is configured to restrict such purchase)
2. Click the checkout button a few times to confirm it sometimes hangs in the loading state and sometimes goes through with the correct error message (try also throttling the internet connection in a few attempts)
3. Checkout this branch, click the checkout button several times and confirm the error message renders consistently

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
