### PR TITLE
fix: make sure membership gate refreshes after variation purchase

### DIFF
--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -651,7 +651,7 @@ domReady( () => {
 
 	const openModal = el => {
 		if ( window.newspackReaderActivation?.overlays ) {
-			modalCheckout.overlayId = window.newspackReaderActivation?.overlays.add();
+			el.overlayId = window.newspackReaderActivation?.overlays.add();
 		}
 		el.setAttribute( 'data-state', 'open' );
 		document.body.style.overflow = 'hidden';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR makes sure the post refreshes after a membership is purchased through a gate through a variable product.

It can be tested separately from https://github.com/Automattic/newspack-plugin/pull/3727, but it may make sense to test them together for a bit of the testing, to make sure they don't clash. 

This is one of those odd fixes that seems to work, but I don't know why: any additional smoke tests/suggestions/etc. are welcome!

See: 1200550061930446-as-1209271919879010

### How to test the changes in this Pull Request:

1. Set up a Membership plan that restricts content.
2. Create two products to use to purchase access to the Membership plan: one simple subscription, and one variable subscription.
3. Enable the Membership Content Gate under Newspack > Engagement > Advanced Settings, and add two checkout button blocks to the gateway content: one for the simple subscription product that can purchase the membership, and one for the variable subscription product that can purchase the membership.
4. In an incognito window, trigger the Content Gate, and run through a checkout using the Simple Subscription product. When finished, confirm that the single post refreshes so the gate goes away.
5. Open a new incognito window, and repeat step four, but this time running through the checkout using the Variable Subscription product. When finished, note the post doesn't refresh, so the content gate is still visible.
6. Apply this PR and run `npm run build`.
7. Repeat steps 4 and 5, and confirm that both checkouts result in the post refreshing when the purchase is successful.

Bonus testing:
8. Under Newspack > Engagement > Advanced Settings, enable "Present newsletter signup after checkout and registration".
9. Repeat testing steps 4 and 5, and confirm that you're presented with a newsletter to sign up in each. Confirm that the post refreshes after you've submitted the newsletter form, and not before. (Note that with the variable product, this happens after a two second delay).

Smoke testing:
10. In an incognito window, log into an existing account that has access to the membership, and visit some posts; confirm that the gateway isn't triggered and you don't see any weirdness.
11. Purchase a regular product using a checkout button block.
12. Under Newspack > Engagement > Advanced Settings, enable "Require sign in or create account before checkout" under Checkout Configuration, and try a few different purchases in incognito windows (both the membership product at the gateway, and regular products elsewhere on the site). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
