### PR TITLE
feat: add CSS class to variation buttons for tracking

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -641,7 +641,7 @@ final class Modal_Checkout {
 										<div class="variation"><?php echo esc_html( $variation_name ); ?></div>
 										<form data-product="<?php echo esc_attr( wp_json_encode( $product_data ) ); ?>">
 											<input type="hidden" name="newspack_checkout" value="1" />
-											<button type="submit" class="<?php echo esc_attr( "{$class_prefix}__button {$class_prefix}__button--primary" ); ?>"><?php echo esc_html( self::get_modal_checkout_labels( 'checkout_confirm_variation' ) ); ?></button>
+											<button type="submit" class="<?php echo esc_attr( "{$class_prefix}__button {$class_prefix}__button--primary" ); ?> newspack-modal-variation-selection"><?php echo esc_html( self::get_modal_checkout_labels( 'checkout_confirm_variation' ) ); ?></button>
 										</form>
 									</li>
 								<?php endforeach; ?>

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -641,7 +641,7 @@ final class Modal_Checkout {
 										<div class="variation"><?php echo esc_html( $variation_name ); ?></div>
 										<form data-product="<?php echo esc_attr( wp_json_encode( $product_data ) ); ?>">
 											<input type="hidden" name="newspack_checkout" value="1" />
-											<button type="submit" class="<?php echo esc_attr( "{$class_prefix}__button {$class_prefix}__button--primary" ); ?> newspack-modal-variation-selection"><?php echo esc_html( self::get_modal_checkout_labels( 'checkout_confirm_variation' ) ); ?></button>
+											<button type="submit" class="<?php echo esc_attr( "{$class_prefix}__button {$class_prefix}__button--primary" ); ?> newspack-modal-checkout-variation-selection"><?php echo esc_html( self::get_modal_checkout_labels( 'checkout_confirm_variation' ) ); ?></button>
 										</form>
 									</li>
 								<?php endforeach; ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a unique CSS class only used by variation picker buttons in the modal checkout to make them easier to apply tracking to. (I am ABSOLUTELY open to feedback on the name since we won't want to change it!!)

See: 1207817176293825-as-1208919248362608

### How to test the changes in this Pull Request:

1. Apply this PR.
2. Set up a checkout button block for a product with variations.
3. Run through the checkout and inspect the buttons on the first step; make sure they have the CSS class `newspack-modal-variation-selection`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
