### PR TITLE
fix(modal-checkout): apply margin to after form rows added via after billing fields hook

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -80,6 +80,10 @@
 			}
 
 		}
+
+		.woocommerce-billing-fields__field-wrapper ~ .form-row {
+			margin: var(--newspack-ui-spacer-5, 24px) 0 0;
+		}
 	}
 
 	// Override billing details spacing.


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Goes with the following Plugin PR: https://github.com/Automattic/newspack-plugin/pull/3546

This PR fixes an issue where checkboxes (or anything else) added via the `woocommerce_after_checkout_billing_form` did not have the correct margin.

We fix this by applying our expected margin to any `.form-row` added to this part of checkout. Note we only target `.form-row` as this is the expected format of anything added here. Anything added using a nonstandard class will need additional custom CSS to integrate correctly.

![Screenshot 2024-11-13 at 10 26 10](https://github.com/user-attachments/assets/97eeee50-1fc2-42b4-b93b-0016d41f13e3)

**NOTE**: The fix for the off-centered text and checkbox input live in the plugin PR: https://github.com/Automattic/newspack-plugin/pull/3546

### How to test the changes in this Pull Request:

1. As admin add Mailchimp for WooCommerce to your test site and get it connected
2. Ensure the Mailchimp for WooCommerce newsletters checkbox is added at checkout via Mailchimp > Store > Checkout page settings
![Screenshot 2024-11-13 at 10 42 29](https://github.com/user-attachments/assets/e788e587-192d-43b5-80f7-f2cde980d8fc)
3. As a reader open modal checkout via any checkout button or donate block
4. On the billing fields screen scroll to the bottom and ensure the added form row has top margin but no bottom margin as pictured above.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
