### PR TITLE
fix: tweak modal iframe size

### DIFF
--- a/src/modal-checkout/modal.scss
+++ b/src/modal-checkout/modal.scss
@@ -5,10 +5,10 @@
 .newspack-ui {
 	iframe[name="newspack_modal_checkout_iframe"] {
 		border: none;
-		height: calc(100% + var(--newspack-ui-spacer-8, 48px));
+		height: calc(100% + var(--newspack-ui-spacer-9, 48px));
 		margin: calc(-1 * var(--newspack-ui-spacer-5, 24px));
 		max-width: unset;
-		width: calc(100% + var(--newspack-ui-spacer-8, 48px));
+		width: calc(100% + var(--newspack-ui-spacer-9, 48px));
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is a small tweak to the default iframe size on load (thanks @thomasguillot!).

See p1734437900696829-slack-newspack-reader-activation.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build` 
2. Load the modal checkout. 
3. Confirm the iframe's initial size uses `--newspack-ui-spacer-9`, not `--newspack-ui-spacer-8` ([the `48px` fallback is correct, though](https://github.com/Automattic/newspack-plugin/blob/51cbc0ab26dcb7208762404c8b33a1906a35ce67/src/newspack-ui/scss/variables/_spacing.scss#L11)). Note: the applied height will be overridden by inline JS. 

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
