### PR TITLE
fix: do not invalidate tax queries

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -1290,8 +1290,17 @@ class Newspack_Blocks {
 		$exclude = $exclude['where'];
 		$authors = " ( {$wpdb->posts}.post_author IN ( $csv ) $exclude ) ";
 
-		// Make sure the authors are set, the tax query is valid (doesn't contain 0 = 1).
-		if ( false === strpos( $tax_query['where'], ' 0 = 1' ) ) {
+		/**
+		 * Make sure the authors are set, the tax query is valid (doesn't contain 0 = 1).
+		 *
+		 * Since we have two clauses (one searching on name, and one on slug), it's ok to have a "0 = 1" clause for
+		 * one of them, but not for both.
+		 *
+		 * The reason we might have invalid queries is because we do a broad search with many possibles term slugs and names.
+		 * There is not one consistent way terms are created, so the slug/name can have different values. We try to search for all of them, and
+		 * if none of the options we are searching for exist as a term, it will create an invalid query.
+		 */
+		if ( substr_count( $tax_query['where'], ' 0 = 1' ) <= 1 ) {
 			// Append to the current join parts. The JOIN statment only needs to exist in the clause once.
 			if ( false === strpos( $clauses['join'], $tax_query['join'] ) ) {
 				$clauses['join'] .= '/* newspack-blocks */ ' . $tax_query['join'] . ' /* /newspack-blocks */';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

On https://github.com/Automattic/newspack-blocks/pull/1954 we changed the tax_query adding a new clause by `slug`. We also expanded the possible values we are searching for. 

As a result, we might end up generating an invalid query for one of the searches (in slug or name), and that's fine. But our condition to consider a that the whole query is invalid now needs to account that we have two clauses and that it's ok for one of them to fail.

### How to test the changes in this Pull Request:

@eddiesshop can you help me here?
1. Make sure that CAP is active.
2. Make sure that Newspack Blocks is active.
3. Create a handful of posts, assign a random author, and publish.
4. Create a new WP_User. If possible, ensure that the `user_login` does not match `user_nicename`.
5. Create another handful of posts and assign the user from the previous step as the author.
6. Create a new post and add a Homepage Post Block, filtered to the author from Step 4.
7. Observe that posts from Step 3 are being displayed for this author.
8. Switch Newspack Blocks to this PR/branch.
9. Attempt to repeat Step 6. Notice however, that now only posts assigned to the author in Step 4 are being displayed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
