### PR TITLE
feat(wcsg): respect checkbox label option in WCSG settings

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1976,7 +1976,12 @@ final class Modal_Checkout {
 				),
 				'after_success'              => __( 'Continue browsing', 'newspack-blocks' ),
 				'donation_gift_details'      => __( 'This donation is a gift', 'newspack-blocks' ),
-				'purchase_gift_details'      => __( 'This purchase is a gift', 'newspack-blocks' ),
+				'purchase_gift_details'      => get_option(
+					'woocommerce_subscriptions_gifting_gifting_checkbox_text',
+					method_exists( 'Newspack\WooCommerce_Subscriptions_Gifting', 'default_gifting_checkbox_text' ) ?
+						\Newspack\WooCommerce_Subscriptions_Gifting::default_gifting_checkbox_text() :
+						__( 'This purchase is a gift', 'newspack-blocks' )
+				),
 				'checkout_confirm'           => __( 'Complete transaction', 'newspack-blocks' ),
 				'checkout_confirm_variation' => __( 'Purchase', 'newspack-blocks' ),
 				'checkout_back'              => __( 'Back', 'newspack-blocks' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

There's an option in the WooCommerce Subscriptions Gifting (WCSG) extension that lets admins set the label of the gifting checkbox. This PR allows non-donation modal checkouts to show this label instead of a hardcoded label. The label is still hardcoded for donation checkouts, as the WCSG extension doesn't provide a filter for adding new custom options.

### How to test the changes in this Pull Request:

Follow testing instructions in https://github.com/Automattic/newspack-plugin/pull/3747

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
