### PR TITLE
fix(checkout-button): handle missing saved product

### DIFF
--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -10,7 +10,7 @@ import { debounce, invert } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	InspectorControls,
 	RichText,
@@ -92,6 +92,7 @@ function ProductControl( props ) {
 	const [ suggestions, setSuggestions ] = useState( {} );
 	const [ selected, setSelected ] = useState( false );
 	const [ isChanging, setIsChanging ] = useState( false );
+	const [ productError, setProductError ] = useState( '' );
 
 	function fetchSuggestions( search ) {
 		setInFlight( true );
@@ -117,7 +118,18 @@ function ProductControl( props ) {
 			.then( product => {
 				setSuggestions( { [ product.id ]: `${ product.id }: ${ product.name }` } );
 				setSelected( product );
+				setProductError( '' );
 				props.onProduct( product );
+			} )
+			.catch( () => {
+				props.onChange( '' );
+				setProductError(
+					sprintf(
+						// translators: %s: product ID.
+						__( 'Product with ID %s was not found. Select a different product.', 'newspack-blocks' ),
+						props.value
+					)
+				);
 			} )
 			.finally( () => setInFlight( false ) );
 	}
@@ -187,6 +199,7 @@ function ProductControl( props ) {
 					) }
 				</>
 			) }
+			{ productError && <p className="newspack-checkout-button__product-field__error">{ productError }</p> }
 		</div>
 	);
 }

--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -97,7 +97,7 @@ function ProductControl( props ) {
 	function fetchSuggestions( search ) {
 		setInFlight( true );
 		return apiFetch( {
-			path: `/wc/v2/products?search=${ encodeURIComponent( search ) }`,
+			path: `/wc/v2/products?search=${ encodeURIComponent( '"' + search + '"' ) }`,
 		} )
 			.then( products => {
 				const _suggestions = {};

--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -97,6 +97,8 @@ function ProductControl( props ) {
 	function fetchSuggestions( search ) {
 		setInFlight( true );
 		return apiFetch( {
+			// The search query is wrapped in quotes to ensure that the search is for
+			// the exact phrase, matching the behavior of the FormTokenField component.
 			path: `/wc/v2/products?search=${ encodeURIComponent( '"' + search + '"' ) }`,
 		} )
 			.then( products => {

--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -126,7 +126,7 @@ function ProductControl( props ) {
 				setProductError(
 					sprintf(
 						// translators: %s: product ID.
-						__( 'Product with ID %s was not found. Select a different product.', 'newspack-blocks' ),
+						__( 'Could not find a product with ID %s. Please select a different product.', 'newspack-blocks' ),
 						props.value
 					)
 				);

--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -122,7 +122,6 @@ function ProductControl( props ) {
 				props.onProduct( product );
 			} )
 			.catch( () => {
-				props.onChange( '' );
 				setProductError(
 					sprintf(
 						// translators: %s: product ID.
@@ -156,7 +155,7 @@ function ProductControl( props ) {
 			setInFlight( false );
 		}
 	};
-	if ( props.value && ! selected && inFlight ) {
+	if ( props.value && ! productError && ! selected && inFlight ) {
 		return <Spinner />;
 	}
 	return (

--- a/src/blocks/checkout-button/edit.scss
+++ b/src/blocks/checkout-button/edit.scss
@@ -1,3 +1,5 @@
+@use "../../shared/sass/colors";
+
 .newspack-checkout-button {
 	&__product-field {
 		&__selected {
@@ -6,6 +8,11 @@
 				width: 100%;
 				text-align: left;
 			}
+		}
+		&__error {
+			color: colors.$color__error;
+			font-size: 0.9em;
+			margin-top: 0.5em;
 		}
 		/* Workaround for hard-coded help text in FormTokenField. */
 		.components-form-token-field__help {
@@ -38,3 +45,4 @@
 		}
 	}
 }
+


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1200550061930446-as-1209290415945917/f

When a Checkout Button block is saved with a non-existing product ID it stays in a broken state, unable to search for products.

This PR handles this case by resetting the block attribute and displaying an error message:

<img width="277" alt="image" src="https://github.com/user-attachments/assets/87ed9a0c-fc04-4769-b9fa-577c7d0765d8" />

### How to test the changes in this Pull Request:

1. While on the release branch, add a checkout button block to a page and select a product
2. In the code editor, modify the ID to a random number (that doesn't match a product ID)
3. Back to the code editor, try to select a product, and confirm you get stuck with the spinner
4. Checkout this branch, repeat step 2 and confirm you get an error message as in the image above and you're able to select a new product and save
5. Refresh the page and confirm the selected product persists

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209290415945917