### PR TITLE
PHP 8.x compatibility: explicitly use ENT_COMPAT

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1525,7 +1525,7 @@ final class Modal_Checkout {
 			/* translators: 1: Checkout button confirmation text. 2: Order total. */
 			__( '%1$s: %2$s', 'newspack-blocks' ),
 			self::get_modal_checkout_labels( 'checkout_confirm' ),
-			'<span class="cart-price">' . html_entity_decode( $total ) . '</span>'
+			'<span class="cart-price">' . html_entity_decode( $total, ENT_COMPAT ) . '</span>'
 		);
 	}
 
@@ -1538,7 +1538,7 @@ final class Modal_Checkout {
 			return;
 		}
 		$total = \wp_strip_all_tags( \wc_price( $cart->total ) );
-		echo esc_html( html_entity_decode( $total ) );
+		echo esc_html( html_entity_decode( $total, ENT_COMPAT ) );
 		wp_die();
 	}
 

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -1101,7 +1101,7 @@ class Newspack_Blocks {
 			}
 
 			// Set excerpt length (https://core.trac.wordpress.org/ticket/29533#comment:3).
-			$excerpt = force_balance_tags( html_entity_decode( wp_trim_words( htmlentities( $excerpt ), $excerpt_length, static::more_excerpt() ) ) );
+			$excerpt = force_balance_tags( html_entity_decode( wp_trim_words( htmlentities( $excerpt, ENT_COMPAT ), $excerpt_length, static::more_excerpt(), ENT_COMPAT ) ) );
 
 			return $excerpt;
 		};


### PR DESCRIPTION
### Changes proposed in this Pull Request:

PHP 8.1 made a backwards-incompatible change to default flags are used in a few functions:

>htmlspecialchars(), htmlentities(), htmlspecialchars_decode(), html_entity_decode(), and get_html_translation_table() now use ENT_QUOTES | ENT_SUBSTITUTE rather than ENT_COMPAT by default. This means that ' is escaped to &#039; while previously nothing was done. Additionally, malformed UTF-8 will be replaced by a Unicode substitution character, instead of resulting in an empty string.

https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.standard

This PR explicitly sets the flag to `ENT_COMPAT` in those functions so everything is consistent between PHP 8.0 and PHP 8.1.

Of note, we've been manually making this change when syncing the Newspack Blocks to Jetpack/WordPress.com:

https://github.com/Automattic/jetpack/blob/trunk/projects/packages/jetpack-mu-wpcom/src/features/newspack-blocks/README.md?plain=1#L45

However, it's better to have the fix upstream, hence this PR.

### How to test the changes in this Pull Request:

Not sure the best way to test this, but the goal is that there's consistent output no matter the PHP version.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
