### PR TITLE
Enqueue carousel style when caching

### DIFF
--- a/includes/class-newspack-blocks-caching.php
+++ b/includes/class-newspack-blocks-caching.php
@@ -210,7 +210,11 @@ class Newspack_Blocks_Caching {
 			return $block_html;
 		}
 
-		Newspack_Blocks::enqueue_view_assets( 'homepage-articles' );
+		if ( 'newspack-blocks/homepage-articles' === $block_data['blockName'] ) {
+			Newspack_Blocks::enqueue_view_assets( 'homepage-articles' );
+		} elseif ( 'newspack-blocks/carousel' === $block_data['blockName'] ) {
+			Newspack_Blocks::enqueue_view_assets( 'carousel' );
+		}
 
 		return $cached_data['cached_content'];
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**Note: This is a hotfix PR**

This PR fixes an issue we've encountered during the rollout of block caching. We enqueue the assets for the homepage posts block when serving a cached version, but we do not enqueue the assets for a carousel block when serving a cached version.

### How to test the changes in this Pull Request:

1. Enable posts block caching with the constant and have an object cache. Add a carousel to a post or page.
2. Refresh the page a couple times so that all of the caches are primed and the carousel serves from the cache. Observe it's an unstyled tower of posts:

<img width="184" alt="Screenshot 2024-10-22 at 11 28 48 AM" src="https://github.com/user-attachments/assets/db0cd366-9022-4e79-88e5-531326a0dc24">

3. Apply this PR. Refresh the page. Observe it's a nice carousel again:

<img width="522" alt="Screenshot 2024-10-22 at 11 30 32 AM" src="https://github.com/user-attachments/assets/cd9044b0-3a32-442e-8154-af0f1e3a0c12">
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
