### PR TITLE
fix: add check if product can be purchased

### DIFF
--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -100,7 +100,9 @@ function ProductControl( props ) {
 			.then( products => {
 				const _suggestions = {};
 				products.forEach( product => {
-					_suggestions[ product.id ] = `${ product.id }: ${ product.name }`;
+					if ( product.purchasable ) {
+						_suggestions[ product.id ] = `${ product.id }: ${ product.name }`;
+					}
 				} );
 				setSuggestions( _suggestions );
 			} )

--- a/src/blocks/checkout-button/view.php
+++ b/src/blocks/checkout-button/view.php
@@ -34,11 +34,27 @@ function render_callback( $attributes, $content ) {
 	}
 	$product_id = $attributes['product'];
 
-	// Check if product can actually be purchased before rendering.
 	if ( function_exists( 'wc_get_product' ) ) {
 		$product = wc_get_product( $product_id );
+
+		// Check if product can actually be purchased before rendering.
 		if ( ! $product || ! $product->is_purchasable() ) {
 			return '';
+		}
+
+		// Check if product is NYP with no prices set at all.
+		if ( class_exists( '\WC_Name_Your_Price_Helpers' ) && \WC_Name_Your_Price_Helpers::is_nyp( $product_id ) ) {
+			$price = $product->get_price();
+			if ( ! empty( $attributes['price'] ) ) {
+				// Default to the price set in the block attributes.
+				$price = $attributes['price'];
+			}
+
+			$suggested_price = \WC_Name_Your_Price_Helpers::get_suggested_price( $product_id );
+			$minimum_price   = \WC_Name_Your_Price_Helpers::get_minimum_price( $product_id );
+			if ( empty( $price ) && empty( $suggested_price ) && empty( $minimum_price ) ) {
+				return '';
+			}
 		}
 	}
 

--- a/src/blocks/checkout-button/view.php
+++ b/src/blocks/checkout-button/view.php
@@ -33,9 +33,19 @@ function render_callback( $attributes, $content ) {
 		return '';
 	}
 	$product_id = $attributes['product'];
+
+	// Check if product can actually be purchased before rendering.
+	if ( function_exists( 'wc_get_product' ) ) {
+		$product = wc_get_product( $product_id );
+		if ( ! $product || ! $product->is_purchasable() ) {
+			return '';
+		}
+	}
+
 	if ( $attributes['is_variable'] && ! empty( $attributes['variation'] ) ) {
 		$product_id = $attributes['variation'];
 	}
+
 	\Newspack_Blocks\Modal_Checkout::enqueue_modal( $product_id );
 	\Newspack_Blocks::enqueue_view_assets( 'checkout-button' );
 	return $content;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR uses WooCommerce's `purchaseable` check to see if a product can be purchased before it can be assigned to a Checkout Button block, or before the Checkout Button block is rendered on the front-end.

This change is to fix an edge case where you can assign a price-less product to the Checkout Button block, which causes the modal checkout to throw an error. Some products -- like NYP products -- don't seem to throw the same error even if they don't have a suggested or minimum price set; using the `purchaseable` check seems to account for this but I'd definitely appreciate thoughts about this approach!

See 1207817176293825-as-1208327956169322

### How to test the changes in this Pull Request:

1. Set up a few different products, including:
   * A regular simple product with a price.
   * A product with variations with prices.
   * A simple product without a price.
   * A product with variations, at least one without a price.
   * A regular NYP product, with a minimum or suggested price.
   * A NYP product without a minimum and suggested price.
2. View the /shop page, and confirm that some of your products can't be purchased (they should include a link to the individual product screen, but no purchase button). This should just be your product with no price, unless I've messed up a test case. 
3. Set up a checkout button block for each. Note that you can do this with the product without a price, but it will throw an error on the front-end about subscriptions, or just return a button:

![CleanShot 2024-10-21 at 15 17 43](https://github.com/user-attachments/assets/0ac892c3-2d14-476a-a219-b05938bc549a)

4. Apply this PR and run `npm run build`.
5. On a new page, try to add a checkout button block for each product. Note your price-less product won't be returned when you search for products in the sidebar. 
6. On the old page, confirm that the price-less product is still in the editor, but no longer renders on the front-end. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
