### PR TITLE
fix: correct grid layout for credit card picker edgecase

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -386,7 +386,7 @@
 
 		// If the only payment option, we're hiding the radio selection so we don't need a grid.
 		&:first-child:last-child .newspack-ui__input-card {
-			grid-template-columns: 1fr;
+			grid-template-columns: 0;
 			gap: 0;
 
 			input.input-radio[name="payment_method"] {

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -386,7 +386,7 @@
 
 		// If the only payment option, we're hiding the radio selection so we don't need a grid.
 		&:first-child:last-child .newspack-ui__input-card {
-			grid-template-columns: none;
+			grid-template-columns: 1fr;
 			gap: 0;
 
 			input.input-radio[name="payment_method"] {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a small issue we're seeing on one of the RAS-ACC beta sites. I couldn't actually recreate this, so testing involves making sure that this update doesn't break anything normally, and doing some ad-hoc stuff on the affected site to make sure it fixes it there.

See 1207817176293825-as-1208733956648852

### How to test the changes in this Pull Request:

1. Apply this PR and run `npm run build`.
2. With only one payment option set up, run through the checkout and confirm that there are no display issues on the second screen -- the credit card/payment information should fill the available space with no gap on the side:

![CleanShot 2024-11-14 at 10 24 28](https://github.com/user-attachments/assets/0519bd8f-de46-4e63-8ae6-b5eb7c065bf1)

3. Enable at least one more payment option (cheque or cash are good for quick options, but you'll need to purchase non-subscription products for them to appear after selected).
4. Retest the checkout; confirm that the radio buttons display nicely:

![CleanShot 2024-11-14 at 10 23 07](https://github.com/user-attachments/assets/4132bc20-16c4-4e53-9f34-23e64a54f046)


5. Go to lookout.co, and run through a checkout until you hit the second screen. 
6. Using the element inspector, find and disable the `display: block !important` applied to `.newspack-ui .payment_method_stripe label[for="payment_method_stripe"]:has(input[type="radio"])`:

![CleanShot 2024-11-14 at 10 18 39](https://github.com/user-attachments/assets/0a24ec43-7eec-4fdc-85bd-076e9c06132c)

7. See the issue:

![CleanShot 2024-11-14 at 10 19 28](https://github.com/user-attachments/assets/bf4be902-a2af-4a0a-b2cf-b9b3cfcc7a77)

8. Still on the same element in the element inspector, scroll to the top of the styles, and change `grid-template-columns: none;` to `grid-template-columns: 0;` for the `#newspack_modal_checkout_container .wc_payment_method:first-child:last-child .newspack-ui__input-card` selector. This will make the site's CSS match this PR.
9. Confirm that it fixes the issue.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
