### PR TITLE
feat: rename all homepage posts patterns to content loop patterns

### DIFF
--- a/includes/class-newspack-blocks-patterns.php
+++ b/includes/class-newspack-blocks-patterns.php
@@ -73,7 +73,7 @@ class Newspack_Blocks_Patterns {
 				);
 			}
 
-			// Homepage Posts: pages only.
+			// Content Loop: pages only.
 			if ( null === $post_type || 'page' === $post_type ) {
 				array_push(
 					$block_patterns,
@@ -155,7 +155,7 @@ class Newspack_Blocks_Patterns {
 			);
 			register_block_pattern_category(
 				'newspack-homepage-posts',
-				[ 'label' => __( 'Newspack Homepage Posts', 'newspack-blocks' ) ]
+				[ 'label' => __( 'Newspack Content Loop', 'newspack-blocks' ) ]
 			);
 			register_block_pattern_category(
 				'newspack-subscribe',

--- a/languages/newspack-blocks-de_DE.po
+++ b/languages/newspack-blocks-de_DE.po
@@ -343,157 +343,157 @@ msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-1.php:9
 #: src/block-patterns/homepage-posts-1.php:9
-msgid "Homepage Posts Pattern 1"
+msgid "Content Loop Pattern 1"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-2.php:9
 #: src/block-patterns/homepage-posts-2.php:9
-msgid "Homepage Posts Pattern 2"
+msgid "Content Loop Pattern 2"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-3.php:9
 #: src/block-patterns/homepage-posts-3.php:9
-msgid "Homepage Posts Pattern 3"
+msgid "Content Loop Pattern 3"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-4.php:9
 #: src/block-patterns/homepage-posts-4.php:9
-msgid "Homepage Posts Pattern 4"
+msgid "Content Loop Pattern 4"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-5.php:9
 #: src/block-patterns/homepage-posts-5.php:9
-msgid "Homepage Posts Pattern 5"
+msgid "Content Loop Pattern 5"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-6.php:9
 #: src/block-patterns/homepage-posts-6.php:9
-msgid "Homepage Posts Pattern 6"
+msgid "Content Loop Pattern 6"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-7.php:9
 #: src/block-patterns/homepage-posts-7.php:9
-msgid "Homepage Posts Pattern 7"
+msgid "Content Loop Pattern 7"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-8.php:9
 #: src/block-patterns/homepage-posts-8.php:9
-msgid "Homepage Posts Pattern 8"
+msgid "Content Loop Pattern 8"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-9.php:9
 #: src/block-patterns/homepage-posts-9.php:9
-msgid "Homepage Posts Pattern 9"
+msgid "Content Loop Pattern 9"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-10.php:9
 #: src/block-patterns/homepage-posts-10.php:9
-msgid "Homepage Posts Pattern 10"
+msgid "Content Loop Pattern 10"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-11.php:9
 #: src/block-patterns/homepage-posts-11.php:9
-msgid "Homepage Posts Pattern 11"
+msgid "Content Loop Pattern 11"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-12.php:9
 #: src/block-patterns/homepage-posts-12.php:9
-msgid "Homepage Posts Pattern 12"
+msgid "Content Loop Pattern 12"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-13.php:9
 #: src/block-patterns/homepage-posts-13.php:9
-msgid "Homepage Posts Pattern 13"
+msgid "Content Loop Pattern 13"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-14.php:9
 #: src/block-patterns/homepage-posts-14.php:9
-msgid "Homepage Posts Pattern 14"
+msgid "Content Loop Pattern 14"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-15.php:9
 #: src/block-patterns/homepage-posts-15.php:9
-msgid "Homepage Posts Pattern 15"
+msgid "Content Loop Pattern 15"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-16.php:9
 #: src/block-patterns/homepage-posts-16.php:9
-msgid "Homepage Posts Pattern 16"
+msgid "Content Loop Pattern 16"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-17.php:9
 #: src/block-patterns/homepage-posts-17.php:9
-msgid "Homepage Posts Pattern 17"
+msgid "Content Loop Pattern 17"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-18.php:9
 #: src/block-patterns/homepage-posts-18.php:9
-msgid "Homepage Posts Pattern 18"
+msgid "Content Loop Pattern 18"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-19.php:9
 #: src/block-patterns/homepage-posts-19.php:9
-msgid "Homepage Posts Pattern 19"
+msgid "Content Loop Pattern 19"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-20.php:9
 #: src/block-patterns/homepage-posts-20.php:9
-msgid "Homepage Posts Pattern 20"
+msgid "Content Loop Pattern 20"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-21.php:9
 #: src/block-patterns/homepage-posts-21.php:9
-msgid "Homepage Posts Pattern 21"
+msgid "Content Loop Pattern 21"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-22.php:9
 #: src/block-patterns/homepage-posts-22.php:9
-msgid "Homepage Posts Pattern 22"
+msgid "Content Loop Pattern 22"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-23.php:9
 #: src/block-patterns/homepage-posts-23.php:9
-msgid "Homepage Posts Pattern 23"
+msgid "Content Loop Pattern 23"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-24.php:9
 #: src/block-patterns/homepage-posts-24.php:9
-msgid "Homepage Posts Pattern 24"
+msgid "Content Loop Pattern 24"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-25.php:9
 #: src/block-patterns/homepage-posts-25.php:9
-msgid "Homepage Posts Pattern 25"
+msgid "Content Loop Pattern 25"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-26.php:9
 #: src/block-patterns/homepage-posts-26.php:9
-msgid "Homepage Posts Pattern 26"
+msgid "Content Loop Pattern 26"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-27.php:9
 #: src/block-patterns/homepage-posts-27.php:9
-msgid "Homepage Posts Pattern 27"
+msgid "Content Loop Pattern 27"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-28.php:9
 #: src/block-patterns/homepage-posts-28.php:9
-msgid "Homepage Posts Pattern 28"
+msgid "Content Loop Pattern 28"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-29.php:9
 #: src/block-patterns/homepage-posts-29.php:9
-msgid "Homepage Posts Pattern 29"
+msgid "Content Loop Pattern 29"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-30.php:9
 #: src/block-patterns/homepage-posts-30.php:9
-msgid "Homepage Posts Pattern 30"
+msgid "Content Loop Pattern 30"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-31.php:9
 #: src/block-patterns/homepage-posts-31.php:9
-msgid "Homepage Posts Pattern 31"
+msgid "Content Loop Pattern 31"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/subscribe-1.php:9

--- a/languages/newspack-blocks-es_ES.po
+++ b/languages/newspack-blocks-es_ES.po
@@ -335,157 +335,157 @@ msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-1.php:9
 #: src/block-patterns/homepage-posts-1.php:9
-msgid "Homepage Posts Pattern 1"
+msgid "Content Loop Pattern 1"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-2.php:9
 #: src/block-patterns/homepage-posts-2.php:9
-msgid "Homepage Posts Pattern 2"
+msgid "Content Loop Pattern 2"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-3.php:9
 #: src/block-patterns/homepage-posts-3.php:9
-msgid "Homepage Posts Pattern 3"
+msgid "Content Loop Pattern 3"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-4.php:9
 #: src/block-patterns/homepage-posts-4.php:9
-msgid "Homepage Posts Pattern 4"
+msgid "Content Loop Pattern 4"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-5.php:9
 #: src/block-patterns/homepage-posts-5.php:9
-msgid "Homepage Posts Pattern 5"
+msgid "Content Loop Pattern 5"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-6.php:9
 #: src/block-patterns/homepage-posts-6.php:9
-msgid "Homepage Posts Pattern 6"
+msgid "Content Loop Pattern 6"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-7.php:9
 #: src/block-patterns/homepage-posts-7.php:9
-msgid "Homepage Posts Pattern 7"
+msgid "Content Loop Pattern 7"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-8.php:9
 #: src/block-patterns/homepage-posts-8.php:9
-msgid "Homepage Posts Pattern 8"
+msgid "Content Loop Pattern 8"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-9.php:9
 #: src/block-patterns/homepage-posts-9.php:9
-msgid "Homepage Posts Pattern 9"
+msgid "Content Loop Pattern 9"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-10.php:9
 #: src/block-patterns/homepage-posts-10.php:9
-msgid "Homepage Posts Pattern 10"
+msgid "Content Loop Pattern 10"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-11.php:9
 #: src/block-patterns/homepage-posts-11.php:9
-msgid "Homepage Posts Pattern 11"
+msgid "Content Loop Pattern 11"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-12.php:9
 #: src/block-patterns/homepage-posts-12.php:9
-msgid "Homepage Posts Pattern 12"
+msgid "Content Loop Pattern 12"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-13.php:9
 #: src/block-patterns/homepage-posts-13.php:9
-msgid "Homepage Posts Pattern 13"
+msgid "Content Loop Pattern 13"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-14.php:9
 #: src/block-patterns/homepage-posts-14.php:9
-msgid "Homepage Posts Pattern 14"
+msgid "Content Loop Pattern 14"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-15.php:9
 #: src/block-patterns/homepage-posts-15.php:9
-msgid "Homepage Posts Pattern 15"
+msgid "Content Loop Pattern 15"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-16.php:9
 #: src/block-patterns/homepage-posts-16.php:9
-msgid "Homepage Posts Pattern 16"
+msgid "Content Loop Pattern 16"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-17.php:9
 #: src/block-patterns/homepage-posts-17.php:9
-msgid "Homepage Posts Pattern 17"
+msgid "Content Loop Pattern 17"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-18.php:9
 #: src/block-patterns/homepage-posts-18.php:9
-msgid "Homepage Posts Pattern 18"
+msgid "Content Loop Pattern 18"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-19.php:9
 #: src/block-patterns/homepage-posts-19.php:9
-msgid "Homepage Posts Pattern 19"
+msgid "Content Loop Pattern 19"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-20.php:9
 #: src/block-patterns/homepage-posts-20.php:9
-msgid "Homepage Posts Pattern 20"
+msgid "Content Loop Pattern 20"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-21.php:9
 #: src/block-patterns/homepage-posts-21.php:9
-msgid "Homepage Posts Pattern 21"
+msgid "Content Loop Pattern 21"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-22.php:9
 #: src/block-patterns/homepage-posts-22.php:9
-msgid "Homepage Posts Pattern 22"
+msgid "Content Loop Pattern 22"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-23.php:9
 #: src/block-patterns/homepage-posts-23.php:9
-msgid "Homepage Posts Pattern 23"
+msgid "Content Loop Pattern 23"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-24.php:9
 #: src/block-patterns/homepage-posts-24.php:9
-msgid "Homepage Posts Pattern 24"
+msgid "Content Loop Pattern 24"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-25.php:9
 #: src/block-patterns/homepage-posts-25.php:9
-msgid "Homepage Posts Pattern 25"
+msgid "Content Loop Pattern 25"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-26.php:9
 #: src/block-patterns/homepage-posts-26.php:9
-msgid "Homepage Posts Pattern 26"
+msgid "Content Loop Pattern 26"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-27.php:9
 #: src/block-patterns/homepage-posts-27.php:9
-msgid "Homepage Posts Pattern 27"
+msgid "Content Loop Pattern 27"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-28.php:9
 #: src/block-patterns/homepage-posts-28.php:9
-msgid "Homepage Posts Pattern 28"
+msgid "Content Loop Pattern 28"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-29.php:9
 #: src/block-patterns/homepage-posts-29.php:9
-msgid "Homepage Posts Pattern 29"
+msgid "Content Loop Pattern 29"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-30.php:9
 #: src/block-patterns/homepage-posts-30.php:9
-msgid "Homepage Posts Pattern 30"
+msgid "Content Loop Pattern 30"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-31.php:9
 #: src/block-patterns/homepage-posts-31.php:9
-msgid "Homepage Posts Pattern 31"
+msgid "Content Loop Pattern 31"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/subscribe-1.php:9

--- a/languages/newspack-blocks-fr_BE.po
+++ b/languages/newspack-blocks-fr_BE.po
@@ -333,157 +333,157 @@ msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-1.php:9
 #: src/block-patterns/homepage-posts-1.php:9
-msgid "Homepage Posts Pattern 1"
+msgid "Content Loop Pattern 1"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-2.php:9
 #: src/block-patterns/homepage-posts-2.php:9
-msgid "Homepage Posts Pattern 2"
+msgid "Content Loop Pattern 2"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-3.php:9
 #: src/block-patterns/homepage-posts-3.php:9
-msgid "Homepage Posts Pattern 3"
+msgid "Content Loop Pattern 3"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-4.php:9
 #: src/block-patterns/homepage-posts-4.php:9
-msgid "Homepage Posts Pattern 4"
+msgid "Content Loop Pattern 4"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-5.php:9
 #: src/block-patterns/homepage-posts-5.php:9
-msgid "Homepage Posts Pattern 5"
+msgid "Content Loop Pattern 5"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-6.php:9
 #: src/block-patterns/homepage-posts-6.php:9
-msgid "Homepage Posts Pattern 6"
+msgid "Content Loop Pattern 6"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-7.php:9
 #: src/block-patterns/homepage-posts-7.php:9
-msgid "Homepage Posts Pattern 7"
+msgid "Content Loop Pattern 7"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-8.php:9
 #: src/block-patterns/homepage-posts-8.php:9
-msgid "Homepage Posts Pattern 8"
+msgid "Content Loop Pattern 8"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-9.php:9
 #: src/block-patterns/homepage-posts-9.php:9
-msgid "Homepage Posts Pattern 9"
+msgid "Content Loop Pattern 9"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-10.php:9
 #: src/block-patterns/homepage-posts-10.php:9
-msgid "Homepage Posts Pattern 10"
+msgid "Content Loop Pattern 10"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-11.php:9
 #: src/block-patterns/homepage-posts-11.php:9
-msgid "Homepage Posts Pattern 11"
+msgid "Content Loop Pattern 11"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-12.php:9
 #: src/block-patterns/homepage-posts-12.php:9
-msgid "Homepage Posts Pattern 12"
+msgid "Content Loop Pattern 12"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-13.php:9
 #: src/block-patterns/homepage-posts-13.php:9
-msgid "Homepage Posts Pattern 13"
+msgid "Content Loop Pattern 13"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-14.php:9
 #: src/block-patterns/homepage-posts-14.php:9
-msgid "Homepage Posts Pattern 14"
+msgid "Content Loop Pattern 14"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-15.php:9
 #: src/block-patterns/homepage-posts-15.php:9
-msgid "Homepage Posts Pattern 15"
+msgid "Content Loop Pattern 15"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-16.php:9
 #: src/block-patterns/homepage-posts-16.php:9
-msgid "Homepage Posts Pattern 16"
+msgid "Content Loop Pattern 16"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-17.php:9
 #: src/block-patterns/homepage-posts-17.php:9
-msgid "Homepage Posts Pattern 17"
+msgid "Content Loop Pattern 17"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-18.php:9
 #: src/block-patterns/homepage-posts-18.php:9
-msgid "Homepage Posts Pattern 18"
+msgid "Content Loop Pattern 18"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-19.php:9
 #: src/block-patterns/homepage-posts-19.php:9
-msgid "Homepage Posts Pattern 19"
+msgid "Content Loop Pattern 19"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-20.php:9
 #: src/block-patterns/homepage-posts-20.php:9
-msgid "Homepage Posts Pattern 20"
+msgid "Content Loop Pattern 20"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-21.php:9
 #: src/block-patterns/homepage-posts-21.php:9
-msgid "Homepage Posts Pattern 21"
+msgid "Content Loop Pattern 21"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-22.php:9
 #: src/block-patterns/homepage-posts-22.php:9
-msgid "Homepage Posts Pattern 22"
+msgid "Content Loop Pattern 22"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-23.php:9
 #: src/block-patterns/homepage-posts-23.php:9
-msgid "Homepage Posts Pattern 23"
+msgid "Content Loop Pattern 23"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-24.php:9
 #: src/block-patterns/homepage-posts-24.php:9
-msgid "Homepage Posts Pattern 24"
+msgid "Content Loop Pattern 24"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-25.php:9
 #: src/block-patterns/homepage-posts-25.php:9
-msgid "Homepage Posts Pattern 25"
+msgid "Content Loop Pattern 25"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-26.php:9
 #: src/block-patterns/homepage-posts-26.php:9
-msgid "Homepage Posts Pattern 26"
+msgid "Content Loop Pattern 26"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-27.php:9
 #: src/block-patterns/homepage-posts-27.php:9
-msgid "Homepage Posts Pattern 27"
+msgid "Content Loop Pattern 27"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-28.php:9
 #: src/block-patterns/homepage-posts-28.php:9
-msgid "Homepage Posts Pattern 28"
+msgid "Content Loop Pattern 28"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-29.php:9
 #: src/block-patterns/homepage-posts-29.php:9
-msgid "Homepage Posts Pattern 29"
+msgid "Content Loop Pattern 29"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-30.php:9
 #: src/block-patterns/homepage-posts-30.php:9
-msgid "Homepage Posts Pattern 30"
+msgid "Content Loop Pattern 30"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-31.php:9
 #: src/block-patterns/homepage-posts-31.php:9
-msgid "Homepage Posts Pattern 31"
+msgid "Content Loop Pattern 31"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/subscribe-1.php:9

--- a/languages/newspack-blocks-nb_NO.po
+++ b/languages/newspack-blocks-nb_NO.po
@@ -335,157 +335,157 @@ msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-1.php:9
 #: src/block-patterns/homepage-posts-1.php:9
-msgid "Homepage Posts Pattern 1"
+msgid "Content Loop Pattern 1"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-2.php:9
 #: src/block-patterns/homepage-posts-2.php:9
-msgid "Homepage Posts Pattern 2"
+msgid "Content Loop Pattern 2"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-3.php:9
 #: src/block-patterns/homepage-posts-3.php:9
-msgid "Homepage Posts Pattern 3"
+msgid "Content Loop Pattern 3"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-4.php:9
 #: src/block-patterns/homepage-posts-4.php:9
-msgid "Homepage Posts Pattern 4"
+msgid "Content Loop Pattern 4"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-5.php:9
 #: src/block-patterns/homepage-posts-5.php:9
-msgid "Homepage Posts Pattern 5"
+msgid "Content Loop Pattern 5"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-6.php:9
 #: src/block-patterns/homepage-posts-6.php:9
-msgid "Homepage Posts Pattern 6"
+msgid "Content Loop Pattern 6"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-7.php:9
 #: src/block-patterns/homepage-posts-7.php:9
-msgid "Homepage Posts Pattern 7"
+msgid "Content Loop Pattern 7"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-8.php:9
 #: src/block-patterns/homepage-posts-8.php:9
-msgid "Homepage Posts Pattern 8"
+msgid "Content Loop Pattern 8"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-9.php:9
 #: src/block-patterns/homepage-posts-9.php:9
-msgid "Homepage Posts Pattern 9"
+msgid "Content Loop Pattern 9"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-10.php:9
 #: src/block-patterns/homepage-posts-10.php:9
-msgid "Homepage Posts Pattern 10"
+msgid "Content Loop Pattern 10"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-11.php:9
 #: src/block-patterns/homepage-posts-11.php:9
-msgid "Homepage Posts Pattern 11"
+msgid "Content Loop Pattern 11"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-12.php:9
 #: src/block-patterns/homepage-posts-12.php:9
-msgid "Homepage Posts Pattern 12"
+msgid "Content Loop Pattern 12"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-13.php:9
 #: src/block-patterns/homepage-posts-13.php:9
-msgid "Homepage Posts Pattern 13"
+msgid "Content Loop Pattern 13"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-14.php:9
 #: src/block-patterns/homepage-posts-14.php:9
-msgid "Homepage Posts Pattern 14"
+msgid "Content Loop Pattern 14"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-15.php:9
 #: src/block-patterns/homepage-posts-15.php:9
-msgid "Homepage Posts Pattern 15"
+msgid "Content Loop Pattern 15"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-16.php:9
 #: src/block-patterns/homepage-posts-16.php:9
-msgid "Homepage Posts Pattern 16"
+msgid "Content Loop Pattern 16"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-17.php:9
 #: src/block-patterns/homepage-posts-17.php:9
-msgid "Homepage Posts Pattern 17"
+msgid "Content Loop Pattern 17"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-18.php:9
 #: src/block-patterns/homepage-posts-18.php:9
-msgid "Homepage Posts Pattern 18"
+msgid "Content Loop Pattern 18"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-19.php:9
 #: src/block-patterns/homepage-posts-19.php:9
-msgid "Homepage Posts Pattern 19"
+msgid "Content Loop Pattern 19"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-20.php:9
 #: src/block-patterns/homepage-posts-20.php:9
-msgid "Homepage Posts Pattern 20"
+msgid "Content Loop Pattern 20"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-21.php:9
 #: src/block-patterns/homepage-posts-21.php:9
-msgid "Homepage Posts Pattern 21"
+msgid "Content Loop Pattern 21"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-22.php:9
 #: src/block-patterns/homepage-posts-22.php:9
-msgid "Homepage Posts Pattern 22"
+msgid "Content Loop Pattern 22"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-23.php:9
 #: src/block-patterns/homepage-posts-23.php:9
-msgid "Homepage Posts Pattern 23"
+msgid "Content Loop Pattern 23"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-24.php:9
 #: src/block-patterns/homepage-posts-24.php:9
-msgid "Homepage Posts Pattern 24"
+msgid "Content Loop Pattern 24"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-25.php:9
 #: src/block-patterns/homepage-posts-25.php:9
-msgid "Homepage Posts Pattern 25"
+msgid "Content Loop Pattern 25"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-26.php:9
 #: src/block-patterns/homepage-posts-26.php:9
-msgid "Homepage Posts Pattern 26"
+msgid "Content Loop Pattern 26"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-27.php:9
 #: src/block-patterns/homepage-posts-27.php:9
-msgid "Homepage Posts Pattern 27"
+msgid "Content Loop Pattern 27"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-28.php:9
 #: src/block-patterns/homepage-posts-28.php:9
-msgid "Homepage Posts Pattern 28"
+msgid "Content Loop Pattern 28"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-29.php:9
 #: src/block-patterns/homepage-posts-29.php:9
-msgid "Homepage Posts Pattern 29"
+msgid "Content Loop Pattern 29"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-30.php:9
 #: src/block-patterns/homepage-posts-30.php:9
-msgid "Homepage Posts Pattern 30"
+msgid "Content Loop Pattern 30"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-31.php:9
 #: src/block-patterns/homepage-posts-31.php:9
-msgid "Homepage Posts Pattern 31"
+msgid "Content Loop Pattern 31"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/subscribe-1.php:9

--- a/languages/newspack-blocks-pt_PT.po
+++ b/languages/newspack-blocks-pt_PT.po
@@ -335,157 +335,157 @@ msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-1.php:9
 #: src/block-patterns/homepage-posts-1.php:9
-msgid "Homepage Posts Pattern 1"
+msgid "Content Loop Pattern 1"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-2.php:9
 #: src/block-patterns/homepage-posts-2.php:9
-msgid "Homepage Posts Pattern 2"
+msgid "Content Loop Pattern 2"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-3.php:9
 #: src/block-patterns/homepage-posts-3.php:9
-msgid "Homepage Posts Pattern 3"
+msgid "Content Loop Pattern 3"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-4.php:9
 #: src/block-patterns/homepage-posts-4.php:9
-msgid "Homepage Posts Pattern 4"
+msgid "Content Loop Pattern 4"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-5.php:9
 #: src/block-patterns/homepage-posts-5.php:9
-msgid "Homepage Posts Pattern 5"
+msgid "Content Loop Pattern 5"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-6.php:9
 #: src/block-patterns/homepage-posts-6.php:9
-msgid "Homepage Posts Pattern 6"
+msgid "Content Loop Pattern 6"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-7.php:9
 #: src/block-patterns/homepage-posts-7.php:9
-msgid "Homepage Posts Pattern 7"
+msgid "Content Loop Pattern 7"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-8.php:9
 #: src/block-patterns/homepage-posts-8.php:9
-msgid "Homepage Posts Pattern 8"
+msgid "Content Loop Pattern 8"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-9.php:9
 #: src/block-patterns/homepage-posts-9.php:9
-msgid "Homepage Posts Pattern 9"
+msgid "Content Loop Pattern 9"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-10.php:9
 #: src/block-patterns/homepage-posts-10.php:9
-msgid "Homepage Posts Pattern 10"
+msgid "Content Loop Pattern 10"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-11.php:9
 #: src/block-patterns/homepage-posts-11.php:9
-msgid "Homepage Posts Pattern 11"
+msgid "Content Loop Pattern 11"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-12.php:9
 #: src/block-patterns/homepage-posts-12.php:9
-msgid "Homepage Posts Pattern 12"
+msgid "Content Loop Pattern 12"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-13.php:9
 #: src/block-patterns/homepage-posts-13.php:9
-msgid "Homepage Posts Pattern 13"
+msgid "Content Loop Pattern 13"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-14.php:9
 #: src/block-patterns/homepage-posts-14.php:9
-msgid "Homepage Posts Pattern 14"
+msgid "Content Loop Pattern 14"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-15.php:9
 #: src/block-patterns/homepage-posts-15.php:9
-msgid "Homepage Posts Pattern 15"
+msgid "Content Loop Pattern 15"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-16.php:9
 #: src/block-patterns/homepage-posts-16.php:9
-msgid "Homepage Posts Pattern 16"
+msgid "Content Loop Pattern 16"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-17.php:9
 #: src/block-patterns/homepage-posts-17.php:9
-msgid "Homepage Posts Pattern 17"
+msgid "Content Loop Pattern 17"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-18.php:9
 #: src/block-patterns/homepage-posts-18.php:9
-msgid "Homepage Posts Pattern 18"
+msgid "Content Loop Pattern 18"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-19.php:9
 #: src/block-patterns/homepage-posts-19.php:9
-msgid "Homepage Posts Pattern 19"
+msgid "Content Loop Pattern 19"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-20.php:9
 #: src/block-patterns/homepage-posts-20.php:9
-msgid "Homepage Posts Pattern 20"
+msgid "Content Loop Pattern 20"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-21.php:9
 #: src/block-patterns/homepage-posts-21.php:9
-msgid "Homepage Posts Pattern 21"
+msgid "Content Loop Pattern 21"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-22.php:9
 #: src/block-patterns/homepage-posts-22.php:9
-msgid "Homepage Posts Pattern 22"
+msgid "Content Loop Pattern 22"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-23.php:9
 #: src/block-patterns/homepage-posts-23.php:9
-msgid "Homepage Posts Pattern 23"
+msgid "Content Loop Pattern 23"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-24.php:9
 #: src/block-patterns/homepage-posts-24.php:9
-msgid "Homepage Posts Pattern 24"
+msgid "Content Loop Pattern 24"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-25.php:9
 #: src/block-patterns/homepage-posts-25.php:9
-msgid "Homepage Posts Pattern 25"
+msgid "Content Loop Pattern 25"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-26.php:9
 #: src/block-patterns/homepage-posts-26.php:9
-msgid "Homepage Posts Pattern 26"
+msgid "Content Loop Pattern 26"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-27.php:9
 #: src/block-patterns/homepage-posts-27.php:9
-msgid "Homepage Posts Pattern 27"
+msgid "Content Loop Pattern 27"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-28.php:9
 #: src/block-patterns/homepage-posts-28.php:9
-msgid "Homepage Posts Pattern 28"
+msgid "Content Loop Pattern 28"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-29.php:9
 #: src/block-patterns/homepage-posts-29.php:9
-msgid "Homepage Posts Pattern 29"
+msgid "Content Loop Pattern 29"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-30.php:9
 #: src/block-patterns/homepage-posts-30.php:9
-msgid "Homepage Posts Pattern 30"
+msgid "Content Loop Pattern 30"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-31.php:9
 #: src/block-patterns/homepage-posts-31.php:9
-msgid "Homepage Posts Pattern 31"
+msgid "Content Loop Pattern 31"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/subscribe-1.php:9

--- a/languages/newspack-blocks.pot
+++ b/languages/newspack-blocks.pot
@@ -333,157 +333,157 @@ msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-1.php:9
 #: src/block-patterns/homepage-posts-1.php:9
-msgid "Homepage Posts Pattern 1"
+msgid "Content Loop Pattern 1"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-2.php:9
 #: src/block-patterns/homepage-posts-2.php:9
-msgid "Homepage Posts Pattern 2"
+msgid "Content Loop Pattern 2"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-3.php:9
 #: src/block-patterns/homepage-posts-3.php:9
-msgid "Homepage Posts Pattern 3"
+msgid "Content Loop Pattern 3"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-4.php:9
 #: src/block-patterns/homepage-posts-4.php:9
-msgid "Homepage Posts Pattern 4"
+msgid "Content Loop Pattern 4"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-5.php:9
 #: src/block-patterns/homepage-posts-5.php:9
-msgid "Homepage Posts Pattern 5"
+msgid "Content Loop Pattern 5"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-6.php:9
 #: src/block-patterns/homepage-posts-6.php:9
-msgid "Homepage Posts Pattern 6"
+msgid "Content Loop Pattern 6"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-7.php:9
 #: src/block-patterns/homepage-posts-7.php:9
-msgid "Homepage Posts Pattern 7"
+msgid "Content Loop Pattern 7"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-8.php:9
 #: src/block-patterns/homepage-posts-8.php:9
-msgid "Homepage Posts Pattern 8"
+msgid "Content Loop Pattern 8"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-9.php:9
 #: src/block-patterns/homepage-posts-9.php:9
-msgid "Homepage Posts Pattern 9"
+msgid "Content Loop Pattern 9"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-10.php:9
 #: src/block-patterns/homepage-posts-10.php:9
-msgid "Homepage Posts Pattern 10"
+msgid "Content Loop Pattern 10"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-11.php:9
 #: src/block-patterns/homepage-posts-11.php:9
-msgid "Homepage Posts Pattern 11"
+msgid "Content Loop Pattern 11"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-12.php:9
 #: src/block-patterns/homepage-posts-12.php:9
-msgid "Homepage Posts Pattern 12"
+msgid "Content Loop Pattern 12"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-13.php:9
 #: src/block-patterns/homepage-posts-13.php:9
-msgid "Homepage Posts Pattern 13"
+msgid "Content Loop Pattern 13"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-14.php:9
 #: src/block-patterns/homepage-posts-14.php:9
-msgid "Homepage Posts Pattern 14"
+msgid "Content Loop Pattern 14"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-15.php:9
 #: src/block-patterns/homepage-posts-15.php:9
-msgid "Homepage Posts Pattern 15"
+msgid "Content Loop Pattern 15"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-16.php:9
 #: src/block-patterns/homepage-posts-16.php:9
-msgid "Homepage Posts Pattern 16"
+msgid "Content Loop Pattern 16"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-17.php:9
 #: src/block-patterns/homepage-posts-17.php:9
-msgid "Homepage Posts Pattern 17"
+msgid "Content Loop Pattern 17"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-18.php:9
 #: src/block-patterns/homepage-posts-18.php:9
-msgid "Homepage Posts Pattern 18"
+msgid "Content Loop Pattern 18"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-19.php:9
 #: src/block-patterns/homepage-posts-19.php:9
-msgid "Homepage Posts Pattern 19"
+msgid "Content Loop Pattern 19"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-20.php:9
 #: src/block-patterns/homepage-posts-20.php:9
-msgid "Homepage Posts Pattern 20"
+msgid "Content Loop Pattern 20"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-21.php:9
 #: src/block-patterns/homepage-posts-21.php:9
-msgid "Homepage Posts Pattern 21"
+msgid "Content Loop Pattern 21"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-22.php:9
 #: src/block-patterns/homepage-posts-22.php:9
-msgid "Homepage Posts Pattern 22"
+msgid "Content Loop Pattern 22"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-23.php:9
 #: src/block-patterns/homepage-posts-23.php:9
-msgid "Homepage Posts Pattern 23"
+msgid "Content Loop Pattern 23"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-24.php:9
 #: src/block-patterns/homepage-posts-24.php:9
-msgid "Homepage Posts Pattern 24"
+msgid "Content Loop Pattern 24"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-25.php:9
 #: src/block-patterns/homepage-posts-25.php:9
-msgid "Homepage Posts Pattern 25"
+msgid "Content Loop Pattern 25"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-26.php:9
 #: src/block-patterns/homepage-posts-26.php:9
-msgid "Homepage Posts Pattern 26"
+msgid "Content Loop Pattern 26"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-27.php:9
 #: src/block-patterns/homepage-posts-27.php:9
-msgid "Homepage Posts Pattern 27"
+msgid "Content Loop Pattern 27"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-28.php:9
 #: src/block-patterns/homepage-posts-28.php:9
-msgid "Homepage Posts Pattern 28"
+msgid "Content Loop Pattern 28"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-29.php:9
 #: src/block-patterns/homepage-posts-29.php:9
-msgid "Homepage Posts Pattern 29"
+msgid "Content Loop Pattern 29"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-30.php:9
 #: src/block-patterns/homepage-posts-30.php:9
-msgid "Homepage Posts Pattern 30"
+msgid "Content Loop Pattern 30"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/homepage-posts-31.php:9
 #: src/block-patterns/homepage-posts-31.php:9
-msgid "Homepage Posts Pattern 31"
+msgid "Content Loop Pattern 31"
 msgstr ""
 
 #: release/newspack-blocks/src/block-patterns/subscribe-1.php:9

--- a/src/block-patterns/homepage-posts-1.php
+++ b/src/block-patterns/homepage-posts-1.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 1.
+ * Content Loop Pattern 1.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 1', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 1', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column {\"width\":\"66.66%\"} -->\n<div class=\"wp-block-column\" style=\"flex-basis:66.66%\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"minHeight\":60,\"showAvatar\":false,\"postsToShow\":1,\"mediaPosition\":\"behind\",\"typeScale\":5} /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"minHeight\":30,\"showAvatar\":false,\"postsToShow\":1,\"mediaPosition\":\"behind\",\"typeScale\":3} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":\"33.33%\"} -->\n<div class=\"wp-block-column\" style=\"flex-basis:33.33%\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"minHeight\":60,\"showAvatar\":false,\"postsToShow\":1,\"mediaPosition\":\"behind\",\"typeScale\":3} /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"minHeight\":30,\"showAvatar\":false,\"postsToShow\":1,\"mediaPosition\":\"behind\",\"typeScale\":2} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-10.php
+++ b/src/block-patterns/homepage-posts-10.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 10.
+ * Content Loop Pattern 10.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 10', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 10', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"showImage\":false,\"showAuthor\":false,\"typeScale\":3} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"showImage\":false,\"showAuthor\":false,\"typeScale\":3} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"showImage\":false,\"showAuthor\":false,\"typeScale\":3} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"showImage\":false,\"showAuthor\":false,\"typeScale\":3} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-11.php
+++ b/src/block-patterns/homepage-posts-11.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 11.
+ * Content Loop Pattern 11.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 11', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 11', 'newspack-blocks' ),
 	'content'       => '<!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"showAvatar":false,"postLayout":"grid","typeScale":3} /-->',
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-12.php
+++ b/src/block-patterns/homepage-posts-12.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 12.
+ * Content Loop Pattern 12.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 12', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 12', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns {\"className\":\"is-style-borders\"} -->\n<div class=\"wp-block-columns is-style-borders\"><!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"showImage\":false,\"showAuthor\":false,\"postLayout\":\"grid\",\"columns\":2,\"postsToShow\":6,\"typeScale\":2} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"showImage\":false,\"showAuthor\":false,\"postLayout\":\"grid\",\"columns\":2,\"postsToShow\":6,\"typeScale\":2} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-13.php
+++ b/src/block-patterns/homepage-posts-13.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 13.
+ * Content Loop Pattern 13.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 13', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 13', 'newspack-blocks' ),
 	'content'       => '<!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"minHeight":40,"showAuthor":false,"postLayout":"grid","mediaPosition":"behind","typeScale":3} /-->',
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-14.php
+++ b/src/block-patterns/homepage-posts-14.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 14.
+ * Content Loop Pattern 14.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 14', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 14', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column {\"width\":66.66} -->\n<div class=\"wp-block-column\" style=\"flex-basis:66.66%\"><!-- wp:newspack-blocks/homepage-articles {\"postsToShow\":1} /-->\n\n<!-- wp:newspack-ads/ad-unit /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"postLayout\":\"grid\",\"columns\":2,\"postsToShow\":2} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":33.33} -->\n<div class=\"wp-block-column\" style=\"flex-basis:33.33%\">\n\n<!-- wp:newspack-ads/ad-unit /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"showExcerpt\":false,\"postsToShow\":1} /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"showExcerpt\":false,\"showImage\":false,\"showAvatar\":false,\"postsToShow\":5,\"typeScale\":3} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-15.php
+++ b/src/block-patterns/homepage-posts-15.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 15.
+ * Content Loop Pattern 15.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 15', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 15', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column {\"width\":66.66} -->\n<div class=\"wp-block-column\" style=\"flex-basis:66.66%\"><!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-default\",\"showExcerpt\":false,\"minHeight\":55,\"showAvatar\":false,\"postsToShow\":1,\"mediaPosition\":\"behind\",\"typeScale\":6} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":33.33} -->\n<div class=\"wp-block-column\" style=\"flex-basis:33.33%\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"showImage\":false,\"showAvatar\":false,\"typeScale\":5} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1280,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-16.php
+++ b/src/block-patterns/homepage-posts-16.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 16.
+ * Content Loop Pattern 16.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 16', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 16', 'newspack-blocks' ),
 	'content'       => "<!-- wp:group {\"backgroundColor\":\"dark-gray\",\"textColor\":\"white\",\"align\":\"full\"} -->\n<div class=\"wp-block-group alignfull has-dark-gray-background-color has-white-color has-text-color has-background\"><div class=\"wp-block-group__inner-container\"><!-- wp:spacer {\"height\":20} -->\n<div style=\"height:20px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer -->\n\n<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"showAuthor\":false,\"showAvatar\":false,\"mediaPosition\":\"left\",\"typeScale\":2,\"imageScale\":1,\"textColor\":\"white\"} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"showAuthor\":false,\"showAvatar\":false,\"mediaPosition\":\"left\",\"typeScale\":2,\"imageScale\":1,\"textColor\":\"white\"} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"showAuthor\":false,\"showAvatar\":false,\"mediaPosition\":\"left\",\"typeScale\":2,\"imageScale\":1,\"textColor\":\"white\"} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->\n\n<!-- wp:spacer {\"height\":20} -->\n<div style=\"height:20px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer --></div></div>\n<!-- /wp:group -->",
 	'viewportWidth' => 1280,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-17.php
+++ b/src/block-patterns/homepage-posts-17.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 17.
+ * Content Loop Pattern 17.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 17', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 17', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column {\"width\":66.66} -->\n<div class=\"wp-block-column\" style=\"flex-basis:66.66%\"><!-- wp:newspack-blocks/homepage-articles {\"excerptLength\":30,\"showAvatar\":false,\"postsToShow\":5,\"mediaPosition\":\"left\",\"typeScale\":3,\"imageScale\":1} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":33.33} -->\n<div class=\"wp-block-column\" style=\"flex-basis:33.33%\"><!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-default\",\"showExcerpt\":false,\"showAvatar\":false,\"postsToShow\":1,\"categories\":[],\"typeScale\":3,\"imageScale\":1,\"mobileStack\":true} /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"showImage\":false,\"showAvatar\":false,\"postsToShow\":5,\"typeScale\":3} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-18.php
+++ b/src/block-patterns/homepage-posts-18.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 18.
+ * Content Loop Pattern 18.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 18', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 18', 'newspack-blocks' ),
 	'content'       => "<!-- wp:group {\"backgroundColor\":\"light-gray\",\"align\":\"full\"} -->\n<div class=\"wp-block-group alignfull has-light-gray-background-color has-background\"><div class=\"wp-block-group__inner-container\"><!-- wp:spacer {\"height\":20} -->\n<div style=\"height:20px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer -->\n\n<!-- wp:columns {\"verticalAlignment\":\"center\"} -->\n<div class=\"wp-block-columns are-vertically-aligned-center\"><!-- wp:column {\"verticalAlignment\":\"center\"} -->\n<div class=\"wp-block-column is-vertically-aligned-center\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"showAuthor\":false,\"mediaPosition\":\"right\",\"imageScale\":1} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"verticalAlignment\":\"center\"} -->\n<div class=\"wp-block-column is-vertically-aligned-center\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"minHeight\":60,\"showAuthor\":false,\"showAvatar\":false,\"postsToShow\":1,\"mediaPosition\":\"behind\",\"typeScale\":6} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->\n\n<!-- wp:spacer {\"height\":20} -->\n<div style=\"height:20px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer --></div></div>\n<!-- /wp:group -->",
 	'viewportWidth' => 1280,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-19.php
+++ b/src/block-patterns/homepage-posts-19.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 19.
+ * Content Loop Pattern 19.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 19', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 19', 'newspack-blocks' ),
 	'content'       => '<!-- wp:newspack-blocks/homepage-articles {"className":"is-style-default","showExcerpt":false,"imageShape":"portrait","minHeight":50,"showAuthor":false,"postLayout":"grid","columns":4,"postsToShow":4,"mediaPosition":"behind"} /-->',
 	'viewportWidth' => 1280,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-2.php
+++ b/src/block-patterns/homepage-posts-2.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 2.
+ * Content Loop Pattern 2.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 2', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 2', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns {\"className\":\"is-style-first-col-to-second\"} -->\n<div class=\"wp-block-columns is-style-first-col-to-second\"><!-- wp:column {\"width\":50} -->\n<div class=\"wp-block-column\" style=\"flex-basis:50%\"><!-- wp:newspack-blocks/homepage-articles {\"postsToShow\":1,\"typeScale\":6} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"minHeight\":25,\"showAvatar\":false,\"postsToShow\":1,\"mediaPosition\":\"behind\",\"typeScale\":2} /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"showExcerpt\":false,\"showImage\":false,\"showAvatar\":false,\"postsToShow\":5,\"typeScale\":2,\"imageScale\":1} /-->\n\n<!-- wp:newspack-ads/ad-unit /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\">\n\n<!-- wp:newspack-ads/ad-unit /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"minHeight\":25,\"showAvatar\":false,\"postsToShow\":1,\"mediaPosition\":\"behind\",\"typeScale\":2} /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"showExcerpt\":false,\"showImage\":false,\"showAvatar\":false,\"postsToShow\":5,\"mediaPosition\":\"left\",\"typeScale\":2,\"imageScale\":1} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-20.php
+++ b/src/block-patterns/homepage-posts-20.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 20.
+ * Content Loop Pattern 20.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 20', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 20', 'newspack-blocks' ),
 	'content'       => "<!-- wp:group {\"backgroundColor\":\"primary\",\"textColor\":\"white\",\"align\":\"full\"} -->\n<div class=\"wp-block-group alignfull has-primary-background-color has-white-color has-text-color has-background\"><div class=\"wp-block-group__inner-container\"><!-- wp:spacer {\"height\":20} -->\n<div style=\"height:20px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer -->\n\n<!-- wp:columns {\"className\":\"is-style-default\"} -->\n<div class=\"wp-block-columns is-style-default\"><!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-default\",\"showExcerpt\":false,\"showImage\":false,\"showAuthor\":false,\"showAvatar\":false,\"columns\":4,\"textColor\":\"white\"} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-default\",\"showExcerpt\":false,\"showImage\":false,\"showAuthor\":false,\"showAvatar\":false,\"columns\":4,\"textColor\":\"white\"} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->\n\n<!-- wp:spacer {\"height\":20} -->\n<div style=\"height:20px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer --></div></div>\n<!-- /wp:group -->",
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-21.php
+++ b/src/block-patterns/homepage-posts-21.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 21.
+ * Content Loop Pattern 21.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 21', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 21', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column {\"width\":50} -->\n<div class=\"wp-block-column\" style=\"flex-basis:50%\"><!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"excerptLength\":50,\"showAvatar\":false,\"postsToShow\":1,\"typeScale\":5} /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"excerptLength\":15,\"showAvatar\":false,\"mediaPosition\":\"left\",\"typeScale\":2,\"imageScale\":1} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\"><!-- wp:newspack-blocks/homepage-articles {\"excerptLength\":20,\"showAvatar\":false,\"typeScale\":2} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\"><!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"excerptLength\":15,\"showImage\":false,\"showAvatar\":false,\"postsToShow\":6,\"typeScale\":2} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-22.php
+++ b/src/block-patterns/homepage-posts-22.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 22.
+ * Content Loop Pattern 22.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 22', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 22', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns {\"className\":\"is-style-default\"} -->\n<div class=\"wp-block-columns is-style-default\"><!-- wp:column {\"width\":67} -->\n<div class=\"wp-block-column\" style=\"flex-basis:67%\"><!-- wp:newspack-blocks/homepage-articles {\"showAvatar\":false,\"postsToShow\":1,\"typeScale\":5} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":33} -->\n<div class=\"wp-block-column\" style=\"flex-basis:33%\"><!-- wp:newspack-blocks/homepage-articles {\"excerptLength\":10,\"showAvatar\":false,\"postsToShow\":5,\"mediaPosition\":\"left\",\"typeScale\":2,\"imageScale\":1} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-23.php
+++ b/src/block-patterns/homepage-posts-23.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 23.
+ * Content Loop Pattern 23.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 23', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 23', 'newspack-blocks' ),
 	'content'       => '<!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"minHeight":40,"showAvatar":false,"postLayout":"grid","columns":2,"postsToShow":4,"mediaPosition":"behind"} /-->',
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-24.php
+++ b/src/block-patterns/homepage-posts-24.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 24.
+ * Content Loop Pattern 24.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 24', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 24', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column {\"width\":50} -->\n<div class=\"wp-block-column\" style=\"flex-basis:50%\"><!-- wp:newspack-blocks/homepage-articles {\"excerptLength\":50,\"showAvatar\":false,\"postsToShow\":1,\"typeScale\":5} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"excerptLength\":20,\"showAvatar\":false,\"postsToShow\":2,\"typeScale\":3} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\"><!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-default\",\"showExcerpt\":false,\"excerptLength\":15,\"showAvatar\":false,\"postsToShow\":2,\"typeScale\":3} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-25.php
+++ b/src/block-patterns/homepage-posts-25.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 25.
+ * Content Loop Pattern 25.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 25', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 25', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column {\"width\":66.66} -->\n<div class=\"wp-block-column\" style=\"flex-basis:66.66%\"><!-- wp:newspack-blocks/homepage-articles {\"postsToShow\":1,\"typeScale\":6} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":33.33} -->\n<div class=\"wp-block-column\" style=\"flex-basis:33.33%\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"showAuthor\":false,\"postsToShow\":5,\"mediaPosition\":\"right\",\"typeScale\":3,\"imageScale\":2} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-26.php
+++ b/src/block-patterns/homepage-posts-26.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 26.
+ * Content Loop Pattern 26.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 26', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 26', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns {\"className\":\"is-style-first-col-to-second\"} -->\n<div class=\"wp-block-columns is-style-first-col-to-second\"><!-- wp:column {\"width\":50} -->\n<div class=\"wp-block-column\" style=\"flex-basis:50%\"><!-- wp:newspack-blocks/homepage-articles {\"showAuthor\":false,\"postsToShow\":1,\"typeScale\":6} /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"excerptLength\":25,\"showAuthor\":false,\"mediaPosition\":\"left\",\"typeScale\":2,\"imageScale\":2} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\"><!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-default\",\"showExcerpt\":false,\"showAuthor\":false,\"showAvatar\":false,\"postsToShow\":4,\"typeScale\":3,\"imageScale\":1} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\"><!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"excerptLength\":12,\"showImage\":false,\"showAuthor\":false,\"showAvatar\":false,\"postsToShow\":2,\"mediaPosition\":\"left\",\"typeScale\":2,\"imageScale\":1} /-->\n\n<!-- wp:newspack-ads/ad-unit /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"excerptLength\":12,\"showImage\":false,\"showAuthor\":false,\"showAvatar\":false,\"postsToShow\":3,\"mediaPosition\":\"left\",\"typeScale\":2,\"imageScale\":1} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-27.php
+++ b/src/block-patterns/homepage-posts-27.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 27.
+ * Content Loop Pattern 27.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 27', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 27', 'newspack-blocks' ),
 	'content'       => '<!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"showAuthor":false,"postLayout":"grid","columns":4,"postsToShow":4,"typeScale":2} /-->',
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-28.php
+++ b/src/block-patterns/homepage-posts-28.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 28.
+ * Content Loop Pattern 28.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 28', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 28', 'newspack-blocks' ),
 	'content'       => '<!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"showAuthor":false,"postLayout":"grid","columns":5,"postsToShow":5,"typeScale":2} /-->',
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-29.php
+++ b/src/block-patterns/homepage-posts-29.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 29.
+ * Content Loop Pattern 29.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 29', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 29', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column {\"width\":50} -->\n<div class=\"wp-block-column\" style=\"flex-basis:50%\"><!-- wp:newspack-blocks/homepage-articles {\"excerptLength\":25,\"showAuthor\":false,\"showAvatar\":false,\"mediaPosition\":\"left\",\"typeScale\":2,\"imageScale\":2} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\"><!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"showExcerpt\":false,\"showImage\":false,\"showAuthor\":false,\"showAvatar\":false,\"postsToShow\":5,\"typeScale\":2} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\"><!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"showExcerpt\":false,\"showImage\":false,\"showAuthor\":false,\"showAvatar\":false,\"postsToShow\":5,\"typeScale\":2} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-3.php
+++ b/src/block-patterns/homepage-posts-3.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 3.
+ * Content Loop Pattern 3.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 3', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 3', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns {\"className\":\"is-style-borders\"} -->\n<div class=\"wp-block-columns is-style-borders\"><!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:newspack-blocks/homepage-articles {\"showImage\":false,\"showAvatar\":false,\"postsToShow\":2,\"typeScale\":3} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:newspack-blocks/homepage-articles {\"showImage\":false,\"showAvatar\":false,\"postsToShow\":2,\"typeScale\":3} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:newspack-blocks/homepage-articles {\"showImage\":false,\"showAvatar\":false,\"postsToShow\":2,\"typeScale\":3} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-30.php
+++ b/src/block-patterns/homepage-posts-30.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 30.
+ * Content Loop Pattern 30.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 30', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 30', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column {\"width\":75} -->\n<div class=\"wp-block-column\" style=\"flex-basis:75%\"><!-- wp:newspack-blocks/homepage-articles {\"excerptLength\":20,\"postsToShow\":1,\"mediaPosition\":\"right\",\"typeScale\":5} /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"excerptLength\":10,\"showAvatar\":false,\"postLayout\":\"grid\",\"typeScale\":3} /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-default\",\"showExcerpt\":false,\"showImage\":false,\"showAvatar\":false,\"postLayout\":\"grid\",\"postsToShow\":6,\"typeScale\":3} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\"><!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-default\",\"showExcerpt\":false,\"showImage\":false,\"showAuthor\":false,\"showAvatar\":false,\"postsToShow\":10,\"typeScale\":2} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-31.php
+++ b/src/block-patterns/homepage-posts-31.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 31.
+ * Content Loop Pattern 31.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 31', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 31', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column {\"width\":\"66.66%\"} -->\n<div class=\"wp-block-column\" style=\"flex-basis:66.66%\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"mediaPosition\":\"left\",\"imageScale\":1,\"mobileStack\":true} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":\"33.33%\"} -->\n<div class=\"wp-block-column\" style=\"flex-basis:33.33%\"><!-- wp:newspack-ads/ad-unit /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-4.php
+++ b/src/block-patterns/homepage-posts-4.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 4.
+ * Content Loop Pattern 4.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 4', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 4', 'newspack-blocks' ),
 	'content'       => '<!-- wp:newspack-blocks/homepage-articles {"excerptLength":20,"minHeight":60,"showAvatar":false,"postLayout":"grid","columns":2,"postsToShow":2,"mediaPosition":"behind"} /-->',
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-5.php
+++ b/src/block-patterns/homepage-posts-5.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 5.
+ * Content Loop Pattern 5.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 5', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 5', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns {\"className\":\"is-style-default\"} -->\n<div class=\"wp-block-columns is-style-default\"><!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"showExcerpt\":false,\"showAvatar\":false,\"postsToShow\":1,\"categories\":[],\"typeScale\":3,\"imageScale\":1} /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"showExcerpt\":false,\"showImage\":false,\"showAuthor\":false,\"showAvatar\":false,\"mediaPosition\":\"left\",\"categories\":[],\"typeScale\":2,\"imageScale\":1} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"showExcerpt\":false,\"showAvatar\":false,\"postsToShow\":1,\"categories\":[],\"typeScale\":3,\"imageScale\":1} /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"showExcerpt\":false,\"showImage\":false,\"showAuthor\":false,\"showAvatar\":false,\"mediaPosition\":\"left\",\"categories\":[],\"typeScale\":2,\"imageScale\":1} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"showExcerpt\":false,\"showAvatar\":false,\"postsToShow\":1,\"categories\":[],\"typeScale\":3,\"imageScale\":1,\"mobileStack\":true} /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"showExcerpt\":false,\"showImage\":false,\"showAuthor\":false,\"showAvatar\":false,\"mediaPosition\":\"left\",\"categories\":[],\"typeScale\":2,\"imageScale\":1} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-6.php
+++ b/src/block-patterns/homepage-posts-6.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 6.
+ * Content Loop Pattern 6.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 6', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 6', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns {\"className\":\"is-style-default\"} -->\n<div class=\"wp-block-columns is-style-default\"><!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\"><!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"showExcerpt\":false,\"showAvatar\":false,\"postsToShow\":1,\"categories\":[],\"typeScale\":3,\"imageScale\":1} /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"showExcerpt\":false,\"showImage\":false,\"showAuthor\":false,\"showAvatar\":false,\"mediaPosition\":\"left\",\"categories\":[],\"typeScale\":2,\"imageScale\":1} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\"><!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"showExcerpt\":false,\"showAvatar\":false,\"postsToShow\":1,\"categories\":[],\"typeScale\":3,\"imageScale\":1} /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"showExcerpt\":false,\"showImage\":false,\"showAuthor\":false,\"showAvatar\":false,\"mediaPosition\":\"left\",\"categories\":[],\"typeScale\":2,\"imageScale\":1} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\"><!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"showExcerpt\":false,\"showAvatar\":false,\"postsToShow\":1,\"categories\":[],\"typeScale\":3,\"imageScale\":1,\"mobileStack\":true} /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"showExcerpt\":false,\"showImage\":false,\"showAuthor\":false,\"showAvatar\":false,\"mediaPosition\":\"left\",\"categories\":[],\"typeScale\":2,\"imageScale\":1} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\"><!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"showExcerpt\":false,\"showAvatar\":false,\"postsToShow\":1,\"categories\":[],\"typeScale\":3,\"imageScale\":1,\"mobileStack\":true} /-->\n\n<!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"showExcerpt\":false,\"showImage\":false,\"showAuthor\":false,\"showAvatar\":false,\"mediaPosition\":\"left\",\"categories\":[],\"typeScale\":2,\"imageScale\":1} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-7.php
+++ b/src/block-patterns/homepage-posts-7.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 7.
+ * Content Loop Pattern 7.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 7', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 7', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns {\"className\":\"is-style-borders\"} -->\n<div class=\"wp-block-columns is-style-borders\"><!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:newspack-blocks/homepage-articles {\"excerptLength\":26,\"imageShape\":\"square\",\"showAvatar\":false,\"postsToShow\":1,\"typeScale\":6} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:newspack-ads/ad-unit /--><!-- wp:newspack-blocks/homepage-articles {\"className\":\"is-style-borders\",\"excerptLength\":28,\"showImage\":false,\"showAuthor\":false,\"showAvatar\":false,\"postsToShow\":5,\"mediaPosition\":\"left\",\"typeScale\":3,\"imageScale\":1} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1000,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-8.php
+++ b/src/block-patterns/homepage-posts-8.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 8.
+ * Content Loop Pattern 8.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 8', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 8', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column {\"width\":50} -->\n<div class=\"wp-block-column\" style=\"flex-basis:50%\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"showAvatar\":false,\"postsToShow\":4,\"mediaPosition\":\"left\",\"imageScale\":1} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"showImage\":false,\"showAvatar\":false,\"postsToShow\":6,\"typeScale\":2} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":25} -->\n<div class=\"wp-block-column\" style=\"flex-basis:25%\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"showImage\":false,\"showAvatar\":false,\"postsToShow\":6,\"typeScale\":2} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1280,
 	'categories'    => array( 'newspack-homepage-posts' ),

--- a/src/block-patterns/homepage-posts-9.php
+++ b/src/block-patterns/homepage-posts-9.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Homepage Posts Pattern 9.
+ * Content Loop Pattern 9.
  *
  * @package Newspack_Blocks
  */
 
 return array(
-	'title'         => __( 'Homepage Posts Pattern 9', 'newspack-blocks' ),
+	'title'         => __( 'Content Loop Pattern 9', 'newspack-blocks' ),
 	'content'       => "<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column {\"width\":\"75%\"} -->\n<div class=\"wp-block-column\" style=\"flex-basis:75%\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"showAvatar\":false,\"postLayout\":\"grid\",\"typeScale\":3} /--></div>\n<!-- /wp:column -->\n\n<!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:newspack-blocks/homepage-articles {\"showExcerpt\":false,\"showImage\":false,\"showAvatar\":false,\"postsToShow\":4,\"typeScale\":2} /--></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->",
 	'viewportWidth' => 1280,
 	'categories'    => array( 'newspack-homepage-posts' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since #2000 we have renamed the block to "Content Loop". This PR makes sure the patterns are named correctly

_Note: once merged we will need to update https://help.newspack.com/publishing-and-appearance/blocks/block-patterns/_

### How to test the changes in this Pull Request:

1. Add a pattern to a page
2. Check if it's called correctly: "Newspack Content Loop" and "Content Loop Pattern x"

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
