### PR TITLE
fix(modal-checkout): account for empty space in error message response

### DIFF
--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -248,7 +248,7 @@ import { domReady } from './utils';
 
 					clearNotices();
 
-					if ( error_message.indexOf( '<' ) !== 0 ) {
+					if ( error_message.trimStart().indexOf( '<' ) !== 0 ) {
 						// If error_message is not an HTML string, wrap it in a <li />.
 						handleErrorItem( $( '<li />' ).append( error_message ) );
 					} else if ( ! error_message.includes( '<li' ) ) {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1208769260234886/f

This PR resolves an issue where billing field errors were not rendering below the billing field inputs as expected. This is because our error handler first checks for a non HTML error, relying on the first character of the error message being `<`. However, in some cases, the HTML string Woo returns begins with a space.

We resolve this by stripping beginning white space when checking the first character of the error message.

Before:
![CleanShot 2024-11-14 at 11 44 40](https://github.com/user-attachments/assets/96ef9407-f852-4c97-b54e-47e288f32f87)

After:
![Screenshot 2024-11-14 at 15 16 23](https://github.com/user-attachments/assets/1e71ff15-cd8e-4681-a956-efa542ec21c2)


### How to test the changes in this Pull Request:

1. As a reader open modal checkout via any checkout or donate button
2. In the billing info step of checkout, make sure some of the required fields are empty and submit
3. On `epic/ras-acc` all errors will render at the top of the modal. On this branch, they will render under the respective fields as pictured in the `After` screenshot above.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
