### PR TITLE
fix: remove OneSignal v2 from modal checkout

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -211,7 +211,7 @@ final class Modal_Checkout {
 		add_filter( 'woocommerce_get_privacy_policy_text', [ __CLASS__, 'woocommerce_get_privacy_policy_text' ], 10, 2 );
 
 		// Remove any hooks that aren't supported by the modal checkout.
-		add_action( 'plugins_loaded', [ __CLASS__, 'remove_hooks' ] );
+		add_action( 'wp_loaded', [ __CLASS__, 'remove_hooks' ] );
 	}
 
 	/**
@@ -953,13 +953,19 @@ final class Modal_Checkout {
 			);
 		}
 		// OneSignal.
-		array_push(
-			$remove_list,
-			[
-				'hook'     => 'wp_head',
-				'callback' => 'onesignal_init',
-			]
-		);
+		if ( class_exists( 'OneSignal_Public' ) ) {
+			array_push(
+				$remove_list,
+				[
+					'hook'     => 'wp_head',
+					'callback' => 'onesignal_init', // V3.
+				],
+				[
+					'hook'     => 'wp_head',
+					'callback' => array( 'OneSignal_Public', 'onesignal_header' ), // V2.
+				]
+			);
+		}
 
 		/**
 		 * Filters the hooks to remove from the modal checkout.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR expands on the change made [here](https://github.com/Automattic/newspack-blocks/pull/2029) to remove OneSignal from the modal checkout, to make sure both v2 and v3 of the plugin code is removed. 

See 1200550061930446-as-1209206364302813

### How to test the changes in this Pull Request:

1. To recreate the testing setup for this bug, start with a site that hasn't run OneSignal before. You can also ping me for a JN site with this setup.
2. Download and install v 2.4.4 of OneSignal from [here](https://wordpress.org/plugins/onesignal-free-web-push-notifications/advanced/).
3. Sign up for [a free account](https://onesignal.com/).
4. Connected the account to your site (you have to fill out some forms and the site's URL, then copy the OneSignal App ID and OneSignal REST API Key to the WP Admin > One Signal Push page on your website).
5. Enable the Subscription bell from the WP Admin > One Signal Push page: 

![CleanShot 2025-02-24 at 14 05 46](https://github.com/user-attachments/assets/e6ad2a7c-37c6-4957-8a82-ab1eb0b0e8c4)

6. Save the settings
7. View the site on the front-end and confirm that the bell is appearing. 
8. Upgrade the plugin from 2.4.4 to the latest version. I ran into issues with this for some reason, but it worked if I downloaded some of the versions in between from [here](https://wordpress.org/plugins/onesignal-free-web-push-notifications/advanced/) and uploaded them (though 3.0.0 threw a fatal).
8. Run through a modal checkout flow and confirm the bell appears in the modal.
9. Apply this PR.
10. Repeat step 8 and confirm that the bell no longer appears in the modal checkout.
11. Test on a second site with the latest version of OneSignal from the get-go, so it's loading the v3 version of the code.
12. Smoke test: retest reCAPTCHA for WooCommerce by following the steps [here](https://github.com/Automattic/newspack-blocks/pull/1984) to make sure it's also still stripped out of the modal checkout, even though the hook changed. You can find a copy of that plugin attached to the Asana task.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
