### PR TITLE
fix(modal-checkout): handle auth modal analytics

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -691,6 +691,7 @@ final class Modal_Checkout {
 		$allowed_assets = [
 			'jquery',
 			'google_gtagjs',
+			'select2',
 			// Newspack.
 			'newspack-newsletters-',
 			'newspack-blocks-modal',

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -718,8 +718,6 @@ final class Modal_Checkout {
 
 		global $wp_scripts, $wp_styles;
 
-		error_log( 'Dequeueing scripts and styles not needed for modal checkout.' );
-
 		foreach ( $wp_scripts->queue as $handle ) {
 			$allowed = false;
 			foreach ( $allowed_assets as $allowed_asset ) {
@@ -729,7 +727,6 @@ final class Modal_Checkout {
 				}
 			}
 			if ( ! $allowed ) {
-				error_log( 'Dequeueing script: ' . $handle );
 				wp_dequeue_script( $handle );
 			}
 		}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -689,8 +689,8 @@ final class Modal_Checkout {
 		}
 
 		$allowed_assets = [
-			// WP.
 			'jquery',
+			'google_gtagjs',
 			// Newspack.
 			'newspack-newsletters-',
 			'newspack-blocks-modal',
@@ -718,6 +718,8 @@ final class Modal_Checkout {
 
 		global $wp_scripts, $wp_styles;
 
+		error_log( 'Dequeueing scripts and styles not needed for modal checkout.' );
+
 		foreach ( $wp_scripts->queue as $handle ) {
 			$allowed = false;
 			foreach ( $allowed_assets as $allowed_asset ) {
@@ -727,6 +729,7 @@ final class Modal_Checkout {
 				}
 			}
 			if ( ! $allowed ) {
+				error_log( 'Dequeueing script: ' . $handle );
 				wp_dequeue_script( $handle );
 			}
 		}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -691,7 +691,6 @@ final class Modal_Checkout {
 		$allowed_assets = [
 			'jquery',
 			'google_gtagjs',
-			'select2',
 			// Newspack.
 			'newspack-newsletters-',
 			'newspack-blocks-modal',

--- a/src/modal-checkout/analytics/ga4/dismissed.js
+++ b/src/modal-checkout/analytics/ga4/dismissed.js
@@ -2,13 +2,17 @@ import { getEventPayload, getProductDetails, sendEvent } from './utils';
 
 /**
  * Event fired when a checkout modal is dismissed (not when closed automatically due to a completed checkout).
+ *
+ * @param {Object} data The data to send with the event.
  */
-export const manageDismissed = () => {
+export const manageDismissed = ( data ) => {
 	if ( 'function' !== typeof window.gtag ) {
 		return;
 	}
 
-	const { action_type, amount = '', currency, price = '', product_id, product_type, recurrence, referrer, variation_id = '' } = getProductDetails( 'newspack_modal_checkout' );
+	data = data || getProductDetails( 'newspack_modal_checkout' );
+
+	const { action_type, amount = '', currency, price = '', product_id, product_type, recurrence, referrer, variation_id = '' } = data;
 
 	const params = {
 		action_type,

--- a/src/modal-checkout/analytics/ga4/opened.js
+++ b/src/modal-checkout/analytics/ga4/opened.js
@@ -3,9 +3,9 @@ import { getEventPayload, sendEvent } from './utils';
 /**
  * Execute a callback function to send a GA event when a prompt is dismissed.
  *
- * @param {Object} getProductDataModal Information about the purchase being made.
+ * @param {Object} data Information about the purchase being made.
  */
-export const manageOpened = ( getProductDataModal = '' ) => {
+export const manageOpened = ( data ) => {
 	if ( 'function' !== typeof window.gtag ) {
 		return;
 	}
@@ -23,7 +23,7 @@ export const manageOpened = ( getProductDataModal = '' ) => {
 		recurrence,
 		referrer,
 		variation_id = '',
-	} = getProductDataModal;
+	} = data;
 
 	const params = {
 		action_type,

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -388,7 +388,7 @@ domReady( () => {
 			// Initialize auth flow if reader is not authenticated.
 			window.newspackReaderActivation.openAuthModal( {
 				title: newspackBlocksModal.labels.auth_modal_title,
-				callback: ( message, authData ) => {
+				onSuccess: ( message, authData ) => {
 					cartReq.then( url => {
 						// If registered, append the registration flag query param to the url.
 						if ( authData?.registered ) {
@@ -402,7 +402,10 @@ domReady( () => {
 						closeCheckout();
 					} );
 				},
-				onClose: () => {
+				onError: () => {
+					closeCheckout();
+				},
+				onDismiss: () => {
 					// Analytics: Track a dismissal event (modal has been manually closed without completing the checkout).
 					manageDismissed( analyticsData );
 					inCheckoutIntent = false;
@@ -524,7 +527,8 @@ domReady( () => {
 
 			if ( window?.newspackReaderActivation?.openNewslettersSignupModal ) {
 				window.newspackReaderActivation.openNewslettersSignupModal( {
-					callback: handleCheckoutComplete,
+					onSuccess: handleCheckoutComplete,
+					onError: handleCheckoutComplete,
 					closeOnSuccess: shouldCloseModal,
 				} );
 			} else {

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -21,7 +21,8 @@ const VARIATON_MODAL_CLASS_PREFIX = 'newspack-blocks__modal-variation';
 
 // Track the checkout state for analytics.
 let analyticsData = {};
-let checkoutOpen = false;
+// Track the checkout intent to avoid multiple analytics events.
+let inCheckoutIntent = false;
 
 domReady( () => {
 	const modalCheckout = document.querySelector( `#${ MODAL_CHECKOUT_ID }` );
@@ -233,10 +234,10 @@ domReady( () => {
 				const formAnalyticsData = form.getAttribute( 'data-product' );
 				analyticsData = formAnalyticsData ? JSON.parse( formAnalyticsData ) : {};
 
-				// For the variation modal we will not set `checkoutOpen = true` and
+				// For the variation modal we will not set `inCheckoutIntent = true` and
 				// let the `opened` event get triggered once the user selects a
 				// variation so we track the selection.
-				if ( ! checkoutOpen ) {
+				if ( ! inCheckoutIntent ) {
 					manageOpened( analyticsData );
 				}
 
@@ -295,10 +296,10 @@ domReady( () => {
 		}
 
 		// Analytics.
-		if ( ! checkoutOpen ) {
+		if ( ! inCheckoutIntent ) {
 			manageOpened( analyticsData );
 		}
-		checkoutOpen = true;
+		inCheckoutIntent = true;
 
 		if (
 			typeof newspack_ras_config !== 'undefined' &&
@@ -404,7 +405,7 @@ domReady( () => {
 				onClose: () => {
 					// Analytics: Track a dismissal event (modal has been manually closed without completing the checkout).
 					manageDismissed( analyticsData );
-					checkoutOpen = false;
+					inCheckoutIntent = false;
 					document.getElementById( 'newspack_modal_checkout' ).removeAttribute( 'data-order-details' );
 				},
 				skipSuccess: true,
@@ -518,7 +519,7 @@ domReady( () => {
 					}
 				}
 				window?.newspackReaderActivation?.setPendingCheckout?.();
-				checkoutOpen = false;
+				inCheckoutIntent = false;
 			};
 
 			if ( window?.newspackReaderActivation?.openNewslettersSignupModal ) {
@@ -540,7 +541,7 @@ domReady( () => {
 
 			// Analytics: Track a dismissal event (modal has been manually closed without completing the checkout).
 			manageDismissed();
-			checkoutOpen = false;
+			inCheckoutIntent = false;
 			document.getElementById( 'newspack_modal_checkout' ).removeAttribute( 'data-order-details' );
 		}
 	};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1200530782742699-as-1208558693529961/f

When a reader starts the modal checkout they may get prompted to authenticate or register, which will not trigger the GA4 event to register the intent.

This PR, along with https://github.com/Automattic/newspack-plugin/pull/3481, implements that support.

Along with that:
 - Some variable names have also been updated for better readability.
 - Fixed the gtag integration within the checkout, which was being dequeued and unable to trigger the `form_submission` event

### How to test the changes in this Pull Request:

1. Checkout this branch and add the following to line 24 of `src/modal-checkout/analytics/ga4/utils/index.js` for easier testing:

```js
console.log({ eventName, payload });
```

2. In a fresh session, start a checkout button block flow
3. Confirm the `opened` event is logged in the console
4. Close the auth modal and confirm the `dismissed` event is logged in the console with the correct payload
5. Start the flow again and confirm it also triggers a new `opened` event (`checkoutOpen` changed to `false`)
6. Go through registration and confirm that opening the checkout does not trigger a new `opened` event
7. Purchase and confirm the `form_submission` event is triggered with the correct payload
8. Confirm that finishing the purchase flow will not trigger the `dismissed` event
9. Start the checkout flow for a variable subscription
10. Confirm that opening the variation modal triggers the `opened_variations` event
11. Select a variation and confirm the `opened` event is triggered
12. Close the modal and confirm `dismissed` is triggered
13. Click again and confirm `opened_variations` triggers again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
