### PR TITLE
Resolves #1995: Prevent TypeError on PHP 8

### DIFF
--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -129,7 +129,7 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function get_items( $request ) {
-		$page        = $request->get_param( 'page' ) ?? 1;
+		$page        = (int) $request->get_param( 'page' ) ?? 1;
 		$exclude_ids = $request->get_param( 'exclude_ids' ) ?? [];
 		$next_page   = $page + 1;
 		$attributes  = wp_parse_args(


### PR DESCRIPTION
This PR is meant to address TypeErrors we found on WordPress.com upstream. More context: p1733838368281199-slack-C034JEXD1RD

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1995 by casting `$page` to an int prior to adding one.

### How to test the changes in this Pull Request:

I wasn't able to reproduce in my environment, but it should be something like this:

1. Ensure you're on PHP 8.
2. Do whatever it takes to trigger `WP_REST_Newspack_Articles_Controller::get_items` with a `page` param.

In `trunk` it'll give a TypeError.

In the `fix/php8_typeerror` branch there is no error.
