### PR TITLE
fix(modal-checkout): add nonce to process_checkout_request

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -18,7 +18,7 @@ final class Modal_Checkout {
 	 *
 	 * @var string
 	 */
-	const CHECKOUT_NONCE = 'newspack_modal_checkout_nonce';
+	const CHECKOUT_NONCE = 'newspack_checkout_nonce';
 
 	/**
 	 * Checkout registration flag.

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -14,6 +14,13 @@ defined( 'ABSPATH' ) || exit;
  */
 final class Modal_Checkout {
 	/**
+	 * Checkout nonce value.
+	 *
+	 * @var string
+	 */
+	const CHECKOUT_NONCE = 'newspack_modal_checkout_nonce';
+
+	/**
 	 * Checkout registration flag.
 	 *
 	 * @var string
@@ -231,10 +238,13 @@ final class Modal_Checkout {
 			return;
 		}
 
-		$is_newspack_checkout = filter_input( INPUT_GET, 'newspack_checkout', FILTER_SANITIZE_NUMBER_INT );
-
-		if ( ! $is_newspack_checkout ) {
+		if ( ! filter_input( INPUT_GET, 'newspack_checkout', FILTER_SANITIZE_NUMBER_INT ) ) {
 			return;
+		}
+
+		if ( ! check_ajax_referer( self::CHECKOUT_NONCE ) ) {
+			wp_send_json_error( [ 'message' => __( 'Invalid nonce.', 'newspack-blocks' ) ] );
+			wp_die();
 		}
 
 		$product_id                 = filter_input( INPUT_GET, 'product_id', FILTER_SANITIZE_NUMBER_INT );
@@ -385,7 +395,7 @@ final class Modal_Checkout {
 			return;
 		}
 
-		if ( ! check_ajax_referer( 'newspack_modal_checkout_nonce' ) ) {
+		if ( ! check_ajax_referer( self::CHECKOUT_NONCE ) ) {
 			wp_send_json_error( [ 'message' => __( 'Invalid nonce.', 'newspack-blocks' ) ] );
 			wp_die();
 		}
@@ -754,7 +764,7 @@ final class Modal_Checkout {
 			[
 				'ajax_url'              => admin_url( 'admin-ajax.php' ),
 				'nyp_nonce'             => wp_create_nonce( 'newspack_checkout_name_your_price' ),
-				'checkout_nonce'        => wp_create_nonce( 'newspack_modal_checkout_nonce' ),
+				'checkout_nonce'        => wp_create_nonce( self::CHECKOUT_NONCE ),
 				'newspack_class_prefix' => self::get_class_prefix(),
 				'is_checkout_complete'  => function_exists( 'is_order_received_page' ) && is_order_received_page(),
 				'divider_text'          => esc_html__( 'Or', 'newspack-blocks' ),
@@ -933,6 +943,7 @@ final class Modal_Checkout {
 			'newspackBlocksModal',
 			[
 				'ajax_url'                   => admin_url( 'admin-ajax.php' ),
+				'checkout_nonce'             => wp_create_nonce( self::CHECKOUT_NONCE ),
 				'checkout_registration_flag' => self::CHECKOUT_REGISTRATION_FLAG,
 				'newspack_class_prefix'      => self::get_class_prefix(),
 				'is_registration_required'   => self::is_registration_required(),

--- a/src/blocks/checkout-button/view.php
+++ b/src/blocks/checkout-button/view.php
@@ -42,8 +42,8 @@ function render_callback( $attributes ) {
 	if ( $attributes['is_variable'] && ! empty( $attributes['variation'] ) ) {
 		$product_id = $attributes['variation'];
 	}
-	\Newspack_Blocks\Modal_Checkout::enqueue_modal( $product_id );
-	\Newspack_Blocks::enqueue_view_assets( 'checkout-button' );
+	Modal_Checkout::enqueue_modal( $product_id );
+	Newspack_Blocks::enqueue_view_assets( 'checkout-button' );
 
 	$background_color           = $attributes['backgroundColor'] ?? '';
 	$gradient                   = $attributes['gradient'] ?? '';
@@ -105,6 +105,7 @@ function render_callback( $attributes ) {
 	$hidden_fields .= $after_success_behavior ? '<input type="hidden" name="after_success_behavior" value="' . esc_attr( $after_success_behavior ) . '" />' : '';
 	$hidden_fields .= $after_success_button_label ? '<input type="hidden" name="after_success_button_label" value="' . esc_attr( $after_success_button_label ) . '" />' : '';
 	$hidden_fields .= $after_success_url ? '<input type="hidden" name="after_success_url" value="' . esc_attr( $after_success_url ) . '" />' : '';
+	$hidden_fields .= wp_nonce_field( Modal_Checkout::CHECKOUT_NONCE );
 
 	// Generate the form.
 	if ( function_exists( 'wc_get_product' ) ) {

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
@@ -7,6 +7,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Newspack_Blocks\Modal_Checkout;
+
 /**
  * Handles the Donate block rendering functionality.
  */
@@ -202,6 +204,8 @@ abstract class Newspack_Blocks_Donate_Renderer_Base {
 			<input type='hidden' name='donation_currency' value='<?php echo esc_attr( $currency ); ?>' />
 			<input type='hidden' name='frequency_ids' value='<?php echo esc_attr( wp_json_encode( $donate_child_ids ) ); ?>' />
 		<?php
+		// Add nonce for the donation form.
+		wp_nonce_field( Modal_Checkout::CHECKOUT_NONCE );
 
 		foreach ( [ [ 'afterSuccessBehavior', 'after_success_behavior' ], [ 'afterSuccessButtonLabel', 'after_success_button_label' ], [ 'afterSuccessURL', 'after_success_url' ] ] as $attribute ) {
 			$attribute_name = $attribute[0];

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -362,7 +362,7 @@ import { domReady } from './utils';
 					const input = $nyp.find( 'input[name="price"]' );
 					input.attr( 'disabled', true );
 					const data = {
-						_ajax_nonce: newspackBlocksModalCheckout.nyp_nonce,
+						_wpnonce: newspackBlocksModalCheckout.nyp_nonce,
 						action: 'process_name_your_price_request',
 						price: $nyp.find( 'input[name="price"]' ).val(),
 						product_id: $nyp.find( 'input[name="product_id"]' ).val(),

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -31,6 +31,8 @@ domReady( () => {
 		return;
 	}
 
+	modalCheckout.checkout_nonce = newspackBlocksModal.checkout_nonce;
+
 	const modalContent = modalCheckout.querySelector( `.${ MODAL_CLASS_PREFIX }__content` );
 	const modalCheckoutHiddenInput = createHiddenInput( 'modal_checkout', '1' );
 	const spinner = modalContent.querySelector( `.${ CLASS_PREFIX }__spinner` );
@@ -119,8 +121,7 @@ domReady( () => {
 				setModalSize();
 				setModalTitle( newspackBlocksModal.labels.checkout_modal_title );
 				if ( iframe.contentWindow?.newspackBlocksModalCheckout?.checkout_nonce ) {
-					// Store the checkout nonce for later use.
-					// We store the nonce from the iframe content window to ensure the nonce was generated for a logged in session
+					// Update to iframe's checkout nonce to ensure nonce is always generated for a logged in session.
 					modalCheckout.checkout_nonce = iframe.contentWindow.newspackBlocksModalCheckout.checkout_nonce;
 				}
 			}
@@ -170,7 +171,6 @@ domReady( () => {
 		body.append( 'modal_checkout', '1' );
 		body.append( 'action', 'abandon_modal_checkout' );
 		body.append( '_wpnonce', modalCheckout.checkout_nonce );
-		modalCheckout.checkout_nonce = null;
 		fetch(
 			newspackBlocksModal.ajax_url,
 			{
@@ -233,6 +233,7 @@ domReady( () => {
 				variationModal
 					.querySelectorAll( `form[target="${ IFRAME_NAME }"]` )
 					.forEach( singleVariationForm => {
+						singleVariationForm.appendChild( createHiddenInput( '_wpnonce', modalCheckout.checkout_nonce ) );
 						// Fill in the after success variables in the variation modal.
 						[
 							'after_success_behavior',


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Goes with this Plugin PR: https://github.com/Automattic/newspack-plugin/pull/3642

Adds nonce verification to the checkout process method so this can't be triggered via direct requests.

### How to test the changes in this Pull Request:

Be sure to also checkout https://github.com/Automattic/newspack-plugin/pull/3642 before testing this.

1. Via curl (or any other tool) make the following GET request:
```
curl --location 'https://SITE.URL/wp-admin/admin-ajax.php?newspack_checkout=1&action=modal_checkout_request&product_id=PRODUCT_ID' \
```
2. On release, this will trigger the process checkout logic and return a checkout URL. On this branch the script should die early.
3. Again via curl (or any other tool) make the following GET request:
```
curl --location 'https://SITE.URL/wp-admin/admin-ajax.php?modal_checkout=1&newspack_donate=1&action=modal_checkout_request&donation_frequency=month&donation_value_month=VALUE' \
```
4. Again, on release, this will trigger the process donation logic and return a checkout URL. On this branch the script should die early.
5. As a reader, smoke test checkout buttons for differing types of products to make sure the checkout flow hasn't broken in any cases:
  - Simple
  - Variable
  - Anything else you can think of
6. Smoke test the donate block and its various layouts

**Bonus**: I wasn't sure how to properly set up NRH to test this flow, so if you have this set up please give it a try!

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
