### PR TITLE
fix: correct some minor visual issues (spacing mostly)

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -330,7 +330,10 @@
 
 				li {
 					display: flex;
-					margin-bottom: var(--newspack-ui-spacer-3, 16px);
+
+					&:not(:last-child) {
+						margin-bottom: var(--newspack-ui-spacer-3, 16px);
+					}
 
 					label {
 						font-size: var(--newspack-ui-font-size-xs, 14px);

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -8,7 +8,8 @@
 	form p {
 		margin: 0 0 var(--newspack-ui-spacer-5, 24px);
 
-		&:last-child {
+		&:last-child,
+		&.form-row-first:has(+ .form-row-last:last-child) {
 			margin-bottom: 0;
 		}
 	}
@@ -81,11 +82,6 @@
 			label {
 				font-size: var(--newspack-ui-font-size-s, 16px);
 				line-height: var(--newspack-ui-line-height-s, 1.5);
-			}
-
-			// Hide if empty - :empty doesn't work for this since there's space between the opening/closing tags.
-			&:not(:has(*)) {
-				display: none;
 			}
 		}
 

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -430,6 +430,7 @@
 					}
 
 					.payment-method-title {
+						margin-left: -0.25em; // Fix space in label string.
 						vertical-align: unset;
 					}
 				}

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -22,6 +22,10 @@
 		tfoot > tr.recurring-totals > th {
 			font-weight: var(--newspack-ui-font-weight-strong, 600);
 		}
+
+		td.product-name {
+			padding-right: 1em;
+		}
 	}
 
 	.order-review-wrapper.hidden {
@@ -79,6 +83,10 @@
 				line-height: var(--newspack-ui-line-height-s, 1.5);
 			}
 
+			// Hide if empty - :empty doesn't work for this since there's space between the opening/closing tags.
+			&:not(:has(*)) {
+				display: none;
+			}
 		}
 
 		.woocommerce-billing-fields__field-wrapper ~ .form-row {
@@ -339,6 +347,10 @@
 			fieldset {
 				margin: 0 0 var(--newspack-ui-spacer-2, 12px);
 				padding: 0 !important; // To override inline styles.
+
+				&.wc-payment-form {
+					margin-top: var(--newspack-ui-spacer-3, 16px);
+				}
 
 				&:last-child {
 					margin-bottom: 0;

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -419,6 +419,25 @@
 			#wc-woocommerce_payments-upe-form {
 				margin-top: var(--newspack-ui-spacer-3, 16px);
 			}
+
+			// Fix icon alignment and display.
+			label:has(.woopayments-rich-payment-method-label) {
+				align-items: unset;
+
+				.woopayments-rich-payment-method-label {
+					img {
+						margin: 0;
+					}
+
+					.payment-method-title {
+						vertical-align: unset;
+					}
+				}
+
+				span > img {
+					display: none;
+				}
+			}
 		}
 	}
 

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -306,6 +306,10 @@
 
 		> label:first-of-type {
 			margin: unset;
+
+			img {
+				float: right;
+			}
 		}
 
 		.payment_box {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR combines fixes for some spacing issues I've noticed on RAS-ACC sites, plus a weird WooPayments issue I ran into trying to test these fixes. It's a bit of a mixed bag -- let me know if it'd be easier to separate them!

See: 
1207817176293825-as-1208782453256611
1207817176293825-as-1208782453256607
1207817176293825-as-1208782453256667

### How to test: WooPayments and Stripe display issues

We change the markup inside of the payment option labels, so some of the styles from WooPayments don't work; others clash with our own label styles. 

Stripe is more minor -- the image placement just looks a little funky.

1. Install and activate WooPayments and Stripe.
2. Run through a checkout and note the appearance of both -- WooPayments looks pretty messed up when opened and closed. Stripe just looks a little off when closed (the image makes the label too tall):

![CleanShot 2024-11-22 at 14 31 14](https://github.com/user-attachments/assets/1aa7e622-efad-40d0-8eac-e0de05798edc)

![CleanShot 2024-11-22 at 14 31 28](https://github.com/user-attachments/assets/b6a9ba5e-9408-400e-82c2-550fb6054905)

3. Apply the PR and make sure both look better:

![CleanShot 2024-11-22 at 15 16 33](https://github.com/user-attachments/assets/b7ddb599-f16b-4b13-9c94-6dd00402381f)

![CleanShot 2024-11-22 at 15 16 43](https://github.com/user-attachments/assets/736ca30b-2361-4372-8c40-741167079d8e)

----

### How to test: Extra space above Continue button in specific situations

This is an odd one I can't recreate, but you can see it (and try to test it) [on this staging site](https://rasbeta-lookout.newspackstaging.com/become-a-member/): the email field appears above the first name/last name fields. The styles are only counting on the last field to be full width, so the bottom margin on the First Name field is still there.

1. Recreate the issue, or [test on this site](https://rasbeta-lookout.newspackstaging.com/become-a-member/). You can also use the element inspector to edit the HTML and make the first name/last name fields -- or other paired fields -- last.

![CleanShot 2024-11-22 at 11 53 45](https://github.com/user-attachments/assets/8afc60dc-d6a1-40b0-ba0b-b726d6e4a881)

5. Apply the PR.
6. Confirm that it fixes the issue, and doesn't cause other spacing issues.

----

### How to test: Add padding to the transaction details table

This is an edge case, but when you have a really long product name in very specific cases (when the line breaks in just the right spot), it can "touch" the text in the next column in the transaction details table. 

1. Set up a product with a really long title, or edit the title when testing in the element inspector.
2. Run a transaction that shows the pricing table -- this will show up if you're charging taxes, if have a free trial, a recurring subscription, or if you opt to cover donation fees.
3. Note the appearance of the table -- the longer text can touch the price (depending on the characters, you might need to adjust your browser window to see it):

![CleanShot 2024-11-22 at 15 24 57](https://github.com/user-attachments/assets/4139d976-8d41-4a66-81bc-fd8dacb97489)

4. Apply the PR, which adds a bit of padding to the right side of the title.
5. Confirm that the title and price don't touch, even if you try to make them, because of the padding:

![CleanShot 2024-11-22 at 15 28 43](https://github.com/user-attachments/assets/170f1a2a-c6ba-4390-beb2-ac957783a574)

----

### How to test: Missing space after credit card header

Another really specific one, but if you're using Stripe and make a purchase as a new reader, space is lost above the credit card field. This looks to be because if you're logged in, the checkout loads an empty `<ul>` for saved payment options in that space, even if you have none saved.

1. Enable Stripe as a payment gateway.
2. In an incognito window, run through a checkout. Note the spacing on the second screen:

![CleanShot 2024-11-22 at 15 44 01](https://github.com/user-attachments/assets/fbf9bff8-ebee-4167-9b4f-d0c4b207d644)

3. Apply the PR.
4. Start another transaction and confirm the spacing is fixed:

![CleanShot 2024-11-22 at 15 45 52](https://github.com/user-attachments/assets/377e4b27-8969-41c8-a5b0-a97dd26aaaa2)

5. Sign in and run a transaction; confirm that the spacing still looks okay, even with the empty `<ul>` now present (you might need to inspect the checkout to confirm):

![CleanShot 2024-11-22 at 15 48 31](https://github.com/user-attachments/assets/21813ca8-5ac1-4001-94c1-6c6985c07fb5)

6. Save your payment option and run a final checkout to make sure thinks look okay when the saved payment options are visible:

![CleanShot 2024-11-22 at 15 53 20](https://github.com/user-attachments/assets/229d4bb4-33f2-4236-ae7c-fd4e685c9983)

![CleanShot 2024-11-22 at 15 53 32](https://github.com/user-attachments/assets/efa935b9-f8ea-4320-84a4-e3177092a4a0)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
