### PR TITLE
fix: let "Cover fees" checkbox work with any payment method

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -551,12 +551,13 @@ final class Modal_Checkout {
 		}
 
 		$custom_templates = [
-			'checkout/form-checkout.php' => 'src/modal-checkout/templates/checkout-form.php',
-			'checkout/form-billing.php'  => 'src/modal-checkout/templates/billing-form.php',
-			'checkout/thankyou.php'      => 'src/modal-checkout/templates/thankyou.php',
+			'checkout/form-checkout.php'  => 'src/modal-checkout/templates/checkout-form.php',
+			'checkout/form-billing.php'   => 'src/modal-checkout/templates/billing-form.php',
+			'checkout/payment-method.php' => 'src/modal-checkout/templates/payment-method.php',
+			'checkout/thankyou.php'       => 'src/modal-checkout/templates/thankyou.php',
 			// Replace the login form with the order summary if using the modal checkout. This is
 			// for the case where the reader used an existing email address.
-			'global/form-login.php'      => 'src/modal-checkout/templates/thankyou.php',
+			'global/form-login.php'       => 'src/modal-checkout/templates/thankyou.php',
 		];
 
 		foreach ( $custom_templates as $original_template => $custom_template ) {

--- a/src/modal-checkout/templates/payment-method.php
+++ b/src/modal-checkout/templates/payment-method.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Payment method fields
+ *
+ * @see https://woo.com/document/template-structure/
+ * @package Newspack_Blocks
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+
+<li class="wc_payment_method payment_method_<?php echo esc_attr( $gateway->id ); ?>">
+	<input id="payment_method_<?php echo esc_attr( $gateway->id ); ?>" type="radio" class="input-radio" name="payment_method" value="<?php echo esc_attr( $gateway->id ); ?>" <?php checked( $gateway->chosen, true ); ?> data-order_button_text="<?php echo esc_attr( $gateway->order_button_text ); ?>" />
+
+	<label for="payment_method_<?php echo esc_attr( $gateway->id ); ?>">
+		<?php echo wp_kses_post( $gateway->get_title() ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?> <?php echo $gateway->get_icon(); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?>
+	</label>
+	<?php if ( $gateway->has_fields() || $gateway->get_description() ) : ?>
+		<div class="payment_box payment_method_<?php echo esc_attr( $gateway->id ); ?>" <?php if ( ! $gateway->chosen ) : /* phpcs:ignore Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace */ ?>style="display:none;"<?php endif; /* phpcs:ignore Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace */ ?>>
+			<?php $gateway->payment_fields(); ?>
+			<?php do_action( 'newspack_blocks_after_payment_fields', $gateway->id ); ?>
+		</div>
+	<?php endif; ?>
+</li>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a custom payment fields checkout template for Woo. The only change in this template is to add a new action hook after the payment fields for each payment method. Supports changes in https://github.com/Automattic/newspack-plugin/pull/3491.

### How to test the changes in this Pull Request:

See testing instructions in https://github.com/Automattic/newspack-plugin/pull/3491

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
