### PR TITLE
fix(modal-checkout): allow metorik scripts

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -740,6 +740,8 @@ final class Modal_Checkout {
 			'wcs-',
 			'stripe',
 			'select2',
+			// Metorik.
+			'metorik',
 		];
 
 		/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The [Metorik](https://metorik.com/) (WC tracking) scripts have to be allowed to load on WC pages for the tracking to work.
 
### How to test the changes in this Pull Request:

1. On the base branch, load the `/checkout/?modal_checkout=1` page, observe the metorik JS is not loaded
2. Switch to this branch, observe it's loaded

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->