### PR TITLE
fix: make sure fields after floated inputs clear floats in the modal checkout

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -101,8 +101,16 @@
 			}
 		}
 
-		.woocommerce-billing-fields__field-wrapper ~ .form-row {
-			margin: var(--newspack-ui-spacer-5, 24px) 0 0;
+		.woocommerce-billing-fields__field-wrapper {
+			&::after {
+				clear: both;
+				content: "";
+				display: table;
+			}
+
+			& ~ .form-row {
+				margin: var(--newspack-ui-spacer-5, 24px) 0 0;
+			}
 		}
 
 		// Additional fields


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This hotfix fixes a really specific situation where the last two fields in the modal checkout are side by side, and there's a non-billing field after them. It adds a clearfix to make sure the final field doesn't end up caught on the last field.

### How to test the changes in this Pull Request:

1. Install and activate ActiveCampaign for WooCommerce and connect it to our sandbox site. By default, this will add an opt-in checkbox to the modal checkout.
2. Under Newspack > Reader Revenue, set the modal checkout to only require the email, first and last names for checkout.
3. Run through a test transaction with a modal checkout. I'm a little unclear when this happens, but when the email appears as the first field, you end up with this odd jumble:

![CleanShot 2025-01-23 at 10 12 16](https://github.com/user-attachments/assets/40b23bac-e7ff-4a83-ae63-af516b48b6cb)

4. Apply this PR and run `npm run build`.
5. Repeat step 3 and confirm things look okay (note you may need to clear the cache to get the CSS updates, since the file size doesn't really change):

![CleanShot 2025-01-23 at 10 10 59](https://github.com/user-attachments/assets/038a2bb9-2b6d-4f6c-b82c-7666146f25a0)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
