### PR TITLE
fix(hpb-caching): include last-modified timestamp in the cache group

### DIFF
--- a/includes/class-newspack-blocks-caching.php
+++ b/includes/class-newspack-blocks-caching.php
@@ -137,10 +137,11 @@ class Newspack_Blocks_Caching {
 	 */
 	protected static function get_cache_group() {
 		if ( is_singular() || is_front_page() ) {
-			$post_type        = get_post_type();
+			$post_type = get_post_type();
+			$last_modified = get_post_modified_time( 'U', true );
 			$post_type_object = get_post_type_object( $post_type );
 			if ( ! $post_type_object->publicly_queryable ) {
-				return sprintf( self::CACHE_GROUP . '-post-%d', get_the_ID() );
+				return sprintf( self::CACHE_GROUP . '-post-%d-%d', get_the_ID(), $last_modified );
 			}
 			return self::CACHE_GROUP;
 		} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The blocks are cached for five minutes and there is no way of invalidating this cache. This change will invalidate the cache if the page containing the block has been modified.

Especially looking for @claudiulodro 's input as the original feature author. 

### How to test the changes in this Pull Request:

1. On `release`, make sure the homepage is set to display the HPB with the latest posts
2. Publish a new post, observe it absent from the homepage
3. Switch to this branch, again publish a new post, observe the homepage contains the new post

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->