### PR TITLE
feat(homepage-articles): rename block and reorganise settings

### DIFF
--- a/src/blocks/homepage-articles/edit.tsx
+++ b/src/blocks/homepage-articles/edit.tsx
@@ -349,7 +349,7 @@ class Edit extends Component< HomepageArticlesProps > {
 				<PanelBody title={ __( 'Settings', 'newspack-blocks' ) }>
 					<PanelRow>
 						<BaseControl
-							label={ __( 'Content display', 'newspack-blocks' ) }
+							label={ __( 'Content', 'newspack-blocks' ) }
 							id="newspack-block__content-display"
 							className="newspack-block__button-group"
 						>
@@ -473,7 +473,7 @@ class Edit extends Component< HomepageArticlesProps > {
 						/>
 					</PanelBody>
 				) }
-				<PanelBody title={ __( 'Filters', 'newspack-blocks' ) } initialOpen={ false }>
+				<PanelBody title={ __( 'Loop', 'newspack-blocks' ) } initialOpen={ false } className="newspack-block__loop-panel">
 					<QueryControls
 						numberOfItems={ postsToShow }
 						onNumberOfItemsChange={ ( _postsToShow: number ) =>
@@ -502,18 +502,16 @@ class Edit extends Component< HomepageArticlesProps > {
 						onCustomTaxonomyExclusionsChange={ handleAttributeChange( 'customTaxonomyExclusions' ) }
 						postType={ postType }
 					/>
-					<PanelRow>
-						<ToggleControl
-							label={ __( 'Allow duplicate stories', 'newspack-blocks' ) }
-							help={ __(
-								"If checked, this block will be excluded from the page's de-duplication logic. Duplicate stories may appear.",
-								'newspack-blocks'
-							) }
-							checked={ ! attributes.deduplicate }
-							onChange={ ( value: boolean ) => setAttributes( { deduplicate: ! value } ) }
-							className="newspack-blocks-deduplication-toggle"
-						/>
-					</PanelRow>
+					<ToggleControl
+						label={ __( 'Allow duplicate stories', 'newspack-blocks' ) }
+						help={ __(
+							"If checked, this block will be excluded from the page's de-duplication logic. Duplicate stories may appear.",
+							'newspack-blocks'
+						) }
+						checked={ ! attributes.deduplicate }
+						onChange={ ( value: boolean ) => setAttributes( { deduplicate: ! value } ) }
+						className="newspack-blocks-deduplication-toggle"
+					/>
 				</PanelBody>
 				<PanelBody title={ __( 'Featured Image', 'newspack-blocks' ) } initialOpen={ false }>
 					<PanelRow>

--- a/src/blocks/homepage-articles/edit.tsx
+++ b/src/blocks/homepage-articles/edit.tsx
@@ -37,7 +37,6 @@ import {
 	Button,
 	ButtonGroup,
 	PanelBody,
-	PanelRow,
 	Path,
 	Placeholder,
 	RangeControl,
@@ -352,7 +351,7 @@ class Edit extends Component< HomepageArticlesProps > {
 						id="newspack-block__content-display"
 						className="newspack-block__button-group"
 					>
-						<ButtonGroup className="components-button-group__3">
+						<ButtonGroup>
 							<Button
 								variant={ ! showExcerpt && ! showFullContent && 'primary' }
 								aria-pressed={ ! showExcerpt && ! showFullContent }
@@ -494,131 +493,107 @@ class Edit extends Component< HomepageArticlesProps > {
 					<ToggleControl
 						label={ __( 'Allow duplicate stories', 'newspack-blocks' ) }
 						help={ __(
-							"If checked, this block will be excluded from the page's de-duplication logic. Duplicate stories may appear.",
+							"Exclude this block from the page's deduplication logic.",
 							'newspack-blocks'
 						) }
 						checked={ ! attributes.deduplicate }
 						onChange={ ( value: boolean ) => setAttributes( { deduplicate: ! value } ) }
 					/>
 				</PanelBody>
-				<PanelBody title={ __( 'Featured Image', 'newspack-blocks' ) } initialOpen={ false }>
-					<PanelRow>
-						<ToggleControl
-							label={ __( 'Show Featured Image', 'newspack-blocks' ) }
-							checked={ showImage }
-							onChange={ () => setAttributes( { showImage: ! showImage } ) }
-						/>
-					</PanelRow>
-					<PanelRow>
-						<ToggleControl
-							label={ __( 'Show Featured Image Caption', 'newspack-blocks' ) }
-							checked={ showCaption }
-							onChange={ () => setAttributes( { showCaption: ! showCaption } ) }
-							disabled={ ! showImage }
-						/>
-					</PanelRow>
-					<PanelRow>
-						<ToggleControl
-							label={ __( 'Show Featured Image Credit', 'newspack-blocks' ) }
-							checked={ showCredit }
-							onChange={ () => setAttributes( { showCredit: ! showCredit } ) }
-							disabled={ ! showImage }
-						/>
-					</PanelRow>
+				<PanelBody title={ __( 'Featured Image', 'newspack-blocks' ) } initialOpen={ false } className="newspack-block__panel">
+					<ToggleControl
+						label={ __( 'Show featured image', 'newspack-blocks' ) }
+						checked={ showImage }
+						onChange={ () => setAttributes( { showImage: ! showImage } ) }
+					/>
+					<ToggleControl
+						label={ __( 'Show caption', 'newspack-blocks' ) }
+						checked={ showCaption }
+						onChange={ () => setAttributes( { showCaption: ! showCaption } ) }
+						disabled={ ! showImage }
+					/>
+					<ToggleControl
+						label={ __( 'Show credit', 'newspack-blocks' ) }
+						checked={ showCredit }
+						onChange={ () => setAttributes( { showCredit: ! showCredit } ) }
+						disabled={ ! showImage }
+					/>
 					{ showImage && mediaPosition !== 'top' && mediaPosition !== 'behind' && (
 						<Fragment>
-							<PanelRow>
-								<ToggleControl
-									label={ __( 'Stack on mobile', 'newspack-blocks' ) }
-									checked={ mobileStack }
-									onChange={ () => setAttributes( { mobileStack: ! mobileStack } ) }
-								/>
-							</PanelRow>
+							<ToggleControl
+								label={ __( 'Stack on mobile', 'newspack-blocks' ) }
+								checked={ mobileStack }
+								onChange={ () => setAttributes( { mobileStack: ! mobileStack } ) }
+							/>
 							<BaseControl
-								label={ __( 'Featured Image Size', 'newspack-blocks' ) }
-								id="newspackfeatured-image-size"
+								label={ __( 'Size', 'newspack-blocks' ) }
+								id="newspack-block__featured-image-size"
+								className="newspack-block__button-group"
 							>
-								<PanelRow>
-									<ButtonGroup
-										id="newspackfeatured-image-size"
-										aria-label={ __( 'Featured Image Size', 'newspack-blocks' ) }
-									>
-										{ imageSizeOptions.map( option => {
-											const isCurrent = imageScale === option.value;
-											return (
-												<Button
-													isPrimary={ isCurrent }
-													aria-pressed={ isCurrent }
-													aria-label={ option.label }
-													key={ option.value }
-													onClick={ () => setAttributes( { imageScale: option.value } ) }
-												>
-													{ option.shortName }
-												</Button>
-											);
-										} ) }
-									</ButtonGroup>
-								</PanelRow>
+								<ButtonGroup>
+									{ imageSizeOptions.map( option => {
+										const isCurrent = imageScale === option.value;
+										return (
+											<Button
+												variant={ isCurrent && 'primary' }
+												aria-pressed={ isCurrent }
+												aria-label={ option.label }
+												key={ option.value }
+												onClick={ () => setAttributes( { imageScale: option.value } ) }
+											>
+												{ option.shortName }
+											</Button>
+										);
+									} ) }
+								</ButtonGroup>
 							</BaseControl>
 						</Fragment>
 					) }
-
 					{ showImage && mediaPosition === 'behind' && (
-						<PanelRow>
-							<RangeControl
-								label={ __( 'Minimum height', 'newspack-blocks' ) }
-								help={ __(
-									"Sets a minimum height for the block, using a percentage of the screen's current height.",
-									'newspack-blocks'
-								) }
-								value={ minHeight }
-								onChange={ ( _minHeight: number ) => setAttributes( { minHeight: _minHeight } ) }
-								min={ 0 }
-								max={ 100 }
-								required
-							/>
-						</PanelRow>
+						<RangeControl
+							label={ __( 'Minimum height', 'newspack-blocks' ) }
+							help={ __(
+								"Sets a minimum height for the block, using a percentage of the screen's current height.",
+								'newspack-blocks'
+							) }
+							value={ minHeight }
+							onChange={ ( _minHeight: number ) => setAttributes( { minHeight: _minHeight } ) }
+							min={ 0 }
+							max={ 100 }
+							required
+							__next40pxDefaultSize
+						/>
 					) }
 				</PanelBody>
 				<PanelBody title={ __( 'Post Meta', 'newspack-blocks' ) } initialOpen={ false }>
 					{ IS_SUBTITLE_SUPPORTED_IN_THEME && (
-						<PanelRow>
-							<ToggleControl
-								label={ __( 'Show Subtitle', 'newspack-blocks' ) }
-								checked={ showSubtitle }
-								onChange={ () => setAttributes( { showSubtitle: ! showSubtitle } ) }
-							/>
-						</PanelRow>
+						<ToggleControl
+							label={ __( 'Show subtitle', 'newspack-blocks' ) }
+							checked={ showSubtitle }
+							onChange={ () => setAttributes( { showSubtitle: ! showSubtitle } ) }
+						/>
 					) }
-					<PanelRow>
-						<ToggleControl
-							label={ __( 'Show Date', 'newspack-blocks' ) }
-							checked={ showDate }
-							onChange={ () => setAttributes( { showDate: ! showDate } ) }
-						/>
-					</PanelRow>
-					<PanelRow>
-						<ToggleControl
-							label={ __( 'Show Category', 'newspack-blocks' ) }
-							checked={ showCategory }
-							onChange={ () => setAttributes( { showCategory: ! showCategory } ) }
-						/>
-					</PanelRow>
-					<PanelRow>
-						<ToggleControl
-							label={ __( 'Show Author', 'newspack-blocks' ) }
-							checked={ showAuthor }
-							onChange={ () => setAttributes( { showAuthor: ! showAuthor } ) }
-						/>
-					</PanelRow>
-					<PanelRow>
-						<ToggleControl
-							label={ __( 'Show Author Avatar', 'newspack-blocks' ) }
-							checked={ showAvatar }
-							onChange={ () => setAttributes( { showAvatar: ! showAvatar } ) }
-							disabled={ ! showAuthor }
-						/>
-					</PanelRow>
+					<ToggleControl
+						label={ __( 'Show date', 'newspack-blocks' ) }
+						checked={ showDate }
+						onChange={ () => setAttributes( { showDate: ! showDate } ) }
+					/>
+					<ToggleControl
+						label={ __( 'Show category', 'newspack-blocks' ) }
+						checked={ showCategory }
+						onChange={ () => setAttributes( { showCategory: ! showCategory } ) }
+					/>
+					<ToggleControl
+						label={ __( 'Show author', 'newspack-blocks' ) }
+						checked={ showAuthor }
+						onChange={ () => setAttributes( { showAuthor: ! showAuthor } ) }
+					/>
+					<ToggleControl
+						label={ __( 'Show avatar', 'newspack-blocks' ) }
+						checked={ showAvatar }
+						onChange={ () => setAttributes( { showAvatar: ! showAvatar } ) }
+						disabled={ ! showAuthor }
+					/>
 				</PanelBody>
 				<PostTypesPanel attributes={ attributes } setAttributes={ setAttributes } />
 				<PostStatusesPanel attributes={ attributes } setAttributes={ setAttributes } />

--- a/src/blocks/homepage-articles/edit.tsx
+++ b/src/blocks/homepage-articles/edit.tsx
@@ -33,19 +33,20 @@ import {
 	AlignmentControl,
 } from '@wordpress/block-editor';
 import {
+	BaseControl,
 	Button,
 	ButtonGroup,
+	Notice,
 	PanelBody,
 	PanelRow,
+	Path,
+	Placeholder,
 	RangeControl,
+	Spinner,
+	SVG,
 	Toolbar,
 	ToggleControl,
 	TextControl,
-	Placeholder,
-	Spinner,
-	BaseControl,
-	Path,
-	SVG,
 } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
@@ -346,7 +347,133 @@ class Edit extends Component< HomepageArticlesProps > {
 
 		return (
 			<Fragment>
-				<PanelBody title={ __( 'Settings', 'newspack-blocks' ) } initialOpen={ true }>
+				<PanelBody title={ __( 'Settings', 'newspack-blocks' ) }>
+					<PanelRow>
+						<BaseControl label={ __( 'Content display', 'newspack-blocks' ) } className="newspack-block__button-group">
+							<ButtonGroup className="components-button-group__3">
+								<Button
+									isPrimary={ ! showExcerpt && ! showFullContent }
+									aria-pressed={ ! showExcerpt && ! showFullContent }
+									aria-label={ __( 'None', 'newspack-blocks' ) }
+									onClick={ () => {
+										setAttributes( {
+											showExcerpt: false,
+											showFullContent: false
+										} )
+									} }
+								>
+									{ __( 'None', 'newspack-blocks' ) }
+								</Button>
+								<Button
+									isPrimary={ showExcerpt && ! showFullContent }
+									aria-pressed={ showExcerpt && ! showFullContent }
+									aria-label={ __( 'Excerpt', 'newspack-blocks' ) }
+									onClick={ () => {
+										setAttributes( {
+											showExcerpt: ! showExcerpt,
+											showFullContent: showFullContent ? false : showFullContent
+										} )
+									} }
+								>
+									{ __( 'Excerpt', 'newspack-blocks' ) }
+								</Button>
+								<Button
+									isPrimary={ ! showExcerpt && showFullContent }
+									aria-pressed={ ! showExcerpt && showFullContent }
+									aria-label={ __( 'Full Post', 'newspack-blocks' ) }
+									onClick={ () => {
+										setAttributes( {
+											showFullContent: ! showFullContent,
+											showExcerpt: showExcerpt ? false : showExcerpt
+										} )
+									} }
+								>
+									{ __( 'Full Post', 'newspack-blocks' ) }
+								</Button>
+							</ButtonGroup>
+						</BaseControl>
+					</PanelRow>
+					{ showExcerpt && (
+						<PanelRow>
+							<RangeControl
+								label={ __( 'Max number of words in excerpt', 'newspack-blocks' ) }
+								value={ excerptLength }
+								onChange={ ( value: number ) => setAttributes( { excerptLength: value } ) }
+								min={ 10 }
+								max={ 100 }
+							/>
+						</PanelRow>
+					) }
+					{ ! showFullContent && (
+					<PanelRow>
+						<ToggleControl
+							label={ __( 'Add a "Read more" link', 'newspack-blocks' ) }
+							checked={ showReadMore }
+							onChange={ () => setAttributes( { showReadMore: ! showReadMore } ) }
+						/>
+					</PanelRow>
+					) }
+					{ showReadMore && (
+						<PanelRow>
+							<TextControl
+								label={ __( '"Read more" link text', 'newspack-blocks' ) }
+								value={ readMoreLabel }
+								placeholder={ readMoreLabel }
+								onChange={ ( value: string ) => setAttributes( { readMoreLabel: value } ) }
+							/>
+						</PanelRow>
+					) }
+					{ ! specificMode && isBlogPrivate() ? (
+						/*
+						 * Hide the "Load more posts" button option on private sites.
+						 *
+						 * Client-side fetching from a private WP.com blog requires authentication,
+						 * which is not provided in the current implementation.
+						 * See https://github.com/Automattic/newspack-blocks/issues/306.
+						 */
+						<PanelRow>
+							<ToggleControl
+								label={ __( 'Show "Load more posts" button', 'newspack-blocks' ) }
+								help={ __( 'This site is private, therefore this feature is not active.', 'newspack-blocks' ) }
+								disabled={ true }
+							/>
+						</PanelRow>
+					) : (
+						! specificMode && (
+							<>
+								<PanelRow>
+									<ToggleControl
+										label={ __( 'Show "Load more posts" button', 'newspack-blocks' ) }
+										checked={ moreButton }
+										onChange={ () => setAttributes( { moreButton: ! moreButton } ) }
+									/>
+								</PanelRow>
+								{ moreButton && (
+									<PanelRow>
+										<ToggleControl
+											label={ __( 'Infinite scroll', 'newspack-blocks' ) }
+											checked={ infiniteScroll }
+											onChange={ () => setAttributes( { infiniteScroll: ! infiniteScroll } ) }
+										/>
+									</PanelRow>
+								) }
+							</>
+						)
+					) }
+				</PanelBody>
+				{ postLayout === 'grid' && (
+					<PanelBody title={ __( 'Grid', 'newspack-blocks' ) }>
+						<RangeControl
+							label={ __( 'Columns', 'newspack-blocks' ) }
+							value={ columns }
+							onChange={ handleAttributeChange( 'columns' ) }
+							min={ 2 }
+							max={ 6 }
+							required
+						/>
+					</PanelBody>
+				) }
+				<PanelBody title={ __( 'Filters', 'newspack-blocks' ) } initialOpen={ false }>
 					<QueryControls
 						numberOfItems={ postsToShow }
 						onNumberOfItemsChange={ ( _postsToShow: number ) =>
@@ -374,119 +501,18 @@ class Edit extends Component< HomepageArticlesProps > {
 						onCustomTaxonomyExclusionsChange={ handleAttributeChange( 'customTaxonomyExclusions' ) }
 						postType={ postType }
 					/>
-					{ ! specificMode && isBlogPrivate() ? (
-						/*
-						 * Hide the "Load more posts" button option on private sites.
-						 *
-						 * Client-side fetching from a private WP.com blog requires authentication,
-						 * which is not provided in the current implementation.
-						 * See https://github.com/Automattic/newspack-blocks/issues/306.
-						 */
-						<i>
-							{ __(
-								'This blog is private, therefore the "Load more posts" feature is not active.',
+					<PanelRow>
+						<ToggleControl
+							label={ __( 'Allow duplicate stories', 'newspack-blocks' ) }
+							help={ __(
+								"If checked, this block will be excluded from the page's de-duplication logic. Duplicate stories may appear.",
 								'newspack-blocks'
 							) }
-						</i>
-					) : (
-						! specificMode && (
-							<>
-								<ToggleControl
-									label={ __( 'Show "Load more posts" Button', 'newspack-blocks' ) }
-									checked={ moreButton }
-									onChange={ () => setAttributes( { moreButton: ! moreButton } ) }
-								/>
-								{ moreButton && (
-									<ToggleControl
-										label={ __( 'Infinite Scroll', 'newspack-blocks' ) }
-										checked={ infiniteScroll }
-										onChange={ () => setAttributes( { infiniteScroll: ! infiniteScroll } ) }
-									/>
-								) }
-							</>
-						)
-					) }
-					<ToggleControl
-						label={ __( 'Allow duplicate stories', 'newspack-blocks' ) }
-						help={ __(
-							"If checked, this block will be excluded from the page's de-duplication logic. Duplicate stories may appear.",
-							'newspack-blocks'
-						) }
-						checked={ ! attributes.deduplicate }
-						onChange={ ( value: boolean ) => setAttributes( { deduplicate: ! value } ) }
-						className="newspack-blocks-deduplication-toggle"
-					/>
-					{ postLayout === 'grid' && (
-						<RangeControl
-							label={ __( 'Columns', 'newspack-blocks' ) }
-							value={ columns }
-							onChange={ handleAttributeChange( 'columns' ) }
-							min={ 2 }
-							max={ 6 }
-							required
-						/>
-					) }
-				</PanelBody>
-				<PanelBody title={ __( 'Post Control', 'newspack-blocks' ) }>
-					{ IS_SUBTITLE_SUPPORTED_IN_THEME && (
-						<PanelRow>
-							<ToggleControl
-								label={ __( 'Show Subtitle', 'newspack-blocks' ) }
-								checked={ showSubtitle }
-								onChange={ () => setAttributes( { showSubtitle: ! showSubtitle } ) }
-							/>
-						</PanelRow>
-					) }
-					<PanelRow>
-						<ToggleControl
-							label={ __( 'Show Excerpt', 'newspack-blocks' ) }
-							checked={ showExcerpt }
-							onChange={ () => {
-								setAttributes({
-									showExcerpt: !showExcerpt,
-									showFullContent: showFullContent ? false : showFullContent
-								})
-							} }
+							checked={ ! attributes.deduplicate }
+							onChange={ ( value: boolean ) => setAttributes( { deduplicate: ! value } ) }
+							className="newspack-blocks-deduplication-toggle"
 						/>
 					</PanelRow>
-					{ showExcerpt && (
-						<PanelRow>
-							<RangeControl
-								label={ __( 'Max number of words in excerpt', 'newspack-blocks' ) }
-								value={ excerptLength }
-								onChange={ ( value: number ) => setAttributes( { excerptLength: value } ) }
-								min={ 10 }
-								max={ 100 }
-							/>
-						</PanelRow>
-					) }
-					<PanelRow>
-						<ToggleControl
-							label={ __( 'Show Full Content', 'newspack-blocks' ) }
-							checked={ showFullContent }
-							onChange={ () => {
-								setAttributes({
-									showFullContent: !showFullContent,
-									showExcerpt: showExcerpt ? false : showExcerpt
-								})
-							} }
-						/>
-					</PanelRow>
-					<PanelRow>
-						<ToggleControl
-							label={ __( 'Add a "Read More" link', 'newspack-blocks' ) }
-							checked={ showReadMore }
-							onChange={ () => setAttributes( { showReadMore: ! showReadMore } ) }
-						/>
-					</PanelRow>
-					{ showReadMore && (
-						<TextControl
-							label={ __( '"Read More" link text', 'newspack-blocks' ) }
-							value={ readMoreLabel }
-							placeholder={ readMoreLabel }
-							onChange={ ( value: string ) => setAttributes( { readMoreLabel: value } ) }
-						/>
-					) }
 				</PanelBody>
 				<PanelBody title={ __( 'Featured Image', 'newspack-blocks' ) } initialOpen={ false }>
 					<PanelRow>
@@ -496,26 +522,22 @@ class Edit extends Component< HomepageArticlesProps > {
 							onChange={ () => setAttributes( { showImage: ! showImage } ) }
 						/>
 					</PanelRow>
-
-					{ showImage && (
-						<>
-							<PanelRow>
-								<ToggleControl
-									label={ __( 'Show Featured Image Caption', 'newspack-blocks' ) }
-									checked={ showCaption }
-									onChange={ () => setAttributes( { showCaption: ! showCaption } ) }
-								/>
-							</PanelRow>
-							<PanelRow>
-								<ToggleControl
-									label={ __( 'Show Featured Image Credit', 'newspack-blocks' ) }
-									checked={ showCredit }
-									onChange={ () => setAttributes( { showCredit: ! showCredit } ) }
-								/>
-							</PanelRow>
-						</>
-					) }
-
+					<PanelRow>
+						<ToggleControl
+							label={ __( 'Show Featured Image Caption', 'newspack-blocks' ) }
+							checked={ showCaption }
+							onChange={ () => setAttributes( { showCaption: ! showCaption } ) }
+							disabled={ ! showImage }
+						/>
+					</PanelRow>
+					<PanelRow>
+						<ToggleControl
+							label={ __( 'Show Featured Image Credit', 'newspack-blocks' ) }
+							checked={ showCredit }
+							onChange={ () => setAttributes( { showCredit: ! showCredit } ) }
+							disabled={ ! showImage }
+						/>
+					</PanelRow>
 					{ showImage && mediaPosition !== 'top' && mediaPosition !== 'behind' && (
 						<Fragment>
 							<PanelRow>
@@ -555,21 +577,32 @@ class Edit extends Component< HomepageArticlesProps > {
 					) }
 
 					{ showImage && mediaPosition === 'behind' && (
-						<RangeControl
-							label={ __( 'Minimum height', 'newspack-blocks' ) }
-							help={ __(
-								"Sets a minimum height for the block, using a percentage of the screen's current height.",
-								'newspack-blocks'
-							) }
-							value={ minHeight }
-							onChange={ ( _minHeight: number ) => setAttributes( { minHeight: _minHeight } ) }
-							min={ 0 }
-							max={ 100 }
-							required
-						/>
+						<PanelRow>
+							<RangeControl
+								label={ __( 'Minimum height', 'newspack-blocks' ) }
+								help={ __(
+									"Sets a minimum height for the block, using a percentage of the screen's current height.",
+									'newspack-blocks'
+								) }
+								value={ minHeight }
+								onChange={ ( _minHeight: number ) => setAttributes( { minHeight: _minHeight } ) }
+								min={ 0 }
+								max={ 100 }
+								required
+							/>
+						</PanelRow>
 					) }
 				</PanelBody>
 				<PanelBody title={ __( 'Post Meta', 'newspack-blocks' ) } initialOpen={ false }>
+					{ IS_SUBTITLE_SUPPORTED_IN_THEME && (
+						<PanelRow>
+							<ToggleControl
+								label={ __( 'Show Subtitle', 'newspack-blocks' ) }
+								checked={ showSubtitle }
+								onChange={ () => setAttributes( { showSubtitle: ! showSubtitle } ) }
+							/>
+						</PanelRow>
+					) }
 					<PanelRow>
 						<ToggleControl
 							label={ __( 'Show Date', 'newspack-blocks' ) }
@@ -591,15 +624,14 @@ class Edit extends Component< HomepageArticlesProps > {
 							onChange={ () => setAttributes( { showAuthor: ! showAuthor } ) }
 						/>
 					</PanelRow>
-					{ showAuthor && (
-						<PanelRow>
-							<ToggleControl
-								label={ __( 'Show Author Avatar', 'newspack-blocks' ) }
-								checked={ showAvatar }
-								onChange={ () => setAttributes( { showAvatar: ! showAvatar } ) }
-							/>
-						</PanelRow>
-					) }
+					<PanelRow>
+						<ToggleControl
+							label={ __( 'Show Author Avatar', 'newspack-blocks' ) }
+							checked={ showAvatar }
+							onChange={ () => setAttributes( { showAvatar: ! showAvatar } ) }
+							disabled={ ! showAuthor }
+						/>
+					</PanelRow>
 				</PanelBody>
 				<PostTypesPanel attributes={ attributes } setAttributes={ setAttributes } />
 				<PostStatusesPanel attributes={ attributes } setAttributes={ setAttributes } />
@@ -626,7 +658,7 @@ class Edit extends Component< HomepageArticlesProps > {
 				/>
 				<PanelBody
 					title={ __( 'Typography', 'newspack-blocks' ) }
-					className="newspack-block__panel"
+					className="newpack-block__panel"
 				>
 					<RangeControl
 						label={ __( 'Type Scale', 'newspack-blocks' ) }

--- a/src/blocks/homepage-articles/edit.tsx
+++ b/src/blocks/homepage-articles/edit.tsx
@@ -36,7 +36,6 @@ import {
 	BaseControl,
 	Button,
 	ButtonGroup,
-	Notice,
 	PanelBody,
 	PanelRow,
 	Path,
@@ -349,7 +348,11 @@ class Edit extends Component< HomepageArticlesProps > {
 			<Fragment>
 				<PanelBody title={ __( 'Settings', 'newspack-blocks' ) }>
 					<PanelRow>
-						<BaseControl label={ __( 'Content display', 'newspack-blocks' ) } className="newspack-block__button-group">
+						<BaseControl
+							label={ __( 'Content display', 'newspack-blocks' ) }
+							id="newspack-block__content-display"
+							className="newspack-block__button-group"
+						>
 							<ButtonGroup className="components-button-group__3">
 								<Button
 									isPrimary={ ! showExcerpt && ! showFullContent }
@@ -407,7 +410,7 @@ class Edit extends Component< HomepageArticlesProps > {
 					{ ! showFullContent && (
 					<PanelRow>
 						<ToggleControl
-							label={ __( 'Add a "Read more" link', 'newspack-blocks' ) }
+							label={ __( 'Show "Read more" link', 'newspack-blocks' ) }
 							checked={ showReadMore }
 							onChange={ () => setAttributes( { showReadMore: ! showReadMore } ) }
 						/>

--- a/src/blocks/homepage-articles/edit.tsx
+++ b/src/blocks/homepage-articles/edit.tsx
@@ -59,6 +59,7 @@ import {
 	postFeaturedImage,
 	pullLeft,
 	pullRight,
+	textColor as typeScaleIcon,
 } from '@wordpress/icons';
 
 let IS_SUBTITLE_SUPPORTED_IN_THEME: boolean;
@@ -99,6 +100,12 @@ const squareIcon = (
 		/>
 	</SVG>
 );
+
+const typeScaleIconSmall = (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<Path d="M13 8H11.6667L9 15.3333H10.2667L11 13.3333H13.8L14.5333 15.3333H15.8L13 8ZM11.3333 12.3333L12.3333 9.06667L13.4667 12.3333H11.3333Z"	/>
+	</SVG>
+)
 
 class Edit extends Component< HomepageArticlesProps > {
 	renderPost = ( post: Post ) => {
@@ -267,7 +274,7 @@ class Edit extends Component< HomepageArticlesProps > {
 	};
 
 	renderInspectorControls = () => {
-		const { attributes, setAttributes, textColor, setTextColor } = this.props;
+		const { attributes, setAttributes } = this.props;
 
 		const {
 			authors,
@@ -277,7 +284,6 @@ class Edit extends Component< HomepageArticlesProps > {
 			includeSubcategories,
 			customTaxonomies,
 			columns,
-			colGap,
 			postType,
 			showImage,
 			showCaption,
@@ -293,7 +299,6 @@ class Edit extends Component< HomepageArticlesProps > {
 			readMoreLabel,
 			excerptLength,
 			showSubtitle,
-			typeScale,
 			showDate,
 			showAuthor,
 			showAvatar,
@@ -336,30 +341,12 @@ class Edit extends Component< HomepageArticlesProps > {
 			},
 		];
 
-		const colGapOptions = [
-			{
-				value: 1,
-				label: /* translators: label for small size option */ __( 'Small', 'newspack-blocks' ),
-				shortName: /* translators: abbreviation for small size */ __( 'S', 'newspack-blocks' ),
-			},
-			{
-				value: 2,
-				label: /* translators: label for medium size option */ __( 'Medium', 'newspack-blocks' ),
-				shortName: /* translators: abbreviation for medium size */ __( 'M', 'newspack-blocks' ),
-			},
-			{
-				value: 3,
-				label: /* translators: label for large size option */ __( 'Large', 'newspack-blocks' ),
-				shortName: /* translators: abbreviation for large size */ __( 'L', 'newspack-blocks' ),
-			},
-		];
-
 		const handleAttributeChange = ( key: HomepageArticlesAttributesKey ) => ( value: any ) =>
 			setAttributes( { [ key ]: value } );
 
 		return (
 			<Fragment>
-				<PanelBody title={ __( 'Display Settings', 'newspack-blocks' ) } initialOpen={ true }>
+				<PanelBody title={ __( 'Settings', 'newspack-blocks' ) } initialOpen={ true }>
 					<QueryControls
 						numberOfItems={ postsToShow }
 						onNumberOfItemsChange={ ( _postsToShow: number ) =>
@@ -387,45 +374,6 @@ class Edit extends Component< HomepageArticlesProps > {
 						onCustomTaxonomyExclusionsChange={ handleAttributeChange( 'customTaxonomyExclusions' ) }
 						postType={ postType }
 					/>
-					{ postLayout === 'grid' && (
-						<Fragment>
-							<RangeControl
-								label={ __( 'Columns', 'newspack-blocks' ) }
-								value={ columns }
-								onChange={ handleAttributeChange( 'columns' ) }
-								min={ 2 }
-								max={ 6 }
-								required
-							/>
-
-							<BaseControl
-								label={ __( 'Columns Gap', 'newspack-blocks' ) }
-								id="newspackcolumns-col-gap"
-							>
-								<PanelRow>
-									<ButtonGroup
-										id="newspackcolumns-col-gap"
-										aria-label={ __( 'Columns Gap', 'newspack-blocks' ) }
-									>
-										{ colGapOptions.map( option => {
-											const isCurrent = colGap === option.value;
-											return (
-												<Button
-													isPrimary={ isCurrent }
-													aria-pressed={ isCurrent }
-													aria-label={ option.label }
-													key={ option.value }
-													onClick={ () => setAttributes( { colGap: option.value } ) }
-												>
-													{ option.shortName }
-												</Button>
-											);
-										} ) }
-									</ButtonGroup>
-								</PanelRow>
-							</BaseControl>
-						</Fragment>
-					) }
 					{ ! specificMode && isBlogPrivate() ? (
 						/*
 						 * Hide the "Load more posts" button option on private sites.
@@ -468,8 +416,79 @@ class Edit extends Component< HomepageArticlesProps > {
 						onChange={ ( value: boolean ) => setAttributes( { deduplicate: ! value } ) }
 						className="newspack-blocks-deduplication-toggle"
 					/>
+					{ postLayout === 'grid' && (
+						<RangeControl
+							label={ __( 'Columns', 'newspack-blocks' ) }
+							value={ columns }
+							onChange={ handleAttributeChange( 'columns' ) }
+							min={ 2 }
+							max={ 6 }
+							required
+						/>
+					) }
 				</PanelBody>
-				<PanelBody title={ __( 'Featured Image Settings', 'newspack-blocks' ) }>
+				<PanelBody title={ __( 'Post Control', 'newspack-blocks' ) }>
+					{ IS_SUBTITLE_SUPPORTED_IN_THEME && (
+						<PanelRow>
+							<ToggleControl
+								label={ __( 'Show Subtitle', 'newspack-blocks' ) }
+								checked={ showSubtitle }
+								onChange={ () => setAttributes( { showSubtitle: ! showSubtitle } ) }
+							/>
+						</PanelRow>
+					) }
+					<PanelRow>
+						<ToggleControl
+							label={ __( 'Show Excerpt', 'newspack-blocks' ) }
+							checked={ showExcerpt }
+							onChange={ () => {
+								setAttributes({
+									showExcerpt: !showExcerpt,
+									showFullContent: showFullContent ? false : showFullContent
+								})
+							} }
+						/>
+					</PanelRow>
+					{ showExcerpt && (
+						<PanelRow>
+							<RangeControl
+								label={ __( 'Max number of words in excerpt', 'newspack-blocks' ) }
+								value={ excerptLength }
+								onChange={ ( value: number ) => setAttributes( { excerptLength: value } ) }
+								min={ 10 }
+								max={ 100 }
+							/>
+						</PanelRow>
+					) }
+					<PanelRow>
+						<ToggleControl
+							label={ __( 'Show Full Content', 'newspack-blocks' ) }
+							checked={ showFullContent }
+							onChange={ () => {
+								setAttributes({
+									showFullContent: !showFullContent,
+									showExcerpt: showExcerpt ? false : showExcerpt
+								})
+							} }
+						/>
+					</PanelRow>
+					<PanelRow>
+						<ToggleControl
+							label={ __( 'Add a "Read More" link', 'newspack-blocks' ) }
+							checked={ showReadMore }
+							onChange={ () => setAttributes( { showReadMore: ! showReadMore } ) }
+						/>
+					</PanelRow>
+					{ showReadMore && (
+						<TextControl
+							label={ __( '"Read More" link text', 'newspack-blocks' ) }
+							value={ readMoreLabel }
+							placeholder={ readMoreLabel }
+							onChange={ ( value: string ) => setAttributes( { readMoreLabel: value } ) }
+						/>
+					) }
+				</PanelBody>
+				<PanelBody title={ __( 'Featured Image', 'newspack-blocks' ) } initialOpen={ false }>
 					<PanelRow>
 						<ToggleControl
 							label={ __( 'Show Featured Image', 'newspack-blocks' ) }
@@ -550,88 +569,7 @@ class Edit extends Component< HomepageArticlesProps > {
 						/>
 					) }
 				</PanelBody>
-				<PanelBody title={ __( 'Post Control Settings', 'newspack-blocks' ) }>
-					{ IS_SUBTITLE_SUPPORTED_IN_THEME && (
-						<PanelRow>
-							<ToggleControl
-								label={ __( 'Show Subtitle', 'newspack-blocks' ) }
-								checked={ showSubtitle }
-								onChange={ () => setAttributes( { showSubtitle: ! showSubtitle } ) }
-							/>
-						</PanelRow>
-					) }
-					<PanelRow>
-						<ToggleControl
-							label={ __( 'Show Excerpt', 'newspack-blocks' ) }
-							checked={ showExcerpt }
-							onChange={ () => {
-								setAttributes({
-									showExcerpt: !showExcerpt,
-									showFullContent: showFullContent ? false : showFullContent
-								})
-							} }
-						/>
-					</PanelRow>
-					{ showExcerpt && (
-						<PanelRow>
-							<RangeControl
-								label={ __( 'Max number of words in excerpt', 'newspack-blocks' ) }
-								value={ excerptLength }
-								onChange={ ( value: number ) => setAttributes( { excerptLength: value } ) }
-								min={ 10 }
-								max={ 100 }
-							/>
-						</PanelRow>
-					) }
-					<PanelRow>
-						<ToggleControl
-							label={ __( 'Show Full Content', 'newspack-blocks' ) }
-							checked={ showFullContent }
-							onChange={ () => {
-								setAttributes({
-									showFullContent: !showFullContent,
-									showExcerpt: showExcerpt ? false : showExcerpt
-								})
-							} }
-						/>
-					</PanelRow>
-					<PanelRow>
-						<ToggleControl
-							label={ __( 'Add a "Read More" link', 'newspack-blocks' ) }
-							checked={ showReadMore }
-							onChange={ () => setAttributes( { showReadMore: ! showReadMore } ) }
-						/>
-					</PanelRow>
-					{ showReadMore && (
-						<TextControl
-							label={ __( '"Read More" link text', 'newspack-blocks' ) }
-							value={ readMoreLabel }
-							placeholder={ readMoreLabel }
-							onChange={ ( value: string ) => setAttributes( { readMoreLabel: value } ) }
-						/>
-					) }
-					<RangeControl
-						className="type-scale-slider"
-						label={ __( 'Type Scale', 'newspack-blocks' ) }
-						value={ typeScale }
-						onChange={ ( _typeScale: number ) => setAttributes( { typeScale: _typeScale } ) }
-						min={ 1 }
-						max={ 10 }
-						required
-					/>
-				</PanelBody>
-				<PanelColorSettings
-					title={ __( 'Color Settings', 'newspack-blocks' ) }
-					initialOpen={ true }
-					colorSettings={ [
-						{
-							value: textColor.color,
-							onChange: setTextColor,
-							label: __( 'Text Color', 'newspack-blocks' ),
-						},
-					] }
-				/>
-				<PanelBody title={ __( 'Post Meta Settings', 'newspack-blocks' ) }>
+				<PanelBody title={ __( 'Post Meta', 'newspack-blocks' ) } initialOpen={ false }>
 					<PanelRow>
 						<ToggleControl
 							label={ __( 'Show Date', 'newspack-blocks' ) }
@@ -665,6 +603,65 @@ class Edit extends Component< HomepageArticlesProps > {
 				</PanelBody>
 				<PostTypesPanel attributes={ attributes } setAttributes={ setAttributes } />
 				<PostStatusesPanel attributes={ attributes } setAttributes={ setAttributes } />
+			</Fragment>
+		);
+	};
+
+	renderStylesInspectorControls = () => {
+		const { attributes, setAttributes, textColor, setTextColor } = this.props;
+
+		const { colGap, postLayout, typeScale } = attributes;
+
+		return (
+			<Fragment>
+				<PanelColorSettings
+					title={ __( 'Color', 'newspack-blocks' ) }
+					colorSettings={ [
+						{
+							value: textColor.color,
+							onChange: setTextColor,
+							label: __( 'Text', 'newspack-blocks' ),
+						},
+					] }
+				/>
+				<PanelBody
+					title={ __( 'Typography', 'newspack-blocks' ) }
+					className="newspack-block__panel"
+				>
+					<RangeControl
+						label={ __( 'Type Scale', 'newspack-blocks' ) }
+						beforeIcon={ typeScaleIconSmall }
+						afterIcon={ typeScaleIcon }
+						className="spacing-sizes-control"
+						value={ typeScale }
+						onChange={ ( _typeScale: number ) => setAttributes( { typeScale: _typeScale } ) }
+						min={ 1 }
+						max={ 10 }
+						marks={ true }
+						withInputField={ false }
+						__nextHasNoMarginBottom={ true }
+						required
+					/>
+				</PanelBody>
+				{ postLayout === 'grid' && (
+					<PanelBody
+						title={ __( 'Dimensions', 'newspack-blocks' ) }
+						initialOpen={ false }
+					>
+						<RangeControl
+							label={ __( 'Grid Spacing', 'newspack-blocks' ) }
+							className="spacing-sizes-control"
+							value={ colGap }
+							onChange={ ( _colGap: number ) => setAttributes( { colGap: _colGap } ) }
+							min={ 1 }
+							max={ 3 }
+							marks={ true }
+							withInputField={ false }
+							__nextHasNoMarginBottom={ true }
+							required
+						/>
+					</PanelBody>
+				) }
 			</Fragment>
 		);
 	};
@@ -860,6 +857,7 @@ class Edit extends Component< HomepageArticlesProps > {
 					{ showImage && <Toolbar controls={ blockControlsImageShape } /> }
 				</BlockControls>
 				<InspectorControls>{ this.renderInspectorControls() }</InspectorControls>
+				<InspectorControls group="styles">{ this.renderStylesInspectorControls() }</InspectorControls>
 			</Fragment>
 		);
 	}

--- a/src/blocks/homepage-articles/edit.tsx
+++ b/src/blocks/homepage-articles/edit.tsx
@@ -346,83 +346,76 @@ class Edit extends Component< HomepageArticlesProps > {
 
 		return (
 			<Fragment>
-				<PanelBody title={ __( 'Settings', 'newspack-blocks' ) }>
-					<PanelRow>
-						<BaseControl
-							label={ __( 'Content', 'newspack-blocks' ) }
-							id="newspack-block__content-display"
-							className="newspack-block__button-group"
-						>
-							<ButtonGroup className="components-button-group__3">
-								<Button
-									variant={ ! showExcerpt && ! showFullContent && 'primary' }
-									aria-pressed={ ! showExcerpt && ! showFullContent }
-									onClick={ () => {
-										setAttributes( {
-											showExcerpt: false,
-											showFullContent: false
-										} )
-									} }
-								>
-									{ __( 'None', 'newspack-blocks' ) }
-								</Button>
-								<Button
-									variant={ showExcerpt && ! showFullContent && 'primary' }
-									aria-pressed={ showExcerpt && ! showFullContent }
-									onClick={ () => {
-										setAttributes( {
-											showExcerpt: ! showExcerpt,
-											showFullContent: showFullContent ? false : showFullContent
-										} )
-									} }
-								>
-									{ __( 'Excerpt', 'newspack-blocks' ) }
-								</Button>
-								<Button
-									variant={ ! showExcerpt && showFullContent && 'primary' }
-									aria-pressed={ ! showExcerpt && showFullContent }
-									onClick={ () => {
-										setAttributes( {
-											showFullContent: ! showFullContent,
-											showExcerpt: showExcerpt ? false : showExcerpt
-										} )
-									} }
-								>
-									{ __( 'Full Post', 'newspack-blocks' ) }
-								</Button>
-							</ButtonGroup>
-						</BaseControl>
-					</PanelRow>
+				<PanelBody title={ __( 'Settings', 'newspack-blocks' ) } className="newspack-block__panel">
+					<BaseControl
+						label={ __( 'Content', 'newspack-blocks' ) }
+						id="newspack-block__content-display"
+						className="newspack-block__button-group"
+					>
+						<ButtonGroup className="components-button-group__3">
+							<Button
+								variant={ ! showExcerpt && ! showFullContent && 'primary' }
+								aria-pressed={ ! showExcerpt && ! showFullContent }
+								onClick={ () => {
+									setAttributes( {
+										showExcerpt: false,
+										showFullContent: false
+									} )
+								} }
+							>
+								{ __( 'None', 'newspack-blocks' ) }
+							</Button>
+							<Button
+								variant={ showExcerpt && ! showFullContent && 'primary' }
+								aria-pressed={ showExcerpt && ! showFullContent }
+								onClick={ () => {
+									setAttributes( {
+										showExcerpt: ! showExcerpt,
+										showFullContent: showFullContent ? false : showFullContent
+									} )
+								} }
+							>
+								{ __( 'Excerpt', 'newspack-blocks' ) }
+							</Button>
+							<Button
+								variant={ ! showExcerpt && showFullContent && 'primary' }
+								aria-pressed={ ! showExcerpt && showFullContent }
+								onClick={ () => {
+									setAttributes( {
+										showFullContent: ! showFullContent,
+										showExcerpt: showExcerpt ? false : showExcerpt
+									} )
+								} }
+							>
+								{ __( 'Full Post', 'newspack-blocks' ) }
+							</Button>
+						</ButtonGroup>
+					</BaseControl>
 					{ showExcerpt && (
-						<PanelRow>
-							<RangeControl
-								label={ __( 'Max number of words in excerpt', 'newspack-blocks' ) }
-								value={ excerptLength }
-								onChange={ ( value: number ) => setAttributes( { excerptLength: value } ) }
-								min={ 10 }
-								max={ 100 }
-								__next40pxDefaultSize
-							/>
-						</PanelRow>
+						<RangeControl
+							label={ __( 'Max number of words in excerpt', 'newspack-blocks' ) }
+							value={ excerptLength }
+							onChange={ ( value: number ) => setAttributes( { excerptLength: value } ) }
+							min={ 10 }
+							max={ 100 }
+							__next40pxDefaultSize
+						/>
 					) }
 					{ ! showFullContent && (
-					<PanelRow>
 						<ToggleControl
 							label={ __( 'Show "Read more" link', 'newspack-blocks' ) }
 							checked={ showReadMore }
 							onChange={ () => setAttributes( { showReadMore: ! showReadMore } ) }
 						/>
-					</PanelRow>
 					) }
 					{ ! showFullContent && showReadMore && (
-						<PanelRow>
-							<TextControl
-								label={ __( '"Read more" link text', 'newspack-blocks' ) }
-								value={ readMoreLabel }
-								placeholder={ readMoreLabel }
-								onChange={ ( value: string ) => setAttributes( { readMoreLabel: value } ) }
-							/>
-						</PanelRow>
+						<TextControl
+							label={ __( '"Read more" link text', 'newspack-blocks' ) }
+							value={ readMoreLabel }
+							placeholder={ readMoreLabel }
+							onChange={ ( value: string ) => setAttributes( { readMoreLabel: value } ) }
+							__next40pxDefaultSize
+						/>
 					) }
 					{ ! specificMode && isBlogPrivate() ? (
 						/*
@@ -432,31 +425,25 @@ class Edit extends Component< HomepageArticlesProps > {
 						 * which is not provided in the current implementation.
 						 * See https://github.com/Automattic/newspack-blocks/issues/306.
 						 */
-						<PanelRow>
-							<ToggleControl
-								label={ __( 'Show "Load more posts" button', 'newspack-blocks' ) }
-								help={ __( 'This site is private, therefore this feature is not active.', 'newspack-blocks' ) }
-								disabled={ true }
-							/>
-						</PanelRow>
+						<ToggleControl
+							label={ __( 'Show "Load more posts" button', 'newspack-blocks' ) }
+							help={ __( 'This site is private, therefore this feature is not active.', 'newspack-blocks' ) }
+							disabled={ true }
+						/>
 					) : (
 						! specificMode && (
 							<>
-								<PanelRow>
-									<ToggleControl
-										label={ __( 'Show "Load more posts" button', 'newspack-blocks' ) }
-										checked={ moreButton }
-										onChange={ () => setAttributes( { moreButton: ! moreButton } ) }
-									/>
-								</PanelRow>
+								<ToggleControl
+									label={ __( 'Show "Load more posts" button', 'newspack-blocks' ) }
+									checked={ moreButton }
+									onChange={ () => setAttributes( { moreButton: ! moreButton } ) }
+								/>
 								{ moreButton && (
-									<PanelRow>
-										<ToggleControl
-											label={ __( 'Infinite scroll', 'newspack-blocks' ) }
-											checked={ infiniteScroll }
-											onChange={ () => setAttributes( { infiniteScroll: ! infiniteScroll } ) }
-										/>
-									</PanelRow>
+									<ToggleControl
+										label={ __( 'Infinite scroll', 'newspack-blocks' ) }
+										checked={ infiniteScroll }
+										onChange={ () => setAttributes( { infiniteScroll: ! infiniteScroll } ) }
+									/>
 								) }
 							</>
 						)
@@ -475,7 +462,7 @@ class Edit extends Component< HomepageArticlesProps > {
 						/>
 					</PanelBody>
 				) }
-				<PanelBody title={ __( 'Loop', 'newspack-blocks' ) } initialOpen={ false } className="newspack-block__loop-panel">
+				<PanelBody title={ __( 'Loop', 'newspack-blocks' ) } initialOpen={ false } className="newspack-block__panel is-loop">
 					<QueryControls
 						numberOfItems={ postsToShow }
 						onNumberOfItemsChange={ ( _postsToShow: number ) =>
@@ -512,7 +499,6 @@ class Edit extends Component< HomepageArticlesProps > {
 						) }
 						checked={ ! attributes.deduplicate }
 						onChange={ ( value: boolean ) => setAttributes( { deduplicate: ! value } ) }
-						className="newspack-blocks-deduplication-toggle"
 					/>
 				</PanelBody>
 				<PanelBody title={ __( 'Featured Image', 'newspack-blocks' ) } initialOpen={ false }>

--- a/src/blocks/homepage-articles/edit.tsx
+++ b/src/blocks/homepage-articles/edit.tsx
@@ -401,6 +401,7 @@ class Edit extends Component< HomepageArticlesProps > {
 								onChange={ ( value: number ) => setAttributes( { excerptLength: value } ) }
 								min={ 10 }
 								max={ 100 }
+								__next40pxDefaultSize
 							/>
 						</PanelRow>
 					) }
@@ -470,6 +471,7 @@ class Edit extends Component< HomepageArticlesProps > {
 							min={ 2 }
 							max={ 6 }
 							required
+							__next40pxDefaultSize
 						/>
 					</PanelBody>
 				) }

--- a/src/blocks/homepage-articles/edit.tsx
+++ b/src/blocks/homepage-articles/edit.tsx
@@ -355,9 +355,8 @@ class Edit extends Component< HomepageArticlesProps > {
 						>
 							<ButtonGroup className="components-button-group__3">
 								<Button
-									isPrimary={ ! showExcerpt && ! showFullContent }
+									variant={ ! showExcerpt && ! showFullContent && 'primary' }
 									aria-pressed={ ! showExcerpt && ! showFullContent }
-									aria-label={ __( 'None', 'newspack-blocks' ) }
 									onClick={ () => {
 										setAttributes( {
 											showExcerpt: false,
@@ -368,9 +367,8 @@ class Edit extends Component< HomepageArticlesProps > {
 									{ __( 'None', 'newspack-blocks' ) }
 								</Button>
 								<Button
-									isPrimary={ showExcerpt && ! showFullContent }
+									variant={ showExcerpt && ! showFullContent && 'primary' }
 									aria-pressed={ showExcerpt && ! showFullContent }
-									aria-label={ __( 'Excerpt', 'newspack-blocks' ) }
 									onClick={ () => {
 										setAttributes( {
 											showExcerpt: ! showExcerpt,
@@ -381,9 +379,8 @@ class Edit extends Component< HomepageArticlesProps > {
 									{ __( 'Excerpt', 'newspack-blocks' ) }
 								</Button>
 								<Button
-									isPrimary={ ! showExcerpt && showFullContent }
+									variant={ ! showExcerpt && showFullContent && 'primary' }
 									aria-pressed={ ! showExcerpt && showFullContent }
-									aria-label={ __( 'Full Post', 'newspack-blocks' ) }
 									onClick={ () => {
 										setAttributes( {
 											showFullContent: ! showFullContent,
@@ -416,7 +413,7 @@ class Edit extends Component< HomepageArticlesProps > {
 						/>
 					</PanelRow>
 					) }
-					{ showReadMore && (
+					{ ! showFullContent && showReadMore && (
 						<PanelRow>
 							<TextControl
 								label={ __( '"Read more" link text', 'newspack-blocks' ) }
@@ -483,7 +480,8 @@ class Edit extends Component< HomepageArticlesProps > {
 							setAttributes( { postsToShow: _postsToShow || 1 } )
 						}
 						specificMode={ specificMode }
-						onSpecificModeChange={ handleAttributeChange( 'specificMode' ) }
+						onSpecificModeChange={ () => setAttributes( { specificMode: true } ) }
+						onLoopModeChange={ () => setAttributes( { specificMode: false } ) }
 						specificPosts={ specificPosts }
 						onSpecificPostsChange={ handleAttributeChange( 'specificPosts' ) }
 						authors={ authors }

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -69,4 +69,32 @@
 			}
 		}
 	}
+
+	&__button-group {
+		flex: 0 0 100%;
+
+		.components-base-control__label {
+			width: 100%;
+		}
+
+		.components-button-group {
+			display: grid;
+
+			&__3 {
+				grid-template-columns: repeat(3, 1fr);
+			}
+
+			button {
+				justify-content: center;
+			}
+		}
+	}
+}
+
+.components-base-control__field:empty {
+	display: none;
+
+	+ .components-base-control__help {
+		margin: 0;
+	}
 }

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -76,10 +76,15 @@
 		> *:not(.components-panel__body-title) {
 			margin-bottom: 24px;
 			margin-top: 0;
+
+			&:last-of-type {
+				margin-bottom: 8px;
+			}
 		}
 
 		.components-button.is-secondary {
 			justify-content: center;
+			margin-bottom: 24px;
 			width: 100%;
 
 			&:has(svg) {
@@ -87,7 +92,7 @@
 			}
 		}
 
-		.autocomplete-tokenfield + .components-toggle-control:not(.newspack-blocks-deduplication-toggle) {
+		.autocomplete-tokenfield + .components-checkbox-control {
 			margin-top: -16px;
 		}
 	}

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -70,9 +70,7 @@
 				}
 			}
 		}
-	}
 
-	&__loop-panel {
 		> *:not(.components-panel__body-title) {
 			margin-bottom: 24px;
 			margin-top: 0;
@@ -82,18 +80,20 @@
 			}
 		}
 
-		.components-button.is-secondary {
-			justify-content: center;
-			margin-bottom: 24px;
-			width: 100%;
+		&.is-loop {
+			.components-button.is-secondary {
+				justify-content: center;
+				margin-bottom: 24px;
+				width: 100%;
 
-			&:has(svg) {
-				justify-content: space-between;
+				&:has(svg) {
+					justify-content: space-between;
+				}
 			}
-		}
 
-		.autocomplete-tokenfield + .components-checkbox-control {
-			margin-top: -16px;
+			.autocomplete-tokenfield + .components-checkbox-control {
+				margin-top: -16px;
+			}
 		}
 	}
 

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -80,6 +80,10 @@
 		.components-button-group {
 			display: grid;
 
+			&__2 {
+				grid-template-columns: repeat(2, 1fr);
+			}
+
 			&__3 {
 				grid-template-columns: repeat(3, 1fr);
 			}

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -62,11 +62,33 @@
 		}
 	}
 
-	&__panel .spacing-sizes-control {
-		.components-range-control__root {
-			> span {
-				margin-top: 0;
+	&__panel {
+		.spacing-sizes-control {
+			.components-range-control__root {
+				> span {
+					margin-top: 0;
+				}
 			}
+		}
+	}
+
+	&__loop-panel {
+		> *:not(.components-panel__body-title) {
+			margin-bottom: 24px;
+			margin-top: 0;
+		}
+
+		.components-button.is-secondary {
+			justify-content: center;
+			width: 100%;
+
+			&:has(svg) {
+				justify-content: space-between;
+			}
+		}
+
+		.autocomplete-tokenfield + .components-toggle-control:not(.newspack-blocks-deduplication-toggle) {
+			margin-top: -16px;
 		}
 	}
 

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -61,4 +61,12 @@
 			opacity: 0.6;
 		}
 	}
+
+	&__panel .spacing-sizes-control {
+		.components-range-control__root {
+			> span {
+				margin-top: 0;
+			}
+		}
+	}
 }

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -72,7 +72,7 @@
 		}
 
 		> *:not(.components-panel__body-title) {
-			margin-bottom: 24px;
+			margin-bottom: 16px;
 			margin-top: 0;
 
 			&:last-of-type {
@@ -81,18 +81,8 @@
 		}
 
 		&.is-loop {
-			.components-button.is-secondary {
-				justify-content: center;
-				margin-bottom: 24px;
-				width: 100%;
-
-				&:has(svg) {
-					justify-content: space-between;
-				}
-			}
-
 			.autocomplete-tokenfield + .components-checkbox-control {
-				margin-top: -16px;
+				margin-top: -8px;
 			}
 		}
 	}
@@ -106,14 +96,7 @@
 
 		.components-button-group {
 			display: grid;
-
-			&__2 {
-				grid-template-columns: repeat(2, 1fr);
-			}
-
-			&__3 {
-				grid-template-columns: repeat(3, 1fr);
-			}
+			grid-template-columns: repeat(auto-fit, minmax(40px, 1fr));
 
 			button {
 				justify-content: center;

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -22,7 +22,7 @@ const { name, attributes, category } = metadata;
 // Name must be exported separately.
 export { name };
 
-export const title = __( 'Homepage Posts', 'newspack-blocks' );
+export const title = __( 'Content Loop', 'newspack-blocks' );
 
 export const icon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
@@ -48,11 +48,22 @@ export const settings = {
 		__( 'posts', 'newspack-blocks' ),
 		__( 'articles', 'newspack-blocks' ),
 		__( 'latest', 'newspack-blocks' ),
+		__( 'homepage', 'newspack-blocks' ),
 	],
-	description: __( 'A block for displaying homepage posts.', 'newspack-blocks' ),
+	description: __(
+		'An advanced block that allows displaying content based on different parameters and visual configurations.',
+		'newspack-blocks'
+	),
 	styles: [
-		{ name: 'default', label: _x( 'Default', 'block style', 'newspack-blocks' ), isDefault: true },
-		{ name: 'borders', label: _x( 'Borders', 'block style', 'newspack-blocks' ) },
+		{
+			name: 'default',
+			label: _x('Default', 'block style', 'newspack-blocks'),
+			isDefault: true,
+		},
+		{
+			name: 'borders',
+			label: _x('Borders', 'block style', 'newspack-blocks'),
+		},
 	],
 	supports: {
 		html: false,

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -49,6 +49,7 @@ export const settings = {
 		__( 'articles', 'newspack-blocks' ),
 		__( 'latest', 'newspack-blocks' ),
 		__( 'homepage', 'newspack-blocks' ),
+		__( 'query', 'newspack-blocks' ),
 	],
 	description: __(
 		'An advanced block that allows displaying content based on different parameters and visual configurations.',

--- a/src/blocks/homepage-articles/utils.ts
+++ b/src/blocks/homepage-articles/utils.ts
@@ -268,7 +268,7 @@ export const postsBlockDispatch = (
 ) => {
 	return {
 		// Only editor blocks can trigger reflows.
-		// @ts-ignore It's a string.
+		// @ts-expect-error It's a string.
 		triggerReflow: isEditorBlock ? dispatch( STORE_NAMESPACE ).reflow : () => undefined,
 	};
 };

--- a/src/components/autocomplete-tokenfield.js
+++ b/src/components/autocomplete-tokenfield.js
@@ -181,6 +181,7 @@ class AutocompleteTokenField extends Component {
 					onChange={ tokens => this.handleOnChange( tokens ) }
 					onInputChange={ input => this.debouncedUpdateSuggestions( input ) }
 					label={ label }
+					__next40pxDefaultSize
 				/>
 				{ loading && <Spinner /> }
 				{ help && <p className="autocomplete-tokenfield__help">{ help }</p> }

--- a/src/components/autocomplete-tokenfield.scss
+++ b/src/components/autocomplete-tokenfield.scss
@@ -5,9 +5,13 @@
 	position: relative;
 
 	.components-spinner {
+		bottom: 12px;
 		position: absolute;
-		top: 2em;
 		right: 0;
+	}
+
+	&:has(.autocomplete-tokenfield__help) .components-spinner {
+		bottom: calc(36px + 8px + 12px);
 	}
 
 	/* Workaround for hard-coded help text in FormTokenField. */

--- a/src/components/autocomplete-tokenfield.scss
+++ b/src/components/autocomplete-tokenfield.scss
@@ -1,4 +1,7 @@
+@use "~@wordpress/base-styles/colors" as wp-colors;
+
 .autocomplete-tokenfield {
+	max-width: 100%;
 	position: relative;
 
 	.components-spinner {
@@ -13,6 +16,8 @@
 	}
 
 	.autocomplete-tokenfield__help {
-		font-style: italic;
+		color: wp-colors.$gray-700;
+		font-size: 12px;
+		margin: 8px 0;
 	}
 }

--- a/src/components/editor-panels.js
+++ b/src/components/editor-panels.js
@@ -50,7 +50,7 @@ export const PostTypesPanel = ( { attributes, setAttributes } ) => {
 	} );
 
 	return (
-		<PanelBody title={ __( 'Post Types', 'newspack-blocks' ) }>
+		<PanelBody title={ __( 'Post Types', 'newspack-blocks' ) } initialOpen={ false }>
 			<CheckboxesGroup
 				options={ availablePostTypes }
 				values={ attributes.postType }
@@ -62,7 +62,7 @@ export const PostTypesPanel = ( { attributes, setAttributes } ) => {
 
 export const PostStatusesPanel = ( { attributes, setAttributes } ) => {
 	return (
-		<PanelBody title={ __( 'Additional Post Statuses', 'newspack-blocks' ) }>
+		<PanelBody title={ __( 'Additional Post Statuses', 'newspack-blocks' ) } initialOpen={ false }>
 			<PanelRow>
 				<i>
 					{ __(

--- a/src/components/editor-panels.js
+++ b/src/components/editor-panels.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { BaseControl, CheckboxControl, PanelBody, PanelRow, Spinner } from '@wordpress/components';
+import { BaseControl, CheckboxControl, PanelBody, Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 
 const CheckboxesGroup = ( { options, values, onChange } ) => {
@@ -10,21 +10,20 @@ const CheckboxesGroup = ( { options, values, onChange } ) => {
 		return <Spinner />;
 	}
 	return options.map( ( { name, slug } ) => (
-		<PanelRow key={ slug }>
-			<CheckboxControl
-				label={ name }
-				checked={ values.indexOf( slug ) > -1 }
-				onChange={ value => {
-					const cleanPostType = [ ...new Set( values ) ];
-					if ( value && cleanPostType.indexOf( slug ) === -1 ) {
-						cleanPostType.push( slug );
-					} else if ( ! value && cleanPostType.indexOf( slug ) > -1 ) {
-						cleanPostType.splice( cleanPostType.indexOf( slug ), 1 );
-					}
-					onChange( cleanPostType );
-				} }
-			/>
-		</PanelRow>
+		<CheckboxControl
+			label={ name }
+			checked={ values.indexOf( slug ) > -1 }
+			onChange={ value => {
+				const cleanPostType = [ ...new Set( values ) ];
+				if ( value && cleanPostType.indexOf( slug ) === -1 ) {
+					cleanPostType.push( slug );
+				} else if ( ! value && cleanPostType.indexOf( slug ) > -1 ) {
+					cleanPostType.splice( cleanPostType.indexOf( slug ), 1 );
+				}
+				onChange( cleanPostType );
+			} }
+			key={ slug }
+		/>
 	) );
 };
 
@@ -63,9 +62,7 @@ export const PostTypesPanel = ( { attributes, setAttributes } ) => {
 export const PostStatusesPanel = ( { attributes, setAttributes } ) => {
 	return (
 		<PanelBody title={ __( 'Additional Post Statuses', 'newspack-blocks' ) } initialOpen={ false }>
-			<PanelRow>
-				<BaseControl help={ __( 'Selection here has effect only for editors, regular users will only see published posts.', 'newspack-blocks' ) } />
-			</PanelRow>
+			<BaseControl help={ __( 'Selection here has effect only for editors, regular users will only see published posts.', 'newspack-blocks' ) } />
 			<CheckboxesGroup
 				values={ attributes.includedPostStatuses }
 				options={ [

--- a/src/components/editor-panels.js
+++ b/src/components/editor-panels.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Spinner, CheckboxControl, PanelBody, PanelRow } from '@wordpress/components';
+import { BaseControl, CheckboxControl, PanelBody, PanelRow, Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 
 const CheckboxesGroup = ( { options, values, onChange } ) => {
@@ -64,12 +64,7 @@ export const PostStatusesPanel = ( { attributes, setAttributes } ) => {
 	return (
 		<PanelBody title={ __( 'Additional Post Statuses', 'newspack-blocks' ) } initialOpen={ false }>
 			<PanelRow>
-				<i>
-					{ __(
-						'Selection here has effect only for editors, regular users will only see published posts.',
-						'newspack-blocks'
-					) }
-				</i>
+				<BaseControl help={ __( 'Selection here has effect only for editors, regular users will only see published posts.', 'newspack-blocks' ) } />
 			</PanelRow>
 			<CheckboxesGroup
 				values={ attributes.includedPostStatuses }

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -3,7 +3,13 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { BaseControl, Button, ButtonGroup, QueryControls as BasicQueryControls, ToggleControl } from '@wordpress/components';
+import {
+	BaseControl,
+	Button,
+	ButtonGroup,
+	CheckboxControl,
+	QueryControls as BasicQueryControls
+} from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -261,6 +267,11 @@ class QueryControls extends Component {
 						label={ __( 'Type', 'newspack-blocks' ) }
 						id="newspack-block__loop-type"
 						className="newspack-block__button-group"
+						help={ specificMode ? (
+							__( 'The block will display only the specifically selected post(s).', 'newspack-blocks' )
+						) : (
+							__( 'The block will display content based on the filtering settings below.', 'newspack-blocks' )
+						) }
 					>
 						<ButtonGroup className="components-button-group__2">
 							<Button
@@ -314,7 +325,7 @@ class QueryControls extends Component {
 							/>
 						) }
 						{ onIncludeSubcategoriesChange && (
-							<ToggleControl
+							<CheckboxControl
 								checked={ includeSubcategories }
 								onChange={ onIncludeSubcategoriesChange }
 								label={ __( 'Include subcategories ', 'newspack-blocks' ) }

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -3,7 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { Button, QueryControls as BasicQueryControls, PanelRow, ToggleControl } from '@wordpress/components';
+import { BaseControl, Button, ButtonGroup, QueryControls as BasicQueryControls, PanelRow, ToggleControl } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -217,6 +217,7 @@ class QueryControls extends Component {
 		const {
 			specificMode,
 			onSpecificModeChange,
+			onLoopModeChange,
 			specificPosts,
 			onSpecificPostsChange,
 			authors,
@@ -256,11 +257,28 @@ class QueryControls extends Component {
 			<>
 				{ enableSpecific && (
 					<PanelRow>
-						<ToggleControl
-							checked={ specificMode }
-							onChange={ onSpecificModeChange }
-							label={ __( 'Choose specific posts', 'newspack-blocks' ) }
-						/>
+						<BaseControl
+							label={ __( 'Query type', 'newspack-blocks' ) }
+							id="newspack-block__query-type"
+							className="newspack-block__button-group"
+						>
+							<ButtonGroup className="components-button-group__2">
+								<Button
+									variant={ ! specificMode && 'primary' }
+									aria-pressed={ ! specificMode }
+									onClick={ onLoopModeChange }
+								>
+									{ __( 'Loop', 'newspack-blocks' ) }
+								</Button>
+								<Button
+									variant={ specificMode && 'primary' }
+									aria-pressed={ specificMode }
+									onClick={ onSpecificModeChange }
+								>
+									{ __( 'Specific', 'newspack-blocks' ) }
+								</Button>
+							</ButtonGroup>
+						</BaseControl>
 					</PanelRow>
 				) }
 				{ specificMode ? (

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -3,7 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { Button, QueryControls as BasicQueryControls, ToggleControl } from '@wordpress/components';
+import { Button, QueryControls as BasicQueryControls, PanelRow, ToggleControl } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -255,60 +255,74 @@ class QueryControls extends Component {
 		return (
 			<>
 				{ enableSpecific && (
-					<ToggleControl
-						checked={ specificMode }
-						onChange={ onSpecificModeChange }
-						label={ __( 'Choose Specific Posts', 'newspack-blocks' ) }
-					/>
+					<PanelRow>
+						<ToggleControl
+							checked={ specificMode }
+							onChange={ onSpecificModeChange }
+							label={ __( 'Choose specific posts', 'newspack-blocks' ) }
+						/>
+					</PanelRow>
 				) }
 				{ specificMode ? (
-					<AutocompleteTokenField
-						tokens={ specificPosts || [] }
-						onChange={ onSpecificPostsChange }
-						fetchSuggestions={ this.fetchPostSuggestions }
-						fetchSavedInfo={ this.fetchSavedPosts }
-						label={ __( 'Posts', 'newspack-blocks' ) }
-						help={ __(
-							'Begin typing post title, click autocomplete result to select.',
-							'newspack-blocks'
-						) }
-					/>
+					<PanelRow>
+						<AutocompleteTokenField
+							tokens={ specificPosts || [] }
+							onChange={ onSpecificPostsChange }
+							fetchSuggestions={ this.fetchPostSuggestions }
+							fetchSavedInfo={ this.fetchSavedPosts }
+							label={ __( 'Posts', 'newspack-blocks' ) }
+							help={ __(
+								'Begin typing post title, click autocomplete result to select.',
+								'newspack-blocks'
+							) }
+						/>
+					</PanelRow>
 				) : (
 					<>
-						<BasicQueryControls { ...this.props } />
+						<PanelRow>
+							<BasicQueryControls { ...this.props } />
+						</PanelRow>
 						{ onAuthorsChange && (
-							<AutocompleteTokenField
-								tokens={ authors || [] }
-								onChange={ onAuthorsChange }
-								fetchSuggestions={ this.fetchAuthorSuggestions }
-								fetchSavedInfo={ this.fetchSavedAuthors }
-								label={ __( 'Authors', 'newspack-blocks' ) }
-							/>
+							<PanelRow>
+								<AutocompleteTokenField
+									tokens={ authors || [] }
+									onChange={ onAuthorsChange }
+									fetchSuggestions={ this.fetchAuthorSuggestions }
+									fetchSavedInfo={ this.fetchSavedAuthors }
+									label={ __( 'Authors', 'newspack-blocks' ) }
+								/>
+							</PanelRow>
 						) }
 						{ onCategoriesChange && (
-							<AutocompleteTokenField
-								tokens={ categories || [] }
-								onChange={ onCategoriesChange }
-								fetchSuggestions={ this.fetchCategorySuggestions }
-								fetchSavedInfo={ this.fetchSavedCategories }
-								label={ __( 'Categories', 'newspack-blocks' ) }
-							/>
+							<PanelRow>
+								<AutocompleteTokenField
+									tokens={ categories || [] }
+									onChange={ onCategoriesChange }
+									fetchSuggestions={ this.fetchCategorySuggestions }
+									fetchSavedInfo={ this.fetchSavedCategories }
+									label={ __( 'Categories', 'newspack-blocks' ) }
+								/>
+							</PanelRow>
 						) }
 						{ onIncludeSubcategoriesChange && (
-							<ToggleControl
-								checked={ includeSubcategories }
-								onChange={ onIncludeSubcategoriesChange }
-								label={ __( 'Include subcategories ', 'newspack-blocks' ) }
-							/>
+							<PanelRow>
+								<ToggleControl
+									checked={ includeSubcategories }
+									onChange={ onIncludeSubcategoriesChange }
+									label={ __( 'Include subcategories ', 'newspack-blocks' ) }
+								/>
+							</PanelRow>
 						) }
 						{ onTagsChange && (
-							<AutocompleteTokenField
-								tokens={ tags || [] }
-								onChange={ onTagsChange }
-								fetchSuggestions={ this.fetchTagSuggestions }
-								fetchSavedInfo={ this.fetchSavedTags }
-								label={ __( 'Tags', 'newspack-blocks' ) }
-							/>
+							<PanelRow>
+								<AutocompleteTokenField
+									tokens={ tags || [] }
+									onChange={ onTagsChange }
+									fetchSuggestions={ this.fetchTagSuggestions }
+									fetchSavedInfo={ this.fetchSavedTags }
+									label={ __( 'Tags', 'newspack-blocks' ) }
+								/>
+							</PanelRow>
 						) }
 						{ onCustomTaxonomiesChange &&
 							registeredCustomTaxonomies.map( tax => (
@@ -331,16 +345,16 @@ class QueryControls extends Component {
 								/>
 							) ) }
 						{ onTagExclusionsChange && (
-							<p>
+							<PanelRow>
 								<Button
-									isLink
+									variant="secondary"
 									onClick={ () => this.setState( { showAdvancedFilters: ! showAdvancedFilters } ) }
 								>
 									{ showAdvancedFilters
-										? __( 'Hide Advanced Filters', 'newspack-blocks' )
-										: __( 'Show Advanced Filters', 'newspack-blocks' ) }
+										? __( 'Hide advanced filters', 'newspack-blocks' )
+										: __( 'Show advanced filters', 'newspack-blocks' ) }
 								</Button>
-							</p>
+							</PanelRow>
 						) }
 						{ showAdvancedFilters && (
 							<>
@@ -350,7 +364,7 @@ class QueryControls extends Component {
 										onChange={ onTagExclusionsChange }
 										fetchSuggestions={ this.fetchTagSuggestions }
 										fetchSavedInfo={ this.fetchSavedTags }
-										label={ __( 'Excluded Tags', 'newspack-blocks' ) }
+										label={ __( 'Excluded tags', 'newspack-blocks' ) }
 									/>
 								) }
 								{ onCategoryExclusionsChange && (
@@ -359,7 +373,7 @@ class QueryControls extends Component {
 										onChange={ onCategoryExclusionsChange }
 										fetchSuggestions={ this.fetchCategorySuggestions }
 										fetchSavedInfo={ this.fetchSavedCategories }
-										label={ __( 'Excluded Categories', 'newspack-blocks' ) }
+										label={ __( 'Excluded categories', 'newspack-blocks' ) }
 									/>
 								) }
 								{ registeredCustomTaxonomies &&

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -3,10 +3,11 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { BaseControl, Button, ButtonGroup, QueryControls as BasicQueryControls, PanelRow, ToggleControl } from '@wordpress/components';
+import { BaseControl, Button, ButtonGroup, QueryControls as BasicQueryControls, ToggleControl } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
+import { chevronDown, chevronUp } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -256,91 +257,77 @@ class QueryControls extends Component {
 		return (
 			<>
 				{ enableSpecific && (
-					<PanelRow>
-						<BaseControl
-							label={ __( 'Query type', 'newspack-blocks' ) }
-							id="newspack-block__query-type"
-							className="newspack-block__button-group"
-						>
-							<ButtonGroup className="components-button-group__2">
-								<Button
-									variant={ ! specificMode && 'primary' }
-									aria-pressed={ ! specificMode }
-									onClick={ onLoopModeChange }
-								>
-									{ __( 'Loop', 'newspack-blocks' ) }
-								</Button>
-								<Button
-									variant={ specificMode && 'primary' }
-									aria-pressed={ specificMode }
-									onClick={ onSpecificModeChange }
-								>
-									{ __( 'Specific', 'newspack-blocks' ) }
-								</Button>
-							</ButtonGroup>
-						</BaseControl>
-					</PanelRow>
+					<BaseControl
+						label={ __( 'Type', 'newspack-blocks' ) }
+						id="newspack-block__loop-type"
+						className="newspack-block__button-group"
+					>
+						<ButtonGroup className="components-button-group__2">
+							<Button
+								variant={ ! specificMode && 'primary' }
+								aria-pressed={ ! specificMode }
+								onClick={ onLoopModeChange }
+							>
+								{ __( 'Query', 'newspack-blocks' ) }
+							</Button>
+							<Button
+								variant={ specificMode && 'primary' }
+								aria-pressed={ specificMode }
+								onClick={ onSpecificModeChange }
+							>
+								{ __( 'Specific', 'newspack-blocks' ) }
+							</Button>
+						</ButtonGroup>
+					</BaseControl>
 				) }
 				{ specificMode ? (
-					<PanelRow>
-						<AutocompleteTokenField
-							tokens={ specificPosts || [] }
-							onChange={ onSpecificPostsChange }
-							fetchSuggestions={ this.fetchPostSuggestions }
-							fetchSavedInfo={ this.fetchSavedPosts }
-							label={ __( 'Posts', 'newspack-blocks' ) }
-							help={ __(
-								'Begin typing post title, click autocomplete result to select.',
-								'newspack-blocks'
-							) }
-						/>
-					</PanelRow>
+					<AutocompleteTokenField
+						tokens={ specificPosts || [] }
+						onChange={ onSpecificPostsChange }
+						fetchSuggestions={ this.fetchPostSuggestions }
+						fetchSavedInfo={ this.fetchSavedPosts }
+						label={ __( 'Posts', 'newspack-blocks' ) }
+						help={ __(
+							'Begin typing post title, click autocomplete result to select.',
+							'newspack-blocks'
+						) }
+					/>
 				) : (
 					<>
-						<PanelRow>
-							<BasicQueryControls { ...this.props } />
-						</PanelRow>
+						<BasicQueryControls { ...this.props } />
 						{ onAuthorsChange && (
-							<PanelRow>
-								<AutocompleteTokenField
-									tokens={ authors || [] }
-									onChange={ onAuthorsChange }
-									fetchSuggestions={ this.fetchAuthorSuggestions }
-									fetchSavedInfo={ this.fetchSavedAuthors }
-									label={ __( 'Authors', 'newspack-blocks' ) }
-								/>
-							</PanelRow>
+							<AutocompleteTokenField
+								tokens={ authors || [] }
+								onChange={ onAuthorsChange }
+								fetchSuggestions={ this.fetchAuthorSuggestions }
+								fetchSavedInfo={ this.fetchSavedAuthors }
+								label={ __( 'Authors', 'newspack-blocks' ) }
+							/>
 						) }
 						{ onCategoriesChange && (
-							<PanelRow>
-								<AutocompleteTokenField
-									tokens={ categories || [] }
-									onChange={ onCategoriesChange }
-									fetchSuggestions={ this.fetchCategorySuggestions }
-									fetchSavedInfo={ this.fetchSavedCategories }
-									label={ __( 'Categories', 'newspack-blocks' ) }
-								/>
-							</PanelRow>
+							<AutocompleteTokenField
+								tokens={ categories || [] }
+								onChange={ onCategoriesChange }
+								fetchSuggestions={ this.fetchCategorySuggestions }
+								fetchSavedInfo={ this.fetchSavedCategories }
+								label={ __( 'Categories', 'newspack-blocks' ) }
+							/>
 						) }
 						{ onIncludeSubcategoriesChange && (
-							<PanelRow>
-								<ToggleControl
-									checked={ includeSubcategories }
-									onChange={ onIncludeSubcategoriesChange }
-									label={ __( 'Include subcategories ', 'newspack-blocks' ) }
-								/>
-							</PanelRow>
+							<ToggleControl
+								checked={ includeSubcategories }
+								onChange={ onIncludeSubcategoriesChange }
+								label={ __( 'Include subcategories ', 'newspack-blocks' ) }
+							/>
 						) }
 						{ onTagsChange && (
-							<PanelRow>
-								<AutocompleteTokenField
-									tokens={ tags || [] }
-									onChange={ onTagsChange }
-									fetchSuggestions={ this.fetchTagSuggestions }
-									fetchSavedInfo={ this.fetchSavedTags }
-									label={ __( 'Tags', 'newspack-blocks' ) }
-								/>
-							</PanelRow>
+							<AutocompleteTokenField
+								tokens={ tags || [] }
+								onChange={ onTagsChange }
+								fetchSuggestions={ this.fetchTagSuggestions }
+								fetchSavedInfo={ this.fetchSavedTags }
+								label={ __( 'Tags', 'newspack-blocks' ) }
+							/>
 						) }
 						{ onCustomTaxonomiesChange &&
 							registeredCustomTaxonomies.map( tax => (
@@ -363,28 +350,18 @@ class QueryControls extends Component {
 								/>
 							) ) }
 						{ onTagExclusionsChange && (
-							<PanelRow>
-								<Button
-									variant="secondary"
-									onClick={ () => this.setState( { showAdvancedFilters: ! showAdvancedFilters } ) }
-								>
-									{ showAdvancedFilters
-										? __( 'Hide advanced filters', 'newspack-blocks' )
-										: __( 'Show advanced filters', 'newspack-blocks' ) }
-								</Button>
-							</PanelRow>
+							<Button
+								variant="secondary"
+								icon={ showAdvancedFilters ? chevronUp : chevronDown }
+								iconPosition="right"
+								iconSize={ 16 }
+								onClick={ () => this.setState( { showAdvancedFilters: ! showAdvancedFilters } ) }
+							>
+								{ __( 'Advanced filters', 'newspack-blocks' ) }
+							</Button>
 						) }
 						{ showAdvancedFilters && (
 							<>
-								{ onTagExclusionsChange && (
-									<AutocompleteTokenField
-										tokens={ tagExclusions || [] }
-										onChange={ onTagExclusionsChange }
-										fetchSuggestions={ this.fetchTagSuggestions }
-										fetchSavedInfo={ this.fetchSavedTags }
-										label={ __( 'Excluded tags', 'newspack-blocks' ) }
-									/>
-								) }
 								{ onCategoryExclusionsChange && (
 									<AutocompleteTokenField
 										tokens={ categoryExclusions || [] }
@@ -392,6 +369,15 @@ class QueryControls extends Component {
 										fetchSuggestions={ this.fetchCategorySuggestions }
 										fetchSavedInfo={ this.fetchSavedCategories }
 										label={ __( 'Excluded categories', 'newspack-blocks' ) }
+									/>
+								) }
+								{ onTagExclusionsChange && (
+									<AutocompleteTokenField
+										tokens={ tagExclusions || [] }
+										onChange={ onTagExclusionsChange }
+										fetchSuggestions={ this.fetchTagSuggestions }
+										fetchSavedInfo={ this.fetchSavedTags }
+										label={ __( 'Excluded tags', 'newspack-blocks' ) }
 									/>
 								) }
 								{ registeredCustomTaxonomies &&

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -13,7 +13,6 @@ import {
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
-import { chevronDown, chevronUp } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -26,10 +25,6 @@ const getCategoryTitle = category =>
 const getTermTitle = term => decodeEntities( term.name ) || __( '(no title)', 'newspack-blocks' );
 
 class QueryControls extends Component {
-	state = {
-		showAdvancedFilters: false,
-	};
-
 	fetchPostSuggestions = search => {
 		const { postType } = this.props;
 		const restUrl = window.newspack_blocks_data.specific_posts_rest_url;
@@ -245,7 +240,6 @@ class QueryControls extends Component {
 			onCustomTaxonomyExclusionsChange,
 			enableSpecific,
 		} = this.props;
-		const { showAdvancedFilters } = this.state;
 
 		const registeredCustomTaxonomies = window.newspack_blocks_data?.custom_taxonomies;
 
@@ -273,7 +267,7 @@ class QueryControls extends Component {
 							__( 'The block will display content based on the filtering settings below.', 'newspack-blocks' )
 						) }
 					>
-						<ButtonGroup className="components-button-group__2">
+						<ButtonGroup>
 							<Button
 								variant={ ! specificMode && 'primary' }
 								aria-pressed={ ! specificMode }
@@ -360,64 +354,49 @@ class QueryControls extends Component {
 									label={ tax.label }
 								/>
 							) ) }
+						{ onCategoryExclusionsChange && (
+							<AutocompleteTokenField
+								tokens={ categoryExclusions || [] }
+								onChange={ onCategoryExclusionsChange }
+								fetchSuggestions={ this.fetchCategorySuggestions }
+								fetchSavedInfo={ this.fetchSavedCategories }
+								label={ __( 'Excluded categories', 'newspack-blocks' ) }
+							/>
+						) }
 						{ onTagExclusionsChange && (
-							<Button
-								variant="secondary"
-								icon={ showAdvancedFilters ? chevronUp : chevronDown }
-								iconPosition="right"
-								iconSize={ 16 }
-								onClick={ () => this.setState( { showAdvancedFilters: ! showAdvancedFilters } ) }
-							>
-								{ __( 'Advanced filters', 'newspack-blocks' ) }
-							</Button>
+							<AutocompleteTokenField
+								tokens={ tagExclusions || [] }
+								onChange={ onTagExclusionsChange }
+								fetchSuggestions={ this.fetchTagSuggestions }
+								fetchSavedInfo={ this.fetchSavedTags }
+								label={ __( 'Excluded tags', 'newspack-blocks' ) }
+							/>
 						) }
-						{ showAdvancedFilters && (
-							<>
-								{ onCategoryExclusionsChange && (
-									<AutocompleteTokenField
-										tokens={ categoryExclusions || [] }
-										onChange={ onCategoryExclusionsChange }
-										fetchSuggestions={ this.fetchCategorySuggestions }
-										fetchSavedInfo={ this.fetchSavedCategories }
-										label={ __( 'Excluded categories', 'newspack-blocks' ) }
-									/>
-								) }
-								{ onTagExclusionsChange && (
-									<AutocompleteTokenField
-										tokens={ tagExclusions || [] }
-										onChange={ onTagExclusionsChange }
-										fetchSuggestions={ this.fetchTagSuggestions }
-										fetchSavedInfo={ this.fetchSavedTags }
-										label={ __( 'Excluded tags', 'newspack-blocks' ) }
-									/>
-								) }
-								{ registeredCustomTaxonomies &&
-									onCustomTaxonomyExclusionsChange &&
-									registeredCustomTaxonomies.map( ( { label, slug } ) => (
-										<AutocompleteTokenField
-											fetchSavedInfo={ termIds => this.fetchSavedCustomTaxonomies( slug, termIds ) }
-											fetchSuggestions={ search =>
-												this.fetchCustomTaxonomiesSuggestions( slug, search )
-											}
-											key={ `${ slug }-exclusions-selector` }
-											label={ sprintf(
-												// translators: %s is the custom taxonomy label.
-												__( 'Excluded %s', 'newspack-blocks' ),
-												label
-											) }
-											onChange={ value =>
-												customTaxonomiesPrepareChange(
-													customTaxonomyExclusions,
-													onCustomTaxonomyExclusionsChange,
-													slug,
-													value
-												)
-											}
-											tokens={ getTermsOfCustomTaxonomy( customTaxonomyExclusions, slug ) }
-										/>
-									) ) }
-							</>
-						) }
+						{ registeredCustomTaxonomies &&
+							onCustomTaxonomyExclusionsChange &&
+							registeredCustomTaxonomies.map( ( { label, slug } ) => (
+								<AutocompleteTokenField
+									fetchSavedInfo={ termIds => this.fetchSavedCustomTaxonomies( slug, termIds ) }
+									fetchSuggestions={ search =>
+										this.fetchCustomTaxonomiesSuggestions( slug, search )
+									}
+									key={ `${ slug }-exclusions-selector` }
+									label={ sprintf(
+										// translators: %s is the custom taxonomy label.
+										__( 'Excluded %s', 'newspack-blocks' ),
+										label
+									) }
+									onChange={ value =>
+										customTaxonomiesPrepareChange(
+											customTaxonomyExclusions,
+											onCustomTaxonomyExclusionsChange,
+											slug,
+											value
+										)
+									}
+									tokens={ getTermsOfCustomTaxonomy( customTaxonomyExclusions, slug ) }
+								/>
+							) ) }
 					</>
 				) }
 			</>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

You can read more about the logic behind this change here: P2-pfaSwu-iT

The main reasons are:

- The block's functionality extends beyond just Posts for the Homepage
- The sidebar settings are disorganised, making navigation through options difficult

__Before:__

![homepage-posts-settings-before](https://github.com/user-attachments/assets/ba734fe7-abf2-49ac-a2aa-9f2a7f763e7f)

__After:__

![content-loop-settings-after](https://github.com/user-attachments/assets/39fb7e89-088d-4dd1-a74d-6b215ad390e7)
![content-loop-styles](https://github.com/user-attachments/assets/e195db0a-6c0a-46fb-9047-44087459e840)

### How to test the changes in this Pull Request:

1. Add a bunch of Homepage post block to a page with various settings
2. Switch to this branch
3. Check if the blocks are still displaying the correct information and has kept the correct settings

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
