### PR TITLE
fix(ras-acc): apply terms and conditions styles

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -556,7 +556,7 @@
 				gap: 0;
 
 				input {
-					margin: 0 var(--newspack-ui-spacer-base, 8px) 0 0;
+					margin: 0 var(--newspack-ui-spacer-2, 12px) 0 0;
 				}
 				// Override checkout form terms and condition text.
 				.woocommerce-terms-and-conditions-checkbox-text {

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -531,6 +531,14 @@
 			color: var(--newspack-ui-color-neutral-60, colors.$newspack-ui-color-neutral-60);
 		}
 
+		.woocommerce-terms-and-conditions {
+			margin-top: var(--newspack-ui-spacer-5, 24px);
+
+			*:first-child {
+				margin-top: 0;
+			}
+		}
+
 		p.form-row {
 			background: var(--newspack-ui-color-neutral-5, #f7f7f7);
 			border-color: var(--newspack-ui-color-border, #ddd);

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -553,6 +553,7 @@
 				height: 20px;
 				margin: 0;
 				padding: 0;
+				gap: 0;
 
 				input {
 					margin: 0 var(--newspack-ui-spacer-base, 8px) 0 0;

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -505,13 +505,6 @@
 		font-family: var(--newspack-ui-font-family, system-ui);
 	}
 
-	// Override checkout form terms and condition text.
-	.woocommerce-terms-and-conditions-wrapper {
-		font-size: var(--newspack-ui-font-size-xs, 14px);
-		line-height: var(--newspack-ui-line-height-xs, 1.4286);
-		margin-bottom: 0;
-	}
-
 	// Errors
 	.woocommerce-invalid {
 		input,
@@ -529,33 +522,39 @@
 		}
 	}
 
-	// Privacy Policy
-	.woocommerce-privacy-policy-text {
-		color: var(--newspack-ui-color-neutral-60, colors.$newspack-ui-color-neutral-60);
-	}
-
 	// Terms and Conditions section
-	.woocommerce-terms-and-conditions {
-		background: var(--newspack-ui-color-neutral-5, #f7f7f7);
-		border-color: var(--newspack-ui-color-border, #ddd);
-		box-shadow: none;
-		margin-top: var(--newspack-ui-spacer-5, 24px);
-		padding: var(--newspack-ui-spacer-5, 24px);
+	.woocommerce-terms-and-conditions-wrapper {
+		margin-bottom: 0;
 
-		+ p.form-row {
+		// Privacy Policy
+		.woocommerce-privacy-policy-text {
+			color: var(--newspack-ui-color-neutral-60, colors.$newspack-ui-color-neutral-60);
+		}
+
+		p.form-row {
+			background: var(--newspack-ui-color-neutral-5, #f7f7f7);
+			border-color: var(--newspack-ui-color-border, #ddd);
+			box-shadow: none;
 			margin-top: var(--newspack-ui-spacer-5, 24px);
+			padding: var(--newspack-ui-spacer-5, 24px);
 
 			label {
-				display: block;
+				display: flex;
+				justify-content: flex-start;
+				align-items: center;
+				height: 20px;
 				margin: 0;
-				padding: 0 0 0 calc(var(--newspack-ui-spacer-4, 20px) + var(--newspack-ui-spacer-base, 8px)); // This is hacky but lets us pair the checkbox width + gap of normal checkboxes.
-				position: relative;
-			}
+				padding: 0;
 
-			input {
-				inset: 0 auto auto 0;
-				margin: 2px var(--newspack-ui-spacer-base, 8px) 0 0;
-				position: absolute;
+				input {
+					margin: 0 var(--newspack-ui-spacer-base, 8px) 0 0;
+				}
+				// Override checkout form terms and condition text.
+				.woocommerce-terms-and-conditions-checkbox-text {
+					font-size: var(--newspack-ui-font-size-xs, 14px);
+					line-height: var(--newspack-ui-line-height-xs, 1.4286);
+					margin-bottom: 0;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1208579907739880

Looks like our terms and conditions styles weren't being applied correctly because we were targeting invalid classnames and nested elements. This PR adjusts our checkout styles to correctly target this section.

**NOTE:** I'm making some assumptions about what this should look like based on the existing styles since I didn't see this checkbox in the Figma. Let me know if this should look differently!

Without T&C set:
![Screenshot 2024-10-18 at 13 49 25](https://github.com/user-attachments/assets/9cf1b5d6-4e1c-4e6f-bd09-78bf4b60e559)

With T&C set:
![Screenshot 2024-10-18 at 13 52 04](https://github.com/user-attachments/assets/98fb8e87-682c-409b-be5c-db927fd1539d)

### How to test the changes in this Pull Request:

1. Set up a terms and conditions page, then apply it in the customizer (WooCommerce > Checkout > Terms and conditions page)
2. As a reader, go through checkout and confirm the Terms and Conditions checkbox appears as shown in the 'With T&C set' screenshot above.
3. Remove the terms and conditions page via the customizer again
4. Repeat step 2, but this time confirm the Terms and Conditions checkbox appears as shown in the 'Without T&C set' screenshot above.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
