### PR TITLE
fix(ras-acc): correct spacing issue around saved credit cards

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -364,7 +364,7 @@
 			}
 
 			ul.wc-saved-payment-methods {
-				margin-top: var(--newspack-ui-spacer-3, 16px);
+				margin: var(--newspack-ui-spacer-3, 16px) 0 0;
 				padding: 0;
 
 				li {
@@ -378,6 +378,7 @@
 						font-size: var(--newspack-ui-font-size-xs, 14px);
 						font-weight: normal;
 						line-height: inherit;
+						margin: 0;
 					}
 
 					input {
@@ -387,15 +388,11 @@
 			}
 
 			fieldset {
-				margin: 0 0 var(--newspack-ui-spacer-2, 12px);
+				margin: var(--newspack-ui-spacer-3, 16px) 0 0;
 				padding: 0 !important; // To override inline styles.
 
 				&.wc-payment-form {
 					margin-top: var(--newspack-ui-spacer-3, 16px);
-				}
-
-				&:last-child {
-					margin-bottom: 0;
 				}
 
 				p {
@@ -535,11 +532,20 @@
 		margin: var(--newspack-ui-spacer-3, 16px) 0 0;
 	}
 
+	// Hide 'Save New' checkbox container if the credit card form is hidden -- this means the checkbox is also hidden and gets rid of extra space.
+	fieldset:has(.woocommerce-SavedPaymentMethods-saveNew[style*="display: none"]) {
+		display: none;
+	}
+
 	// WooPayments inputs
 	#wcpay-upe-element,
 	.wcpay-upe-element {
-		margin: 0 0 var(--newspack-ui-spacer-3, 16px);
+		margin: 0;
 		padding: 0;
+
+		+ div:has(.woocommerce-SavedPaymentMethods-saveNew) {
+			margin-top: var(--newspack-ui-spacer-3, 16px);
+		}
 	}
 
 	.payment_method_woocommerce_payments {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes some spacing between elements when at least one credit card has been saved.

Just a warning: the styles in this PR ended up kind of funky because different payment options treat the same elements slightly differently (like placing them in slightly different spots in the markup).

See 1207817176293825-as-1208840400972712

### How to test the changes in this Pull Request:

1. Set up both Stripe and WooPay as payment options, so both can be tested. 
2. Set up a page with a regular product, and a donation block with at least One-Time and Monthly donations enabled.
3. Under the Reader Revenue settings, enable the checkbox for the reader to pay the transaction fees.
4. In an incognito window, run a few transactions as the reader, saving at least one credit card per payment processor.
5. Run a donation transaction, and see how the radio-radio-checkbox version of the form looks for each payment processor:

![CleanShot 2024-11-28 at 17 07 23](https://github.com/user-attachments/assets/ec101702-693d-49aa-98be-1c6a17b9b1a5)

![CleanShot 2024-11-28 at 17 07 34](https://github.com/user-attachments/assets/241cd9d2-4185-49b5-810f-54d627b2f052)

6. Apply this PR and run `npm run build`.
7. Run through a few different transactions and make sure the spacing looks good in all cases. First run a simple product transaction and check the spacing with the saved credit card and new credit card fields opened for both payment providers -- this will show the 'Save credit card info' checkbox:

![CleanShot 2024-11-28 at 17 08 44](https://github.com/user-attachments/assets/a20cbe28-345d-4182-b123-8afa5012e9fb)

![CleanShot 2024-11-28 at 17 08 56](https://github.com/user-attachments/assets/0a65f174-4cd8-4e4b-aa84-7414594cd2a1)

![CleanShot 2024-11-28 at 17 09 08](https://github.com/user-attachments/assets/4bad49a3-40a8-452e-955c-617a71403e2d)

![CleanShot 2024-11-28 at 17 09 20](https://github.com/user-attachments/assets/4658c009-7692-4a69-8eab-0b3cf0c74b41)

8. Run a one-time donation and check the same spacing -- this will show a 'Save credit card info' and 'Pay transaction fees' checkbox:

![CleanShot 2024-11-28 at 17 09 42](https://github.com/user-attachments/assets/e43bc6da-1934-4168-be0c-fa172b072881)

![CleanShot 2024-11-28 at 17 10 02](https://github.com/user-attachments/assets/dce4e973-764e-4609-b709-4ec3862a5a70)

![CleanShot 2024-11-28 at 17 10 15](https://github.com/user-attachments/assets/e588b6a0-1f3c-4921-9765-3d4407de73ce)

![CleanShot 2024-11-28 at 17 10 25](https://github.com/user-attachments/assets/6c24ec3a-dc00-4540-899c-66ec44db3f46)

9. Run a monthly donation and check the same spacing -- this will show just the 'Pay transaction fees' checkbox:

![CleanShot 2024-11-28 at 17 10 52](https://github.com/user-attachments/assets/645308ca-636f-4d92-9843-73c541a6c337)

![CleanShot 2024-11-28 at 17 11 02](https://github.com/user-attachments/assets/95eefe13-c5f6-4d8d-b4d7-86d92b68e214)

![CleanShot 2024-11-28 at 17 11 17](https://github.com/user-attachments/assets/593cb6f4-ca7d-4a85-9415-03e6f74a783c)

![CleanShot 2024-11-28 at 17 11 29](https://github.com/user-attachments/assets/6cb418b4-9359-4a4a-9b74-053a3577c171)

10. Navigate to the Reader Revenue settings and disable the option to collect transaction fees.
11. Repeat the one-time and monthly donation transactions and confirm everything looks okay.
12. Fire up a fresh incognito window and use the Sign In button to create an account.
13. Repeat steps 8 - 11 (but without completing transaction so nothing is saved), and make sure everything still looks okay with no saved credit cards.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
