### PR TITLE
fix: make sure separate error messages stack

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -632,6 +632,10 @@
 			list-style-type: none;
 			margin: 0;
 			padding: 0;
+
+			li {
+				width: 100%;
+			}
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes multiple errors or other Woo messages stack in the modal checkout.

See 1207817176293825-as-1208760835332924

### How to test the changes in this Pull Request:

1. Fire up the modal checkout, and submit the form without filling out anything.
2. Note you get multiple error messages, and they run together into one long string (I'm working on the Link alignment, that can be ignored!):

![CleanShot 2024-11-14 at 10 42 40](https://github.com/user-attachments/assets/6b098605-0901-42ba-8eb5-bd8f225deb79)

3. Apply this PR and run `npm run build`.
4. Repeat step one and confirm the messages are now stacked and easier to read:

![CleanShot 2024-11-14 at 10 41 32](https://github.com/user-attachments/assets/173d03d9-474a-4cce-8725-40c712bf4248)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
