### PR TITLE
fix: also search for coauthor posts by term slug

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -710,6 +710,7 @@ class Newspack_Blocks {
 									}
 								} else {
 									$author_names[]  = $author_data->user_login;
+									$author_names[]  = $author_data->user_nicename;
 									$author_emails[] = $author_data->user_email;
 								}
 							}
@@ -719,6 +720,13 @@ class Newspack_Blocks {
 
 				// Reset numeric indexes.
 				$authors = array_values( $authors );
+
+				// Prepare slugs for search.
+				$__author_names = $author_names;
+				foreach ( $__author_names as $an ) {
+					$author_names[] = 'cap-' . $an;
+				}
+
 				if ( empty( $authors ) && count( $co_authors_names ) ) {
 					// Look for co-authors posts.
 					$args['tax_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
@@ -742,6 +750,11 @@ class Newspack_Blocks {
 								],
 								[
 									'field'    => 'name',
+									'taxonomy' => 'author',
+									'terms'    => $author_names,
+								],
+								[
+									'field'    => 'slug',
 									'taxonomy' => 'author',
 									'terms'    => $author_names,
 								],

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -678,8 +678,6 @@ class Newspack_Blocks {
 
 			if ( $authors && count( $authors ) ) {
 				$co_authors_names = [];
-				$author_names     = [];
-				$author_emails    = [];
 
 				if ( $is_co_authors_plus_active ) {
 					$co_authors_guest_authors = new CoAuthors_Guest_Authors();
@@ -697,21 +695,23 @@ class Newspack_Blocks {
 							$co_authors_names[] = $co_author->user_nicename;
 							unset( $authors[ $index ] );
 						} else {
-							// If the given ID is linked to a guest author.
 							$authors_controller = new WP_REST_Newspack_Authors_Controller();
 							$author_data        = get_userdata( $author_id );
 							if ( $author_data ) {
 								$linked_guest_author = $authors_controller->get_linked_guest_author( $author_data->user_login );
+								// If the given ID is linked to a guest author.
 								if ( $linked_guest_author ) {
 									$guest_author_name = sanitize_title( $linked_guest_author->post_title );
 									if ( ! in_array( $guest_author_name, $co_authors_names, true ) ) {
 										$co_authors_names[] = $guest_author_name;
+										$co_authors_names[] = $linked_guest_author->post_name;
 										unset( $authors[ $index ] );
 									}
 								} else {
-									$author_names[]  = $author_data->user_login;
-									$author_names[]  = $author_data->user_nicename;
-									$author_emails[] = $author_data->user_email;
+									$co_authors_names[]  = $author_data->user_login;
+									$co_authors_names[]  = $author_data->user_nicename;
+									$co_authors_names[]  = 'cap-' . $author_data->user_nicename;
+									$co_authors_names[] = $author_data->user_email;
 								}
 							}
 						}
@@ -721,15 +721,15 @@ class Newspack_Blocks {
 				// Reset numeric indexes.
 				$authors = array_values( $authors );
 
-				// Prepare slugs for search.
-				$__author_names = $author_names;
-				foreach ( $__author_names as $an ) {
-					$author_names[] = 'cap-' . $an;
-				}
-
 				if ( empty( $authors ) && count( $co_authors_names ) ) {
-					// Look for co-authors posts.
+					// We are only looking for Guest Authors post. So we need to only search by taxonomy.
 					$args['tax_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+						'relation' => 'OR',
+						[
+							'field'    => 'slug',
+							'taxonomy' => 'author',
+							'terms'    => $co_authors_names,
+						],
 						[
 							'field'    => 'name',
 							'taxonomy' => 'author',
@@ -737,37 +737,11 @@ class Newspack_Blocks {
 						],
 					];
 				} elseif ( empty( $co_authors_names ) && count( $authors ) ) {
+					// Simple search by author. Co-Authors plus is not active.
 					$args['author__in'] = $authors;
-
-					if ( $is_co_authors_plus_active ) {
-						// Don't get any posts that are attributed to other CAP guest authors.
-						$args['tax_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-							[
-								'relation' => 'OR',
-								[
-									'taxonomy' => 'author',
-									'operator' => 'NOT EXISTS',
-								],
-								[
-									'field'    => 'name',
-									'taxonomy' => 'author',
-									'terms'    => $author_names,
-								],
-								[
-									'field'    => 'slug',
-									'taxonomy' => 'author',
-									'terms'    => $author_names,
-								],
-								[
-									'field'    => 'name',
-									'taxonomy' => 'author',
-									'terms'    => $author_emails,
-								],
-							],
-						];
-					}
 				} else {
 					// The query contains both WP users and CAP guest authors. We need to filter the SQL query.
+					// That's because author__in and tax_query would be combined with AND, not OR.
 					self::$filter_clauses = [
 						'authors'   => $authors,
 						'coauthors' => $co_authors_names,
@@ -1267,9 +1241,15 @@ class Newspack_Blocks {
 
 		// co-author tax query.
 		$tax_query = [
+			'relation' => 'OR',
 			[
 				'taxonomy' => 'author',
 				'field'    => 'name',
+				'terms'    => $co_authors_names,
+			],
+			[
+				'taxonomy' => 'author',
+				'field'    => 'slug',
 				'terms'    => $co_authors_names,
 			],
 		];

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -674,17 +674,16 @@ class Newspack_Blocks {
 				}
 			}
 
-			$is_co_authors_plus_active = class_exists( 'CoAuthors_Guest_Authors' );
+			$is_co_authors_plus_active = class_exists( 'CoAuthors_Plus' );
+			$co_authors_guest_authors = class_exists( 'CoAuthors_Guest_Authors' ) ? new CoAuthors_Guest_Authors() : null;
 
 			if ( $authors && count( $authors ) ) {
 				$co_authors_names = [];
 
 				if ( $is_co_authors_plus_active ) {
-					$co_authors_guest_authors = new CoAuthors_Guest_Authors();
-
 					foreach ( $authors as $index => $author_id ) {
 						// If the given ID is a guest author.
-						$co_author = $co_authors_guest_authors->get_guest_author_by( 'id', $author_id );
+						$co_author = $co_authors_guest_authors ? $co_authors_guest_authors->get_guest_author_by( 'id', $author_id ) : null;
 						if ( $co_author ) {
 							if ( ! empty( $co_author->linked_account ) ) {
 								$linked_account = get_user_by( 'login', $co_author->linked_account );

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -721,7 +721,7 @@ class Newspack_Blocks {
 				$authors = array_values( $authors );
 
 				if ( empty( $authors ) && count( $co_authors_names ) ) {
-					// We are only looking for Guest Authors post. So we need to only search by taxonomy.
+					// We are only looking for Guest Authors posts. So we need to only search by taxonomy.
 					$args['tax_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 						'relation' => 'OR',
 						[

--- a/tests/test-homepage-posts-block.php
+++ b/tests/test-homepage-posts-block.php
@@ -34,7 +34,6 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 				'resulting_query_partial' => [
 					'posts_per_page' => 1,
 					'post_type'      => 'some-type',
-					'author__in'     => [ 1 ],
 				],
 				'description'             => 'With custom post type and author',
 				'ignore_tax_query'        => true,

--- a/tests/wp-unittestcase-blocks.php
+++ b/tests/wp-unittestcase-blocks.php
@@ -6,6 +6,11 @@
  */
 
 /**
+ * Mock CoAuthors_Plus class to pretend the plugin is active.
+ */
+class CoAuthors_Plus {} // phpcs:ignore
+
+/**
  * Mock CoAuthors_Guest_Authors class.
  */
 class CoAuthors_Guest_Authors { // phpcs:ignore


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When searching for posts from an author that is a WP User (not a guest author), we should also (actually maybe only) search by term slug.

This PR adds a few extra conditions to make sure we find posts by an author when searching by terms.

The specific case we are fixing here is from users that ended up with their Display Name as the term `name`, and thus the search term name using the user_login as input would never find anything. We also need to search by user_nicename and make sure we search in the slug field.

### How to test the changes in this Pull Request:

1. Activate CoAuthors Plus
2. Create a user and assign a few posts to it
3. Create a post and assign this user as a secondary co-author (a co-author, but not the author on the `post_author` field in the database
4. On a page, add a Home Page posts block and filter by this author
5. Make sure all the posts show up, including the one they are not the main author (on `trunk` it won't show up)
6. Add this somewhere:

```
// Disable guest authors before CoAuthors plus is initialized
add_action(
	'init',
	function() {
		add_filter( 'coauthors_guest_authors_enabled', '__return_false' );
	},
	9
);
```

7. Make sure the block still fetch the correct posts.
8. Remove the snippet to re-enable Guest Authors
9. Create a guest author
10. Create a post and assign only the guest author to it.
11. You can confirm and see that the `post_author` field in the DB still points to your admin
12. In the HPP block, filter posts by the guest author and confirm it works
13. Now filter posts by your admin, and confirm the post by the guest author is NOT returned


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
