### PR TITLE
fix: correct spacing of under-Stripe checkmarks

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -291,7 +291,6 @@
 		}
 	}
 
-
 	.wc_payment_method {
 		+ .wc_payment_method {
 			margin-top: var(--newspack-ui-spacer-2, 12px);

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -291,6 +291,7 @@
 		}
 	}
 
+
 	.wc_payment_method {
 		+ .wc_payment_method {
 			margin-top: var(--newspack-ui-spacer-2, 12px);
@@ -455,6 +456,10 @@
 				}
 			}
 		}
+	}
+
+	#stripe-payment-data ~ fieldset {
+		margin: var(--newspack-ui-spacer-3, 16px) 0 0;
 	}
 
 	// WooPayments inputs


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes the spacing of checkboxes that appear under the Stripe payment gateway.

See: 1207817176293825-as-1208730419008818

### How to test the changes in this Pull Request:

1. Start with a site using Stripe Gateway.
2. Under the RAS settings, enable the option for reader to pay the Stripe fees.
3. As a reader, run through a One-Time donation purchase.
4. On the second screen, note the two checkboxes are touching:

![CleanShot 2024-11-13 at 11 03 12](https://github.com/user-attachments/assets/b480b676-0db4-4beb-961f-6e07fd6ae542)

5. Apply this PR and run `npm run build`.
6. Confirm the issue is fixed.

![CleanShot 2024-11-13 at 11 03 37](https://github.com/user-attachments/assets/0714ff55-ef5b-4a87-bdce-885288ae09f3)

7. Try a checkout with a monthly/yearly donation (which won't have the checkbox about saving information), and try disabling the fees checkbox to make sure things still look okay.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
