### PR TITLE
fix(ras-acc): prevent iframeobserving from observing empty container

### DIFF
--- a/src/blocks/donate/tiers-based/view.ts
+++ b/src/blocks/donate/tiers-based/view.ts
@@ -93,18 +93,27 @@ export default ( parentEl: HTMLElement ) => {
 		buttonEl.addEventListener( 'click', () => {
 			const tierIndex = parseInt( buttonEl.getAttribute( 'data-tier-index' ) || '' );
 
-			// Remove hidden index input from tiers form.
+			// Remove hidden index and value inputs from tiers form.
 			const hiddenIndexInputEl = initFormEl.querySelector( 'input[name="donation_tier_index"]' );
+			const hiddenValueInputEl = initFormEl.querySelector( `input[name="donation_value_${ selectedFrequency }"]` );
 			if ( hiddenIndexInputEl ) {
 				hiddenIndexInputEl.remove();
+			}
+			if ( hiddenValueInputEl ) {
+				hiddenValueInputEl.remove();
 			}
 
 			// Append hidden index input to tiers form.
 			const indexInputEl = document.createElement( 'input' );
+			const valueInputEl = document.createElement( 'input' );
 			indexInputEl.setAttribute( 'type', 'hidden' );
+			valueInputEl.setAttribute( 'type', 'hidden' );
 			indexInputEl.setAttribute( 'name', 'donation_tier_index' );
+			valueInputEl.setAttribute( 'name', `donation_value_${ selectedFrequency }` );
 			indexInputEl.setAttribute( 'value', tierIndex.toString() );
+			valueInputEl.setAttribute( 'value', config.amounts[ selectedFrequency ][ tierIndex ] );
 			initFormEl.appendChild( indexInputEl );
+			initFormEl.appendChild( valueInputEl );
 
 			const tierHeadingEl: HTMLElement | null = parentEl.querySelector(
 				'.wpbnbd__tiers__tier-tile h2'

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -384,6 +384,7 @@ domReady( () => {
 					} )
 					.catch( error => {
 						console.warn( 'Unable to generate cart:', error ); // eslint-disable-line no-console
+						closeCheckout();
 					} );
 				},
 				skipSuccess: true,

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -56,7 +56,8 @@ domReady( () => {
 			if ( this.readyState === "complete" ) {
 				ready.call( this );
 			}
-		}		function checkLoaded() {
+		}
+		function checkLoaded() {
 			if ( iframe._ready ) {
 				clearTimeout( iframe._readyTimer );
 				return;
@@ -120,10 +121,6 @@ domReady( () => {
 			} else {
 				container.addEventListener( 'checkout-ready', setModalReady );
 			}
-		// Make sure the iframe has actually loaded something, even if not the expected container.
-		// This check prevents an issue in Chrome where the 'load' event fired twice and the spinner was hidden too soon.
-		} else if ( 'about:blank' !== location.href ) {
-			setModalReady();
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While working on a bug on TheFifthEstate, I ran into the following error:

![Screenshot 2024-10-17 at 10 47 35](https://github.com/user-attachments/assets/874a4dab-8a2e-4a53-afcf-3c79d89bfaaf)

Seems for tier based donation forms, the `process_donation_request` method returns early since there is a missing `donation_value_FREQUENCY` input: https://github.com/Automattic/newspack-plugin/blob/c9e91743c9ac7bf0053b506ed343da2a2e77609f/includes/class-donations.php#L679

In this case, the checkout url returned during the checkout process ends up being something like: `.../undefined&_newspack_checkout_registration=1`

There is also a case where `setModalReady` can be called before container is available: https://github.com/Automattic/newspack-blocks/blob/7ed3c4ee0b84a273fe1bda013fef54ef3e2db264/src/modal-checkout/modal.js#L126. Which will trigger in this case and lead to the console error above.

This PR fixes these issues by adding the input to the tiered donation form on button click, and removing the additional `setModalReady` case since this is no longer solely tied to the iframe `load` event.

### How to test the changes in this Pull Request:

1. Set up a tier based donation form on any page or post
2. As a new reader, go through the auth + checkout flow using the donation form
3. On `epic/ras-acc` the form will hang with an error. On this branch it should render checkout as expected.
4. Smoke test the checkout flow as a new reader, an existing reader, etc.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
