### PR TITLE
feat: add Bluesky support to the Author Profile, List blocks

### DIFF
--- a/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
+++ b/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
@@ -418,6 +418,7 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 			'tumblr',
 			'youtube',
 			'wikipedia',
+			'bluesky',
 			'website', // This is the only "social media" link for CAP guest authors.
 		];
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes the Author Profile & List blocks pick up the Bluesky link from the User Profile settings if populated.

### How to test the changes in this Pull Request:

1. Make sure the theme is up-to-date to the latest, and apply this PR.
2. Edit at least one user to add a https://bsky.app/ URL to the Bluesky field.
3. Add an author profile block to a post or page, and make sure at least one of your users with a Bluesky link is populating the block.
4. Enable social icons for the block.
5. Confirm you're getting the Bluesky icon:

![CleanShot 2024-11-21 at 11 43 26](https://github.com/user-attachments/assets/9df8e573-b71b-4dd6-a3d3-62055e65d4f8)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
