### PR TITLE
fix(ras-acc): handle recaptcha v2 errors

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -596,6 +596,8 @@
 
 	form.checkout .woocommerce-NoticeGroup,
 	.woocommerce .woocommerce-notices-wrapper {
+		scroll-margin-top: var(--newspack-ui-spacer-10, 64px);
+
 		li div {
 			display: block; // Overrides display: flex from theme with listed errors.
 		}

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -456,7 +456,10 @@ import { domReady } from './utils';
 						// Initiate reCAPTCHA, if available.
 						if ( newspack_grecaptcha?.render ) {
 							$form.data( 'newspack-recaptcha', 'newspack_modal_checkout' );
-							const onSuccess = () => $form.get( 0 ).scrollIntoView( true, { behavior: 'smooth' } );
+							const onSuccess = () => {
+								clearNotices();
+								$form.get( 0 ).scrollIntoView( { behavior: 'smooth' } );
+							}
 							const onError = ( error ) => handleFormError( error );
 							newspack_grecaptcha.render( $form.get(), onSuccess, onError );
 							// Refresh reCAPTCHAs on Woo checkout update and error.

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -252,7 +252,11 @@ import { domReady } from './utils';
 					 * of errors when only one field failed validation.
 					 */
 					if ( ! error_message.includes( '<li' ) ) {
-						handleErrorItem( $( error_message ) );
+						try {
+							handleErrorItem( $( error_message ) );
+						} catch {
+							handleErrorItem( $( '<p />' ).append( error_message ) );
+						}
 					} else {
 						const $errors = $( error_message );
 						$errors.find( 'li' ).each( function () {
@@ -260,15 +264,16 @@ import { domReady } from './utils';
 						} );
 					}
 
+					clearNotices();
+
 					// Handle generic errors.
 					if ( genericErrors.length ) {
 						$fieldToFocus = false; // Don't focus a field if validation returned generic errors.
-						$form.prepend(
-							$( '<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout"/>' ).append(
-								$( '<ul class="woocommerce-error" role="alert" />' ).append( genericErrors )
-							)
+						const $notices = $( '<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout"/>' ).append(
+							$( '<ul class="woocommerce-error" role="alert" />' ).append( genericErrors )
 						);
-						window.scroll( { top: 0, left: 0, behavior: 'smooth' } );
+						$form.prepend( $notices );
+						$notices.get( 0 ).scrollIntoView( { behavior: 'smooth' } );
 					}
 
 					if ( $fieldToFocus?.length ) {
@@ -450,7 +455,11 @@ import { domReady } from './utils';
 						// Initiate reCAPTCHA, if available.
 						if ( newspack_grecaptcha?.render ) {
 							$form.data( 'newspack-recaptcha', 'newspack_modal_checkout' );
-							newspack_grecaptcha.render( $form.get(), ( error ) => handleFormError( error ) );
+							newspack_grecaptcha.render(
+								$form.get(),
+								() => window.scroll( { top: 0, left: 0, behavior: 'smooth' } ),
+								( error ) => handleFormError( error )
+							);
 						}
 						if ( $coupon.length ) {
 							$coupon.show();

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -248,17 +248,14 @@ import { domReady } from './utils';
 
 					clearNotices();
 
-					/**
-					 * The new "wc-block-components-notice-banner" does not provide a <li />
-					 * of errors when only one field failed validation.
-					 */
-					if ( ! error_message.includes( '<li' ) ) {
-						try {
-							handleErrorItem( $( error_message ) );
-						} catch {
-							handleErrorItem( $( '<p />' ).append( error_message ) );
-						}
+					if ( error_message.indexOf( '<' ) !== 0 ) {
+						// If error_message is not an HTML string, wrap it in a <li />.
+						handleErrorItem( $( '<li />' ).append( error_message ) );
+					} else if ( ! error_message.includes( '<li' ) ) {
+						// If not a list, handle as a single error.
+						handleErrorItem( $( error_message ) );
 					} else {
+						// Handle multiple errors.
 						const $errors = $( error_message );
 						$errors.find( 'li' ).each( function () {
 							handleErrorItem( $( this ) );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1208344705374759/f

Part of https://github.com/Automattic/newspack-plugin/pull/3489.

This PR fixes how we handle recaptcha v2 errors. The recaptcha script currently returns a string error which our blocks script seems to not handle correctly. To fix this, we add a try/catch when handling the error message and if jquery fails to convert the string to a jquery object, we append it to a paragraph instead. We also add new onSuccess and onError callbacks to the recaptcha render call to handle rendering the recaptcha error and scrolling on success.

![Screenshot 2024-10-21 at 17 06 55](https://github.com/user-attachments/assets/46f71149-9f60-4dd8-a329-5401cea5876d)

### How to test the changes in this Pull Request:

BEFORE TESTING BE SURE TO CHECKOUT https://github.com/Automattic/newspack-plugin/pull/3489 AS WELL

**Recaptcha V2**
1. As admin enable recaptcha v2 via Newspack > Connections > reCAPTCHA
2. Temporarily comment out [this line](https://github.com/Automattic/newspack-plugin/blob/f9d4c5389ff6d1824844e64f91a70932efe0ecca/src/other-scripts/recaptcha/index.js#L171) and replace it with `onError?.( 'There was an error with reCAPTCHA. Please try again.' )` (and build) to force a v2 error.
3. As a reader, go through the checkout flow via any checkout or donation button on the site
4. Confirm you see a checkout form error appear with the message hardcoded from step 2 above.
5. Revert the change you made in step 2
6. Smoke test the following flows:
  - Registration flow via signin button in site header
  - Checkout flow as logged in reader
  - Registration + Checkout flow as new reader via any checkout or donation button

**Recaptcha V3**
1. As admin enable recaptcha v3 via Newspack > Connections > reCAPTCHA
2. Smoke test the following flows:
  - Registration flow via signin button in site header
  - Checkout flow as logged in reader
  - Registration + Checkout flow as new reader via any checkout or donation button

**No Recaptcha**
1. As admin disable recaptcha altogether via Newspack > Connections > reCAPTCHA
2. Smoke test the following flows:
  - Registration flow via signin button in site header
  - Checkout flow as logged in reader
  - Registration + Checkout flow as new reader via any checkout or donation button

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
