### PR TITLE
feat: add README for the modal checkout GA4 tracking

### DIFF
--- a/src/modal-checkout/analytics/ga4/README.md
+++ b/src/modal-checkout/analytics/ga4/README.md
@@ -1,0 +1,44 @@
+# Newspack Modal Checkout Google Analytics Tracking
+
+The Newspack Modal Checkout uses <a href="https://github.com/Automattic/newspack-plugin/blob/trunk/includes/data-events/README.md">Newspack Data Events</a> to help track information for Google Analytics 4.
+
+## Actions
+
+Each sequence will include the following actions:
+
+| `action`                   | When it's used                                                                                                     |
+| ---------------------------| ------------------------------------------------------------------------------------------------------------------ |
+| `opened`                   | When the modal checkout is opened, either from the Donate Block, Checkout Button Block, or Variation picker screen |
+| `opened_variations`        | When a variation picker is opened from a Checkout button block                                                     |
+| `loaded`                   | When the modal finishes loading                                                                                    |
+| `continue`                 | When the 'Continue' button is clicked                                                                              |
+|`back`                      | When the 'Back' button is clicked                                                                                  |
+|`dismissed`                 | When the modal is closed before completion                                                                         |
+|`form_submission`           | When a submission attempt is made                                                                                  |
+|`form_submission_success`   | When a submission attempt is completed (back-end event)
+
+## Action Types
+
+The action types used are:
+
+| `action_type`     | When it's used      |
+| ------------- | ------------- |
+| `checkout_button` | When the modal trigger is the Checkout Button block |
+| `donation`       | When the modal trigger is the Donation block |
+
+## What's captured
+
+We're capturing the following information on most steps:
+
+| What's captured     | When it's captured      |
+| -------------------- | --------------------- |
+| `amount` | For each step, except when opening a variation picker since the price isn't known |
+| `currency` | For each step |
+| `is_variable` | Only the initial `open_variations` step when opening a variation picker |
+| `product_id` | For each step |
+| `product_type`*** | For each step |
+| `recurrence` | For each step, except when opening a variation picker for a variable subscription product |
+| `referer` | For each step |
+| `variation_id` | For steps after picking a product variation |
+
+*** The product types have yet to be finalized, but currently are: `product`, `subscription`, `membership`, and `donation`.

--- a/src/modal-checkout/analytics/ga4/README.md
+++ b/src/modal-checkout/analytics/ga4/README.md
@@ -30,16 +30,16 @@ Each checkout will include the following action types:
 
 Each checkout will capture the following information on most actions.
 
-| What's captured      | When it's captured                                                                                                               |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `amount`             | For each action, except when opening a variation picker since the price isn't yet known                                          |
-| `currency`           | For each action                                                                                                                  |
-| `is_variable`        | Only the initial `open_variations` action when opening a variation picker                                                        |
-| `product_id`         | For each action                                                                                                                  |
-| `product_type`***    | For each action                                                                                                                  |
-| `recurrence`         | For each action, except when opening a variation picker for a variable subscription product since the recurrence isn't yet known |
-| `referer`            | For each action                                                                                                                  |
-| `variation_id`       | For each action after picking a product variation when purchasing a variable product                                             |
+| What's captured    | When it's captured                                                                                                  |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `amount`           | For each action, except when opening a variation picker since the price isn't known                                 |
+| `currency`         | For each action                                                                                                     |
+| `is_variable`      | Only the initial `open_variations` action when opening a variation picker                                           |
+| `product_id`       | For each action                                                                                                     |
+| `product_type`***  | For each action                                                                                                     |
+| `recurrence`       | For each action, except when opening a variation picker for a subscription product since the recurrence isn't known |
+| `referer`          | For each action                                                                                                     |
+| `variation_id`     | For each action after picking a product variation when purchasing a variable product                                |
 
 
 *** Note: The product types have yet to be finalized, but currently are: `product`, `subscription`, `membership`, and `donation`.

--- a/src/modal-checkout/analytics/ga4/README.md
+++ b/src/modal-checkout/analytics/ga4/README.md
@@ -4,7 +4,7 @@ The Newspack Modal Checkout uses <a href="https://github.com/Automattic/newspack
 
 ## Actions
 
-Each sequence will include the following actions:
+Each checkout will include the following actions:
 
 | `action`                   | When it's used                                                                                                     |
 | ---------------------------| ------------------------------------------------------------------------------------------------------------------ |
@@ -12,33 +12,34 @@ Each sequence will include the following actions:
 | `opened_variations`        | When a variation picker is opened from a Checkout button block                                                     |
 | `loaded`                   | When the modal finishes loading                                                                                    |
 | `continue`                 | When the 'Continue' button is clicked                                                                              |
-|`back`                      | When the 'Back' button is clicked                                                                                  |
-|`dismissed`                 | When the modal is closed before completion                                                                         |
-|`form_submission`           | When a submission attempt is made                                                                                  |
-|`form_submission_success`   | When a submission attempt is completed (back-end event)
+| `back`                     | When the 'Back' button is clicked                                                                                  |
+| `dismissed`                | When the modal is closed before completion                                                                         |
+| `form_submission`          | When a submission attempt is made                                                                                  |
+| `form_submission_success`  | When a submission attempt is completed (back-end event)
 
-## Action Types
+## Action types
 
-The action types used are:
+Each checkout will include the following action types:
 
-| `action_type`     | When it's used      |
-| ------------- | ------------- |
-| `checkout_button` | When the modal trigger is the Checkout Button block |
-| `donation`       | When the modal trigger is the Donation block |
+| `action_type`     | When it's used                                                    |
+| ----------------- | ----------------------------------------------------------------- |
+| `checkout_button` | When the modal checkout is triggered by the Checkout Button block |
+| `donation`        | When the modal checkout is triggered by the Donation block        |
 
 ## What's captured
 
-We're capturing the following information on most steps:
+Each checkout will capture the following information on most actions.
 
-| What's captured     | When it's captured      |
-| -------------------- | --------------------- |
-| `amount` | For each step, except when opening a variation picker since the price isn't known |
-| `currency` | For each step |
-| `is_variable` | Only the initial `open_variations` step when opening a variation picker |
-| `product_id` | For each step |
-| `product_type`*** | For each step |
-| `recurrence` | For each step, except when opening a variation picker for a variable subscription product |
-| `referer` | For each step |
-| `variation_id` | For steps after picking a product variation |
+| What's captured      | When it's captured                                                                                                               |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `amount`             | For each action, except when opening a variation picker since the price isn't yet known                                          |
+| `currency`           | For each action                                                                                                                  |
+| `is_variable`        | Only the initial `open_variations` action when opening a variation picker                                                        |
+| `product_id`         | For each action                                                                                                                  |
+| `product_type`***    | For each action                                                                                                                  |
+| `recurrence`         | For each action, except when opening a variation picker for a variable subscription product since the recurrence isn't yet known |
+| `referer`            | For each action                                                                                                                  |
+| `variation_id`       | For each action after picking a product variation when purchasing a variable product                                             |
 
-*** The product types have yet to be finalized, but currently are: `product`, `subscription`, `membership`, and `donation`.
+
+*** Note: The product types have yet to be finalized, but currently are: `product`, `subscription`, `membership`, and `donation`.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a README to the /modal-checkout/analytics/ga4 folder that captures the `actions`, `action_types`, and what's captured for GA4 when making a purchase with the modal checkout.

This information is a near-copy of the tables in the original PR: https://github.com/Automattic/newspack-blocks/pull/1819

### How to test the changes in this Pull Request:

1. Read through the README and confirm it makes sense?
2. Check for formatting issues (either in the code, or using a site like https://markdownlivepreview.com/). 
3. Let me know if anything's missing! 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
