### PR TITLE
fix(modal-checkout): empty cart when modal checkout is abandoned

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -316,7 +316,7 @@ final class Modal_Checkout {
 	 * Process abandon checkout for modal.
 	 */
 	public static function process_abandon_checkout() {
-		if ( is_admin() || ! defined( 'DOING_AJAX' ) ) {
+		if ( ! defined( 'DOING_AJAX' ) ) {
 			return;
 		}
 
@@ -324,7 +324,7 @@ final class Modal_Checkout {
 			return;
 		}
 
-		if ( ! check_ajax_referer( 'newspack_modal_checkout_nonce', 'security', false ) ) {
+		if ( ! check_ajax_referer( 'newspack_modal_checkout_nonce' ) ) {
 			wp_send_json_error( [ 'message' => __( 'Invalid nonce.', 'newspack-blocks' ) ] );
 			wp_die();
 		}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -688,6 +688,7 @@ final class Modal_Checkout {
 			[
 				'ajax_url'              => admin_url( 'admin-ajax.php' ),
 				'nyp_nonce'             => wp_create_nonce( 'newspack_checkout_name_your_price' ),
+				'checkout_nonce'        => wp_create_nonce( 'newspack_modal_checkout_nonce' ),
 				'newspack_class_prefix' => self::get_class_prefix(),
 				'is_checkout_complete'  => function_exists( 'is_order_received_page' ) && is_order_received_page(),
 				'divider_text'          => esc_html__( 'Or', 'newspack-blocks' ),
@@ -798,7 +799,6 @@ final class Modal_Checkout {
 			'newspackBlocksModal',
 			[
 				'ajax_url'                   => admin_url( 'admin-ajax.php' ),
-				'checkout_nonce'             => wp_create_nonce( 'newspack_modal_checkout_nonce' ),
 				'checkout_registration_flag' => self::CHECKOUT_REGISTRATION_FLAG,
 				'newspack_class_prefix'      => self::get_class_prefix(),
 				'labels'                     => [

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -164,7 +164,7 @@ domReady( () => {
 		const body = new FormData();
 		body.append( 'modal_checkout', '1' );
 		body.append( 'action', 'abandon_modal_checkout' );
-		body.append( 'security', newspackBlocksModal.checkout_nonce );
+		body.append( '_wpnonce', newspackBlocksModal.checkout_nonce );
 		fetch(
 			newspackBlocksModal.ajax_url,
 			{

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -158,6 +158,23 @@ domReady( () => {
 	}
 
 	/**
+	 * Empty cart via ajax.
+	 */
+	const emptyCart = () => {
+		const body = new FormData();
+		body.append( 'modal_checkout', '1' );
+		body.append( 'action', 'abandon_modal_checkout' );
+		body.append( 'security', newspackBlocksModal.checkout_nonce );
+		fetch(
+			newspackBlocksModal.ajax_url,
+			{
+				method: 'POST',
+				body,
+			}
+		);
+	}
+
+	/**
 	 * Handle checkout form submit.
 	 *
 	 * @param {Event} ev
@@ -542,7 +559,8 @@ domReady( () => {
 			}
 		} else {
 			window?.newspackReaderActivation?.setPendingCheckout?.();
-
+			// Empty the cart if the checkout was not completed.
+			emptyCart();
 			// Analytics: Track a dismissal event (modal has been manually closed without completing the checkout).
 			manageDismissed();
 			inCheckoutIntent = false;

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -164,7 +164,7 @@ domReady( () => {
 		const body = new FormData();
 		body.append( 'modal_checkout', '1' );
 		body.append( 'action', 'abandon_modal_checkout' );
-		body.append( '_wpnonce', newspackBlocksModal.checkout_nonce );
+		body.append( '_wpnonce', iframe?.contentWindow?.newspackBlocksModalCheckout?.checkout_nonce );
 		fetch(
 			newspackBlocksModal.ajax_url,
 			{
@@ -500,9 +500,15 @@ domReady( () => {
 		);
 		const hasNewsletterPopup = document?.querySelector( '.newspack-newsletters-signup-modal' );
 
+		// Empty cart if checkout is not complete.
+		// We grab the nonce from the iframe content window to ensure the nonce was generated for a logged in session
+		// so we need to call this before closing and resetting the iframe.
+		if ( ! container?.checkoutComplete && iframe?.contentWindow?.newspackBlocksModalCheckout ) {
+			emptyCart();
+		}
+
 		// We want to block closing the modal if redirecting elsewhere:
 		const shouldCloseModal = ! afterSuccessUrlInput || ! afterSuccessBehaviorInput || ! container?.checkoutComplete;
-
 		if ( shouldCloseModal || hasNewsletterPopup ) {
 			spinner.style.display = 'flex';
 			if ( iframe && modalContent.contains( iframe ) ) {
@@ -559,8 +565,6 @@ domReady( () => {
 			}
 		} else {
 			window?.newspackReaderActivation?.setPendingCheckout?.();
-			// Empty the cart if the checkout was not completed.
-			emptyCart();
 			// Analytics: Track a dismissal event (modal has been manually closed without completing the checkout).
 			manageDismissed();
 			inCheckoutIntent = false;


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1208620127411764/f

This PR adds an ajax request to empty cart when modal checkout is abandoned.

![Screenshot 2024-10-24 at 12 32 08](https://github.com/user-attachments/assets/6b1a0ee1-2ebd-4565-9c81-06e4c5e01ecf)

### How to test the changes in this Pull Request:

1. Via any checkout or donate button open modal checkout as a reader
2. In another tab (in the same session) open the cart page `test.site/cart`
3. Verify the item is present in the cart
4. Back in the modal checkout tab, close the checkout modal without completing checkout
5. Go back to the cart tab. On `epic/ras-acc` the item will still be present. On this branch, the cart should be empty.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
