### PR TITLE
fix(modal-checkout): better iframe sizing

### DIFF
--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -539,13 +539,16 @@ domReady( () => {
 		if ( ! entries || ! entries.length ) {
 			return;
 		}
-		iframe.scrollIntoView( { behavior: 'smooth', block: 'start' } );
 		if ( ! iframe.contentDocument ) {
 			return;
 		}
 		const contentRect = entries[ 0 ].contentRect;
 		if ( contentRect ) {
-			const iframeHeight = contentRect.top + contentRect.bottom;
+			const vh = 0.01 * Math.max( document.documentElement.clientHeight, window.innerHeight || 0 );
+			const headerHeight = modalCheckout.querySelector( `.${ MODAL_CLASS_PREFIX }__header` )?.offsetHeight || 0;
+			const maxHeight = 90 * vh - headerHeight;
+			const contentHeight = contentRect.top + contentRect.bottom;
+			const iframeHeight = Math.min( contentHeight, maxHeight );
 			if ( iframeHeight === 0 ) {
 				// If height is 0, hide iframe content instead of resizing to avoid layout shift.
 				iframe.style.visibility = 'hidden';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Improves the sizing of the modal checkout iframe and its content wrapper element to allow fixed-position elements and `scrollTo` methods to work inside the iframe content.

The max-height of a Newspack UI modal element is [90% of its fixed full-viewport parent element](https://github.com/Automattic/newspack-plugin/blob/fix/modal-iframe-sizing/src/newspack-ui/scss/_modals.scss#L51), effectively 90vh or 90% of the total viewport height. The height of the iframe should not exceed this height, minus the height of the modal's header element, if present, to allow for proper content scrolling and positioning behavior inside the iframe's content window.

See also: https://github.com/Automattic/newspack-plugin/pull/3741

### How to test the changes in this Pull Request:

1. On `trunk`, connect reCAPTCHA v2 and set up a shippable product that can be purchased via Checkout Button.
2. As a reader, start a modal checkout transaction for the shippable product.
3. Observe the following behavior:

  - When checking or unchecking the "Ship to a different address?" checkbox, the modal will scroll near (but not all the way to) the top of the iframe content window
  - When rendering the reCAPTCHA v2 widget upon clicking "Complete transaction", the widget appears at the top of the page, and the modal will scroll near (but not all the way to) the top of the iframe content window, to bring it into view

4. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/3741.
5. Refresh your site and start a new modal checkout transaction again. This time confirm the following behavior:

  - When checking or unchecking the "Ship to a different address?" checkbox, the modal will NOT scroll away from the checkbox
  - When transitioning between screens of the modal checkout form, the modal checkout WILL scroll all the way to the top of the iframe content window
  - When rendering the reCAPTCHA v2 widget upon clicking "Complete transaction", the widget appears directly over the button, and the modal will NOT scroll away from the "Complete transaction" button
  - After completing the transaction, the modal will still properly resize to contain the success message

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
