### PR TITLE
fix(modal-checkout): tweak Woo Payments behavior

### DIFF
--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -602,7 +602,13 @@ import { domReady } from './utils';
 						$genericErrors.remove();
 					}
 
-					const serializedForm = $form.serializeArray();
+					const removeFromValidation = [
+						'save_user_in_woopay',
+					];
+					// Serialize form and remove fields that shouldn't be included for validation.
+					const serializedForm = $form.serializeArray().filter(
+						item => ! removeFromValidation.includes( item.name )
+					);
 					// Add 'update totals' parameter so it just performs validation.
 					serializedForm.push( { name: 'woocommerce_checkout_update_totals', value: '1' } );
 					// Ajax request.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements a few tweaks to fix the modal checkout integration with Woo Payments:

 - Removes WooPay from the modal checkout: The WooPay external/platform checkout is not supported in the modal checkout because it loads the page inside the modal checkout iframe, blocked by WooPay.
 - Fixes a validation preventing the reader from advancing the checkout step
 - Removes a gateway hook that changes the priority of the email address field and appends a broken Stripelink button to the checkout

### How to test the changes in this Pull Request:

1. While on `epic/ras-acc`, setup the Woo Payments in sandbox mode
2. Confirm WooPay is enabled in the gateway settings
3. With a new reader account, start a purchase via modal checkout
4. Confirm the email address field is repositioned:

| Expected | Actual |
| --- | --- |
| <img width="672" alt="image" src="https://github.com/user-attachments/assets/f2b1dbed-39d4-4ce6-afb7-43aa78860880"> | <img width="676" alt="image" src="https://github.com/user-attachments/assets/0a7925c1-1002-4850-80c7-2dc768ae435a"> |

5. Still on the same modal, attempt to continue and confirm you get the following error:

<img width="612" alt="image" src="https://github.com/user-attachments/assets/31640349-7f74-4c70-944e-56088c8ba039">

6. In the Woo Payments gateway settings, deactivate WooPay
7. Visit the modal checkout again and confirm the email field is still repositioned but now with an odd button attached next to it:

<img width="674" alt="image" src="https://github.com/user-attachments/assets/e31cb07c-ca23-47ad-b965-d1b5f2a710ae">

8. Checkout this branch, refresh the modal checkout and confirm it renders as expected, also without the attached button
9. Confirm you can complete the purchase using the gateway and also save the card
10. Back to the gateway settings, reactivate WooPay
11. Go through the modal checkout and confirm WooPay does not render and you are able to complete the purchase
12. Visit the regular `/checkout` page and confirm WooPay is available


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
