### PR TITLE
fix: update block classes for the site editor

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -134,34 +134,34 @@ function newspack_blocks_get_homepage_articles_css_string( $attrs ) {
 
 	ob_start();
 	?>
-		.wpnbha article .entry-title {
+		.wp-block-newspack-blocks-homepage-articles article .entry-title {
 			font-size: 1.2em;
 		}
-		.wpnbha .entry-meta {
+		.wp-block-newspack-blocks-homepage-articles .entry-meta {
 			display: flex;
 			flex-wrap: wrap;
 			align-items: center;
 			margin-top: 0.5em;
 		}
-		.wpnbha article .entry-meta {
+		.wp-block-newspack-blocks-homepage-articles article .entry-meta {
 			font-size: 0.8em;
 		}
-		.wpnbha article .avatar {
+		.wp-block-newspack-blocks-homepage-articles article .avatar {
 			height: 25px;
 			width: 25px;
 		}
-		.wpnbha .post-thumbnail{
+		.wp-block-newspack-blocks-homepage-articles .post-thumbnail{
 			margin: 0;
 			margin-bottom: 0.25em;
 		}
-		.wpnbha .post-thumbnail img {
+		.wp-block-newspack-blocks-homepage-articles .post-thumbnail img {
 			height: auto;
 			width: 100%;
 		}
-		.wpnbha .post-thumbnail figcaption {
+		.wp-block-newspack-blocks-homepage-articles .post-thumbnail figcaption {
 			margin-bottom: 0.5em;
 		}
-		.wpnbha p {
+		.wp-block-newspack-blocks-homepage-articles p {
 			margin: 0.5em 0;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR switches some CSS classes from `wpnbha` to the full `wp-block-newspack-blocks-homepage-articles`; [the lack of the `wp-block` prefix](https://developer.wordpress.org/reference/hooks/enqueue_block_editor_assets/#user-contributed-notes) was causing some styles to get stripped from the Site Editor.

This only seems to affect the styles loaded [here](https://github.com/Automattic/newspack-blocks/blob/cbe0cdb805354ae9dea6c0c35659d401198a30c2/src/blocks/homepage-articles/editor.js#L19-L27) and not the regular SCSS.

Closes #1826 and see 1200550061930446-as-1208594353528752

### How to test the changes in this Pull Request:

1. Start with a block theme like Twenty Twenty Four (don't use the Newspack Block theme because it has some CSS in it that hides this issue).
2. Add a homepage posts block to the footer template part, and set it to 'Grid' layout.
3. Note the oversized images you get in the Site Editor; if you have a post with more than one you'll also get a weird overlap:

![CleanShot 2024-10-22 at 12 41 27](https://github.com/user-attachments/assets/99d45dee-72c6-48cb-9b59-e066effe3460)

4. Apply this PR.
5. Confirm the images look as expected in the Site Editor:

![CleanShot 2024-10-22 at 12 40 05](https://github.com/user-attachments/assets/df7c036d-a3bd-4277-a339-8fe3c2850c60)

6. Confirm a block with the same settings in the regular page editor or on the front end looks okay.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
