### PR TITLE
Dont cache blocks for staff

### DIFF
--- a/includes/class-newspack-blocks-caching.php
+++ b/includes/class-newspack-blocks-caching.php
@@ -35,12 +35,21 @@ class Newspack_Blocks_Caching {
 	 * Add hooks and filters.
 	 */
 	public static function init() {
-		add_action( 'template_redirect', [ __CLASS__, 'check_all_blocks_cache_status' ] );
-		add_filter( 'pre_render_block', [ __CLASS__, 'maybe_serve_cached_block' ], 10, 2 );
-		add_filter( 'render_block', [ __CLASS__, 'maybe_cache_block' ], 9999, 2 );
+		add_action( 'init', [ __CLASS__, 'setup_block_caching' ] );
+	}
 
-		if ( ! defined( 'NEWSPACK_BLOCKS_CACHE_BLOCKS_TIME' ) ) {
-			define( 'NEWSPACK_BLOCKS_CACHE_BLOCKS_TIME', 300 );
+	/**
+	 * Initialize block caching if needed.
+	 */
+	public static function setup_block_caching() {
+		if ( ! is_user_logged_in() || ! current_user_can( 'edit_posts' ) ) {
+			add_action( 'template_redirect', [ __CLASS__, 'check_all_blocks_cache_status' ] );
+			add_filter( 'pre_render_block', [ __CLASS__, 'maybe_serve_cached_block' ], 10, 2 );
+			add_filter( 'render_block', [ __CLASS__, 'maybe_cache_block' ], 9999, 2 );
+
+			if ( ! defined( 'NEWSPACK_BLOCKS_CACHE_BLOCKS_TIME' ) ) {
+				define( 'NEWSPACK_BLOCKS_CACHE_BLOCKS_TIME', 300 );
+			}
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**Note: This is a hotfix**

This PR adjusts the block caching logic so that it only applies to readers and does not apply to staff.

### How to test the changes in this Pull Request:

1. You should get cached blocks as a logged out user.
2. You should get cached blocks as a logged in reader (`subscriber` role or similar)
3. You should not get cached blocks as a logged in editor or admin

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
