### PR TITLE
fix(modal-checkout): make price string check more explicit

### DIFF
--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -361,11 +361,12 @@ domReady( () => {
 
 							donationTiers.forEach( el => {
 								const donationData = JSON.parse( el.dataset.product );
-								if (
-									donationData.hasOwnProperty( `donation_price_summary_${ frequency }` ) &&
-									donationData?.[ `donation_price_summary_${ frequency }` ].includes( price )
-								) {
-									priceSummary = donationData[ `donation_price_summary_${ frequency }` ];
+								if ( donationData.hasOwnProperty( `donation_price_summary_${ frequency }` ) ) {
+									const priceData = donationData[ `donation_price_summary_${ frequency }` ];
+									const priceRegex = new RegExp( `(?<=\\D)${ price }(?=\\D)` );
+									if ( priceRegex.test( priceData ) ) {
+										priceSummary = priceData;
+									}
 								}
 
 								if ( price === '0' && priceSummary ) {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1208733956648874/f

This PR fixes an issue where the donation block price summary string that displays for logged out readers when forced registration is enabled can be off if there are multiple donation amounts containing the same number within a given frequency:
![Screenshot 2024-11-14 at 16 02 52](https://github.com/user-attachments/assets/04b0f4e9-9af2-4d2b-94c5-06e7b5ab509a)

### How to test the changes in this Pull Request:

1. As admin, ensure forced registration is on (Newspack > Engagement > Show Advanced Settings > Checkout Configuration and toggle on `Require sign in or create account before checkout`)
2. Set up a tiered donation block with frequency layout (in Newspack > Reader Revenue > Donation select `Tiered`, then in any page or post with a donation block select the Frequency layout in block settings)
3. Within each frequency, ensure each donation tier contains the same number. (For example, one-time donations: 5, 15, 50, monthly donations: 9, 49, 90, etc.)
4. As a logged out reader, visit the page or post with the donation block and, one-by-one, select a frequency tier and click the donate button to bring up the auth modal. Confirm the price summary at the top matches your selected tier, then close and repeat

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
