### PR TITLE
fix: correct Link icon placement

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -495,6 +495,16 @@
 		}
 	}
 
+	// Fix Link payment processor icon placement
+	.woocommerce-input-wrapper:has(.stripe-gateway-stripelink-modal-trigger) {
+		display: block;
+		position: relative;
+
+		.stripe-gateway-stripelink-modal-trigger {
+			inset: calc(50% - 24px) 20px auto auto !important; // !important override inline styles.
+		}
+	}
+
 	// Order review table.
 	.woocommerce-checkout-review-order-table {
 		th,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When the Link payment option is enabled under the Stripe Gateway, the icon is placed absolutely based on the window. Unfortunately, the alignment of this button isn't always bang on -- I think (especially in the modal checkout) this is because the JavaScript adding the styles for it isn't always firing at the best time.

This PR overrides the styles and absolutely positions them inside of any Woo input element that may contain them, for greater accuracy.

This PR can be tested with https://github.com/Automattic/newspack-theme/pull/2407 to make sure the Link button doesn't disappear when you hover over it.

(When the Link icon appears in the input, it doesn't do anything on click; this will be handled separately!)

### How to test the changes in this Pull Request:

1. Under WooCommerce > Payments > Stripe, enable the new non-legacy checkout experience, and enable Link as an express payment option:

![CleanShot 2024-11-14 at 11 27 52](https://github.com/user-attachments/assets/2c0d8852-0d5c-412f-8dd7-83db00dd665c)

2. Run a checkout using the modal checkout, and note the appearance of the Link button in the Email field. Sometimes it's just slightly offset in the input; other times (like for me if you hit Continue and Back), it will be super mis-aligned. You can also try submitting the form without filling anything out -- the shift from the error messages will also break the placement:

![image](https://github.com/user-attachments/assets/58959610-2f7f-4921-9a3f-953a84b816c8)

3. Apply this PR and run `npm run build`. 
4. Repeat step 2 a couple times, including clicking Continue and Back a few times, and confirm the button is always placed inside of the input:

![CleanShot 2024-11-14 at 11 33 49](https://github.com/user-attachments/assets/833d9f1f-dc2e-4b73-8cfc-41d6786d0581)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
