### PR TITLE
fix: improve formatting of donation amount options

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -1415,13 +1415,13 @@ class Newspack_Blocks {
 	/**
 	 * Get a formatted HTML string containing amount and frequency of a donation.
 	 *
-	 * @param float|string $amount Amount.
-	 * @param string       $frequency Frequency.
-	 * @param bool         $hide_once_label Whether to hide the "once" label.
+	 * @param float  $amount Amount.
+	 * @param string $frequency Frequency.
+	 * @param bool   $hide_once_label Whether to hide the "once" label.
 	 *
 	 * @return string
 	 */
-	public static function get_formatted_amount( $amount = 'AMOUNT_PLACEHOLDER', $frequency = 'day', $hide_once_label = false ) {
+	public static function get_formatted_amount( $amount = null, $frequency = null, $hide_once_label = false ) {
 		if ( ! function_exists( 'wc_price' ) || ( method_exists( 'Newspack\Donations', 'is_platform_wc' ) && ! \Newspack\Donations::is_platform_wc() ) ) {
 			if ( 0 === $amount ) {
 				return false;
@@ -1434,29 +1434,32 @@ class Newspack_Blocks {
 			return str_replace( '.00', '', $formatted_price );
 		}
 
-		// Format the amount with currency symbol and separators.
-		$amount_string = \wc_price(
-			$amount,
-			[ 'decimals' => is_int( $amount ) ? 0 : 2 ]
-		);
+		$wc_formatted_amount = '';
+		if ( null === $amount && null === $frequency ) {
+			$currency_symbol     = function_exists( 'get_woocommerce_currency_symbol' ) ? \get_woocommerce_currency_symbol() : '&#36;';
+			$wc_formatted_amount = '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">' . $currency_symbol . '</span>AMOUNT_PLACEHOLDER</bdi></span> FREQUENCY_PLACEHOLDER';
+		} else {
+			// Format the amount with currency symbol and separators.
+			$amount_string = \wc_price(
+				$amount,
+				[ 'decimals' => is_int( $amount ) ? 0 : 2 ]
+			);
 
-		if ( ! function_exists( 'wcs_price_string' ) ) {
-			return $amount_string;
-		}
-		$price_args          = [
-			'recurring_amount'    => $amount_string,
-			'subscription_period' => 'once' === $frequency ? 'day' : $frequency,
-		];
-		$wc_formatted_amount = \wcs_price_string( $price_args );
+			if ( ! function_exists( 'wcs_price_string' ) ) {
+				return $amount_string;
+			}
+			$price_args          = [
+				'recurring_amount'    => $amount_string,
+				'subscription_period' => 'once' === $frequency ? 'day' : $frequency,
+			];
+			$wc_formatted_amount = \wcs_price_string( $price_args );
 
-		// A 'day' frequency means we want a placeholder string to replace in the editor.
-		if ( 'day' === $frequency ) {
-			$wc_formatted_amount = preg_replace( '/ \/ ?.*/', 'FREQUENCY_PLACEHOLDER', $wc_formatted_amount );
-		} elseif ( 'once' === $frequency ) {
-			$once_label          = $hide_once_label ? '' : __( ' once', 'newspack-blocks' );
-			$wc_formatted_amount = preg_replace( '/ \/ ?.*/', $once_label, $wc_formatted_amount );
+			if ( 'once' === $frequency ) {
+				$once_label          = $hide_once_label ? '' : __( ' once', 'newspack-blocks' );
+				$wc_formatted_amount = preg_replace( '/ \/ ?.*/', $once_label, $wc_formatted_amount );
+			}
+			$wc_formatted_amount = str_replace( ' / ', __( ' per ', 'newspack-blocks' ), $wc_formatted_amount );
 		}
-		$wc_formatted_amount = str_replace( ' / ', __( ' per ', 'newspack-blocks' ), $wc_formatted_amount );
 
 		return '<span class="wpbnbd__tiers__amount__value">' . $wc_formatted_amount . '</span>';
 	}

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -213,6 +213,7 @@ class Newspack_Blocks {
 				'custom_taxonomies'          => self::get_custom_taxonomies(),
 				'can_use_name_your_price'    => self::can_use_name_your_price(),
 				'tier_amounts_template'      => self::get_formatted_amount(),
+				'currency'                   => function_exists( 'get_woocommerce_currency' ) ? \get_woocommerce_currency() : 'USD',
 			];
 
 			if ( class_exists( 'WP_REST_Newspack_Author_List_Controller' ) ) {
@@ -1414,13 +1415,13 @@ class Newspack_Blocks {
 	/**
 	 * Get a formatted HTML string containing amount and frequency of a donation.
 	 *
-	 * @param float  $amount Amount.
-	 * @param string $frequency Frequency.
-	 * @param bool   $hide_once_label Whether to hide the "once" label.
+	 * @param float|string $amount Amount.
+	 * @param string       $frequency Frequency.
+	 * @param bool         $hide_once_label Whether to hide the "once" label.
 	 *
 	 * @return string
 	 */
-	public static function get_formatted_amount( $amount = 0, $frequency = 'day', $hide_once_label = false ) {
+	public static function get_formatted_amount( $amount = 'AMOUNT_PLACEHOLDER', $frequency = 'day', $hide_once_label = false ) {
 		if ( ! function_exists( 'wc_price' ) || ( method_exists( 'Newspack\Donations', 'is_platform_wc' ) && ! \Newspack\Donations::is_platform_wc() ) ) {
 			if ( 0 === $amount ) {
 				return false;
@@ -1432,22 +1433,21 @@ class Newspack_Blocks {
 			$formatted_price  = '<span class="price-amount">' . $formatter->formatCurrency( $amount, 'USD' ) . '</span> <span class="tier-frequency">' . $frequency_string . '</span>';
 			return str_replace( '.00', '', $formatted_price );
 		}
+
+		// Format the amount with currency symbol and separators.
+		$amount_string = \wc_price(
+			$amount,
+			[ 'decimals' => is_int( $amount ) ? 0 : 2 ]
+		);
+
 		if ( ! function_exists( 'wcs_price_string' ) ) {
-			return \wc_price( $amount );
+			return $amount_string;
 		}
 		$price_args          = [
-			'recurring_amount'    => $amount,
+			'recurring_amount'    => $amount_string,
 			'subscription_period' => 'once' === $frequency ? 'day' : $frequency,
 		];
 		$wc_formatted_amount = \wcs_price_string( $price_args );
-
-		// A '0' value means we want a placeholder string to replace in the editor.
-		if ( 0 === $amount ) {
-			preg_match( '/<\/span>(.*)<\/bdi>/', $wc_formatted_amount, $matches );
-			if ( ! empty( $matches[1] ) ) {
-				$wc_formatted_amount = str_replace( $matches[1], 'AMOUNT_PLACEHOLDER', $wc_formatted_amount );
-			}
-		}
 
 		// A 'day' frequency means we want a placeholder string to replace in the editor.
 		if ( 'day' === $frequency ) {

--- a/src/blocks/donate/edit/FrequencyBasedLayout.tsx
+++ b/src/blocks/donate/edit/FrequencyBasedLayout.tsx
@@ -14,7 +14,7 @@ import { RichText } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import { AmountValueInput } from './components';
-import { getColorForContrast, getFrequencyLabel, getFrequencyLabelWithAmount } from '../utils';
+import { getColorForContrast, getFrequencyLabel, getFormattedAmount, getFrequencyLabelWithAmount } from '../utils';
 import { FREQUENCIES } from '../consts';
 import type { ComponentProps, DonationFrequencySlug } from '../types';
 import { updateBlockClassName, getFormData } from '../view'
@@ -105,9 +105,6 @@ const FrequencyBasedLayout = ( props: { isTiered: boolean } & ComponentProps ) =
 		</button>
 	);
 
-	// This code is fired on tab select and updates aria elements, tabindex states, and radio buttons
-	const displayAmount = ( amount: number ) => amount.toFixed( 2 ).replace( /\.?0*$/, '' );
-
 	const renderFormHeader = () => {
 		return ! rendersSingleFrequency && (
 			<div className="tab-container">{ availableFrequencies.map( renderTab ) }</div>
@@ -197,7 +194,7 @@ const FrequencyBasedLayout = ( props: { isTiered: boolean } & ComponentProps ) =
 								}`;
 								const tierLabel = isOtherTier
 									? __( 'Other', 'newspack-blocks' )
-									: `${settings.currencySymbol}${displayAmount( suggestedAmount )}` 
+									: getFormattedAmount( suggestedAmount, true );
 								return (
 									<div
 										className={ classNames(

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-frequency-based.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-frequency-based.php
@@ -264,6 +264,12 @@ class Newspack_Blocks_Donate_Renderer_Frequency_Based extends Newspack_Blocks_Do
 													'donation_price_summary_' . $frequency_slug => $product_price_summary,
 												]
 											);
+
+											$decimals         = intval( $amount ) == floatval( $amount ) ? 0 : 2;
+											$format_options   = [ 'decimals' => $decimals ];
+											$formatted_amount = function_exists( 'wc_price' ) ?
+												wp_strip_all_tags( \wc_price( (float) $amount, $format_options ) ) :
+												$configuration['currencySymbol'] . number_format( $amount, $decimals );
 										?>
 										<div
 											class='wp-block-newspack-blocks-donate__tier donation-tier__<?php echo esc_attr( $frequency_slug ); ?>'
@@ -315,7 +321,7 @@ class Newspack_Blocks_Donate_Renderer_Frequency_Based extends Newspack_Blocks_Do
 													class='tier-select-label tier-label'
 													for='newspack-tier-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-<?php echo (int) $index; ?>'
 												>
-													<?php echo esc_html( $configuration['currencySymbol'] . $amount ); ?>
+													<?php echo wp_kses_post( $formatted_amount ); ?>
 												</label>
 											<?php endif; ?>
 										</div>

--- a/src/blocks/donate/styles/style-variations.scss
+++ b/src/blocks/donate/styles/style-variations.scss
@@ -103,7 +103,7 @@
 		}
 	}
 
-	// Tiers-based version.
+	/* Tiers-based version. */
 	.wpbnbd__tiers .wpbnbd__button {
 		border: 0.19rem solid transparent;
 
@@ -113,7 +113,7 @@
 	}
 
 	.wpbnbd__tiers .wpbnbd__button--active,
-	// Frequency-based version.
+	/* Frequency-based version. */
 	.tab-container .freq-label.wpbnbd__button--active::after {
 		background: white;
 		border-radius: 5px;
@@ -146,7 +146,7 @@
 		}
 	}
 
-	// Show/hide the tab content.
+	/* Show/hide the tab content. */
 	.frequencies input[type="radio"]:checked ~ .tiers {
 		display: grid;
 		grid-gap: 0.28rem;
@@ -204,7 +204,7 @@
 		}
 	}
 
-	// Tiers-based version.
+	/* Tiers-based version. */
 	.wpbnbd__tiers {
 		&__selection {
 			.wpbnbd__button {
@@ -407,7 +407,7 @@
 	}
 
 	.wpbnbd__tiers .wpbnbd__button--active,
-	// Frequency-based version.
+	/* Frequency-based version. */
 	.tab-container .freq-label.wpbnbd__button--active::after {
 		background: var(--newspack-ui-color-neutral-0, colors.$newspack-ui-color-neutral-0);
 		border: 1px solid var(--newspack-ui-color-neutral-30, colors.$newspack-ui-color-neutral-30);
@@ -444,7 +444,7 @@
 		grid-template-columns: repeat(3, 1fr);
 	}
 
-	// Layout: Frequency
+	/* Layout: Frequency */
 	&.wpbnbd--frequency-based {
 		form {
 			&::after {
@@ -635,7 +635,7 @@
 		}
 	}
 
-	// Layout: Tiers
+	/* Layout: Tiers */
 	&.wpbnbd--tiers-based {
 		color: var(--newspack-ui-color-neutral-90, colors.$newspack-ui-color-neutral-90);
 
@@ -757,6 +757,7 @@
 					font-family: inherit;
 					font-size: var(--newspack-ui-font-size-xl, clamp(1.375rem, 0.394rem + 2.008vw, 2rem));
 					line-height: var(--newspack-ui-line-height-xl, 1.375);
+					word-break: break-all;
 				}
 			}
 

--- a/src/blocks/donate/utils.ts
+++ b/src/blocks/donate/utils.ts
@@ -66,6 +66,24 @@ export const getFrequencyLabel = (
 		);
 }
 
+export const getFormattedAmount = ( amount: number, withCurrency = false ) => {
+	type NumberFormatOptions = {
+		minimumFractionDigits: number;
+		style?: string;
+		currency?: string;
+	}
+	const options = <NumberFormatOptions>{
+		minimumFractionDigits: 0 === amount % 1 ? 0 : 2,
+	};
+	if ( withCurrency ) {
+		options.style = 'currency';
+		options.currency = window.newspack_blocks_data?.currency || 'USD';
+	}
+	const formatter = new Intl.NumberFormat( navigator?.language || 'en-US', options as object );
+
+	return formatter.format( amount );
+}
+
 export const getFrequencyLabelWithAmount = (
 	amount: number,
 	frequencySlug: DonationFrequencySlug,
@@ -75,11 +93,6 @@ export const getFrequencyLabelWithAmount = (
 
 	if ( ! template ) {
 		try {
-			const formatter = new Intl.NumberFormat( navigator?.language || 'en-US', {
-				style: 'currency',
-				currency: 'USD',
-			} );
-
 			const frequencyString =
 				frequencySlug === 'once'
 					? frequencySlug
@@ -91,7 +104,7 @@ export const getFrequencyLabelWithAmount = (
 
 			const formattedPrice =
 				'<span class="price-amount">' +
-				formatter.format( amount ) +
+				getFormattedAmount( amount, true ) +
 				'</span> <span class="tier-frequency">' +
 				frequencyString +
 				'</span>';
@@ -102,11 +115,9 @@ export const getFrequencyLabelWithAmount = (
 		}
 	}
 
-	const formattedAmount = ( amount || 0 ).toFixed( 2 ).replace( /\.?0*$/, '' );
-
-	const frequency = getFrequencyLabel(frequencySlug, hideOnceLabel)
+	const frequency = getFrequencyLabel( frequencySlug, hideOnceLabel );
 
 	return template
-		.replace( 'AMOUNT_PLACEHOLDER', formattedAmount )
+		.replace( 'AMOUNT_PLACEHOLDER', getFormattedAmount( amount ) )
 		.replace( 'FREQUENCY_PLACEHOLDER', frequency );
 };

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -11,6 +11,7 @@ declare global {
 			post_subtitle: boolean;
 			can_use_name_your_price: boolean;
 			tier_amounts_template: string;
+			currency: string;
 		};
 		grecaptcha: any;
 		newspackReaderActivation: {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes display of number amounts in the Donate block in editor and front-end contexts. Eventually we may want to refactor this block to fetch rendered HTML via PHP in the future, but that's beyond the scope of this fix.

### How to test the changes in this Pull Request:

1. Add a Donate block, set to configure manually + tiered and enter very large numbers in all amount inputs (ensuring that some numbers are integers and others have fractional amounts), like so:

<img width="271" alt="Screenshot 2025-01-24 at 3 13 01 PM" src="https://github.com/user-attachments/assets/7f655e8e-2005-48a2-aec6-b25745d19cbb" />

2. Observe that in the editor, the amounts are shown without formatting, e.g. `500000` instead of `500,000` for both Frequency and Tiers layouts.

<img width="851" alt="Screenshot 2025-01-24 at 3 15 37 PM" src="https://github.com/user-attachments/assets/e360ab88-8a33-4010-90ba-62a67e950bf8" />
<img width="800" alt="Screenshot 2025-01-24 at 3 16 19 PM" src="https://github.com/user-attachments/assets/1b0b748e-ead1-4cb5-bf34-31ca3df8ab47" />

3. Observe that on the front-end, the amounts are shown either without formatting (Frequency layout) OR with formatting, but that integers are shown with trailing `00` decimals (Tiers layout):

<img width="820" alt="Screenshot 2025-01-24 at 3 16 06 PM" src="https://github.com/user-attachments/assets/b5632362-07f3-41f2-9359-4067b48f1eb8" />
<img width="800" alt="Screenshot 2025-01-24 at 3 16 19 PM" src="https://github.com/user-attachments/assets/3f9e4158-c1ec-47e9-a869-05d4f0614dde" />

4. Check out this branch, and confirm that the numbers are properly formatted and that integers do not include the trailing `00` decimals, in both front-end and editor contexts:

<img width="796" alt="Screenshot 2025-01-24 at 3 15 53 PM" src="https://github.com/user-attachments/assets/0a5d0bec-12db-4c1e-bc67-ca6ee91f86ef" />
<img width="794" alt="Screenshot 2025-01-24 at 3 16 36 PM" src="https://github.com/user-attachments/assets/b46d2716-807d-41b7-b210-446a57ab37f7" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208923545061655