### PR TITLE
fix(modal-checkout): correctly generate tiered donation price summaries

### DIFF
--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -342,49 +342,51 @@ domReady( () => {
 				);
 
 				if ( donationTiers?.length ) {
-					const frequencyInputs = form.querySelectorAll(
-						`input[name="donation_value_${ frequency }"], input[name="donation_value_${ frequency }_untiered"]`
-					);
+					const donationTierIndex = formData.get( 'donation_tier_index' );
 
-					if ( frequencyInputs?.length ) {
-						// Handle frequency based donation tiers.
-						frequencyInputs.forEach( input => {
-							if ( input.checked && input.value !== 'other' ) {
-								price = input.value;
-							}
-						} );
+					if ( ! donationTierIndex ) {
+						// Handle untiered and frequency donations.
 
-						donationTiers.forEach( el => {
-							const donationData = JSON.parse( el.dataset.product );
-							if (
-								donationData.hasOwnProperty( `donation_price_summary_${ frequency }` ) &&
-								donationData?.[ `donation_price_summary_${ frequency }` ].includes( price )
-							) {
-								priceSummary = donationData[ `donation_price_summary_${ frequency }` ];
-							}
+						const frequencyInputs = form.querySelectorAll(
+							`input[name="donation_value_${ frequency }"], input[name="donation_value_${ frequency }_untiered"]`
+						);
 
-							if ( price === '0' && priceSummary ) {
-								// Replace placeholder price with price input for other.
-								let otherPrice = formData.get( `donation_value_${ frequency }_other` );
+						if ( frequencyInputs?.length ) {
+							// Handle frequency based donation tiers.
+							frequencyInputs.forEach( input => {
+								if ( input.checked && input.value !== 'other' ) {
+									price = input.value;
+								}
+							} );
 
-								// Fallback to untiered price if other price is not set.
-								if ( ! otherPrice ) {
-									otherPrice = formData.get( `donation_value_${ frequency }_untiered` );
+							donationTiers.forEach( el => {
+								const donationData = JSON.parse( el.dataset.product );
+								if (
+									donationData.hasOwnProperty( `donation_price_summary_${ frequency }` ) &&
+									donationData?.[ `donation_price_summary_${ frequency }` ].includes( price )
+								) {
+									priceSummary = donationData[ `donation_price_summary_${ frequency }` ];
 								}
 
-								if ( otherPrice ) {
-									priceSummary = priceSummary.replace( '0', otherPrice );
+								if ( price === '0' && priceSummary ) {
+									// Replace placeholder price with price input for other.
+									let otherPrice = formData.get( `donation_value_${ frequency }_other` );
+
+									// Fallback to untiered price if other price is not set.
+									if ( ! otherPrice ) {
+										otherPrice = formData.get( `donation_value_${ frequency }_untiered` );
+									}
+
+									if ( otherPrice ) {
+										priceSummary = priceSummary.replace( '0', otherPrice );
+									}
 								}
-							}
-						} );
+							} );
+						}
 					} else {
-						// Handle tiers based donation tiers.
-						const index = formData.get( 'donation_tier_index' );
-						if ( index ) {
-							const donationData = JSON.parse( donationTiers?.[ index ].dataset.product );
-							if ( donationData.hasOwnProperty( `donation_price_summary_${ frequency }` ) ) {
-								priceSummary = donationData[ `donation_price_summary_${ frequency }` ];
-							}
+						const donationData = JSON.parse( donationTiers?.[ donationTierIndex ].dataset.product );
+						if ( donationData.hasOwnProperty( `donation_price_summary_${ frequency }` ) ) {
+							priceSummary = donationData[ `donation_price_summary_${ frequency }` ];
 						}
 					}
 				}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1208733956648866/1208751945335388/f

This PR fixes an issue where the logic for tiered donation price summary generation was never being run since it relied on no frequency input in the donation form for this layout.

We fix this by explicitly checking for a donation tier index value in the form data and if present running that logic first.

### How to test the changes in this Pull Request:

1. As a logged out reader, with forced registration enabled select any donation value to trigger the auth modal with a price summary at the top.
2. Confirm the price summary is correct
3. Repeat the above steps for all three donation layout types (tiered, untiered, frequency) and for multiple frequencies and values

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
