### PR TITLE
fix: correct spacing around AutomateWoo opt-in

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -672,6 +672,12 @@
 		}
 	}
 
+
+	// Automate Woo Opt in
+	form .automatewoo-optin {
+		margin: var(--newspack-ui-spacer-5, 24px) 0 0;
+	}
+
 	// Buttons - adjust spacing
 	#place-order {
 		margin-bottom: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes some spacing around the AutomateWoo opt-in checkbox.

See 1207817176293825-as-1208851280188397

### How to test the changes in this Pull Request:

1. Install and activate AutomateWoo (a premium plugin).
2. Navigate to WP Admin > AutomateWoo > Settings, and switch the Marketing Opt-In to "Opt In" at the top:

![CleanShot 2024-11-26 at 16 46 14](https://github.com/user-attachments/assets/311949cc-f729-4d0f-beac-7e28f3e83dc7)

3. Run through a checkout and note the spacing on the checkbox on the second screen.

![CleanShot 2024-11-26 at 16 48 31](https://github.com/user-attachments/assets/3a490143-0f24-4298-956a-4185fc609da6)

4. Apply this PR and run `npm run build`.
5. Repeat step 3 and confirm the spacing looks okay:

![CleanShot 2024-11-26 at 16 47 31](https://github.com/user-attachments/assets/f9ea9b6c-7d0e-4e05-919d-a3b7da5bdd44)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
