### PR TITLE
fix(modal-checkout): check WC before enqueueing

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -259,7 +259,7 @@ final class Modal_Checkout {
 	 */
 	public static function has_unsupported_payment_gateway() {
 		$supported_gateways          = self::get_supported_payment_gateways();
-		$available_gateways          = \WC()->payment_gateways->get_available_payment_gateways();
+		$available_gateways          = function_exists( 'WC' ) ? \WC()->payment_gateways->get_available_payment_gateways() : [];
 		$unsupported_payment_gateway = false;
 		foreach ( $available_gateways as $id => $gateway ) {
 			if ( ! in_array( $id, $supported_gateways, true ) ) {
@@ -966,6 +966,11 @@ final class Modal_Checkout {
 	 * @param int $product_id Product ID (optional).
 	 */
 	public static function enqueue_modal( $product_id = null ) {
+		// Don't enqueue the modal if WooCommerce is not available.
+		if ( ! function_exists( 'WC' ) ) {
+			return;
+		}
+
 		self::$has_modal = true;
 		if ( ! empty( $product_id ) ) {
 			self::$products[ $product_id ] = true;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

#2009 introduced a change that may call a WC function without checking whether the plugin is available. In this case, the call stack starts in the Donate block renderer:

https://github.com/Automattic/newspack-blocks/blob/ae3a088fa839395aa5979916dbede12e01422a32/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer.php#L103-L105

This PR introduces to 2 new checks:

1. In the new `Modal_Checkout::has_unsupported_payment_gateway()` method
2. Bail early on `Modal_Checkout::enqueue_modal()`, since the modal should never get enqueued without WC available

### How to test the changes in this Pull Request:

1. Go through #2009 test instructions and confirm it still works as intended
2. Deactivate WooCommerce and confirm you get no errors while navigating pages that render the Donate block

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
