### PR TITLE
fix: don't allow NYP products with no prices

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -596,6 +596,10 @@ final class Modal_Checkout {
 									// Use suggested price if NYP is active and set for variation.
 									if ( \Newspack_Blocks::can_use_name_your_price() && \WC_Name_Your_Price_Helpers::is_nyp( $variation_id ) ) {
 										$price = \WC_Name_Your_Price_Helpers::get_suggested_price( $variation_id );
+										$min_price = \WC_Name_Your_Price_Helpers::get_minimum_price( $variation_id );
+										if ( ! $price && ! $min_price ) {
+											continue;
+										}
 									}
 
 									if ( class_exists( '\WC_Subscriptions_Product' ) && \WC_Subscriptions_Product::is_subscription( $variation ) ) {

--- a/src/blocks/checkout-button/view.php
+++ b/src/blocks/checkout-button/view.php
@@ -115,16 +115,16 @@ function render_callback( $attributes ) {
 		// Get the product type.
 		$product_type = \Newspack_Blocks\Tracking\Data_Events::get_product_type( $product_id );
 
-		$name   = $product->get_name();
-		$price  = $product->get_price();
-		$is_nyp = false;
+		$name      = $product->get_name();
+		$price     = $product->get_price();
+		$min_price = '';
 		if ( ! empty( $attributes['price'] ) ) {
 			// Default to the price set in the block attributes.
 			$price = $attributes['price'];
 		} elseif ( class_exists( '\WC_Name_Your_Price_Helpers' ) && \WC_Name_Your_Price_Helpers::is_nyp( $product_id ) ) {
 			// Use suggested price if NYP is active and set for variation.
-			$price  = \WC_Name_Your_Price_Helpers::get_suggested_price( $product_id );
-			$is_nyp = true;
+			$price     = \WC_Name_Your_Price_Helpers::get_suggested_price( $product_id );
+			$min_price = \WC_Name_Your_Price_Helpers::get_minimum_price( $product_id );
 		}
 
 		$is_variable           = $attributes['is_variable'];
@@ -160,7 +160,10 @@ function render_callback( $attributes ) {
 		}
 
 		// Check if the button should be output: it needs a price, or needs to be a product with variations to pick.
-		if ( ( ! $is_variable && ! $variation_id && ! $price && ! $is_nyp ) || ( $variation_id && ! $price && ! $is_nyp ) ) {
+		if ( $min_price && ! $price ) {
+			$price = $min_price;
+		}
+		if ( ( ! $is_variable && ! $variation_id && ! $price ) || ( $variation_id && ! $price ) ) {
 			return '';
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR refines https://github.com/Automattic/newspack-blocks/pull/1925 and hides either Checkout Button Blocks or individual variations in the modal checkout if they're associated with a NYP product that has neither a minimum or suggested price set.

These products should still be available for selection in the editor because you can set a price in the sidebar from there (both for a NYP product assigned directly to a checkout button block, or a NYP variation set to be the only product available of a variation product.

### How to test the changes in this Pull Request:

Some of this testing repeats the steps in https://github.com/Automattic/newspack-blocks/pull/1925 to make sure these tweaks don't introduce any regressions:

1. Set up the following products: 
    * A simple product with a price
    * A simple product without a price
    * A NYP product with no prices set
    * A NYP product with at least one price (suggested or minimum)
    * A variable product with at least one NYP variation, and at least one variation without a price.
2. In the editor, confirm that all but the "simple product without a price" are available to assign to different checkout button blocks.
3. On the front-end, confirm that the button assigned to a "NYP product with no prices set" does not display.
4. Go back to the editor and assign a price to the "NYP product with no prices set" checkout button using the option in the sidebar. Publish and confirm that the button now displays. 
5. On the front-end, confirm that the checkout button block with the "NYP product with at least one price" product assigned displays. 
6. On the front-end, click the checkout button block for the variation picker. Confirm that the NYP variation without a price does not show, but any variations with prices do show.
7. In the editor, edit the "A variable product with at least one NYP variation" checkout button, and set it to have a variation pre-selected. Pick the NYP product.
8. Publish and confirm that the button doesn't show on the front-end.
9. Edit again, and set a NYP product for the variation using the checkout button block options. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
