### PR TITLE
fix(modal-checkout): allow all gateway assets

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -49,6 +49,66 @@ final class Modal_Checkout {
 	private static $modal_checkout_labels = [];
 
 	/**
+	 * Allowed assets for modal checkout.
+	 *
+	 * @var string[]
+	 */
+	private static $allowed_scripts = [
+		'jquery',
+		'google_gtagjs',
+		// Newspack.
+		'newspack-newsletters-',
+		'newspack-blocks-modal',
+		'newspack-blocks-modal-checkout',
+		'newspack-wc',
+		'newspack-ui',
+		'newspack-style',
+		'newspack-recaptcha',
+		'newspack-woocommerce-style',
+		// Woo.
+		'woocommerce',
+		'WCPAY',
+		'Woo',
+		'wc-',
+		'wc_',
+		'wcs-',
+		'stripe',
+		'select2',
+		'selectWoo',
+		// Metorik.
+		'metorik',
+	];
+
+	/**
+	 * Allowed styles for modal checkout.
+	 *
+	 * @var string[]
+	 */
+	private static $allowed_styles = [
+		// Newspack.
+		'newspack-newsletters-',
+		'newspack-blocks-modal',
+		'newspack-blocks-modal-checkout',
+		'newspack-wc',
+		'newspack-ui',
+		'newspack-style',
+		'newspack-recaptcha',
+		'newspack-woocommerce-style',
+		// Woo.
+		'woocommerce',
+		'WCPAY',
+		'Woo',
+		'wc-',
+		'wc_',
+		'wcs-',
+		'stripe',
+		'select2',
+		'selectWoo',
+		// Metorik.
+		'metorik',
+	];
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
@@ -722,65 +782,59 @@ final class Modal_Checkout {
 		if ( ! self::is_modal_checkout() ) {
 			return;
 		}
-
-		$allowed_assets = [
-			'jquery',
-			'google_gtagjs',
-			// Newspack.
-			'newspack-newsletters-',
-			'newspack-blocks-modal',
-			'newspack-blocks-modal-checkout',
-			'newspack-wc',
-			'newspack-ui',
-			'newspack-style',
-			'newspack-recaptcha',
-			'newspack-woocommerce-style',
-			// Woo.
-			'woocommerce',
-			'WCPAY',
-			'Woo',
-			'wc-',
-			'wc_',
-			'wcs-',
-			'stripe',
-			'select2',
-			'selectWoo',
-			'metorik', // Metorik.
-			'ppcp', // PayPal Payments.
-			'gateway',  // PayPal Payments.
-		];
-
 		/**
-		 * Filters the allowed assets to render in the modal checkout
+		 * Filters the allowed scripts to render in the modal checkout
 		 *
-		 * @param string[] $allowed_assets Array of allowed assets handles.
+		 * @param string[] $allowed_scripts Array of allowed assets handles.
 		 */
-		$allowed_assets = apply_filters( 'newspack_blocks_modal_checkout_allowed_assets', $allowed_assets );
+		$allowed_scripts = apply_filters( 'newspack_blocks_modal_checkout_allowed_scripts', self::$allowed_scripts );
+		/**
+		 * Filters the allowed styles to render in the modal checkout
+		 *
+		 * @param string[] $allowed_styles Array of allowed assets handles.
+		 */
+		$allowed_styles   = apply_filters( 'newspack_blocks_modal_checkout_allowed_styles', self::$allowed_styles );
+		$payment_gateways = \WC()->payment_gateways->get_available_payment_gateways();
 
 		global $wp_scripts, $wp_styles;
-
-		foreach ( $wp_scripts->queue as $handle ) {
+		foreach ( $wp_styles->registered as $handle => $wp_style ) {
 			$allowed = false;
-			foreach ( $allowed_assets as $allowed_asset ) {
-				if ( 0 === strpos( $handle, $allowed_asset ) ) {
+			foreach ( $allowed_styles as $allowed_style ) {
+				if ( 0 === strpos( $handle, $allowed_style ) ) {
 					$allowed = true;
 					break;
 				}
 			}
-			if ( ! $allowed ) {
-				wp_dequeue_script( $handle );
-			}
-		}
-		foreach ( $wp_styles->queue as $handle ) {
-			$allowed = false;
-			foreach ( $allowed_assets as $allowed_asset ) {
-				if ( 0 === strpos( $handle, $allowed_asset ) ) {
-					$allowed = true;
-					break;
+			if ( ! empty( $payment_gateways ) ) {
+				foreach ( array_keys( $payment_gateways ) as $gateway ) {
+					if ( false !== strpos( $wp_style->src, $gateway->id ) ) {
+						$allowed = true;
+						break;
+					}
 				}
 			}
 			if ( ! $allowed ) {
 				wp_dequeue_style( $handle );
+			}
+		}
+		foreach ( $wp_scripts->registered as $handle => $wp_script ) {
+			$allowed = false;
+			foreach ( $allowed_scripts as $allowed_script ) {
+				if ( 0 === strpos( $handle, $allowed_script ) ) {
+					$allowed = true;
+					break;
+				}
+			}
+			if ( ! empty( $payment_gateways ) ) {
+				foreach ( array_keys( $payment_gateways ) as $gateway ) {
+					if ( false !== strpos( $wp_script->src, $gateway ) ) {
+						$allowed = true;
+						break;
+					}
+				}
+			}
+			if ( ! $allowed ) {
+				wp_dequeue_script( $handle );
 			}
 		}
 	}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -782,21 +782,27 @@ final class Modal_Checkout {
 		if ( ! self::is_modal_checkout() ) {
 			return;
 		}
-		/**
-		 * Filters the allowed scripts to render in the modal checkout
-		 *
-		 * @param string[] $allowed_scripts Array of allowed assets handles.
-		 */
-		$allowed_scripts = apply_filters( 'newspack_blocks_modal_checkout_allowed_scripts', self::$allowed_scripts );
+
+		global $wp_scripts, $wp_styles;
+
+		$payment_gateways       = \WC()->payment_gateways->get_available_payment_gateways();
+		$allowed_gateway_assets = [];
+		if ( ! empty( $payment_gateways ) ) {
+			foreach ( array_keys( $payment_gateways ) as $gateway ) {
+				$class                    = get_class( $payment_gateways[ $gateway ] );
+				$plugin_file              = ( new \ReflectionClass( $class ) )->getFileName();
+				$plugin_base              = \plugin_basename( $plugin_file );
+				$plugin_slug              = explode( '/', $plugin_base )[0];
+				$allowed_gateway_assets[] = $plugin_slug;
+			}
+		}
+
 		/**
 		 * Filters the allowed styles to render in the modal checkout
 		 *
 		 * @param string[] $allowed_styles Array of allowed assets handles.
 		 */
-		$allowed_styles   = apply_filters( 'newspack_blocks_modal_checkout_allowed_styles', self::$allowed_styles );
-		$payment_gateways = \WC()->payment_gateways->get_available_payment_gateways();
-
-		global $wp_scripts, $wp_styles;
+		$allowed_styles = apply_filters( 'newspack_blocks_modal_checkout_allowed_styles', self::$allowed_styles );
 		foreach ( $wp_styles->registered as $handle => $wp_style ) {
 			$allowed = false;
 			foreach ( $allowed_styles as $allowed_style ) {
@@ -806,8 +812,8 @@ final class Modal_Checkout {
 				}
 			}
 			if ( ! empty( $payment_gateways ) ) {
-				foreach ( array_keys( $payment_gateways ) as $gateway ) {
-					if ( false !== strpos( $wp_style->src, $gateway->id ) ) {
+				foreach ( $allowed_gateway_assets as $gateway ) {
+					if ( false !== strpos( $wp_style->src, $gateway ) ) {
 						$allowed = true;
 						break;
 					}
@@ -817,6 +823,13 @@ final class Modal_Checkout {
 				wp_dequeue_style( $handle );
 			}
 		}
+
+		/**
+		 * Filters the allowed scripts to render in the modal checkout
+		 *
+		 * @param string[] $allowed_scripts Array of allowed assets handles.
+		 */
+		$allowed_scripts = apply_filters( 'newspack_blocks_modal_checkout_allowed_scripts', self::$allowed_scripts );
 		foreach ( $wp_scripts->registered as $handle => $wp_script ) {
 			$allowed = false;
 			foreach ( $allowed_scripts as $allowed_script ) {
@@ -825,12 +838,10 @@ final class Modal_Checkout {
 					break;
 				}
 			}
-			if ( ! empty( $payment_gateways ) ) {
-				foreach ( array_keys( $payment_gateways ) as $gateway ) {
-					if ( false !== strpos( $wp_script->src, $gateway ) ) {
-						$allowed = true;
-						break;
-					}
+			foreach ( $allowed_gateway_assets as $gateway ) {
+				if ( false !== strpos( $wp_script->src, $gateway ) ) {
+					$allowed = true;
+					break;
 				}
 			}
 			if ( ! $allowed ) {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR makes it so modal checkout allows all scripts and styles from available payment gateways by default.

### How to test the changes in this Pull Request:

1. Set up paypal payments
2. Open modal checkout and get to the payments step
3. Confirm paypal scripts are loading (smart buttons should be present or you can check for `ppcp` scripts/styles via network dev tools tab)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
