### PR TITLE
feat: add support for Newspack Guest Contributor in HPP blocks

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -745,6 +745,9 @@ class Newspack_Blocks {
 						'authors'   => $authors,
 						'coauthors' => $co_authors_names,
 					];
+
+					// Also, in these cases, never offload the query to Elastic Search.
+					$args['newspack_no_es_query'] = true;
 				}
 			}
 		}

--- a/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
+++ b/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
@@ -142,8 +142,14 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 				}
 			}
 		} else {
+			$role_in = [ 'Administrator', 'Editor', 'Author', 'Contributor' ];
+			// Support for Newspack's Guest Contributor Role.
+			if ( class_exists( 'Newspack\Guest_Contributor_Role' ) ) {
+				$role_in[] = Newspack\Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME;
+			}
+
 			$user_args = [
-				'role__in' => [ 'Administrator', 'Editor', 'Author', 'Contributor' ],
+				'role__in' => $role_in,
 				'offset'   => $offset,
 				'orderby'  => 'registered',
 				'order'    => 'DESC',

--- a/tests/test-homepage-posts-block.php
+++ b/tests/test-homepage-posts-block.php
@@ -32,8 +32,9 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 					'authors'     => [ 1 ],
 				],
 				'resulting_query_partial' => [
-					'posts_per_page' => 1,
-					'post_type'      => 'some-type',
+					'posts_per_page'       => 1,
+					'post_type'            => 'some-type',
+					'newspack_no_es_query' => true,
 				],
 				'description'             => 'With custom post type and author',
 				'ignore_tax_query'        => true,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds support for the Newspack's Guest Contributor role in the Homepage posts and Carousel blocks

### How to test the changes in this Pull Request:

1. Create a user with only the Guest Contributor role and assign a post to it
2. Add a Home page posts block
3. Search by that author name and confirm it finds the author and their posts
4. Do the same for the Carousel block

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
