### PR TITLE
fix(modal-checkout): add custom modal checkout validation

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -118,6 +118,8 @@ final class Modal_Checkout {
 		add_action( 'wp', [ __CLASS__, 'process_checkout_request' ] );
 		add_action( 'wp_ajax_abandon_modal_checkout', [ __CLASS__, 'process_abandon_checkout' ] );
 		add_action( 'wp_ajax_nopriv_abandon_modal_checkout', [ __CLASS__, 'process_abandon_checkout' ] );
+		add_action( 'wp_ajax_validate_modal_checkout', [ __CLASS__, 'validate_checkout_request' ] );
+		add_action( 'wp_ajax_nopriv_validate_modal_checkout', [ __CLASS__, 'validate_checkout_request' ] );
 
 		add_filter( 'wp_redirect', [ __CLASS__, 'pass_url_param_on_redirect' ] );
 		add_filter( 'woocommerce_cart_product_cannot_be_purchased_message', [ __CLASS__, 'woocommerce_cart_product_cannot_be_purchased_message' ], 10, 2 );
@@ -378,11 +380,7 @@ final class Modal_Checkout {
 	 * Process abandon checkout for modal.
 	 */
 	public static function process_abandon_checkout() {
-		if ( ! defined( 'DOING_AJAX' ) ) {
-			return;
-		}
-
-		if ( ! self::is_modal_checkout() ) {
+		if ( ! defined( 'DOING_AJAX' ) || ! self::is_modal_checkout() ) {
 			return;
 		}
 
@@ -399,6 +397,26 @@ final class Modal_Checkout {
 
 		wp_send_json_success( [ 'message' => __( 'Cart has been emptied.', 'newspack-blocks' ) ] );
 		wp_die();
+	}
+
+	/**
+	 * Process modal checkout validation.
+	 */
+	public static function validate_checkout_request() {
+		if ( ! defined( 'DOING_AJAX' ) || ! self::is_modal_checkout() ) {
+			return;
+		}
+		if ( ! check_ajax_referer( 'newspack_modal_checkout_nonce' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Invalid nonce.', 'newspack-blocks' ) ] );
+			wp_die();
+		}
+		// WC process_checkout expects checkout nonce to be in REQUEST and update totals flag to be in POST.
+		$_REQUEST['woocommerce-process-checkout-nonce'] = filter_input( INPUT_POST, 'newspack-process-checkout-nonce', FILTER_SANITIZE_STRING );
+		$_POST['woocommerce_checkout_update_totals']    = 1;
+		// We don't want to validate payment methods at this point, so we temporarily override needs payment flag.
+		add_filter( 'woocommerce_cart_needs_payment', '__return_false' );
+		\WC()->checkout()->process_checkout();
+		remove_filter( 'woocommerce_cart_needs_payment', '__return_false' );
 	}
 
 	/**

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -827,18 +827,10 @@ final class Modal_Checkout {
 		$allowed_styles = apply_filters( 'newspack_blocks_modal_checkout_allowed_styles', self::$allowed_styles );
 		foreach ( $wp_styles->registered as $handle => $wp_style ) {
 			$allowed = false;
-			foreach ( $allowed_styles as $allowed_style ) {
-				if ( 0 === strpos( $handle, $allowed_style ) ) {
+			foreach ( array_merge( $allowed_styles, $allowed_gateway_assets ) as $allowed_style ) {
+				if ( 0 === strpos( $handle, $allowed_style ) || false !== strpos( $wp_style->src, $allowed_style ) ) {
 					$allowed = true;
 					break;
-				}
-			}
-			if ( ! empty( $payment_gateways ) ) {
-				foreach ( $allowed_gateway_assets as $gateway ) {
-					if ( false !== strpos( $handle, $gateway ) || false !== strpos( $wp_script->src, $gateway ) ) {
-						$allowed = true;
-						break;
-					}
 				}
 			}
 			if ( ! $allowed ) {
@@ -854,14 +846,8 @@ final class Modal_Checkout {
 		$allowed_scripts = apply_filters( 'newspack_blocks_modal_checkout_allowed_scripts', self::$allowed_scripts );
 		foreach ( $wp_scripts->registered as $handle => $wp_script ) {
 			$allowed = false;
-			foreach ( $allowed_scripts as $allowed_script ) {
-				if ( 0 === strpos( $handle, $allowed_script ) ) {
-					$allowed = true;
-					break;
-				}
-			}
-			foreach ( $allowed_gateway_assets as $gateway ) {
-				if ( false !== strpos( $wp_script->src, $gateway ) ) {
+			foreach ( array_merge( $allowed_scripts, $allowed_gateway_assets ) as $allowed_script ) {
+				if ( 0 === strpos( $handle, $allowed_script ) || false !== strpos( $wp_script->src, $allowed_script ) ) {
 					$allowed = true;
 					break;
 				}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -805,14 +805,17 @@ final class Modal_Checkout {
 		global $wp_scripts, $wp_styles;
 
 		$payment_gateways       = \WC()->payment_gateways->get_available_payment_gateways();
-		$allowed_gateway_assets = [];
+		$allowed_gateway_assets = array_keys( $payment_gateways );
 		if ( ! empty( $payment_gateways ) ) {
+			// Payment gateway id doesn't always match the plugin slug, so account for these cases.
 			foreach ( array_keys( $payment_gateways ) as $gateway ) {
-				$class                    = get_class( $payment_gateways[ $gateway ] );
-				$plugin_file              = ( new \ReflectionClass( $class ) )->getFileName();
-				$plugin_base              = \plugin_basename( $plugin_file );
-				$plugin_slug              = explode( '/', $plugin_base )[0];
-				$allowed_gateway_assets[] = $plugin_slug;
+				$class       = get_class( $payment_gateways[ $gateway ] );
+				$plugin_file = ( new \ReflectionClass( $class ) )->getFileName();
+				$plugin_base = \plugin_basename( $plugin_file );
+				$plugin_slug = explode( '/', $plugin_base )[0];
+				if ( ! in_array( $plugin_slug, $allowed_gateway_assets, true ) ) {
+					$allowed_gateway_assets[] = $plugin_slug;
+				}
 			}
 		}
 
@@ -832,7 +835,7 @@ final class Modal_Checkout {
 			}
 			if ( ! empty( $payment_gateways ) ) {
 				foreach ( $allowed_gateway_assets as $gateway ) {
-					if ( false !== strpos( $wp_style->src, $gateway ) ) {
+					if ( false !== strpos( $handle, $gateway ) || false !== strpos( $wp_script->src, $gateway ) ) {
 						$allowed = true;
 						break;
 					}

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -640,7 +640,6 @@ import { domReady } from './utils';
 						url: newspackBlocksModalCheckout.ajax_url,
 						data: serializedForm,
 						success: response => {
-							console.info( 'Success', response ); // eslint-disable-line no-console
 							let result;
 							if ( typeof response === 'object' ) {
 								result = response;
@@ -696,7 +695,6 @@ import { domReady } from './utils';
 							cb( result );
 						},
 						error: ( jqXHR, textStatus, errorThrown ) => {
-							console.info( 'Error', jqXHR, textStatus, errorThrown ); // eslint-disable-line no-console
 							let messages = '';
 							if ( ! silent ) {
 								messages =

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -615,32 +615,46 @@ import { domReady } from './utils';
 						$genericErrors.remove();
 					}
 
+					const checkoutNonce        = $form.find( 'input[name="woocommerce-process-checkout-nonce"]' );
 					const removeFromValidation = [
 						'save_user_in_woopay',
+						// Remove these fields to avoid triggering Woo's validation.
+						'woocommerce_checkout_place_order',
+						'woocommerce-process-checkout-nonce',
 					];
 					// Serialize form and remove fields that shouldn't be included for validation.
 					const serializedForm = $form.serializeArray().filter(
 						item => ! removeFromValidation.includes( item.name )
 					);
-					// Add 'update totals' parameter so it just performs validation.
-					serializedForm.push( { name: 'woocommerce_checkout_update_totals', value: '1' } );
+					if ( checkoutNonce.length ) {
+						serializedForm.push( {
+							name: 'newspack-process-checkout-nonce',
+							value: checkoutNonce.val(),
+						} );
+					}
+					serializedForm.push( { name: 'action', value: 'validate_modal_checkout' } );
+					serializedForm.push( { name: '_wpnonce', value: newspackBlocksModalCheckout.checkout_nonce } );
 					// Ajax request.
 					$.ajax( {
 						type: 'POST',
-						url: wc_checkout_params.checkout_url,
+						url: newspackBlocksModalCheckout.ajax_url,
 						data: serializedForm,
-						dataType: 'html',
 						success: response => {
+							console.info( 'Success', response ); // eslint-disable-line no-console
 							let result;
-							try {
-								result = JSON.parse( response );
-							} catch ( e ) {
-								result = {
-									messages:
-										'<div class="woocommerce-error">' +
-										wc_checkout_params.i18n_checkout_error +
-										'</div>',
-								};
+							if ( typeof response === 'object' ) {
+								result = response;
+							} else {
+								try {
+									result = JSON.parse( response );
+								} catch ( e ) {
+									result = {
+										messages:
+											'<div class="woocommerce-error">' +
+											wc_checkout_params.i18n_checkout_error +
+											'</div>',
+									};
+								}
 							}
 
 							// Reload page
@@ -682,6 +696,7 @@ import { domReady } from './utils';
 							cb( result );
 						},
 						error: ( jqXHR, textStatus, errorThrown ) => {
+							console.info( 'Error', jqXHR, textStatus, errorThrown ); // eslint-disable-line no-console
 							let messages = '';
 							if ( ! silent ) {
 								messages =

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -494,8 +494,8 @@ domReady( () => {
 		if ( ! entries || ! entries.length ) {
 			return;
 		}
-		iframe.scrollIntoView( { behavior: 'smooth', block: 'start' } );
 		if ( ! iframe.contentDocument ) {
+			iframe.scrollIntoView( { behavior: 'smooth', block: 'start' } );
 			return;
 		}
 		const contentRect = entries[ 0 ].contentRect;


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR moves the modal checkout validation request to newspack blocks. We still call `WC_Checkout::process_checkout`, but beforehand we override the needs payment flag so that step 1 of modal checkout doesn't validate payment method (not needed at this point).

### How to test the changes in this Pull Request:

1. Smoke test modal checkout using various supported payment methods, as a logged in and logged out reader:
 - Stripe
 - WCPay
 - PayPal Payments

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
