### PR TITLE
fix(modal-checkout) remove body outline

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -2,6 +2,7 @@
 
 // stylelint-disable-next-line selector-id-pattern
 #newspack_modal_checkout_container {
+	outline: none;
 	background: var(--newspack-ui-color-neutral-0, #fff);
 	padding: var(--newspack-ui-spacer-5, 24px);
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This fixes an issue where our joseph theme added an outline to modal checkout. We fix this by setting an outline of none in the modal checkout styles
![Screenshot 2024-12-09 at 16 39 01](https://github.com/user-attachments/assets/d24214df-a8bb-4156-8498-b73132294027)

### How to test the changes in this Pull Request:

1. Activate the joseph theme
2. Open modal checkout via any checkout button or donate button
3. Confirm there is no body outline

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
