### PR TITLE
fix: add select2 to whitelisted scripts

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -707,6 +707,7 @@ final class Modal_Checkout {
 			'wc_',
 			'wcs-',
 			'stripe',
+			'select2',
 		];
 
 		/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds Select2 to the allowed scripts in the modal checkout.

### How to test the changes in this Pull Request:

1. Run through a modal checkout with a physical product.
2. Note the appearance of the country/state dropdowns:

![CleanShot 2024-10-18 at 09 07 53](https://github.com/user-attachments/assets/e2bc2c12-d165-40f7-9d64-0c62105bbc7e)

3. Apply this PR.
4. Confirm that the dropdowns are styled correctly:

![CleanShot 2024-10-18 at 09 08 23](https://github.com/user-attachments/assets/2519ae81-3538-4e19-9654-f5eab9765c1b)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
