### PR TITLE
fix: improve appearance of password in modal checkout

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -89,6 +89,8 @@ final class Modal_Checkout {
 		add_action( 'wp_ajax_process_name_your_price_request', [ __CLASS__, 'process_name_your_price_request' ] );
 		add_filter( 'option_woocommerce_woocommerce_payments_settings', [ __CLASS__, 'filter_woocommerce_payments_settings' ] );
 		add_action( 'init', [ __CLASS__, 'unhook_woocommerce_payments_update_billing_fields' ] );
+		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'update_password_strength_message' ], 9999 );
+
 
 		/** Custom handling for registered users. */
 		add_filter( 'woocommerce_checkout_customer_id', [ __CLASS__, 'associate_existing_user' ] );
@@ -944,6 +946,23 @@ final class Modal_Checkout {
 		return add_query_arg(
 			$args,
 			$url
+		);
+	}
+
+	/**
+	 * Update the text used for the Password Strength message from WooCommerce.
+	 */
+	public static function update_password_strength_message() {
+		wp_localize_script(
+			'wc-password-strength-meter',
+			'pwsL10n',
+			array(
+				'mismatch' => __( 'Password mismatch', 'newspack-blocks' ),
+				'short'    => __( 'Password strength: Very weak', 'newspack-blocks' ),
+				'bad'      => __( 'Password strength: Weak', 'newspack-blocks' ),
+				'good'     => __( 'Password strength: Medium', 'newspack-blocks' ),
+				'strong'   => __( 'Password strength: Strong', 'newspack-blocks' ),
+			)
 		);
 	}
 

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -206,6 +206,7 @@
 
 			.woocommerce-password-strength {
 				font-size: var(--newspack-ui-font-size-xs, 14px);
+				margin: var(--newspack-ui-spacer-base, 8px) 0 0;
 			}
 
 			> p.form-row:last-of-type {

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -206,7 +206,27 @@
 
 			.woocommerce-password-strength {
 				font-size: var(--newspack-ui-font-size-xs, 14px);
+				line-height: var(--newspack-ui-line-height-xs, 1.4286);
 				margin: var(--newspack-ui-spacer-base, 8px) 0 0;
+
+				&.short,
+				&.bad {
+					color: var(--newspack-ui-color-error-50, #d63638);
+				}
+
+				&.good {
+					color: var(--newspack-ui-color-warning-40, #bd8600);
+				}
+
+				&.strong {
+					color: var(--newspack-ui-color-success-50, #008a20);
+				}
+			}
+
+			.woocommerce-password-hint {
+				color: var(--newspack-ui-color-neutral-60, #6c6c6c);
+				font-size: var(--newspack-ui-font-size-xs, 14px);
+				line-height: var(--newspack-ui-line-height-xs, 1.4286);
 			}
 
 			> p.form-row:last-of-type {

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -189,11 +189,29 @@
 	}
 
 	// Create an account
-	.woocommerce-account-fields .create-account label:has(input[type="checkbox"]) {
-		display: grid;
-		gap: 0 var(--newspack-ui-spacer-base, 8px);
-		grid-template-columns: var(--newspack-ui-spacer-4, 20px) 1fr;
+	.woocommerce-account-fields {
 		margin: var(--newspack-ui-spacer-5, 24px) 0 0;
+
+		h3:has(+ .create-account) {
+			display: none;
+		}
+
+		.create-account {
+			label:has(input[type="checkbox"]) {
+				display: grid;
+				gap: 0 var(--newspack-ui-spacer-base, 8px);
+				grid-template-columns: var(--newspack-ui-spacer-4, 20px) 1fr;
+				margin: var(--newspack-ui-spacer-5, 24px) 0 0;
+			}
+
+			.woocommerce-password-strength {
+				font-size: var(--newspack-ui-font-size-xs, 14px);
+			}
+
+			> p.form-row:last-of-type {
+				margin-bottom: 0;
+			}
+		}
 	}
 
 	// Name Your Price styles


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

While this won't be our recommended setting -- it's better if publishers require registration on purchase in the Reader Activation settings -- this PR improves the appearance of the password field when "Send password setup link" is unchecked under the WooCommerce settings.

See 1207817176293825-as-1208733956648888

### How to test the changes in this Pull Request:

1. Under WooCommerce > Settings > Accounts & Privacy, uncheck "Send password setup link (recommended)"
2. Under Newspack > Engagement > Reader Activation > Advanced Settings, toggle off "Require sign in or create account before checkout".
3. In an incognito window, run through a checkout (ideally both with a product that requires shipping and one that does not) -- note the appearance of the password section:

![CleanShot 2024-11-14 at 16 45 43](https://github.com/user-attachments/assets/81129c52-30e2-4cf0-acb6-f9a46f2321e2)

![CleanShot 2024-11-14 at 16 46 06](https://github.com/user-attachments/assets/4ff0e30c-07e4-40e5-82f6-26f3527feb5c)

5. Apply this PR and run `npm run build`.
6. Repeat step 3; confirm that the spacing looks better, and the extra header is gone. Bonus points: 

![CleanShot 2024-11-14 at 16 38 50](https://github.com/user-attachments/assets/dfe1e8e7-e871-4357-8ddb-133f22b9514d)

![CleanShot 2024-11-14 at 16 37 56](https://github.com/user-attachments/assets/08767b3a-938e-4b12-a092-b05936704669)

7. Try entering a password; you'll immediately get a message about it being too short, and confirm it doesn't look too wildly out of place.

![CleanShot 2024-11-14 at 16 41 22](https://github.com/user-attachments/assets/5da414dc-b88f-4aae-b2dd-e18b6abd6528)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
