### PR TITLE
fix(modal-checkout): disable Continue button until JS is loaded

### DIFF
--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -28,6 +28,7 @@ function domReady( callback ) {
 domReady( () => {
 	const continueButton = document.querySelector( '.modal-continue' );
 	if ( continueButton ) {
+		continueButton.removeAttribute( 'disabled' );
 		continueButton.addEventListener( 'click', () => {
 			const form = document.querySelector( 'form.checkout' );
 			form.submit();

--- a/src/modal-checkout/templates/checkout-form.php
+++ b/src/modal-checkout/templates/checkout-form.php
@@ -101,7 +101,7 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 		<?php if ( $edit_billing ) : ?>
 			<div class="checkout-billing">
 				<?php do_action( 'woocommerce_checkout_billing' ); ?>
-				<button type="button" class="button alt wp-element-button modal-continue"><?php esc_html_e( 'Continue', 'newspack-blocks' ); ?></button>
+				<button type="button" class="button alt wp-element-button modal-continue" disabled><?php esc_html_e( 'Continue', 'newspack-blocks' ); ?></button>
 			</div>
 		<?php else : ?>
 			<div class="checkout-billing checkout-billing-summary">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In modal checkout, the "Continue" button is enabled by default, but it will have no effect until JS is loaded. This PR makes it disabled until the relevant JS is loaded. 

### How to test the changes in this Pull Request:

1. On `trunk`, initiate a donation (only click the "Donate" button) and visit `/checkout/?modal_checkout=1`
2. In the Network tab of devtools, block the request to `modalCheckout.js`
3. Refresh the page, observe the button is enabled, but nothing happens on click
4. Switch to this branch, reload the page, observe the button is disabled
5. Disable network request blocking, refresh the page, observe the button is enabled as soon as JS loads

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->