### PR TITLE
fix: enforce the password strength on checkout

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -165,6 +165,7 @@ final class Modal_Checkout {
 		add_filter( 'option_woocommerce_woocommerce_payments_settings', [ __CLASS__, 'filter_woocommerce_payments_settings' ] );
 		add_action( 'init', [ __CLASS__, 'unhook_woocommerce_payments_update_billing_fields' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'update_password_strength_message' ], 9999 );
+		add_filter( 'woocommerce_enforce_password_strength_meter_on_checkout', '__return_true' );
 
 		/** Custom handling for registered users. */
 		add_filter( 'woocommerce_checkout_customer_id', [ __CLASS__, 'associate_existing_user' ] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR enforces the password strength check in the modal checkout, so you can't proceed to the next screen if you don't have at least a medium-strength password.

This addresses the last bit of feedback from https://github.com/Automattic/newspack-blocks/pull/1961 in a way that was waaaay simpler than I expected.

See: 1200550061930446-as-1208733956648888

### How to test the changes in this Pull Request:

1. Apply this PR.
2. Under WooCommerce > Settings > Accounts & Privacy, uncheck "Send password setup link (recommended)"
3. Under Newspack > Engagement > Reader Activation > Advanced Settings, toggle off "Require sign in or create account before checkout".
4. In an incognito window, run through a checkout. Fill out the password form and note that the Continue button gets greyed out and can't be clicked when the password is deemed weak:

![CleanShot 2025-01-30 at 12 37 58](https://github.com/user-attachments/assets/8961e56f-0d4a-44d7-a48a-b126f0bcb3ac)

5. Keep adding complexity/characters until the password is deemed Medium or Strong strength. Confirm that the Continue button becomes active again, and that you can click it:

![CleanShot 2025-01-30 at 12 40 55](https://github.com/user-attachments/assets/a6c23b07-b9a4-47d6-a2b9-ec687d49a6b8)

6. Confirm that you can complete your transaction.
7. Smoke test the modal checkout with "Send password setup link (recommended)" enabled again, and confirm things work as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
