### PR TITLE
fix: remove expensive query before registering video playlist block

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -241,7 +241,6 @@ class Newspack_Blocks {
 				'custom_taxonomies'          => self::get_custom_taxonomies(),
 				'can_use_name_your_price'    => self::can_use_name_your_price(),
 				'tier_amounts_template'      => self::get_formatted_amount(),
-				'can_use_video_playlist'     => self::can_use_video_playlist_block(),
 			];
 
 			if ( class_exists( 'WP_REST_Newspack_Author_List_Controller' ) ) {
@@ -1643,30 +1642,6 @@ class Newspack_Blocks {
 		);
 
 		return $combined_caption;
-	}
-
-	/**
-	 * Check if the current site can use the Video Playlist block.
-	 * If the block doesn't already exist in site content, it won't be registered.
-	 */
-	public static function can_use_video_playlist_block() {
-		// Check if the block exists in any content on the site.
-		$existing_blocks = new WP_Query(
-			[
-				'fields'         => 'ids',
-				'post_type'      => 'any',
-				'post_status'    => 'publish',
-				's'              => 'newspack-blocks/youtube-video-playlist',
-				'posts_per_page' => 1,
-			]
-		);
-
-		// Don't register the block if it's not already on the site.
-		if ( 0 < $existing_blocks->found_posts ) {
-			return true;
-		}
-
-		return false;
 	}
 }
 Newspack_Blocks::init();

--- a/src/blocks/video-playlist/editor.js
+++ b/src/blocks/video-playlist/editor.js
@@ -4,6 +4,4 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { name, settings } from '.';
 
-if ( window.newspack_blocks_data?.can_use_video_playlist ) {
-	registerBlockType( `newspack-blocks/${ name }`, settings );
-}
+registerBlockType( `newspack-blocks/${ name }`, settings );

--- a/src/blocks/video-playlist/view.php
+++ b/src/blocks/video-playlist/view.php
@@ -23,10 +23,6 @@ function newspack_blocks_render_block_video_playlist( $attributes ) {
  * Registers the `newspack-blocks/donate` block on server.
  */
 function newspack_blocks_register_video_playlist() {
-	if ( ! Newspack_Blocks::can_use_video_playlist_block() ) {
-		return;
-	}
-
 	register_block_type(
 		'newspack-blocks/youtube-video-playlist',
 		array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes an expensive query before deciding to register the video playlist block. Now, the block will always be registered but will show an uneditable/deprecated state in the editor.

<img width="811" alt="Screenshot 2024-10-29 at 9 41 16 AM" src="https://github.com/user-attachments/assets/c5ca271d-cc86-4184-b4c9-e8d2852a8c0b">

### How to test the changes in this Pull Request:

No functional changes, just removing a performance hog.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
