### PR TITLE
fix(ras-acc): fix display issues with Additional Fields

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -88,6 +88,15 @@
 		.woocommerce-billing-fields__field-wrapper ~ .form-row {
 			margin: var(--newspack-ui-spacer-5, 24px) 0 0;
 		}
+
+		// Additional fields
+		.woocommerce-additional-fields {
+			margin: var(--newspack-ui-spacer-5, 24px) 0 0;
+
+			h3 {
+				display: none;
+			}
+		}
 	}
 
 	// Override billing details spacing.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes the appearance of the Order Notes field when enabled.

See 1207817176293825-as-1208840400972789

### How to test the changes in this Pull Request:

1. Under Newspack > Reader Revenue > Donations, enable the Order Notes field in the Modal Checkout settings.
2. Run through a checkout; note the appearance of the Order Notes, with weird spacing. Depending on the settings you may also see an extra heading (for me it just doesn't seem to appear when the product needs shipping):

![CleanShot 2024-11-28 at 14 52 16](https://github.com/user-attachments/assets/c409d369-1eaf-44ac-bae8-0b3f4f667b88)

![CleanShot 2024-11-28 at 14 53 02](https://github.com/user-attachments/assets/6546a8e6-03b6-4825-a294-a5f22d0f40db)

3. Apply this PR and run `npm run build`.
4. Confirm that the spacing looks better.

![CleanShot 2024-11-28 at 14 48 43](https://github.com/user-attachments/assets/e94038fd-0e01-46f1-a88c-e280d66170f1)

5. As a bonus, try a couple more products, like one that can be shipped, or a subscription with the Gift Subscriptions plugin enabled. This helps test this change with additional form fields that appear around the notes:

![CleanShot 2024-11-28 at 14 49 08](https://github.com/user-attachments/assets/b29de19e-3ad1-4718-a3e3-76e55dbe0cd0)

![CleanShot 2024-11-28 at 14 49 42](https://github.com/user-attachments/assets/06bfd068-876f-47fa-986a-3bb9c693b478)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
