### PR TITLE
fix: add styles for create account checkmark

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -183,6 +183,14 @@
 		}
 	}
 
+	// Create an account
+	.woocommerce-account-fields .create-account label:has(input[type="checkbox"]) {
+		display: grid;
+		gap: 0 var(--newspack-ui-spacer-base, 8px);
+		grid-template-columns: var(--newspack-ui-spacer-4, 20px) 1fr;
+		margin: var(--newspack-ui-spacer-5, 24px) 0 0;
+	}
+
 	// Name Your Price styles
 	.name-your-price {
 		margin-bottom: var(--newspack-ui-spacer-5, 24px);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a minor display issue that happens with the modal checkout when RAS is not enabled. 

See 1207817176293825-as-1208560808613909

### How to test the changes in this Pull Request:

1. Disable RAS on your test site by running `wp option delete newspack_reader_activation_enabled`.
2. Under your WooCommerce settings, make sure readers can create an account on checkout -- these are the exact settings I used under WooCommerce > Settings > Accounts & Privacy:

![image](https://github.com/user-attachments/assets/d5feebbc-c99c-4873-b482-13b573cbe513)

3. In an incognito window, run through a checkout using the modal checkout and a non-subscription product (since subscriptions will create accounts without asking). Note the appearance of the checkbox on the bottom of the first screen:

![CleanShot 2024-10-22 at 10 49 54](https://github.com/user-attachments/assets/9e4028ee-9dad-4512-8a7d-683bd9be7f5f)

4. Apply this PR and run `npm run build`.
5. Confirm that the Create Account checkbox looks okay:

![CleanShot 2024-10-22 at 10 48 21](https://github.com/user-attachments/assets/a7acd157-59ba-4f2a-a76f-aa6f0e059f42)

6. As a bonus, test with a product that has shipping so you see the Ship to a Different Address prompt, and confirm that the spacing looks okay:

![CleanShot 2024-10-22 at 10 46 30](https://github.com/user-attachments/assets/c4212880-6a40-46df-ba9b-5f4b33530ab6)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
