### PR TITLE
fix(modal-checkout): force checkout registration option

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -171,6 +171,7 @@ final class Modal_Checkout {
 		add_filter( 'googlesitekit_adsense_tag_blocked', [ __CLASS__, 'is_modal_checkout' ] );
 		add_filter( 'jetpack_active_modules', [ __CLASS__, 'jetpack_active_modules' ] );
 		add_filter( 'woocommerce_checkout_update_order_review_expired', [ __CLASS__, 'is_not_modal_checkout_filter' ] );
+		add_filter( 'woocommerce_checkout_registration_enabled', [ __CLASS__, 'is_modal_checkout_filter' ] );
 
 		// Make the current cart price available to the JavaScript.
 		add_action( 'wp_ajax_get_cart_total', [ __CLASS__, 'get_cart_total_js' ] );
@@ -1782,7 +1783,19 @@ final class Modal_Checkout {
 	}
 
 	/**
-	 * Filter the a value dependent on the page not being modal checkout.
+	 * Filter a value to true dependent on the page not being modal checkout.
+	 *
+	 * @param bool $value The value.
+	 */
+	public static function is_modal_checkout_filter( $value ) {
+		if ( self::is_modal_checkout() ) {
+			return true;
+		}
+		return $value;
+	}
+
+	/**
+	 * Filter a value to false dependent on the page not being modal checkout.
 	 *
 	 * @param bool $value The value.
 	 */


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1205234045751551/1208932231357058/f

This PR forces the value of the WC checkout registration setting to true in modal checkout context. This is because we always register new accounts when one doesn't exist and when this setting is disabled, modal checkout breaks.

![Screenshot 2024-12-17 at 15 27 56](https://github.com/user-attachments/assets/9ca3bd2f-d2b0-45f4-92c5-37f9567c5f15)


### How to test the changes in this Pull Request:

1. Go to WooCommerce > Settings > Accounts & Privacy in WP Admin
2. Disable checkout registration via the `During checkout` checkbox pictured above
3. As a reader, open modal checkout via any checkout or donate button
4. On `trunk` modal checkout will get stuck loading. On this branch it wont

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
