### PR TITLE
fix: revert check for is product purchaseable

### DIFF
--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -100,9 +100,7 @@ function ProductControl( props ) {
 			.then( products => {
 				const _suggestions = {};
 				products.forEach( product => {
-					if ( product.purchasable ) {
-						_suggestions[ product.id ] = `${ product.id }: ${ product.name }`;
-					}
+					_suggestions[ product.id ] = `${ product.id }: ${ product.name }`;
 				} );
 				setSuggestions( _suggestions );
 			} )

--- a/src/blocks/checkout-button/view.php
+++ b/src/blocks/checkout-button/view.php
@@ -33,35 +33,9 @@ function render_callback( $attributes, $content ) {
 		return '';
 	}
 	$product_id = $attributes['product'];
-
-	if ( function_exists( 'wc_get_product' ) ) {
-		$product = wc_get_product( $product_id );
-
-		// Check if product can actually be purchased before rendering.
-		if ( ! $product || ! $product->is_purchasable() ) {
-			return '';
-		}
-
-		// Check if product is NYP with no prices set at all.
-		if ( class_exists( '\WC_Name_Your_Price_Helpers' ) && \WC_Name_Your_Price_Helpers::is_nyp( $product_id ) ) {
-			$price = $product->get_price();
-			if ( ! empty( $attributes['price'] ) ) {
-				// Default to the price set in the block attributes.
-				$price = $attributes['price'];
-			}
-
-			$suggested_price = \WC_Name_Your_Price_Helpers::get_suggested_price( $product_id );
-			$minimum_price   = \WC_Name_Your_Price_Helpers::get_minimum_price( $product_id );
-			if ( empty( $price ) && empty( $suggested_price ) && empty( $minimum_price ) ) {
-				return '';
-			}
-		}
-	}
-
 	if ( $attributes['is_variable'] && ! empty( $attributes['variation'] ) ) {
 		$product_id = $attributes['variation'];
 	}
-
 	\Newspack_Blocks\Modal_Checkout::enqueue_modal( $product_id );
 	\Newspack_Blocks::enqueue_view_assets( 'checkout-button' );
 	return $content;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR reverts https://github.com/Automattic/newspack-blocks/pull/1916. 

That change introduced some unintended consequences, like buttons not appearing once a reader had purchased the membership product they were selling.

This needs to be reworked to focus on the lack of price (the underlying issue), and not a generic "is purchasable" check because that's not quite the same thing -- I'll work on that in the RAS-ACC branch.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Confirm you can add checkout button blocks, even for products without prices. 
3. Spot check against the code changes in https://github.com/Automattic/newspack-blocks/pull/1916.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
