### PR TITLE
fix: show x.com URLs and icons instead of Twitter in Author blocks

### DIFF
--- a/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
+++ b/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
@@ -435,7 +435,7 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 				$handle     = $is_website ? get_post_meta( $author_id, 'cap-website', true ) : get_the_author_meta( $profile, $author_id );
 
 				if ( $handle ) {
-					$url             = 'twitter' === $profile ? esc_url( 'https://twitter.com/' . $handle ) : esc_url( $handle );
+					$url             = 'twitter' === $profile ? esc_url( 'https://x.com/' . $handle ) : esc_url( $handle );
 					$acc[ $profile ] = [ 'url' => $url ];
 
 					if ( class_exists( 'Newspack_SVG_Icons' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Replaces Twitter URLs and icons with X URLs and icons for Author Profile and Author List blocks.

### How to test the changes in this Pull Request:

1. Add an **X username** handle to a WP author's user profile.
2. Add an Author Profile and Author List block to a post and make sure both target the user from step 1.
3. On `trunk`, observe that the X username is shown with a Twitter logo and link in both the editor and on the front-end.
4. Check out this branch, refresh, and confirm that the X username is shown with an X logo and link in both the editor and on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208941786244715