### PR TITLE
fix: override some common Custom CSS issues

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -2,6 +2,7 @@
 
 // stylelint-disable-next-line selector-id-pattern
 #newspack_modal_checkout_container {
+	background: var(--newspack-ui-color-neutral-0, #fff);
 	padding: var(--newspack-ui-spacer-5, 24px);
 
 	form p {
@@ -322,7 +323,7 @@
 					label {
 						font-size: var(--newspack-ui-font-size-xs, 14px);
 						font-weight: normal;
-						line-height: var(--newspack-ui-line-height-xs, 1.4286);
+						line-height: inherit;
 					}
 
 					input {
@@ -551,6 +552,8 @@
 			background: var(--newspack-ui-color-neutral-5, #f7f7f7);
 			border-color: var(--newspack-ui-color-border, #ddd);
 			box-shadow: none;
+			font-size: var(--newspack-ui-font-size-xs, 14px);
+			line-height: var(--newspack-ui-line-height-xs, 1.4286);
 			margin-top: var(--newspack-ui-spacer-5, 24px);
 			padding: var(--newspack-ui-spacer-5, 24px);
 

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -464,6 +464,7 @@
 		// WooPayments test credit card number
 		.js-woopayments-copy-test-number {
 			font-size: inherit;
+			font-style: inherit;
 			font-weight: normal;
 			line-height: var(--newspack-ui-line-height-xs, 1.4286);
 			padding: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This ended up being a pretty minor PR, but along with https://github.com/Automattic/newspack-plugin/pull/3496 it fixes some issues I noticed when testing RAS-ACC against the Custom CSS from 20 of our publisher sites. 

I skipped a couple of the more opinionated issues (like styles that use `!important`) so this doesn't cover all the issues I ran into, only the ones that seemed less intentional/less super specific.

### How to test the changes in this Pull Request:

1. Copy the following CSS into the Additional CSS field in the Customizer -- it captures snippets of CSS that caused issues that these PRs fix.

```
h1, h2, h3, h4, h5, h6 {
	letter-spacing: 0.02em;
	text-transform: uppercase;
}

body {
	background-color: #FCF9F3;
}

.wp-block-button__link:not(.has-background),
.button, 
button, 
input[type="button"],
input[type="reset"], 
input[type="submit"], 
.wp-block-search__button-outside .wp-block-search__button {
	font-style: italic;
}

p,
li {
	font-size: 16px;
	line-height: 24px;
}

```

2. On the front-end, test a purchase flow as a not-logged in user. You'll notice some issues like:
    * Odd headings
    * Italicized buttons
    * A beige background on the modal checkout
    * Too-large footer disclaimer text.
![CleanShot 2024-10-23 at 17 02 04](https://github.com/user-attachments/assets/027e099b-ee42-4f36-a31f-5234c72fc2c5)

![CleanShot 2024-10-23 at 17 01 31](https://github.com/user-attachments/assets/557aeef1-9e03-455c-9558-d99cdb7b22cd)


3. Apply this PR and https://github.com/Automattic/newspack-plugin/pull/3496 and run `npm run build` in both.
4. Confirm that the odd issues noted above have been fixed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
