### PR TITLE
fix: correct flutterwave display

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -129,6 +129,7 @@ final class Modal_Checkout {
 		add_action( 'template_include', [ __CLASS__, 'get_checkout_template' ] );
 		add_filter( 'woocommerce_get_return_url', [ __CLASS__, 'woocommerce_get_return_url' ], 10, 2 );
 		add_filter( 'woocommerce_get_checkout_order_received_url', [ __CLASS__, 'woocommerce_get_return_url' ], 10, 2 );
+		add_filter( 'woocommerce_get_checkout_payment_url', [ __CLASS__, 'woocommerce_get_return_url' ], 10, 2 );
 		add_filter( 'wc_get_template', [ __CLASS__, 'wc_get_template' ], 10, 2 );
 		add_filter( 'woocommerce_checkout_fields', [ __CLASS__, 'woocommerce_checkout_fields' ] );
 		add_filter( 'woocommerce_update_order_review_fragments', [ __CLASS__, 'order_review_fragments' ] );

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -703,10 +703,24 @@
 		}
 	}
 
-
 	// Automate Woo Opt in
 	form .automatewoo-optin {
 		margin: var(--newspack-ui-spacer-5, 24px) 0 0;
+	}
+
+	// Flutterwave
+	.payment_method_tbz_rave {
+		// stylelint-disable-next-line selector-id-pattern
+		.form-row:has(#wc-tbz_rave-new-payment-method) {
+			display: grid !important;
+			gap: 0 var(--newspack-ui-spacer-base, 8px);
+			grid-template-columns: var(--newspack-ui-spacer-4, 20px) 1fr;
+
+			label {
+				font-size: var(--newspack-ui-font-size-s);
+				line-height: var(--newspack-ui-line-height-s);
+			}
+		}
 	}
 
 	// Buttons - adjust spacing

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -708,7 +708,7 @@
 		margin: var(--newspack-ui-spacer-5, 24px) 0 0;
 	}
 
-	// Flutterwave
+	// Flutterwave Payment Gateway
 	.payment_method_tbz_rave {
 		// stylelint-disable-next-line selector-id-pattern
 		.form-row:has(#wc-tbz_rave-new-payment-method) {
@@ -721,6 +721,22 @@
 				line-height: var(--newspack-ui-line-height-s);
 			}
 		}
+	}
+
+	iframe[src*="flutterwave.com"] {
+		border: var(--newspack-ui-spacer-6, 32px) solid #fff !important;
+	}
+
+	// stylelint-disable-next-line selector-id-pattern
+	.order_details:has(+ #tbz_wc_flutterwave_form) {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	// stylelint-disable-next-line selector-id-pattern
+	#tbz_wc_flutterwave_form {
+		display: none;
 	}
 
 	// Buttons - adjust spacing


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes some display issues with the Flutterwave Payment Gateway. 

Note: this experience is still a bit subpar -- Flutterwave opens in its own iframe inside of the modal checkout, and I haven't gotten it to trigger the thank you step at the very end. 

See 1207817176293825-as-1208919243890764

### How to test the changes in this Pull Request:

1. Apply this PR and run `npm run build`.
2. Install the Flutterwave payment gateway: https://wordpress.org/plugins/woo-rave/ 
3. Under WooCommerce > Settings > Payments, enable the payment gateway and set it to test mode. You can use the keys in the above Asana task:

![CleanShot 2024-12-12 at 13 39 35](https://github.com/user-attachments/assets/3e334ff1-a09a-4bfd-9442-2a9235e50c3d)

4. Run through a transaction; on the second screen, confirm you get Flutterwave as a payment gateway:

![CleanShot 2024-12-12 at 13 40 47](https://github.com/user-attachments/assets/8ab03d73-c42e-43bf-b719-32f1245e3cc6)

5. Complete the transaction using Flutterwave; you may get a brief flash of the Order Details, then an iFrame should open:

![CleanShot 2024-12-12 at 13 43 17](https://github.com/user-attachments/assets/c7d2709c-9326-4720-985e-c7800221d927)

6. Run a transaction using the test credit card number, `4111 1111 1111 1111`. You'll need to fill out additional fake information (billing details).
7. You should get a step to go to your bank to complete the transaction that opens in a new tab:

![CleanShot 2024-12-12 at 13 44 31](https://github.com/user-attachments/assets/dd54d42c-1494-4f05-a889-12af3c01166e)

8. Click the 'Submit' button on the test screen from Flutterwave:

![CleanShot 2024-12-12 at 13 45 01](https://github.com/user-attachments/assets/6f8bbd02-1ad6-4554-b379-3ba9df6ad131)

9. Flutterwave should redirect you back to the original tab and show a success message:

![CleanShot 2024-12-12 at 13 45 20](https://github.com/user-attachments/assets/214487f3-3a5f-4c95-8b8b-2ee48c36b93f)

10. The success message will then close to the Order Details:

![CleanShot 2024-12-13 at 10 45 23](https://github.com/user-attachments/assets/19444cb6-69a2-4872-8888-5aa5f035c9bb)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
