### PR TITLE
fix(ras-acc): remove space caused by empty divs

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -83,6 +83,11 @@
 				font-size: var(--newspack-ui-font-size-s, 16px);
 				line-height: var(--newspack-ui-line-height-s, 1.5);
 			}
+
+			// A hacky way to hide these fields if they have no children; :empty is not working since they contain line breaks when empty.
+			&:not(:has(> *)) {
+				display: none;
+			}
 		}
 
 		.woocommerce-billing-fields__field-wrapper ~ .form-row {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In _really_ specific circumstances, some empty divs are inserted into the first screen of the modal checkout, causing extra space. This PR fixes it with possibly the best/worst CSS I've ever written 😆 

See 1207817176293825-as-1208782453256667

### How to test the changes in this Pull Request:

1. Under Reader Activation > Additional Settings, turn off "Require sign in or create account before checkout".
2. Under Reader Revenue > Donations, turn off the Order Notes option under the Modal Checkout Settings.
3. Set up a product that doesn't require shipping, and assign it to a Checkout Button block.
4. In an incognito window (this won't happen if you're logged in), run through a checkout using that product -- note there's extra space in the modal, sometimes directly above the Continue button, or possibly between the last fields and a final checkbox (depending on your plugins). If you inspect this space, you'll see it's caused by empty shipping or additional fields divs:

![CleanShot 2024-11-28 at 14 20 46](https://github.com/user-attachments/assets/9b00f5d6-9015-45c5-b6f4-afa1e83b10cb)

5. Apply this PR and run `npm run build`. 
6. Confirm that the space is now gone:

![CleanShot 2024-11-28 at 14 22 01](https://github.com/user-attachments/assets/f229f80a-93eb-4596-afa7-f3d986004333)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
