### PR TITLE
feat: submit checkout form on "Enter" keypress

### DIFF
--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -73,23 +73,20 @@ import { domReady } from './utils';
 					console.warn( 'Form is not available' ); // eslint-disable-line no-console
 					return;
 				}
+
+				// Trigger form submission on "Enter" key press.
+				$form.on( 'keydown', function ( ev ) {
+					if ( ev.key === 'Enter' ) {
+						$form.submit();
+					}
+				} );
+
 				const $coupon = $( 'form.modal_checkout_coupon' );
 				const $nyp = $( 'form.modal_checkout_nyp' );
 				const $checkout_continue = $( '#checkout_continue' );
 				const $customer_details = $( '#customer_details' );
 				const $after_customer_details = $( '#after_customer_details' );
 				const $gift_options = $( '.newspack-wcsg--wrapper' );
-
-				// Trigger form submission on "Enter" key press.
-				$form.on( 'keydown', function ( ev ) {
-					if ( ev.key === 'Enter' ) {
-						if ( $form.data( 'is-editing-details' ) ) {
-							$checkout_continue.trigger( 'click' );
-						} else {
-							$form.trigger( 'submit' );
-						}
-					}
-				} );
 
 				/**
 				 * Handle styling update for selected payment method.
@@ -436,7 +433,6 @@ import { domReady } from './utils';
 					// Clear checkout details.
 					$( '#checkout_details' ).remove();
 					if ( isEditingDetails ) {
-						$form.data( 'is-editing-details', true );
 						$form.append( '<input name="is_validation_only" type="hidden" value="1" />' );
 						// Destroy reCAPTCHA inputs so we don't trigger validation between checkout steps.
 						if ( 'v3' === newspack_grecaptcha?.version ) {
@@ -458,7 +454,6 @@ import { domReady } from './utils';
 						} );
 						$form.on( 'submit', handleFormSubmit );
 					} else {
-						$form.data( 'is-editing-details', false );
 						const $validationOnlyField = $form.find( '[name="is_validation_only"]' );
 						if ( $validationOnlyField.length ) {
 							$validationOnlyField.remove();

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -74,13 +74,6 @@ import { domReady } from './utils';
 					return;
 				}
 
-				// Trigger form submission on "Enter" key press.
-				$form.on( 'keydown', function ( ev ) {
-					if ( ev.key === 'Enter' ) {
-						$form.submit();
-					}
-				} );
-
 				const $coupon = $( 'form.modal_checkout_coupon' );
 				const $nyp = $( 'form.modal_checkout_nyp' );
 				const $checkout_continue = $( '#checkout_continue' );
@@ -744,6 +737,13 @@ import { domReady } from './utils';
 					form.removeClass( 'modal-processing' );
 					return true;
 				}
+
+				// Trigger form submission on "Enter" key press.
+				$form.on( 'keydown', function ( ev ) {
+					if ( ev.key === 'Enter' ) {
+						$form.submit();
+					}
+				} );
 			}
 			init();
 		}

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -80,6 +80,17 @@ import { domReady } from './utils';
 				const $after_customer_details = $( '#after_customer_details' );
 				const $gift_options = $( '.newspack-wcsg--wrapper' );
 
+				// Trigger form submission on "Enter" key press.
+				$form.on( 'keydown', function ( ev ) {
+					if ( ev.key === 'Enter' ) {
+						if ( $form.data( 'is-editing-details' ) ) {
+							$checkout_continue.trigger( 'click' );
+						} else {
+							$form.trigger( 'submit' );
+						}
+					}
+				} );
+
 				/**
 				 * Handle styling update for selected payment method.
 				 */
@@ -425,6 +436,7 @@ import { domReady } from './utils';
 					// Clear checkout details.
 					$( '#checkout_details' ).remove();
 					if ( isEditingDetails ) {
+						$form.data( 'is-editing-details', true );
 						$form.append( '<input name="is_validation_only" type="hidden" value="1" />' );
 						// Destroy reCAPTCHA inputs so we don't trigger validation between checkout steps.
 						if ( 'v3' === newspack_grecaptcha?.version ) {
@@ -446,6 +458,7 @@ import { domReady } from './utils';
 						} );
 						$form.on( 'submit', handleFormSubmit );
 					} else {
+						$form.data( 'is-editing-details', false );
 						const $validationOnlyField = $form.find( '[name="is_validation_only"]' );
 						if ( $validationOnlyField.length ) {
 							$validationOnlyField.remove();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Allows an "enter" keypress to submit the checkout form, to maintain parity with `trunk`.

### How to test the changes in this Pull Request:

1. Check out this branch
2. Start a modal checkout.
3. Focus on the form by clicking into an input field and press "enter". Confirm that it submits the form and returns any applicable errors (e.g. for required fields)
4. Fill out all fields and hit "enter" again. Confirm that the checkout modal proceeds to the payment form.
5. Confirm that you can submit the payment form by hitting "enter" too.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
