### PR TITLE
fix(modal-checkout): use post checkout text option to populate thank you page text

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -95,6 +95,7 @@ final class Modal_Checkout {
 		add_filter( 'woocommerce_checkout_customer_id', [ __CLASS__, 'associate_existing_user' ] );
 		add_filter( 'woocommerce_checkout_posted_data', [ __CLASS__, 'skip_account_creation' ], 11 );
 		add_action( 'woocommerce_checkout_create_order', [ __CLASS__, 'maybe_add_checkout_registration_order_meta' ], 10, 1 );
+		add_action( 'newpack_blocks_thankyou', [ __CLASS__, 'maybe_reset_checkout_registration_flag' ] );
 
 		// Remove some stuff from the modal checkout page. It's displayed in an iframe, so it should not be treated as a separate page.
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'dequeue_scripts' ], PHP_INT_MAX );
@@ -155,17 +156,6 @@ final class Modal_Checkout {
 		unset( $enqueue_styles['woocommerce-general'] );
 		unset( $enqueue_styles['woocommerce-smallscreen'] );
 		return $enqueue_styles;
-	}
-
-	/**
-	 * Set the checkout registration flag to WC session.
-	 */
-	public static function set_checkout_registration_flag() {
-		// Flag the checkout as a registration.
-		$is_checkout_registration = filter_input( INPUT_GET, self::CHECKOUT_REGISTRATION_FLAG, FILTER_SANITIZE_NUMBER_INT );
-		if ( $is_checkout_registration ) {
-			\WC()->session->set( self::CHECKOUT_REGISTRATION_FLAG, true );
-		}
 	}
 
 	/**
@@ -1775,6 +1765,33 @@ final class Modal_Checkout {
 	}
 
 	/**
+	 * Set the checkout registration flag to WC session.
+	 */
+	public static function set_checkout_registration_flag() {
+		// Flag the checkout as a registration.
+		$is_checkout_registration = filter_input( INPUT_GET, self::CHECKOUT_REGISTRATION_FLAG, FILTER_SANITIZE_NUMBER_INT );
+		if ( $is_checkout_registration ) {
+			\WC()->session->set( self::CHECKOUT_REGISTRATION_FLAG, true );
+		}
+	}
+
+	/**
+	 * Conditionally reset the checkout registration flag from WC session.
+	 */
+	public static function maybe_reset_checkout_registration_flag() {
+		if ( self::is_checkout_registration() ) {
+			\WC()->session->set( self::CHECKOUT_REGISTRATION_FLAG, null );
+		}
+	}
+
+	/**
+	 * Whether the WC session is for checkout registration.
+	 */
+	public static function is_checkout_registration() {
+		return \WC()->session->get( self::CHECKOUT_REGISTRATION_FLAG, false );
+	}
+
+	/**
 	 * Conditionally adds the checkout registration order meta flag.
 	 *
 	 * @param WC_Order $order    The order object.
@@ -1786,10 +1803,8 @@ final class Modal_Checkout {
 			return;
 		}
 
-		$is_checkout_registration = \WC()->session->get( self::CHECKOUT_REGISTRATION_FLAG );
-		if ( $is_checkout_registration ) {
+		if ( self::is_checkout_registration() ) {
 			$order->add_meta_data( self::CHECKOUT_REGISTRATION_ORDER_META_KEY, true, true );
-			\WC()->session->set( self::CHECKOUT_REGISTRATION_FLAG, null );
 		}
 	}
 
@@ -1846,11 +1861,9 @@ final class Modal_Checkout {
 	/**
 	 * Get post checkout success message text.
 	 *
-	 * @param bool $is_registration Whether the text is for checkout registration.
-	 *
 	 * @return string Post checkout success message text.
 	 */
-	public static function get_post_checkout_success_text( $is_registration = false ) {
+	public static function get_post_checkout_success_text() {
 		if ( ! class_exists( '\Newspack\Reader_Activation' ) ) {
 			return sprintf(
 				// Translators: %s is the site name.
@@ -1858,7 +1871,7 @@ final class Modal_Checkout {
 				get_option( 'blogname' )
 			);
 		}
-		if ( $is_registration ) {
+		if ( self::is_checkout_registration() ) {
 			return \Newspack\Reader_Activation::get_post_checkout_registration_success_text();
 		} else {
 			return \Newspack\Reader_Activation::get_post_checkout_success_text();

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -59,7 +59,6 @@ final class Modal_Checkout {
 		add_action( 'wp_ajax_abandon_modal_checkout', [ __CLASS__, 'process_abandon_checkout' ] );
 		add_action( 'wp_ajax_nopriv_abandon_modal_checkout', [ __CLASS__, 'process_abandon_checkout' ] );
 
-		add_action( 'wp_loaded', [ __CLASS__, 'set_checkout_registration_flag' ] );
 		add_filter( 'wp_redirect', [ __CLASS__, 'pass_url_param_on_redirect' ] );
 		add_filter( 'woocommerce_cart_product_cannot_be_purchased_message', [ __CLASS__, 'woocommerce_cart_product_cannot_be_purchased_message' ], 10, 2 );
 		add_filter( 'woocommerce_add_error', [ __CLASS__, 'hide_expiry_message_shop_link' ] );
@@ -93,9 +92,10 @@ final class Modal_Checkout {
 
 		/** Custom handling for registered users. */
 		add_filter( 'woocommerce_checkout_customer_id', [ __CLASS__, 'associate_existing_user' ] );
+		add_action( 'woocommerce_after_checkout_validation', [ __CLASS__, 'maybe_reset_checkout_registration_flag' ], 10, 2 );
 		add_filter( 'woocommerce_checkout_posted_data', [ __CLASS__, 'skip_account_creation' ], 11 );
 		add_action( 'woocommerce_checkout_create_order', [ __CLASS__, 'maybe_add_checkout_registration_order_meta' ], 10, 1 );
-		add_action( 'newpack_blocks_thankyou', [ __CLASS__, 'maybe_reset_checkout_registration_flag' ] );
+		add_action( 'newpack_blocks_modal_checkout_thankyou', [ __CLASS__, 'reset_checkout_registration_flag' ] );
 
 		// Remove some stuff from the modal checkout page. It's displayed in an iframe, so it should not be treated as a separate page.
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'dequeue_scripts' ], PHP_INT_MAX );
@@ -256,6 +256,11 @@ final class Modal_Checkout {
 		\WC()->cart->empty_cart();
 		\WC()->cart->add_to_cart( $product_id, 1, 0, [], $cart_item_data );
 
+		// Set checkout registration flag if user is logged not logged in.
+		if ( ! is_user_logged_in() ) {
+			self::set_checkout_registration_flag();
+		}
+
 		$query_args = [];
 		if ( ! empty( $referer_tags ) ) {
 			$query_args['referer_tags'] = implode( ',', $referer_tags );
@@ -324,6 +329,7 @@ final class Modal_Checkout {
 		if ( $cart && ! $cart->is_empty() ) {
 			$cart->empty_cart();
 		}
+		self::reset_checkout_registration_flag();
 
 		wp_send_json_success( [ 'message' => __( 'Cart has been emptied.', 'newspack-blocks' ) ] );
 		wp_die();
@@ -1768,19 +1774,31 @@ final class Modal_Checkout {
 	 * Set the checkout registration flag to WC session.
 	 */
 	public static function set_checkout_registration_flag() {
-		// Flag the checkout as a registration.
-		$is_checkout_registration = filter_input( INPUT_GET, self::CHECKOUT_REGISTRATION_FLAG, FILTER_SANITIZE_NUMBER_INT );
-		if ( $is_checkout_registration ) {
-			\WC()->session->set( self::CHECKOUT_REGISTRATION_FLAG, true );
+		\WC()->session->set( self::CHECKOUT_REGISTRATION_FLAG, true );
+	}
+
+	/**
+	 * Reset the checkout registration flag from WC session.
+	 */
+	public static function reset_checkout_registration_flag() {
+		if ( self::is_checkout_registration() ) {
+			\WC()->session->set( self::CHECKOUT_REGISTRATION_FLAG, null );
 		}
 	}
 
 	/**
-	 * Conditionally reset the checkout registration flag from WC session.
+	 * Conditionally reset the checkout registration flag from WC session if user exists.
+	 *
+	 * @param array    $data  Checkout data.
+	 * @param WP_Error $error Checkout errors.
 	 */
-	public static function maybe_reset_checkout_registration_flag() {
-		if ( self::is_checkout_registration() ) {
-			\WC()->session->set( self::CHECKOUT_REGISTRATION_FLAG, null );
+	public static function maybe_reset_checkout_registration_flag( $data, $error ) {
+		if ( ! self::is_checkout_registration() || ! isset( $data['billing_email'] ) ) {
+			return;
+		}
+
+		if ( get_user_by( 'email', $data['billing_email'] ) ) {
+			self::reset_checkout_registration_flag();
 		}
 	}
 
@@ -1864,14 +1882,14 @@ final class Modal_Checkout {
 	 * @return string Post checkout success message text.
 	 */
 	public static function get_post_checkout_success_text() {
-		if ( ! class_exists( '\Newspack\Reader_Activation' ) ) {
+		if ( ! class_exists( '\Newspack\Reader_Activation' ) || ! \Newspack\Reader_Activation::is_enabled() ) {
 			return sprintf(
 				// Translators: %s is the site name.
-				__( 'Thank you for supporting %s. Your transaction was successful.', 'newspack-blocks' ),
+				__( 'Thank you for supporting %s. Your transaction was completed successfully.', 'newspack-blocks' ),
 				get_option( 'blogname' )
 			);
 		}
-		if ( self::is_checkout_registration() ) {
+		if ( ! self::is_registration_required() && self::is_checkout_registration() ) {
 			return \Newspack\Reader_Activation::get_post_checkout_registration_success_text();
 		} else {
 			return \Newspack\Reader_Activation::get_post_checkout_success_text();

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1716,11 +1716,6 @@ final class Modal_Checkout {
 				'checkout_confirm_variation' => __( 'Purchase', 'newspack-blocks' ),
 				'checkout_back'              => __( 'Back', 'newspack-blocks' ),
 				'checkout_success'           => __( 'Transaction successful', 'newspack-blocks' ),
-				'thankyou'                   => sprintf(
-					// Translators: %s is the site name.
-					__( 'Thank you for supporting %s. Your transaction was successful.', 'newspack-blocks' ),
-					get_option( 'blogname' )
-				),
 				'checkout_nyp'               => __( "Your contribution directly funds our work. If you're moved to do so, you can opt to pay more than the standard rate.", 'newspack-blocks' ),
 				'checkout_nyp_thankyou'      => __( "Thank you for your generosity! We couldn't do this without you!", 'newspack-blocks' ),
 				'checkout_nyp_title'         => __( 'Increase your support', 'newspack-blocks' ),
@@ -1846,6 +1841,28 @@ final class Modal_Checkout {
 		}
 
 		return \Newspack\Reader_Activation::get_checkout_privacy_policy_text();
+	}
+
+	/**
+	 * Get post checkout success message text.
+	 *
+	 * @param bool $is_registration Whether the text is for checkout registration.
+	 *
+	 * @return string Post checkout success message text.
+	 */
+	public static function get_post_checkout_success_text( $is_registration = false ) {
+		if ( ! class_exists( '\Newspack\Reader_Activation' ) ) {
+			return sprintf(
+				// Translators: %s is the site name.
+				__( 'Thank you for supporting %s. Your transaction was successful.', 'newspack-blocks' ),
+				get_option( 'blogname' )
+			);
+		}
+		if ( $is_registration ) {
+			return \Newspack\Reader_Activation::get_post_checkout_registration_success_text();
+		} else {
+			return \Newspack\Reader_Activation::get_post_checkout_success_text();
+		}
 	}
 }
 Modal_Checkout::init();

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -51,6 +51,11 @@ import { domReady } from './utils';
 		}
 
 		if ( newspackBlocksModalCheckout.is_checkout_complete ) {
+			if ( parent?.window?.newspackReaderActivation?.getPendingCheckout?.() ) {
+				$( '#checkout_success' ).hide();
+			} else {
+				$( '#checkout_registration_success' ).hide();
+			}
 			/**
 			 * Set the checkout as complete so the modal can resolve post checkout flows.
 			 */

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -51,11 +51,6 @@ import { domReady } from './utils';
 		}
 
 		if ( newspackBlocksModalCheckout.is_checkout_complete ) {
-			if ( parent?.window?.newspackReaderActivation?.getPendingCheckout?.() ) {
-				$( '#checkout_success' ).hide();
-			} else {
-				$( '#checkout_registration_success' ).hide();
-			}
 			/**
 			 * Set the checkout as complete so the modal can resolve post checkout flows.
 			 */

--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -51,10 +51,17 @@ function newspack_blocks_replace_login_with_order_summary() {
 					<path d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"></path>
 				</svg>
 			</span>
-			<p>
+			<p id="checkout_success">
 				<strong>
 					<?php
-						echo esc_html( Modal_Checkout::get_modal_checkout_labels( 'thankyou' ) );
+						echo esc_html( Modal_Checkout::get_post_checkout_success_text() );
+					?>
+				</strong>
+			</p>
+			<p id="checkout_registration_success">
+				<strong>
+					<?php
+						echo esc_html( Modal_Checkout::get_post_checkout_success_text( true ) );
 					?>
 				</strong>
 			</p>

--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -82,7 +82,7 @@ function newspack_blocks_replace_login_with_order_summary() {
 		<?php endif; ?>
 		<?php
 	endif;
-	do_action( 'newpack_blocks_thankyou' );
+	do_action( 'newpack_blocks_modal_checkout_thankyou' );
 }
 
 newspack_blocks_replace_login_with_order_summary();

--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -51,17 +51,10 @@ function newspack_blocks_replace_login_with_order_summary() {
 					<path d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"></path>
 				</svg>
 			</span>
-			<p id="checkout_success">
+			<p>
 				<strong>
 					<?php
 						echo esc_html( Modal_Checkout::get_post_checkout_success_text() );
-					?>
-				</strong>
-			</p>
-			<p id="checkout_registration_success">
-				<strong>
-					<?php
-						echo esc_html( Modal_Checkout::get_post_checkout_success_text( true ) );
 					?>
 				</strong>
 			</p>
@@ -89,6 +82,7 @@ function newspack_blocks_replace_login_with_order_summary() {
 		<?php endif; ?>
 		<?php
 	endif;
+	do_action( 'newpack_blocks_thankyou' );
 }
 
 newspack_blocks_replace_login_with_order_summary();


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Goes with and should be merged after https://github.com/Automattic/newspack-plugin/pull/3533

This PR uses the new post checkout success text setting added in the main plugin PR linked above.

![Screenshot 2024-11-07 at 17 09 04](https://github.com/user-attachments/assets/bcfb48b6-bba7-4b3a-b56d-7c9ce1140eff)


### How to test the changes in this Pull Request:

Be sure to checkout https://github.com/Automattic/newspack-plugin/pull/3533 before testing

1. As admin, ensure the `Prompt logged out readers to sign in or register a new account before checkout` setting is DISABLED via Newspack > Engagement > Show Advanced Settings > Checkout Configuration
2. As a logged out reader, go through checkout using a new email address not associated with an existing user account until you get to the thankyou modal.
3. Verify whatever text in the post-checkout registration success message setting appears in the thankyou modal
4. As a logged in reader, go through checkout again until you get to the thankyou modal.
5. Verify whatever text in the post-checkout success message setting appears in the thankyou modal
6. As a logged out reader, go through checkout again, this time using an email address associated with an existing user, until you get to the thankyou modal.
7. Verify whatever text in the post-checkout success message setting appears in the thankyou modal
8. As admin, enable the toggle from step 1
9. Go through checkout as a logged out new user, a logged out existing user, and a logged in reader
10. In all cases confirm the post-checkout success message appears in the thankyou modal

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
