### PR TITLE
fix: remove OneSignal script from the modal checkout

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -947,6 +947,16 @@ final class Modal_Checkout {
 				]
 			);
 		}
+		if ( is_plugin_active( 'onesignal-free-web-push-notifications/onesignal.php' ) ) {
+			array_push(
+				$remove_list,
+				[
+					'hook'     => 'wp_head',
+					'callback' => 'onesignal_init',
+				]
+			);
+		}
+
 		/**
 		 * Filters the hooks to remove from the modal checkout.
 		 *

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -947,15 +947,14 @@ final class Modal_Checkout {
 				]
 			);
 		}
-		if ( is_plugin_active( 'onesignal-free-web-push-notifications/onesignal.php' ) ) {
-			array_push(
-				$remove_list,
-				[
-					'hook'     => 'wp_head',
-					'callback' => 'onesignal_init',
-				]
-			);
-		}
+		// OneSignal.
+		array_push(
+			$remove_list,
+			[
+				'hook'     => 'wp_head',
+				'callback' => 'onesignal_init',
+			]
+		);
 
 		/**
 		 * Filters the hooks to remove from the modal checkout.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The OneSignal signup bell shows in the modal checkout; it shouldn't be loaded there.

See 1200550061930446-as-1209206364302813

### How to test the changes in this Pull Request:

1. Install the [OneSignal plugin](https://wordpress.org/plugins/onesignal-free-web-push-notifications/) and [sign up for a free account](https://onesignal.com/).
2. Connected the account to your site (you have to fill out some forms and the site's URL, then copy the OneSignal App ID and OneSignal REST API Key to the WP Admin > One Signal page on your website.
3. In your OneSignal account, navigate to Settings > Push Platforms > Web, and add a Subscription Bell prompt under "Permission Prompt Setup".
4. View your site and confirm you have the little Subscription bell in the bottom right corner.
5. Run through a checkout using the modal checkout, and confirm the bell also appears there:

![CleanShot 2025-01-22 at 12 25 45](https://github.com/user-attachments/assets/2ff35d05-3887-4044-9004-4535d7b24c06)

6. Apply this PR.
7. Repeat steps 4-5 and confirm the bell still shows on regular pages, but not in the modal checkout.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
