### PR TITLE
fix: make new debugging arg optional to avoid potential fatals

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1380,7 +1380,7 @@ final class Modal_Checkout {
 	 * @param string $url The URL from which the verification request originated.
 	 * @param string $context The context that triggered the verification request.
 	 */
-	public static function recaptcha_verify_captcha( $should_verify, $url, $context ) {
+	public static function recaptcha_verify_captcha( $should_verify, $url, $context = 'unknown' ) {
 		if ( 'checkout' !== $context ) {
 			return $should_verify;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

https://github.com/Automattic/newspack-plugin/pull/3676 added a new third param to the `newspack_recaptcha_verify_captcha` filter hook for debugging purposes. However, to avoid potential fatal errors and maintain backwards-compatibility with Newspack Plugin releases older than v5.11.1, this PR makes the new param optional.

### How to test the changes in this Pull Request:

A code review should suffice.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
