### PR TITLE
fix: remove reCAPTCHA for Woo from modal checkout

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -133,10 +133,8 @@ final class Modal_Checkout {
 		add_filter( 'woocommerce_subscriptions_product_limited_for_user', [ __CLASS__, 'subscriptions_product_limited_for_user' ], 10, 3 );
 		add_filter( 'woocommerce_get_privacy_policy_text', [ __CLASS__, 'woocommerce_get_privacy_policy_text' ], 10, 2 );
 
-		// Remove any hooks related to reCAPTCHA for WooCommerce.
-		if ( self::is_modal_checkout() ) {
-			add_action( 'plugins_loaded', [ __CLASS__, 'remove_recaptcha_hooks' ] );
-		}
+		// Remove any hooks that aren't supported by the modal checkout.
+		add_action( 'plugins_loaded', [ __CLASS__, 'remove_hooks' ] );
 	}
 
 	/**
@@ -761,7 +759,7 @@ final class Modal_Checkout {
 		foreach ( $wp_scripts->queue as $handle ) {
 			$allowed = false;
 			foreach ( $allowed_assets as $allowed_asset ) {
-				if ( false !== strpos( $handle, $allowed_asset, 0 ) ) {
+				if ( 0 === strpos( $handle, $allowed_asset, 0 ) ) {
 					$allowed = true;
 					break;
 				}
@@ -773,7 +771,7 @@ final class Modal_Checkout {
 		foreach ( $wp_styles->queue as $handle ) {
 			$allowed = false;
 			foreach ( $allowed_assets as $allowed_asset ) {
-				if ( false !== strpos( $handle, $allowed_asset, 0 ) ) {
+				if ( 0 === strpos( $handle, $allowed_asset, 0 ) ) {
 					$allowed = true;
 					break;
 				}
@@ -785,16 +783,46 @@ final class Modal_Checkout {
 	}
 
 	/**
-	 * Remove hooks related to reCAPTCHA for WooCommerce
+	 * Remove any hooks that may not work nicely with the modal checkout.
 	 */
-	public static function remove_recaptcha_hooks() {
-		remove_action( 'woocommerce_review_order_before_payment', 'rcfwc_field_checkout', 10 );
-		remove_action( 'woocommerce_review_order_before_payment', 'rcfwc_field_checkout', 10 );
-		remove_action( 'woocommerce_review_order_after_payment', 'rcfwc_field_checkout', 10 );
-		remove_action( 'woocommerce_before_checkout_billing_form', 'rcfwc_field_checkout', 10 );
-		remove_action( 'woocommerce_after_checkout_billing_form', 'rcfwc_field_checkout', 10 );
-		remove_action( 'woocommerce_review_order_before_submit', 'rcfwc_field_checkout', 10 );
-		remove_action( 'woocommerce_checkout_process', 'rcfwc_checkout_check', 10 );
+	public static function remove_hooks() {
+		if ( ! self::is_modal_checkout() ) {
+			return;
+		}
+		$remove_list = [
+			// reCAPTCHA for WooCommerce.
+			[
+				'hooks'    => [
+					'woocommerce_review_order_before_payment',
+					'woocommerce_review_order_after_payment',
+					'woocommerce_before_checkout_billing_form',
+					'woocommerce_after_checkout_billing_form',
+					'woocommerce_review_order_before_submit',
+				],
+				'callback' => 'rcfwc_field_checkout',
+			],
+			[
+
+				'hooks'    => [
+					'woocommerce_checkout_process',
+				],
+				'callback' => 'rcfwc_checkout_check',
+			],
+		];
+
+		/**
+		 * Filters the hooks to remove from the modal checkout.
+		 *
+		 * @param string[] $remove_list Array of hooks to remove.
+		 */
+		$remove_list = apply_filters( 'newspack_blocks_modal_checkout_remove_hooks', $remove_list );
+
+		foreach ( $remove_list as $remove ) {
+			foreach ( $remove['hooks'] as $hook ) {
+				$priority = has_action( $hook, 'callback' );
+				remove_action( $hook, $remove['callback'], $priority );
+			}
+		}
 	}
 
 	/**

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -759,7 +759,7 @@ final class Modal_Checkout {
 		foreach ( $wp_scripts->queue as $handle ) {
 			$allowed = false;
 			foreach ( $allowed_assets as $allowed_asset ) {
-				if ( 0 === strpos( $handle, $allowed_asset, 0 ) ) {
+				if ( 0 === strpos( $handle, $allowed_asset ) ) {
 					$allowed = true;
 					break;
 				}
@@ -771,7 +771,7 @@ final class Modal_Checkout {
 		foreach ( $wp_styles->queue as $handle ) {
 			$allowed = false;
 			foreach ( $allowed_assets as $allowed_asset ) {
-				if ( 0 === strpos( $handle, $allowed_asset, 0 ) ) {
+				if ( 0 === strpos( $handle, $allowed_asset ) ) {
 					$allowed = true;
 					break;
 				}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -791,34 +791,40 @@ final class Modal_Checkout {
 		if ( ! self::is_modal_checkout() ) {
 			return;
 		}
-		$remove_list = [
-			// reCAPTCHA for WooCommerce.
-			[
-				'hook'     => 'woocommerce_review_order_before_payment',
-				'callback' => 'rcfwc_field_checkout',
-			],
-			[
-				'hook'     => 'woocommerce_review_order_after_payment',
-				'callback' => 'rcfwc_field_checkout',
-			],
-			[
-				'hook'     => 'woocommerce_before_checkout_billing_form',
-				'callback' => 'rcfwc_field_checkout',
-			],
-			[
-				'hook'     => 'woocommerce_after_checkout_billing_form',
-				'callback' => 'rcfwc_field_checkout',
-			],
-			[
-				'hook'     => 'woocommerce_review_order_before_submit',
-				'callback' => 'rcfwc_field_checkout',
-			],
-			[
-				'hook'     => 'woocommerce_checkout_process',
-				'callback' => 'rcfwc_checkout_check',
-			],
-		];
 
+		$remove_list = [];
+
+		// reCaptcha for WooCommerce.
+		if ( method_exists( 'I13_Woo_Recpatcha', '__construct' ) ) {
+			global $i13_woo_recpatcha;
+			array_push(
+				$remove_list,
+				[
+					'hook'     => 'woocommerce_review_order_before_payment',
+					'callback' => array( $i13_woo_recpatcha, 'i13woo_extra_checkout_fields' ),
+				],
+				[
+					'hook'     => 'woocommerce_after_checkout_validation',
+					'callback' => array( $i13_woo_recpatcha, 'i13_woocomm_validate_checkout_captcha' ),
+				],
+				[
+					'hook'     => 'woocommerce_pay_order_before_submit',
+					'callback' => array( $i13_woo_recpatcha, 'i13woo_extra_checkout_fields' ),
+				],
+				[
+					'hook'     => 'woocommerce_review_order_before_submit',
+					'callback' => array( $i13_woo_recpatcha, 'i13woo_extra_checkout_fields' ),
+				],
+				[
+					'hook'     => 'woocommerce_pay_order_before_submit',
+					'callback' => array( $i13_woo_recpatcha, 'i13woo_extra_checkout_fields_pay_order' ),
+				],
+				[
+					'hook'     => 'woocommerce_proceed_to_checkout',
+					'callback' => array( $i13_woo_recpatcha, 'i13_woocommerce_payment_request_btn_captcha' ),
+				]
+			);
+		}
 		/**
 		 * Filters the hooks to remove from the modal checkout.
 		 *

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -822,6 +822,10 @@ final class Modal_Checkout {
 				[
 					'hook'     => 'woocommerce_proceed_to_checkout',
 					'callback' => array( $i13_woo_recpatcha, 'i13_woocommerce_payment_request_btn_captcha' ),
+				],
+				[
+					'hook'     => 'wp_head',
+					'callback' => array( $i13_woo_recpatcha, 'i13_add_header_metadata' ),
 				]
 			);
 		}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -795,7 +795,7 @@ final class Modal_Checkout {
 		$remove_list = [];
 
 		// reCaptcha for WooCommerce.
-		if ( method_exists( 'I13_Woo_Recpatcha', '__construct' ) ) {
+		if ( class_exists( 'I13_Woo_Recpatcha' ) ) {
 			global $i13_woo_recpatcha;
 			array_push(
 				$remove_list,

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -734,6 +734,7 @@ final class Modal_Checkout {
 			'newspack-ui',
 			'newspack-style',
 			'newspack-recaptcha',
+			'newspack-woocommerce-style',
 			// Woo.
 			'woocommerce',
 			'WCPAY',
@@ -792,20 +793,27 @@ final class Modal_Checkout {
 		$remove_list = [
 			// reCAPTCHA for WooCommerce.
 			[
-				'hooks'    => [
-					'woocommerce_review_order_before_payment',
-					'woocommerce_review_order_after_payment',
-					'woocommerce_before_checkout_billing_form',
-					'woocommerce_after_checkout_billing_form',
-					'woocommerce_review_order_before_submit',
-				],
+				'hook'     => 'woocommerce_review_order_before_payment',
 				'callback' => 'rcfwc_field_checkout',
 			],
 			[
-
-				'hooks'    => [
-					'woocommerce_checkout_process',
-				],
+				'hook'     => 'woocommerce_review_order_after_payment',
+				'callback' => 'rcfwc_field_checkout',
+			],
+			[
+				'hook'     => 'woocommerce_before_checkout_billing_form',
+				'callback' => 'rcfwc_field_checkout',
+			],
+			[
+				'hook'     => 'woocommerce_after_checkout_billing_form',
+				'callback' => 'rcfwc_field_checkout',
+			],
+			[
+				'hook'     => 'woocommerce_review_order_before_submit',
+				'callback' => 'rcfwc_field_checkout',
+			],
+			[
+				'hook'     => 'woocommerce_checkout_process',
 				'callback' => 'rcfwc_checkout_check',
 			],
 		];
@@ -818,10 +826,8 @@ final class Modal_Checkout {
 		$remove_list = apply_filters( 'newspack_blocks_modal_checkout_remove_hooks', $remove_list );
 
 		foreach ( $remove_list as $remove ) {
-			foreach ( $remove['hooks'] as $hook ) {
-				$priority = has_action( $hook, 'callback' );
-				remove_action( $hook, $remove['callback'], $priority );
-			}
+			$priority = has_action( $remove['hook'], $remove['callback'] );
+			remove_action( $remove['hook'], $remove['callback'], $priority );
 		}
 	}
 

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -751,7 +751,6 @@ final class Modal_Checkout {
 
 		$skip_assets = [
 			// reCAPTCHA for Woo.
-			'recaptcha',
 			'rcfwc-js',
 		];
 

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -749,25 +749,19 @@ final class Modal_Checkout {
 			'metorik',
 		];
 
-		$skip_assets = [
-			// reCAPTCHA for Woo.
-			'rcfwc-js',
-		];
-
 		/**
 		 * Filters the allowed assets to render in the modal checkout
 		 *
 		 * @param string[] $allowed_assets Array of allowed assets handles.
 		 */
 		$allowed_assets = apply_filters( 'newspack_blocks_modal_checkout_allowed_assets', $allowed_assets );
-		$skip_assets    = apply_filters( 'newspack_blocks_modal_checkout_skip_assets', $skip_assets );
 
 		global $wp_scripts, $wp_styles;
 
 		foreach ( $wp_scripts->queue as $handle ) {
 			$allowed = false;
 			foreach ( $allowed_assets as $allowed_asset ) {
-				if ( false !== strpos( $handle, $allowed_asset ) && ! in_array( $handle, $skip_assets ) ) {
+				if ( false !== strpos( $handle, $allowed_asset, 0 ) ) {
 					$allowed = true;
 					break;
 				}
@@ -779,7 +773,7 @@ final class Modal_Checkout {
 		foreach ( $wp_styles->queue as $handle ) {
 			$allowed = false;
 			foreach ( $allowed_assets as $allowed_asset ) {
-				if ( false !== strpos( $handle, $allowed_asset ) && ! in_array( $handle, $skip_assets ) ) {
+				if ( false !== strpos( $handle, $allowed_asset, 0 ) ) {
 					$allowed = true;
 					break;
 				}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -132,6 +132,11 @@ final class Modal_Checkout {
 		}
 		add_filter( 'woocommerce_subscriptions_product_limited_for_user', [ __CLASS__, 'subscriptions_product_limited_for_user' ], 10, 3 );
 		add_filter( 'woocommerce_get_privacy_policy_text', [ __CLASS__, 'woocommerce_get_privacy_policy_text' ], 10, 2 );
+
+		// Remove any hooks related to reCAPTCHA for WooCommerce.
+		if ( self::is_modal_checkout() ) {
+			add_action( 'plugins_loaded', [ __CLASS__, 'remove_recaptcha_hooks' ] );
+		}
 	}
 
 	/**
@@ -744,19 +749,26 @@ final class Modal_Checkout {
 			'metorik',
 		];
 
+		$skip_assets = [
+			// reCAPTCHA for Woo.
+			'recaptcha',
+			'rcfwc-js',
+		];
+
 		/**
 		 * Filters the allowed assets to render in the modal checkout
 		 *
 		 * @param string[] $allowed_assets Array of allowed assets handles.
 		 */
 		$allowed_assets = apply_filters( 'newspack_blocks_modal_checkout_allowed_assets', $allowed_assets );
+		$skip_assets    = apply_filters( 'newspack_blocks_modal_checkout_skip_assets', $skip_assets );
 
 		global $wp_scripts, $wp_styles;
 
 		foreach ( $wp_scripts->queue as $handle ) {
 			$allowed = false;
 			foreach ( $allowed_assets as $allowed_asset ) {
-				if ( false !== strpos( $handle, $allowed_asset ) ) {
+				if ( false !== strpos( $handle, $allowed_asset ) && ! in_array( $handle, $skip_assets ) ) {
 					$allowed = true;
 					break;
 				}
@@ -768,7 +780,7 @@ final class Modal_Checkout {
 		foreach ( $wp_styles->queue as $handle ) {
 			$allowed = false;
 			foreach ( $allowed_assets as $allowed_asset ) {
-				if ( false !== strpos( $handle, $allowed_asset ) ) {
+				if ( false !== strpos( $handle, $allowed_asset ) && ! in_array( $handle, $skip_assets ) ) {
 					$allowed = true;
 					break;
 				}
@@ -777,6 +789,19 @@ final class Modal_Checkout {
 				wp_dequeue_style( $handle );
 			}
 		}
+	}
+
+	/**
+	 * Remove hooks related to reCAPTCHA for WooCommerce
+	 */
+	public static function remove_recaptcha_hooks() {
+		remove_action( 'woocommerce_review_order_before_payment', 'rcfwc_field_checkout', 10 );
+		remove_action( 'woocommerce_review_order_before_payment', 'rcfwc_field_checkout', 10 );
+		remove_action( 'woocommerce_review_order_after_payment', 'rcfwc_field_checkout', 10 );
+		remove_action( 'woocommerce_before_checkout_billing_form', 'rcfwc_field_checkout', 10 );
+		remove_action( 'woocommerce_after_checkout_billing_form', 'rcfwc_field_checkout', 10 );
+		remove_action( 'woocommerce_review_order_before_submit', 'rcfwc_field_checkout', 10 );
+		remove_action( 'woocommerce_checkout_process', 'rcfwc_checkout_check', 10 );
 	}
 
 	/**

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -744,6 +744,7 @@ final class Modal_Checkout {
 			'wcs-',
 			'stripe',
 			'select2',
+			'selectWoo',
 			// Metorik.
 			'metorik',
 		];

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -226,6 +226,7 @@ import { domReady } from './utils';
 					const handleErrorItem = $error => {
 						// Add errors to known fields.
 						const $field = $( '#' + $error.data( 'id' ) + '_field' );
+
 						if ( $field?.length ) {
 							if ( ! $fieldToFocus ) {
 								$fieldToFocus = $field;

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -226,7 +226,6 @@ import { domReady } from './utils';
 					const handleErrorItem = $error => {
 						// Add errors to known fields.
 						const $field = $( '#' + $error.data( 'id' ) + '_field' );
-
 						if ( $field?.length ) {
 							if ( ! $fieldToFocus ) {
 								$fieldToFocus = $field;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes and dequeues code from the reCAPTCHA for WooCommerce plugin from our modal checkout.

See 1207817176293825-as-1208873550136264

Note: the way I went about removing the scripts might be terrible; it seemed kind of duplicative, but I couldn't think of a better way that didn't require spelling out each allowed script. 

### How to test the changes in this Pull Request:

1. Install reCAPTCHA for WooCommerce and enable it on your site.
2. Try running through a modal checkout; note you get an error.
3. Apply this PR.
4. Confirm that you can complete the modal checkout.
5. View source in the modal checkout and confirm you don't have anything referencing `recaptcha` from the plugin (a `g-recaptcha` div, plus the script, rcfwc.js).
6. Confirm that those elements still exist in the regular checkout and that the reCAPTCHA there doesn't throw errors.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
