### PR TITLE
fix(carousel): avoid editor crash on empty

### DIFF
--- a/src/blocks/carousel/create-swiper.js
+++ b/src/blocks/carousel/create-swiper.js
@@ -135,6 +135,9 @@ export default function createSwiper( els, config = {} ) {
 			},
 
 			slideChange() {
+				if ( this.slides.length < 1 ) {
+					return; // No slides, no need to do anything.
+				}
 				const currentSlide = this.slides[ this.activeIndex ];
 
 				deactivateSlide( this.slides[ this.previousIndex ] );

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -113,7 +113,7 @@ class Edit extends Component {
 	initializeSwiper( initialSlide ) {
 		const { latestPosts } = this.props;
 
-		if ( latestPosts && latestPosts.length ) {
+		if ( latestPosts ) {
 			const { aspectRatio, autoplay, delay, slidesPerView } = this.props.attributes;
 			const swiperInstance = createSwiper(
 				{

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -34,7 +34,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 
 	$article_query = new WP_Query( Newspack_Blocks::build_articles_query( $attributes, apply_filters( 'newspack_blocks_block_name', 'newspack-blocks/carousel' ) ) );
 	if ( false === $article_query->have_posts() ) {
-		return;
+		return '';
 	}
 
 	$counter = 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:
This fixes a bug where the Content Carousel block would "crash" in the editor and just show a spinner and not be responsive to changes made from the sidebar.

### How to test the changes in this Pull Request:

Before applying the patch, trigger the bug:

1. Create a Content Carousel on a post in the editor
2. In the "Content" panel, set a post category or tag - I just used "Science"
3. In the "Post Types" panel, select a different post type in addition to "Posts" that can't have any post categories or tags – I just used "Page"
4. Deselect "Posts" and observe editor crash and JS console error

Now apply the patch:
* Check that toggling between having post and page selected under post type will not crash the block 
* Check that the "Sorry, no posts were found." text is displayed when only page is selected.
* Check that there are no console errors
* Check that the block behaves as expected (shows the content you asked it to).



### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209344644455228