### PR TITLE
fix: return no posts for authors without term

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -688,6 +688,10 @@ class Newspack_Blocks {
 							$term = $coauthors_plus->get_author_term( $co_author );
 							if ( $term ) {
 								$authors_term_ids[] = $term->term_id;
+							} else {
+								// If the author term does not exist, force a non-match, otherwise all posts will be returned.
+								// CAP's cli command to create author terms will only create terms for users that have authored posts.
+								$authors_term_ids[] = -1;
 							}
 
 							// If it's a guest author, also check the linked author.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When using CAP, the HPP relies on the author terms to search for posts when filtered by authors.

As described in the docs, this requires the site to have created all terms for all authors in case they are missing, running `wp co-authors-plus create-author-terms-for-posts`.

However, for newly created users, or for users that are not authors of any posts, terms are not created.

The end result is that if you filter by such users, there will be no filter by the `author` taxonomy and all posts will be returned.

This PR fixes this.

### How to test the changes in this Pull Request:

1. on `trunk`
2. Create a new user
3. Add a HPP block anywhere and filter by this user.
4. Note that all posts are returned
5. checkout this branch
6. note that no posts are returned, as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
