### PR TITLE
fix: rework approach of removing invalid products from Checkout Block

### DIFF
--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -92,6 +92,7 @@ function ProductControl( props ) {
 	const [ suggestions, setSuggestions ] = useState( {} );
 	const [ selected, setSelected ] = useState( false );
 	const [ isChanging, setIsChanging ] = useState( false );
+
 	function fetchSuggestions( search ) {
 		setInFlight( true );
 		return apiFetch( {
@@ -100,7 +101,7 @@ function ProductControl( props ) {
 			.then( products => {
 				const _suggestions = {};
 				products.forEach( product => {
-					if ( product.purchasable ) {
+					if ( '' !== product.price || getNYP( product ).isNYP ) { // Variable products will populate price with one of the variations prices.
 						_suggestions[ product.id ] = `${ product.id }: ${ product.name }`;
 					}
 				} );
@@ -200,12 +201,20 @@ function CheckoutButtonEdit( props ) {
 
 	function handleProduct( data ) {
 		setProductData( data );
-
 		// Handle product variation data.
 		if ( data?.variations?.length ) {
 			setAttributes( { is_variable: true } );
 			apiFetch( { path: `/wc/v2/products/${ data.id }/variations?per_page=100` } )
-				.then( res => setVariations( res ) )
+				.then( res => {
+					// Remove any variations without prices set.
+					const priced_variations = [];
+					res.forEach( re => {
+						if ( '' !== re.price || getNYP( re ).isNYP ) {
+							priced_variations.push( re );
+						}
+					} );
+					setVariations( priced_variations );
+				} )
 				.catch( () => setVariations( [] ) );
 		} else {
 			setAttributes( { is_variable: false } );

--- a/src/blocks/checkout-button/view.php
+++ b/src/blocks/checkout-button/view.php
@@ -115,14 +115,16 @@ function render_callback( $attributes ) {
 		// Get the product type.
 		$product_type = \Newspack_Blocks\Tracking\Data_Events::get_product_type( $product_id );
 
-		$name  = $product->get_name();
-		$price = $product->get_price();
+		$name   = $product->get_name();
+		$price  = $product->get_price();
+		$is_nyp = false;
 		if ( ! empty( $attributes['price'] ) ) {
 			// Default to the price set in the block attributes.
 			$price = $attributes['price'];
 		} elseif ( class_exists( '\WC_Name_Your_Price_Helpers' ) && \WC_Name_Your_Price_Helpers::is_nyp( $product_id ) ) {
 			// Use suggested price if NYP is active and set for variation.
-			$price = \WC_Name_Your_Price_Helpers::get_suggested_price( $product_id );
+			$price  = \WC_Name_Your_Price_Helpers::get_suggested_price( $product_id );
+			$is_nyp = true;
 		}
 
 		$is_variable           = $attributes['is_variable'];
@@ -158,7 +160,7 @@ function render_callback( $attributes ) {
 		}
 
 		// Check if the button should be output: it needs a price, or needs to be a product with variations to pick.
-		if ( ( ! $is_variable && ! $variation_id && ! $price ) || ( $variation_id && ! $price ) ) {
+		if ( ( ! $is_variable && ! $variation_id && ! $price && ! $is_nyp ) || ( $variation_id && ! $price && ! $is_nyp ) ) {
 			return '';
 		}
 

--- a/src/blocks/checkout-button/view.php
+++ b/src/blocks/checkout-button/view.php
@@ -103,8 +103,7 @@ function render_callback( $attributes ) {
 	// Generate the form.
 	if ( function_exists( 'wc_get_product' ) ) {
 		$product = wc_get_product( $product_id );
-		// Check if product can actually be purchased before rendering.
-		if ( ! $product || ! $product->is_purchasable() ) {
+		if ( ! $product ) {
 			return '';
 		}
 
@@ -143,7 +142,7 @@ function render_callback( $attributes ) {
 			'product_id'   => $product_id,
 			'product_type' => $product_type,
 			'recurrence'   => $recurrence,
-			'referrer'     => substr( \get_permalink(), strlen( home_url() ) ), // TODO: Is this OK?
+			'referrer'     => substr( \get_permalink(), strlen( home_url() ) ),
 		];
 
 		if ( ! $is_variable || $variation_id ) {
@@ -156,7 +155,11 @@ function render_callback( $attributes ) {
 			$product_data['product_id']   = $product->get_parent_id(); // Reset Product ID as parent ID.
 			$product_data['product_type'] = \Newspack_Blocks\Tracking\Data_Events::get_product_type( $product->get_parent_id() );
 			$product_data['variation_id'] = $product_id; // Overwrite us setting the product ID as the variation ID.
+		}
 
+		// Check if the button should be output: it needs a price, or needs to be a product with variations to pick.
+		if ( ( ! $is_variable && ! $variation_id && ! $price ) || ( $variation_id && ! $price ) ) {
+			return '';
 		}
 
 		$form = sprintf(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR uses a different approach to add a check for whether a product should be useable with the Checkout Button block. 

On the front-end, the criteria is:
* The product need to be a variable product without a variation pre-selected, OR
* The product needs to have a price set (whether it's a regular product, or a variable product with variation selected), OR
* The product needs to be a NYP product. 

If products don't match, the button won't be visible on the front-end.

On the backend, the criteria for the Product selector is:
* The product needs to have a price set, OR
* The product needs to be a variable product, OR
* The product needs to be set to NYP.

If products don't match, they won't show up as suggestions for future buttons.

On the backend, the criteria for the variation selector is:
* The variation needs to have a price, OR
* The variation needs to be set to NYP.

If variations don't match, they won't show up as suggestions for future buttons. (Right now if a variation doesn't have a price, it won't show up in the variation picker step of the modal checkout).

See: 1207817176293825-as-1208327956169322

### How to test the changes in this Pull Request:

1. Set up a bunch of different products. These include:
* A simple product with a price
* A simple product without a price
* A NYP product with no prices set
* A NYP product with at least one price (suggested or minimum)
* A variable product with at least one NYP variation, and at least one variation without a price.
2. Prior to applying this PR, try adding once of each to a page. For the variable product, add two buttons, one that allows readers to pick the variation, and one with the variation set to the option without a price.
3. Apply this PR and run `npm run build`.
4. On the front-end, confirm the buttons assigned to price-less products (the simple product without a price, and the variable product set to a price-less variation) don't appear.
5. Create a new page. 
6. Repeat step 2; confirm that when you try to assign price-less product to a button, it doesn't show up in the search.
7. Confirm the NYP button without prices shows up in the search.
8. When you add your product with variations and try to assign a specific variation, confirm that the variation without a price doesn't appear, but that the NYP one does. 
9. Publish your page; confirm that all of the newly added buttons appear.
10. Smoke test other product types and settings, like subscriptions, sale prices, free trials...
11. Let me know if you think I'm missing anything!!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
