### PR TITLE
fix: add supported gateways check

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -115,7 +115,7 @@ final class Modal_Checkout {
 	 */
 	private static $supported_gateways = [
 		'bacs', // Direct bank transfer.
-		'check',
+		'cheque',
 		'cod', // Cash on delivery.
 		'ppcp-gateway', // PayPal Payments.
 		'stripe',
@@ -238,21 +238,35 @@ final class Modal_Checkout {
 	}
 
 	/**
-	 * Disable the Modal Checkout if a payment gateway that's not supported is enabled.
+	 * Get list of supported payment gateways for Modal Checkout.
+	 *
+	 * @return string[] Supported payment gateways.
 	 */
-	public static function supported_payment_gateways() {
-		$supported_gateways     = apply_filters( 'newspack_blocks_modal_checkout_supported_gateways', self::$supported_gateways );
-		$available_gateways     = \WC()->payment_gateways->get_available_payment_gateways();
-		$modal_checkout_enabled = true;
+	public static function get_supported_payment_gateways() {
+		/**
+		 * Filters the list of supported gateways in modal checkout.
+		 *
+		 * @param array $supported_gateways
+		 */
+		return apply_filters( 'newspack_blocks_modal_checkout_supported_gateways', self::$supported_gateways );
+	}
 
+	/**
+	 * Whether any available payment gateways are not suppored in modal checkout.
+	 *
+	 * @return boolean
+	 */
+	public static function has_unsupported_payment_gateway() {
+		$supported_gateways          = self::get_supported_payment_gateways();
+		$available_gateways          = \WC()->payment_gateways->get_available_payment_gateways();
+		$unsupported_payment_gateway = false;
 		foreach ( $available_gateways as $id => $gateway ) {
-			// Check if the enabled gateway is supported.
-			if ( ! in_array( $gateway->id, $supported_gateways ) ) {
-				$modal_checkout_enabled = false;
+			if ( ! in_array( $id, $supported_gateways, true ) ) {
+				$unsupported_payment_gateway = true;
 				break;
 			}
 		}
-		return $modal_checkout_enabled;
+		return $unsupported_payment_gateway;
 	}
 
 	/**
@@ -964,12 +978,12 @@ final class Modal_Checkout {
 			'newspack-blocks-modal',
 			'newspackBlocksModal',
 			[
-				'ajax_url'                   => admin_url( 'admin-ajax.php' ),
-				'checkout_registration_flag' => self::CHECKOUT_REGISTRATION_FLAG,
-				'newspack_class_prefix'      => self::get_class_prefix(),
-				'is_registration_required'   => self::is_registration_required(),
-				'is_gateway_supported'       => self::supported_payment_gateways(),
-				'labels'                     => [
+				'ajax_url'                        => admin_url( 'admin-ajax.php' ),
+				'checkout_registration_flag'      => self::CHECKOUT_REGISTRATION_FLAG,
+				'newspack_class_prefix'           => self::get_class_prefix(),
+				'is_registration_required'        => self::is_registration_required(),
+				'has_unsupported_payment_gateway' => self::has_unsupported_payment_gateway(),
+				'labels'                          => [
 					'auth_modal_title'     => self::get_modal_checkout_labels( 'auth_modal_title' ),
 					'checkout_modal_title' => self::get_modal_checkout_labels( 'checkout_modal_title' ),
 					'register_modal_title' => self::get_modal_checkout_labels( 'register_modal_title' ),

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -380,7 +380,10 @@ final class Modal_Checkout {
 		if ( ! empty( $referer_categories ) ) {
 			$query_args['referer_categories'] = implode( ',', $referer_categories );
 		}
-		$query_args['modal_checkout'] = 1;
+
+		if ( ! self::has_unsupported_payment_gateway() ) {
+			$query_args['modal_checkout'] = 1;
+		}
 
 		// Pass through UTM and after_success params so they can be forwarded to the WooCommerce checkout flow.
 		foreach ( $params as $param => $value ) {
@@ -1101,7 +1104,7 @@ final class Modal_Checkout {
 	 * @return string
 	 */
 	public static function woocommerce_get_return_url( $url, $order ) {
-		if ( ! self::is_modal_checkout() ) {
+		if ( ! self::is_modal_checkout() || self::has_unsupported_payment_gateway() ) {
 			return $url;
 		}
 

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -385,8 +385,10 @@ final class Modal_Checkout {
 		// Pass through UTM and after_success params so they can be forwarded to the WooCommerce checkout flow.
 		foreach ( $params as $param => $value ) {
 			if ( 'utm' === substr( $param, 0, 3 ) || 'after_success' === substr( $param, 0, 13 ) ) {
-				$param                = sanitize_text_field( $param );
-				$query_args[ $param ] = sanitize_text_field( $value );
+				if ( ! empty( $value ) ) {
+					$param                = sanitize_text_field( $param );
+					$query_args[ $param ] = sanitize_text_field( $value );
+				}
 			}
 		}
 

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -109,6 +109,21 @@ final class Modal_Checkout {
 	];
 
 	/**
+	 * Supported Payment Gateways
+	 *
+	 * @var string[]
+	 */
+	private static $supported_gateways = [
+		'bacs', // Direct bank transfer.
+		'check',
+		'cod', // Cash on delivery.
+		'ppcp-gateway', // PayPal Payments.
+		'stripe',
+		'stripe-link',
+		'woocommerce_payments',
+	];
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
@@ -151,7 +166,6 @@ final class Modal_Checkout {
 		add_action( 'init', [ __CLASS__, 'unhook_woocommerce_payments_update_billing_fields' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'update_password_strength_message' ], 9999 );
 
-
 		/** Custom handling for registered users. */
 		add_filter( 'woocommerce_checkout_customer_id', [ __CLASS__, 'associate_existing_user' ] );
 		add_action( 'woocommerce_after_checkout_validation', [ __CLASS__, 'maybe_reset_checkout_registration_flag' ], 10, 2 );
@@ -175,6 +189,7 @@ final class Modal_Checkout {
 		// Make the current cart price available to the JavaScript.
 		add_action( 'wp_ajax_get_cart_total', [ __CLASS__, 'get_cart_total_js' ] );
 		add_action( 'wp_ajax_nopriv_get_cart_total', [ __CLASS__, 'get_cart_total_js' ] );
+
 
 		/**
 		 * Ensure that options to limit the number of subscriptions per product are respected.
@@ -221,6 +236,24 @@ final class Modal_Checkout {
 		unset( $enqueue_styles['woocommerce-general'] );
 		unset( $enqueue_styles['woocommerce-smallscreen'] );
 		return $enqueue_styles;
+	}
+
+	/**
+	 * Disable the Modal Checkout if a payment gateway that's not supported is enabled.
+	 */
+	public static function supported_payment_gateways() {
+		$supported_gateways     = apply_filters( 'newspack_blocks_modal_checkout_supported_gateways', self::$supported_gateways );
+		$available_gateways     = \WC()->payment_gateways->get_available_payment_gateways();
+		$modal_checkout_enabled = true;
+
+		foreach ( $available_gateways as $id => $gateway ) {
+			// Check if the enabled gateway is supported.
+			if ( ! in_array( $gateway->id, $supported_gateways ) ) {
+				$modal_checkout_enabled = false;
+				break;
+			}
+		}
+		return $modal_checkout_enabled;
 	}
 
 	/**
@@ -538,6 +571,7 @@ final class Modal_Checkout {
 		if ( ! self::$has_modal ) {
 			return;
 		}
+
 		/**
 		* Filters the header title for the modal checkout.
 		*
@@ -787,6 +821,7 @@ final class Modal_Checkout {
 
 		$payment_gateways       = \WC()->payment_gateways->get_available_payment_gateways();
 		$allowed_gateway_assets = [];
+
 		if ( ! empty( $payment_gateways ) ) {
 			foreach ( array_keys( $payment_gateways ) as $gateway ) {
 				$class                    = get_class( $payment_gateways[ $gateway ] );
@@ -936,6 +971,7 @@ final class Modal_Checkout {
 				'checkout_registration_flag' => self::CHECKOUT_REGISTRATION_FLAG,
 				'newspack_class_prefix'      => self::get_class_prefix(),
 				'is_registration_required'   => self::is_registration_required(),
+				'is_gateway_supported'       => self::supported_payment_gateways(),
 				'labels'                     => [
 					'auth_modal_title'     => self::get_modal_checkout_labels( 'auth_modal_title' ),
 					'checkout_modal_title' => self::get_modal_checkout_labels( 'checkout_modal_title' ),
@@ -1468,6 +1504,7 @@ final class Modal_Checkout {
 		}
 
 		$is_modal_checkout = isset( $_REQUEST['modal_checkout'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
 		if ( ! $is_modal_checkout && isset( $_REQUEST['post_data'] ) && is_string( $_REQUEST['post_data'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$is_modal_checkout = strpos( $_REQUEST['post_data'], 'modal_checkout=1' ) !== false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -190,7 +190,6 @@ final class Modal_Checkout {
 		add_action( 'wp_ajax_get_cart_total', [ __CLASS__, 'get_cart_total_js' ] );
 		add_action( 'wp_ajax_nopriv_get_cart_total', [ __CLASS__, 'get_cart_total_js' ] );
 
-
 		/**
 		 * Ensure that options to limit the number of subscriptions per product are respected.
 		 * Note: This is normally called only for regular checkout pages and REST API requests,
@@ -571,7 +570,6 @@ final class Modal_Checkout {
 		if ( ! self::$has_modal ) {
 			return;
 		}
-
 		/**
 		* Filters the header title for the modal checkout.
 		*
@@ -821,7 +819,6 @@ final class Modal_Checkout {
 
 		$payment_gateways       = \WC()->payment_gateways->get_available_payment_gateways();
 		$allowed_gateway_assets = [];
-
 		if ( ! empty( $payment_gateways ) ) {
 			foreach ( array_keys( $payment_gateways ) as $gateway ) {
 				$class                    = get_class( $payment_gateways[ $gateway ] );
@@ -1504,7 +1501,6 @@ final class Modal_Checkout {
 		}
 
 		$is_modal_checkout = isset( $_REQUEST['modal_checkout'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-
 		if ( ! $is_modal_checkout && isset( $_REQUEST['post_data'] ) && is_string( $_REQUEST['post_data'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$is_modal_checkout = strpos( $_REQUEST['post_data'], 'modal_checkout=1' ) !== false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		}

--- a/src/blocks/checkout-button/view.php
+++ b/src/blocks/checkout-button/view.php
@@ -101,10 +101,12 @@ function render_callback( $attributes ) {
 	);
 
 	// Generate hidden fields for the form.
-	$hidden_fields  = '<input type="hidden" name="newspack_checkout" value="1" />';
-	$hidden_fields .= $after_success_behavior ? '<input type="hidden" name="after_success_behavior" value="' . esc_attr( $after_success_behavior ) . '" />' : '';
-	$hidden_fields .= $after_success_button_label ? '<input type="hidden" name="after_success_button_label" value="' . esc_attr( $after_success_button_label ) . '" />' : '';
-	$hidden_fields .= $after_success_url ? '<input type="hidden" name="after_success_url" value="' . esc_attr( $after_success_url ) . '" />' : '';
+	$hidden_fields = '<input type="hidden" name="newspack_checkout" value="1" />';
+	if ( ! Modal_Checkout::has_unsupported_payment_gateway() ) {
+		$hidden_fields .= $after_success_behavior ? '<input type="hidden" name="after_success_behavior" value="' . esc_attr( $after_success_behavior ) . '" />' : '';
+		$hidden_fields .= $after_success_button_label ? '<input type="hidden" name="after_success_button_label" value="' . esc_attr( $after_success_button_label ) . '" />' : '';
+		$hidden_fields .= $after_success_url ? '<input type="hidden" name="after_success_url" value="' . esc_attr( $after_success_url ) . '" />' : '';
+	}
 
 	// Generate the form.
 	if ( function_exists( 'wc_get_product' ) ) {

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
@@ -203,13 +203,15 @@ abstract class Newspack_Blocks_Donate_Renderer_Base {
 			<input type='hidden' name='frequency_ids' value='<?php echo esc_attr( wp_json_encode( $donate_child_ids ) ); ?>' />
 		<?php
 
-		foreach ( [ [ 'afterSuccessBehavior', 'after_success_behavior' ], [ 'afterSuccessButtonLabel', 'after_success_button_label' ], [ 'afterSuccessURL', 'after_success_url' ] ] as $attribute ) {
-			$attribute_name = $attribute[0];
-			$param_name     = $attribute[1];
-			$value          = isset( $attributes[ $attribute_name ] ) ? $attributes[ $attribute_name ] : '';
-			?>
-				<input type='hidden' name='<?php echo esc_attr( $param_name ); ?>' value='<?php echo esc_attr( $value ); ?>' />
-			<?php
+		if ( ! \Newspack_Blocks\Modal_Checkout::has_unsupported_payment_gateway() ) {
+			foreach ( [ [ 'afterSuccessBehavior', 'after_success_behavior' ], [ 'afterSuccessButtonLabel', 'after_success_button_label' ], [ 'afterSuccessURL', 'after_success_url' ] ] as $attribute ) {
+				$attribute_name = $attribute[0];
+				$param_name     = $attribute[1];
+				$value          = isset( $attributes[ $attribute_name ] ) ? $attributes[ $attribute_name ] : '';
+				?>
+					<input type='hidden' name='<?php echo esc_attr( $param_name ); ?>' value='<?php echo esc_attr( $value ); ?>' />
+				<?php
+			}
 		}
 		return ob_get_clean();
 	}

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer.php
@@ -100,7 +100,7 @@ class Newspack_Blocks_Donate_Renderer {
 		Newspack_Blocks::enqueue_view_assets( 'donate' );
 		wp_script_add_data( 'newspack-blocks-donate', 'async', true );
 
-		if ( true === $attributes['useModalCheckout'] ) {
+		if ( true === $attributes['useModalCheckout'] && true === \Newspack_Blocks\Modal_Checkout::supported_payment_gateways() ) {
 			\Newspack_Blocks\Modal_Checkout::enqueue_modal();
 		}
 

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer.php
@@ -100,7 +100,7 @@ class Newspack_Blocks_Donate_Renderer {
 		Newspack_Blocks::enqueue_view_assets( 'donate' );
 		wp_script_add_data( 'newspack-blocks-donate', 'async', true );
 
-		if ( true === $attributes['useModalCheckout'] && ! Newspack_Blocks\Modal_Checkout::has_unsupported_payment_gateway() ) {
+		if ( true === $attributes['useModalCheckout'] ) {
 			\Newspack_Blocks\Modal_Checkout::enqueue_modal();
 		}
 

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer.php
@@ -100,7 +100,7 @@ class Newspack_Blocks_Donate_Renderer {
 		Newspack_Blocks::enqueue_view_assets( 'donate' );
 		wp_script_add_data( 'newspack-blocks-donate', 'async', true );
 
-		if ( true === $attributes['useModalCheckout'] && true === \Newspack_Blocks\Modal_Checkout::supported_payment_gateways() ) {
+		if ( true === $attributes['useModalCheckout'] && ! Newspack_Blocks\Modal_Checkout::has_unsupported_payment_gateway() ) {
 			\Newspack_Blocks\Modal_Checkout::enqueue_modal();
 		}
 

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -26,7 +26,6 @@ let inCheckoutIntent = false;
 
 domReady( () => {
 	const modalCheckout = document.querySelector( `#${ MODAL_CHECKOUT_ID }` );
-
 	if ( ! modalCheckout ) {
 		return;
 	}
@@ -203,7 +202,6 @@ domReady( () => {
 		}
 		const form = ev.target;
 		form.classList.add( 'modal-processing' );
-
 		const productData = form.dataset.product;
 		if ( productData ) {
 			const data = JSON.parse( productData );
@@ -227,15 +225,6 @@ domReady( () => {
 				closeModal( variationModal );
 			}
 		} );
-
-		// Generate URL for non-modal checkout
-		const generateNonModalCheckoutUrl = ( url ) => {
-			// Regex for after_success URL params used by the modal checkout.
-			const successParams = /(after_success|&after_success)[^&]*?(?=&|$)/gi;
-			// Remove modal_checkout, success params, and any trailing ? from the URL.
-			const nonModalUrl = url.replace( /&?modal_checkout=1/, '' ).replaceAll(successParams, '').replace( /\?$/, '' ); // remove question mark only if last character.
-			return nonModalUrl;
-		}
 
 		// Trigger variation modal if variation is not selected.
 		if ( formData.get( 'is_variable' ) && ! formData.get( 'variation_id' ) ) {
@@ -295,22 +284,23 @@ domReady( () => {
 				return;
 			}
 		}
+
 		// Populate cart and redirect to checkout if there is an unsupported payment gateway.
 		if ( ! isModalCheckout && ! shouldPromptRegistration() ) {
-				generateCart( formData ).then( url => {
-					window.location.href = generateNonModalCheckoutUrl( url );
+			generateCart( formData ).then( url => {
+				// Remove modal checkout query string and trailing question mark (if any).
+				window.location.href = url.replace( /&?modal_checkout=1/, '' ).replace( /\?$/, '' );
+			} );
+			// Add some animation to the Checkout Button while the non-modal checkout is loading.
+			// For now, don't do it when any popup opens, just when we go right to the checkout page.
+			if ( ! ( formData.get( 'is_variable' ) && ! formData.get( 'variation_id' ) ) ) {
+				const buttons = form.querySelectorAll( 'button[type=submit]:focus' );
+				buttons.forEach( button => {
+					button.classList.add( 'non-modal-checkout-loading' );
+					const buttonText = button.innerHTML;
+					button.innerHTML = '<span>' + buttonText + '</span>';
 				} );
-				// Add some animation to the Checkout Button and Donate block while the non-modal checkout is loading.
-				// For now, don't do it when any popup opens, just when we go right to the checkout page.
-				if ( ! ( formData.get( 'is_variable' ) && ! formData.get( 'variation_id' ) ) ) {
-					// Use :focus to try to limit submit buttons in tiered donate button block.
-					const buttons = form.querySelectorAll( 'button[type=submit]:focus' );
-					buttons.forEach( button => {
-						button.classList.add( 'non-modal-checkout-loading' );
-						const buttonText = button.innerHTML;
-						button.innerHTML = '<span>' + buttonText + '</span>';
-					} );
-				}
+			}
 			return;
 		}
 		form.classList.remove( 'modal-processing' );
@@ -450,12 +440,14 @@ domReady( () => {
 				onSuccess: ( message, authData ) => {
 					cartReq.then( url => {
 						// If registered, append the registration flag query param to the url.
+						// if ( authData?.registered && ! isModalCheckout ) {
 						if ( authData?.registered ) {
 							url += `&${ newspackBlocksModal.checkout_registration_flag }=1`;
 						}
 						// Populate cart and redirect to checkout if there is an unsupported payment gateway.
 						if ( ! isModalCheckout ) {
-							generateCart( formData ).then( window.location.href = generateNonModalCheckoutUrl( url ) );
+							// Remove modal checkout query string, and trailing question mark (if any).
+							generateCart( formData ).then( window.location.href = url.replace( /&?modal_checkout=1/, '' ).replace( /\?$/, '' ) );
 						} else {
 							const checkoutForm = generateCheckoutPageForm( url );
 							triggerCheckout( checkoutForm );

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -222,8 +222,8 @@ domReady( () => {
 		// Clear any open variation modal.
 		const variationModals = document.querySelectorAll( `.${ VARIATON_MODAL_CLASS_PREFIX }` );
 		variationModals.forEach( variationModal => {
-			// Only close the variation picker if is the modal checkout.
-			if ( isModalCheckout ) {
+			// Only close the variation picker if is the modal checkout, or if registration is required.
+			if ( shouldPromptRegistration() || isModalCheckout ) {
 				closeModal( variationModal );
 			}
 		} );

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -203,6 +203,7 @@ domReady( () => {
 		}
 		const form = ev.target;
 		form.classList.add( 'modal-processing' );
+
 		const productData = form.dataset.product;
 		if ( productData ) {
 			const data = JSON.parse( productData );
@@ -282,10 +283,22 @@ domReady( () => {
 			}
 		}
 		// Populate cart and redirect to checkout if there is an unsupported payment gateway.
-		if ( ! isModalCheckout && ! shouldPromptRegistration() ) {
-			generateCart( formData ).then( url => {
-				window.location.href = url.replace( /&?modal_checkout=1/, '' );
-			} );
+		if ( ! isModalCheckout ) {
+			if ( ! shouldPromptRegistration() ) {
+				generateCart( formData ).then( url => {
+					window.location.href = url.replace( /&?modal_checkout=1/, '' );
+				} );
+			}
+			// Add some animation to the Checkout Button and Donate block while the non-modal checkout is loading.
+			// For now, don't do it when any popup opens, just when we go right to the checkout page.
+			if ( ! ( formData.get( 'is_variable' ) && ! formData.get( 'variation_id' ) ) && ! shouldPromptRegistration() ) {
+				const buttons = form.querySelectorAll( 'button[type=submit]' );
+				buttons.forEach( button => {
+					button.classList.add( 'non-modal-checkout-loading' );
+					const buttonText = button.innerHTML;
+					button.innerHTML = '<span>' + buttonText + '</span>';
+				} );
+			}
 			return;
 		}
 		form.classList.remove( 'modal-processing' );

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -700,7 +700,7 @@ domReady( () => {
 		.forEach( element => {
 			const forms = element.querySelectorAll( 'form' );
 			forms.forEach( form => {
-				if ( newspackBlocksModal.is_gateway_supported ) {
+				if ( ! newspackBlocksModal.has_unsupported_payment_gateway ) {
 					form.appendChild( modalCheckoutHiddenInput.cloneNode() );
 					form.target = IFRAME_NAME;
 					form.addEventListener( 'submit', handleCheckoutFormSubmit );

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -229,11 +229,12 @@ domReady( () => {
 		} );
 
 		// Generate URL for non-modal checkout
-		const nonModalCheckout = ( url ) => {
-			// Remove success params, and modal_checkout from URL.
-			const remove_from_url = /(after_success|&after_success)[^&]*?(?=&|$)/gi;
-			const updatedUrl = url.replace( /&?modal_checkout=1/, '' ).replaceAll(remove_from_url, '').replace( /\?$/, '' ); // remove question mark only if last character.
-			return updatedUrl;
+		const generateNonModalCheckoutUrl = ( url ) => {
+			// Regex for after_success URL params used by the modal checkout.
+			const successParams = /(after_success|&after_success)[^&]*?(?=&|$)/gi;
+			// Remove modal_checkout, success params, and any trailing ? from the URL.
+			const nonModalUrl = url.replace( /&?modal_checkout=1/, '' ).replaceAll(successParams, '').replace( /\?$/, '' ); // remove question mark only if last character.
+			return nonModalUrl;
 		}
 
 		// Trigger variation modal if variation is not selected.
@@ -297,7 +298,7 @@ domReady( () => {
 		// Populate cart and redirect to checkout if there is an unsupported payment gateway.
 		if ( ! isModalCheckout && ! shouldPromptRegistration() ) {
 				generateCart( formData ).then( url => {
-					window.location.href = nonModalCheckout( url );
+					window.location.href = generateNonModalCheckoutUrl( url );
 				} );
 				// Add some animation to the Checkout Button and Donate block while the non-modal checkout is loading.
 				// For now, don't do it when any popup opens, just when we go right to the checkout page.
@@ -453,7 +454,7 @@ domReady( () => {
 						}
 						// Populate cart and redirect to checkout if there is an unsupported payment gateway.
 						if ( ! isModalCheckout ) {
-							generateCart( formData ).then( window.location.href = nonModalCheckout( url ) );
+							generateCart( formData ).then( window.location.href = generateNonModalCheckoutUrl( url ) );
 						} else {
 							const checkoutForm = generateCheckoutPageForm( url );
 							triggerCheckout( checkoutForm );

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -292,7 +292,7 @@ domReady( () => {
 				} );
 				// Add some animation to the Checkout Button and Donate block while the non-modal checkout is loading.
 				// For now, don't do it when any popup opens, just when we go right to the checkout page.
-				if ( ! ( formData.get( 'is_variable' ) && ! formData.get( 'variation_id' ) ) && ! shouldPromptRegistration() ) {
+				if ( ! ( formData.get( 'is_variable' ) && ! formData.get( 'variation_id' ) ) ) {
 					const buttons = form.querySelectorAll( 'button[type=submit]' );
 					buttons.forEach( button => {
 						button.classList.add( 'non-modal-checkout-loading' );

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -283,22 +283,20 @@ domReady( () => {
 			}
 		}
 		// Populate cart and redirect to checkout if there is an unsupported payment gateway.
-		if ( ! isModalCheckout ) {
-			if ( ! shouldPromptRegistration() ) {
+		if ( ! isModalCheckout && ! shouldPromptRegistration() ) {
 				generateCart( formData ).then( url => {
 					window.location.href = url.replace( /&?modal_checkout=1/, '' );
 				} );
-			}
-			// Add some animation to the Checkout Button and Donate block while the non-modal checkout is loading.
-			// For now, don't do it when any popup opens, just when we go right to the checkout page.
-			if ( ! ( formData.get( 'is_variable' ) && ! formData.get( 'variation_id' ) ) && ! shouldPromptRegistration() ) {
-				const buttons = form.querySelectorAll( 'button[type=submit]' );
-				buttons.forEach( button => {
-					button.classList.add( 'non-modal-checkout-loading' );
-					const buttonText = button.innerHTML;
-					button.innerHTML = '<span>' + buttonText + '</span>';
-				} );
-			}
+				// Add some animation to the Checkout Button and Donate block while the non-modal checkout is loading.
+				// For now, don't do it when any popup opens, just when we go right to the checkout page.
+				if ( ! ( formData.get( 'is_variable' ) && ! formData.get( 'variation_id' ) ) && ! shouldPromptRegistration() ) {
+					const buttons = form.querySelectorAll( 'button[type=submit]' );
+					buttons.forEach( button => {
+						button.classList.add( 'non-modal-checkout-loading' );
+						const buttonText = button.innerHTML;
+						button.innerHTML = '<span>' + buttonText + '</span>';
+					} );
+				}
 			return;
 		}
 		form.classList.remove( 'modal-processing' );

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -282,7 +282,7 @@ domReady( () => {
 			}
 		}
 		// Populate cart and redirect to checkout if there is an unsupported payment gateway.
-		if ( ! isModalCheckout ) {
+		if ( ! isModalCheckout && ! shouldPromptRegistration() ) {
 			generateCart( formData ).then( url => {
 				window.location.href = url.replace( /&?modal_checkout=1/, '' );
 			} );
@@ -429,8 +429,13 @@ domReady( () => {
 						if ( authData?.registered ) {
 							url += `&${ newspackBlocksModal.checkout_registration_flag }=1`;
 						}
-						const checkoutForm = generateCheckoutPageForm( url );
-						triggerCheckout( checkoutForm );
+						// Populate cart and redirect to checkout if there is an unsupported payment gateway.
+						if ( ! isModalCheckout ) {
+							generateCart( formData ).then( window.location.href = url.replace( /&?modal_checkout=1/, '' ) );
+						} else {
+							const checkoutForm = generateCheckoutPageForm( url );
+							triggerCheckout( checkoutForm );
+						}
 					} )
 					.catch( error => {
 						console.warn( 'Unable to generate cart:', error ); // eslint-disable-line no-console

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -33,6 +33,16 @@ const closeModal = el => {
 	document.body.style.overflow = 'auto';
 };
 
+// Cleanup if page is loaded via back button.
+window.onpageshow = event => {
+	if ( event.persisted ) {
+		// If the page is loaded from the back button, find and remove any loading-related classes and modals:
+		document.querySelectorAll( '.modal-processing' ).forEach( el => el.classList.remove( 'modal-processing' ) );
+		document.querySelectorAll( '.non-modal-checkout-loading' ).forEach( el => el.classList.remove( 'non-modal-checkout-loading' ) );
+		document.querySelectorAll( `.${ MODAL_CLASS_PREFIX }-container` ).forEach( el => closeModal( el ) );
+	}
+}
+
 domReady( () => {
 	const modalCheckout = document.querySelector( `#${ MODAL_CHECKOUT_ID }` );
 	if ( ! modalCheckout ) {
@@ -175,7 +185,9 @@ domReady( () => {
 	 */
 	const emptyCart = () => {
 		const body = new FormData();
-		body.append( 'modal_checkout', '1' );
+		if ( ! newspackBlocksModal.has_unsupported_payment_gateway ) {
+			body.append( 'modal_checkout', '1' );
+		}
 		body.append( 'action', 'abandon_modal_checkout' );
 		body.append( '_wpnonce', modalCheckout.checkout_nonce );
 		modalCheckout.checkout_nonce = null;
@@ -298,7 +310,7 @@ domReady( () => {
 		if ( ! isModalCheckout && ! shouldPromptRegistration() ) {
 			generateCart( formData ).then( url => {
 				// Remove modal checkout query string and trailing question mark (if any).
-				window.location.href = url.replace( /&?modal_checkout=1/, '' ).replace( /\?$/, '' );
+				window.location.href = url;
 			} );
 			// Add some animation to the Checkout Button while the non-modal checkout is loading.
 			// For now, don't do it when any popup opens, just when we go right to the checkout page.
@@ -448,15 +460,14 @@ domReady( () => {
 				title: newspackBlocksModal.labels.auth_modal_title,
 				onSuccess: ( message, authData ) => {
 					cartReq.then( url => {
-						// If registered, append the registration flag query param to the url.
-						// if ( authData?.registered && ! isModalCheckout ) {
-						if ( authData?.registered ) {
+						// If registered and in a modal checkout, append the registration flag query param to the url.
+						if ( authData?.registered && isModalCheckout ) {
 							url += `&${ newspackBlocksModal.checkout_registration_flag }=1`;
 						}
 						// Populate cart and redirect to checkout if there is an unsupported payment gateway.
 						if ( ! isModalCheckout ) {
 							// Remove modal checkout query string, and trailing question mark (if any).
-							generateCart( formData ).then( window.location.href = url.replace( /&?modal_checkout=1/, '' ).replace( /\?$/, '' ) );
+							generateCart( formData ).then( window.location.href = url );
 						} else {
 							const checkoutForm = generateCheckoutPageForm( url );
 							triggerCheckout( checkoutForm );
@@ -726,7 +737,9 @@ domReady( () => {
 		.forEach( element => {
 			const forms = element.querySelectorAll( 'form' );
 			forms.forEach( form => {
-				form.appendChild( modalCheckoutHiddenInput.cloneNode() );
+				if ( ! newspackBlocksModal.has_unsupported_payment_gateway ) {
+					form.appendChild( modalCheckoutHiddenInput.cloneNode() );
+				}
 				form.target = IFRAME_NAME;
 				form.addEventListener( 'submit', handleCheckoutFormSubmit );
 			} );
@@ -870,13 +883,3 @@ domReady( () => {
 	};
 	handleModalCheckoutUrlParams();
 } );
-
-// Cleanup if page is loaded via back button
-window.onpageshow = event => {
-	if ( event.persisted ) {
-		// If the page is loaded from the back button, find and remove any loading-related classes and modals:
-		document.querySelectorAll( '.modal-processing' ).forEach( el => el.classList.remove( 'modal-processing' ) );
-		document.querySelectorAll( '.non-modal-checkout-loading' ).forEach( el => el.classList.remove( 'non-modal-checkout-loading' ) );
-		document.querySelectorAll( `.${ MODAL_CLASS_PREFIX }-container` ).forEach( el => closeModal( el ) );
-	}
-}

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -227,6 +227,15 @@ domReady( () => {
 				closeModal( variationModal );
 			}
 		} );
+
+		// Generate URL for non-modal checkout
+		const nonModalCheckout = ( url ) => {
+			// Remove success params, and modal_checkout from URL.
+			const remove_from_url = /(after_success|&after_success)[^&]*?(?=&|$)/gi;
+			const updatedUrl = url.replace( /&?modal_checkout=1/, '' ).replaceAll(remove_from_url, '').replace( /\?$/, '' ); // remove question mark only if last character.
+			return updatedUrl;
+		}
+
 		// Trigger variation modal if variation is not selected.
 		if ( formData.get( 'is_variable' ) && ! formData.get( 'variation_id' ) ) {
 			const variationModal = [ ...variationModals ].find(
@@ -288,7 +297,7 @@ domReady( () => {
 		// Populate cart and redirect to checkout if there is an unsupported payment gateway.
 		if ( ! isModalCheckout && ! shouldPromptRegistration() ) {
 				generateCart( formData ).then( url => {
-					window.location.href = url.replace( /&?modal_checkout=1/, '' );
+					window.location.href = nonModalCheckout( url );
 				} );
 				// Add some animation to the Checkout Button and Donate block while the non-modal checkout is loading.
 				// For now, don't do it when any popup opens, just when we go right to the checkout page.
@@ -433,7 +442,6 @@ domReady( () => {
 			cartReq.then( url => {
 				window.newspackReaderActivation?.setPendingCheckout?.( url );
 			} );
-
 			// Initialize auth flow if reader is not authenticated.
 			window.newspackReaderActivation.openAuthModal( {
 				title: newspackBlocksModal.labels.auth_modal_title,
@@ -445,7 +453,7 @@ domReady( () => {
 						}
 						// Populate cart and redirect to checkout if there is an unsupported payment gateway.
 						if ( ! isModalCheckout ) {
-							generateCart( formData ).then( window.location.href = url.replace( /&?modal_checkout=1/, '' ) );
+							generateCart( formData ).then( window.location.href = nonModalCheckout( url ) );
 						} else {
 							const checkoutForm = generateCheckoutPageForm( url );
 							triggerCheckout( checkoutForm );

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -222,7 +222,10 @@ domReady( () => {
 		// Clear any open variation modal.
 		const variationModals = document.querySelectorAll( `.${ VARIATON_MODAL_CLASS_PREFIX }` );
 		variationModals.forEach( variationModal => {
-			closeModal( variationModal );
+			// Only close the variation picker if is the modal checkout.
+			if ( isModalCheckout ) {
+				closeModal( variationModal );
+			}
 		} );
 		// Trigger variation modal if variation is not selected.
 		if ( formData.get( 'is_variable' ) && ! formData.get( 'variation_id' ) ) {

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -24,6 +24,15 @@ let analyticsData = {};
 // Track the checkout intent to avoid multiple analytics events.
 let inCheckoutIntent = false;
 
+// Close the modal.
+const closeModal = el => {
+	if ( el.overlayId && window.newspackReaderActivation?.overlays ) {
+		window.newspackReaderActivation?.overlays.remove( el.overlayId );
+	}
+	el.setAttribute( 'data-state', 'closed' );
+	document.body.style.overflow = 'auto';
+};
+
 domReady( () => {
 	const modalCheckout = document.querySelector( `#${ MODAL_CHECKOUT_ID }` );
 	if ( ! modalCheckout ) {
@@ -629,14 +638,6 @@ domReady( () => {
 		iframeReady( handleIframeReady );
 	};
 
-	const closeModal = el => {
-		if ( el.overlayId && window.newspackReaderActivation?.overlays ) {
-			window.newspackReaderActivation?.overlays.remove( el.overlayId );
-		}
-		el.setAttribute( 'data-state', 'closed' );
-		document.body.style.overflow = 'auto';
-	};
-
 	const openModal = el => {
 		if ( window.newspackReaderActivation?.overlays ) {
 			modalCheckout.overlayId = window.newspackReaderActivation?.overlays.add();
@@ -869,3 +870,13 @@ domReady( () => {
 	};
 	handleModalCheckoutUrlParams();
 } );
+
+// Cleanup if page is loaded via back button
+window.onpageshow = event => {
+	if ( event.persisted ) {
+		// If the page is loaded from the back button, find and remove any loading-related classes and modals:
+		document.querySelectorAll( '.modal-processing' ).forEach( el => el.classList.remove( 'modal-processing' ) );
+		document.querySelectorAll( '.non-modal-checkout-loading' ).forEach( el => el.classList.remove( 'non-modal-checkout-loading' ) );
+		document.querySelectorAll( `.${ MODAL_CLASS_PREFIX }-container` ).forEach( el => closeModal( el ) );
+	}
+}

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -700,9 +700,11 @@ domReady( () => {
 		.forEach( element => {
 			const forms = element.querySelectorAll( 'form' );
 			forms.forEach( form => {
-				form.appendChild( modalCheckoutHiddenInput.cloneNode() );
-				form.target = IFRAME_NAME;
-				form.addEventListener( 'submit', handleCheckoutFormSubmit );
+				if ( newspackBlocksModal.is_gateway_supported ) {
+					form.appendChild( modalCheckoutHiddenInput.cloneNode() );
+					form.target = IFRAME_NAME;
+					form.addEventListener( 'submit', handleCheckoutFormSubmit );
+				}
 			} );
 		} );
 
@@ -818,6 +820,7 @@ domReady( () => {
 			return;
 		}
 		const type = urlParams.get( 'type' );
+
 		if ( type === 'donate' ) {
 			const layout = urlParams.get( 'layout' );
 			const frequency = urlParams.get( 'frequency' );

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -197,12 +197,13 @@ domReady( () => {
 	 * @param {Event} ev
 	 */
 	const handleCheckoutFormSubmit = ev => {
+		const isModalCheckout = ! newspackBlocksModal.has_unsupported_payment_gateway;
+		if ( ! isModalCheckout ) {
+			ev.preventDefault();
+		}
 		const form = ev.target;
-
 		form.classList.add( 'modal-processing' );
-
 		const productData = form.dataset.product;
-
 		if ( productData ) {
 			const data = JSON.parse( productData );
 			Object.keys( data ).forEach( key => {
@@ -213,14 +214,12 @@ domReady( () => {
 			} );
 		}
 		const formData = new FormData( form );
-
 		// If we're not going from variation picker to checkout, set the modal trigger:
 		if ( ! formData.get( 'variation_id' ) ) {
 			modalTrigger = ev.submitter;
 		}
-
-		const variationModals = document.querySelectorAll( `.${ VARIATON_MODAL_CLASS_PREFIX }` );
 		// Clear any open variation modal.
+		const variationModals = document.querySelectorAll( `.${ VARIATON_MODAL_CLASS_PREFIX }` );
 		variationModals.forEach( variationModal => {
 			closeModal( variationModal );
 		} );
@@ -282,12 +281,16 @@ domReady( () => {
 				return;
 			}
 		}
-
+		// Populate cart and redirect to checkout if there is an unsupported payment gateway.
+		if ( ! isModalCheckout ) {
+			generateCart( formData ).then( url => {
+				window.location.href = url.replace( /&?modal_checkout=1/, '' );
+			} );
+			return;
+		}
 		form.classList.remove( 'modal-processing' );
-
 		const isDonateBlock = formData.get( 'newspack_donate' );
 		const isCheckoutButtonBlock = formData.get( 'newspack_checkout' );
-
 		// Set up some GA4 information.
 		if ( isCheckoutButtonBlock ) { // this fires on the second in-modal variations screen, too
 			const formAnalyticsData = form.getAttribute( 'data-product' );
@@ -700,11 +703,9 @@ domReady( () => {
 		.forEach( element => {
 			const forms = element.querySelectorAll( 'form' );
 			forms.forEach( form => {
-				if ( ! newspackBlocksModal.has_unsupported_payment_gateway ) {
-					form.appendChild( modalCheckoutHiddenInput.cloneNode() );
-					form.target = IFRAME_NAME;
-					form.addEventListener( 'submit', handleCheckoutFormSubmit );
-				}
+				form.appendChild( modalCheckoutHiddenInput.cloneNode() );
+				form.target = IFRAME_NAME;
+				form.addEventListener( 'submit', handleCheckoutFormSubmit );
 			} );
 		} );
 

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -820,7 +820,6 @@ domReady( () => {
 			return;
 		}
 		const type = urlParams.get( 'type' );
-
 		if ( type === 'donate' ) {
 			const layout = urlParams.get( 'layout' );
 			const frequency = urlParams.get( 'frequency' );

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -477,6 +477,7 @@ domReady( () => {
 				},
 				content,
 				trigger: ev.submitter,
+				closeOnSuccess: isModalCheckout,
 			} );
 		} else {
 			// Otherwise initialize checkout.

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -303,7 +303,8 @@ domReady( () => {
 				// Add some animation to the Checkout Button and Donate block while the non-modal checkout is loading.
 				// For now, don't do it when any popup opens, just when we go right to the checkout page.
 				if ( ! ( formData.get( 'is_variable' ) && ! formData.get( 'variation_id' ) ) ) {
-					const buttons = form.querySelectorAll( 'button[type=submit]' );
+					// Use :focus to try to limit submit buttons in tiered donate button block.
+					const buttons = form.querySelectorAll( 'button[type=submit]:focus' );
 					buttons.forEach( button => {
 						button.classList.add( 'non-modal-checkout-loading' );
 						const buttonText = button.innerHTML;

--- a/src/modal-checkout/modal.scss
+++ b/src/modal-checkout/modal.scss
@@ -226,6 +226,28 @@
 	}
 }
 
+.non-modal-checkout-loading {
+	position: relative;
+
+	span {
+		visibility: hidden;
+	}
+
+	&::before {
+		animation: spin 900ms infinite linear;
+		border: 1.5px solid;
+		border-color: currentcolor currentcolor transparent transparent;
+		border-radius: 50%;
+		content: "";
+		display: block;
+		height: 18px;
+		inset: calc(50% - 9px) calc(50% - 9px) auto auto;
+		position: absolute;
+		width: 18px;
+	}
+}
+
+
 @keyframes spin {
 	0% {
 		transform: rotate(0deg);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Along with https://github.com/Automattic/newspack-plugin/pull/3650, adds a check to see if there's an unsupported payment gateway enabled in WooCommerce. If there is, the Donate Block and Checkout Button block will use the regular checkout instead of the modal checkout.

See 1205234045751551-as-1208992708114862

## How to test the changes in this Pull Request:

### Testing set up
1. Set up a test page with a regular Donate Block, a tiered Donate block, and a couple different Checkout Button Blocks -- one with a regular product, and one with a variable product.
2. Apply this PR and https://github.com/Automattic/newspack-plugin/pull/3650, and run `npm run build` for each.
3. Under WooCommerce > Settings > Payments, install and activate at least one unsupported payment gateway -- right now, this includes any gateways not listed [here](https://github.com/Automattic/newspack-blocks/pull/2009/files#diff-74a92f16c32d2a94751337aaff7d24de10881675f81809bae9d09e79cc47e10eR116).

----

### Testing with unsupported gateways

It's a lot, but ideally most of these steps should be repeated with a couple different block types, including Checkout Button block + simple product, Checkout Button block + product with variations, Donate Block, and Donate Block with tiers. 

#### Account creation required & create account
_Please test this with a simple product, a product with variations, and one of the donate blocks._
1. Under Newspack > Engagement > Advanced Settings, check "Require sign in or create account before checkout" under the Checkout Configuration header.
2. In an incognito window, run through a checkout.
3. When prompted, create a new account.
5. Confirm that while the modal is processing, it maintains the 'loading' faded out appearance.
6. Confirm that the modal redirects to the full checkout page, with no "cruft" in the URL (no query string related to the modal checkout, like with the `after_success` params.

#### Account creation required & log in
_Please test this with a simple product, a product with variations, and one of the donate blocks._
1. In a new incognito window, run through a checkout.
2. When prompted, log into an existing account.
3. Confirm that while the modal is processing, it maintains the 'loading' faded out appearance.
4. Confirm that when you hit different steps (the OTP stage, or password stage, or clicking the 'Back' button) the faded out 'loading' appearance is not used. You may want to use a couple different users to test the different blocks, so you can test both OTP and password steps.
5. Confirm that the modal redirects to the full checkout page, with no "cruft" in the URL (no query string related to the modal checkout, like with the `after_success` params.

#### Account creation required & already logged in
_Please test this with a simple product, a product with variations, and both donate blocks._
1. While still logged in to the above account, run through a checkout.
2. In the Donate Block and Checkout button block with a simple product, confirm that the button displays a rotating animation until the page reloads:

![CleanShot 2025-01-03 at 15 28 15@2x](https://github.com/user-attachments/assets/f3b6e015-b8f1-4fec-b12b-3a17423f7a68)

3. For the checkout button block with a product with variations, the initial modal should open, and then the variation-specific button should display the animation until the page reloads.
4. Confirm that you're redirected to the regular checkout page.

#### Account creation required & login failures

Smoke test a few scenarios where the login is not successful, like:

1. In an incognito window, try to sign in with an email that's not associated with an account yet.
2. In an incognito window, try to create an account with an email that's already used.
3. In an incognito window, try to create an account with a malformed email.
4. In an incognito window, try to log in and mess up the password or OTP step.

... plus any other cases you can think of. Most of these are to spook out any issues with my messing with the registration modal (making it not close, or messing with the loading styles 🙂 ).

----

#### Account creation not required

1. Under Newspack > Engagement > Advanced Settings, uncheck "Require sign in or create account before checkout" under the Checkout Configuration header.
2. Repeat a couple of the test scenarios above (making a purchase when not logged in, making a purchase when already logged in). You should have a similar experience to the "Account creation required & already logged in" section, where you see a "loading" style on the button, and are brought to the /checkout page.

----

### Testing with supported gateways

Before testing this section, navigate to WooCommerce > Settings > Payments, and deactivate any unsupported payment gateways.

Run through the following with 1-2 blocks each, just to smoke test and make sure no new issues have been introduced:

1. Retest the steps under "Account creation required & create account".
2. Retest the steps under "Account creation required & log in".
3. Retest the steps under "Account creation required & already logged in".
4. Retest the steps under "Account creation required & login failures".
5. Run a purchase with the 'Newsletter Coda' enabled.
6. Run a purchase with some different Checkout Button Block settings enabled (eg. redirecting after the purchase is complete). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
