### PR TITLE
fix: restore non-API version of the editor styles

### DIFF
--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -387,20 +387,6 @@ class Newspack_Blocks_API {
 		$where .= ' AND post_title LIKE "%' . $search . '%" ';
 		return $where;
 	}
-
-	/**
-	 * Return CSS for the Homepage Articles block, when rendered in the editor.
-	 *
-	 * @return WP_REST_Response.
-	 */
-	public static function css_endpoint() {
-		return newspack_blocks_get_homepage_articles_css_string(
-			[
-				'typeScale'    => range( 1, 10 ),
-				'showSubtitle' => [ 1 ],
-			]
-		);
-	}
 }
 
 add_action( 'rest_api_init', array( 'Newspack_Blocks_API', 'register_video_playlist_endpoint' ) );

--- a/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -107,19 +107,6 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 				},
 			]
 		);
-
-		// Endpoint to get styles in the editor.
-		register_rest_route(
-			$this->namespace,
-			'/homepage-articles-css',
-			[
-				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => [ 'Newspack_Blocks_API', 'css_endpoint' ],
-				'permission_callback' => function() {
-					return current_user_can( 'edit_posts' );
-				},
-			]
-		);
 	}
 
 	/**

--- a/src/blocks/homepage-articles/editor.js
+++ b/src/blocks/homepage-articles/editor.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -15,13 +14,3 @@ const BLOCK_NAME = `newspack-blocks/${ name }`;
 
 registerBlockType( BLOCK_NAME, settings );
 registerQueryStore( [ BLOCK_NAME, `newspack-blocks/${ carouselBlockName }` ] );
-
-// Fetch CSS and insert it in a style tag.
-apiFetch( {
-	path: '/newspack-blocks/v1/homepage-articles-css',
-} ).then( css => {
-	const style = document.createElement( 'style' );
-	style.innerHTML = css;
-	style.id = 'newspack-blocks-homepage-articles-styles';
-	document.head.appendChild( style );
-} );

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -26,6 +26,7 @@
 	/* Article meta */
 	.entry-meta {
 		display: flex;
+		font-size: 0.8em;
 		flex-wrap: wrap;
 		align-items: center;
 		margin-top: 0.5em;
@@ -50,19 +51,14 @@
 
 	/* Typescale */
 	// Default typescale:
-	article {
-		.entry-title {
-			font-size: 1.2em;
-			margin: 0 0 0.25em;
-		}
-		.entry-meta {
-			font-size: 0.8em;
-		}
+	.entry-title {
+		font-size: 1.2em;
+		margin: 0 0 0.25em;
+	}
 
-		.avatar {
-			height: 25px;
-			width: 25px;
-		}
+	.avatar {
+		height: 25px;
+		width: 25px;
 	}
 
 	@include mixins.media( tablet ) {
@@ -119,24 +115,22 @@
 			".newspack-post-subtitle": "0.8em",
 			".entry-wrapper p": "0.8em",
 			".entry-wrapper .more-link": "0.8em",
-			".entry-meta" : "0.8em",
 		),
 		"ts-2" (
 			".entry-title": "0.9em",
-			".newspack-post-subtitle": "0.8em",
-			".entry-wrapper p": "0.8em",
-			".entry-wrapper .more-link": "0.8em",
-			".entry-meta" : "0.8em",
+			"article .newspack-post-subtitle": "0.8em",
+			"article .entry-wrapper p": "0.8em",
+			"article .entry-wrapper .more-link": "0.8em",
 		),
 		"ts-1" (
 			".entry-title": "0.9em",
-			".newspack-post-subtitle": "0.8em",
-			".entry-wrapper p": "0.8em",
-			".entry-wrapper .more-link": "0.8em",
-			".entry-meta" : "0.8em",
+			"article .newspack-post-subtitle": "0.8em",
+			"article .entry-wrapper p": "0.8em",
+			"article .entry-wrapper .more-link": "0.8em",
 		),
 	);
 
+	// Loop through all our $typescales and generate font size CSS:
 	@each $type, $selectors in $typescales {
 		@each $selector, $values in $selectors {
 			@each $value in $values {

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -4,21 +4,33 @@
 @use "../../shared/sass/mixins";
 
 .wpnbha {
-	article .entry-title {
-		margin: 0 0 0.25em;
-	}
-
-	@include mixins.media( tablet ) {
-		&.ts-4 article .entry-title {
-			font-size: 1.6em;
-		}
-	}
-
 	.editor-rich-text {
 		width: 100%;
 	}
 
+	/* Image styles */
+	.post-thumbnail {
+		margin: 0;
+		margin-bottom: 0.25em;
+
+		img {
+			height: auto;
+			width: 100%;
+		}
+
+		figcaption {
+			margin-bottom: 0.5em;
+		}
+	}
+
 	/* Article meta */
+	.entry-meta {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		margin-top: 0.5em;
+	}
+
 	.cat-links {
 		font-size: variables.$font__size-xs;
 	}
@@ -36,7 +48,106 @@
 		margin: 0.5em 0;
 	}
 
+	/* Typescale */
+	// Default typescale:
+	article {
+		.entry-title {
+			font-size: 1.2em;
+			margin: 0 0 0.25em;
+		}
+		.entry-meta {
+			font-size: 0.8em;
+		}
 
+		.avatar {
+			height: 25px;
+			width: 25px;
+		}
+	}
+
+	@include mixins.media( tablet ) {
+		&.ts-4 article .entry-title {
+			font-size: 1.6em;
+		}
+	}
+
+	.newspack-post-subtitle {
+		&--in-homepage-block {
+			margin-top: 0.3em;
+			margin-bottom: 0;
+			line-height: 1.4;
+			font-style: italic;
+		}
+	}
+
+	// Different typescales:
+	&.ts-10,
+	&.ts-9,
+	&.ts-8 {
+		.entry-title {
+			line-height: 1.1;
+		}
+	}
+
+	$typescales: (
+		"ts-10" (
+			".entry-title": "2.6em",
+			".newspack-post-subtitle": "1.4em",
+		),
+		"ts-9" (
+			".entry-title": "2.4em",
+			".newspack-post-subtitle": "1.4em",
+		),
+		"ts-8" (
+			".entry-title": "2.2em",
+			".newspack-post-subtitle": "1.4em",
+		),
+		"ts-7" (
+			".entry-title": "2em",
+			".newspack-post-subtitle": "1.4em",
+		),
+		"ts-6" (
+			".entry-title": "1.7em",
+			".newspack-post-subtitle": "1.4em",
+		),
+		"ts-5" (
+			".entry-title": "1.4em",
+			".newspack-post-subtitle": "1.2em",
+		),
+		"ts-3" (
+			".entry-title": "1em",
+			".newspack-post-subtitle": "0.8em",
+			".entry-wrapper p": "0.8em",
+			".entry-wrapper .more-link": "0.8em",
+			".entry-meta" : "0.8em",
+		),
+		"ts-2" (
+			".entry-title": "0.9em",
+			".newspack-post-subtitle": "0.8em",
+			".entry-wrapper p": "0.8em",
+			".entry-wrapper .more-link": "0.8em",
+			".entry-meta" : "0.8em",
+		),
+		"ts-1" (
+			".entry-title": "0.9em",
+			".newspack-post-subtitle": "0.8em",
+			".entry-wrapper p": "0.8em",
+			".entry-wrapper .more-link": "0.8em",
+			".entry-meta" : "0.8em",
+		),
+	);
+
+	@each $type, $selectors in $typescales {
+		@each $selector, $values in $selectors {
+			@each $value in $values {
+				&.#{$type} {
+					#{$selector} {
+						font-size: #{$value};
+					}
+				}
+			}
+		}
+	}
 }
 
 .editor-styles-wrapper.wpnbha__wp-block-button__wrapper {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes the API-based inline CSS introduced [here](https://github.com/Automattic/newspack-blocks/pull/1548) and moves it back into the editor.scss for easier syncing with WP.com.

See: 1200550061930446-as-1209502971732489

~~Maddeningly, it looks like https://github.com/Automattic/newspack-blocks/pull/1548 may have changed how the `@media` styles cascaded, so this PR corrects that as well. I based what the correct size should be off the front-end, rather than the current editor styles. This changes the smaller types scales (1-3) by a couple pixels in the editor only.~~ Edited to add: this is my mistake, I double-checked and I had this wrong!

This is a chart based on the front-end in case it helps with testing; `---` means same as the previous breakpoint size. It's a lot, but it should be enough to spot check a few of these at different breakpoints:

<details>
<summary>Sizes from front-end</summary>

| Typescale     | Selector                                      | Default         | `min-width: 782px` | `min-width: 1168px` |
| ------------ | ------------------------------- | ------------- | --------------- |--------------------- |
| 10                 | `.entry-title`                              |       `2.6em`     |     `3.6em`            |      `4.8em`            |
|                      | `.newspack-post-subtitle`     |       `1.4em`        |       `---`         |         `---`           |
|                      | `.newspack-post-subtitle`     |    inherits               |       `---`         |         `---`           |
|                      | `.entry-wrapper p`                  |   inherits               |       `---`         |         `---`           |
|                      | `.entry-wrapper .more-link`     |    `0.8em`         |       `---`         |         `---`           |
|                      | `.entry-meta`                            |    `0.8em`          |       `---`         |         `---`           |
| 9                 | `.entry-title`                              |      `2.4em`             |        `3.4em`           |     `4.2em`           |
|                      | `.newspack-post-subtitle`     |       `1.4em`           |       `---`         |         `---`           |
|                      | `.newspack-post-subtitle`     |    inherits              |       `---`         |         `---`           |
|                      | `.entry-wrapper p`                  |   inherits               |       `---`         |         `---`           |
|                      | `.entry-wrapper .more-link`     |    `0.8em`         |       `---`         |         `---`           |
|                      | `.entry-meta`                            |    `0.8em`          |       `---`         |         `---`           |
| 8                 | `.entry-title`                              |       `2.2em`         |       `3em`            |    `3.6em`            |
|                      | `.newspack-post-subtitle`    |        `1.4em`        |       `---`         |         `---`           |
|                      | `.newspack-post-subtitle`     |    inherits               |       `---`         |         `---`           |
|                      | `.entry-wrapper p`                  |   inherits              |       `---`         |         `---`           |
|                      | `.entry-wrapper .more-link`     |    `0.8em`        |       `---`         |         `---`           |
|                      | `.entry-meta`                            |    `0.8em`           |       `---`         |         `---`           |
| 7                 | `.entry-title`                              |       `2em`         |           `2.4em`                 |         `3em`                  |
|                      | `.newspack-post-subtitle`     |        `1.4em`          |       `---`         |         `---`           |
|                      | `.newspack-post-subtitle`     |    inherits               |       `---`         |         `---`           |
|                      | `.entry-wrapper p`                  |   inherits               |       `---`         |         `---`           |
|                      | `.entry-wrapper .more-link`     |    `0.8em`         |       `---`         |         `---`           |
|                      | `.entry-meta`                            |    `0.8em`           |       `---`         |         `---`           |
| 6                 | `.entry-title`                              |        `1.7em`          |      `2em`           |      `2.4em`          |
|                      | `.newspack-post-subtitle`     |        `1.4em`         |       `---`         |         `---`           |
|                      | `.newspack-post-subtitle`     |    inherits               |       `---`         |         `---`           |
|                      | `.entry-wrapper p`                  |   inherits               |       `---`         |         `---`           |
|                      | `.entry-wrapper .more-link`     |    `0.8em`         |       `---`         |         `---`           |
|                      | `.entry-meta`                            |    `0.8em`           |       `---`         |         `---`           |
| 5                 | `.entry-title`                              |       `1.4em`            |      `1.6em`          |    `2em`             |
|                      | `.newspack-post-subtitle`     |       `1.2em`          |       `---`         |         `---`           |
|                      | `.newspack-post-subtitle`     |    inherits                |       `---`         |         `---`           |
|                      | `.entry-wrapper p`                  |   inherits                |       `---`         |         `---`           |
|                      | `.entry-wrapper .more-link`     |    `0.8em`          |       `---`         |         `---`           |
|                      | `.entry-meta`                            |    `0.8em`            |       `---`         |         `---`           |
| 4                 | `.entry-title`                              |   `1.2em`             |        `1.6em`       |                           |
|                      | `.newspack-post-subtitle`     |    inherits               |   `---`        |      `---`              |
|                      | `.entry-wrapper p`                  |   inherits               |    `---`         |        `---`           |
|                      | `.entry-wrapper .more-link`     |    `0.8em`         |       `---`         |         `---`           |
|                      | `.entry-meta`                            |    `0.8em`           |    `---`          |    `---`              |
| 3                 | `.entry-title`                              |     `1em`               |     `1.2em`          |       `---`           |
|                      | `.newspack-post-subtitle`     |   `0.8em`             |  `---`              |          `---`           |
|                      | `.entry-wrapper p`                  |   `0.8em`             |   `---`             |         `---`            |
|                      | `.entry-wrapper .more-link`     |    `0.8em`           | `---`            |              `---`             |
|                      | `.entry-meta`                            |    `0.8em`           |   `---`             |`---`
| 2                 | `.entry-title`                              |          `0.9em`      |    `---`      |               `---`            |
|                      | `.newspack-post-subtitle`     |   `0.8em`              |    `0.7em`           |     `---`                         |
|                      | `.entry-wrapper p`                  |   `0.8em`           |    `0.7em`           |       `---`                    |
|                      | `.entry-wrapper .more-link`     |    `0.8em`         |    `0.7em`           |       `---`                    |
|                      | `.entry-meta`                            |    `0.8em`           |    `0.7em`          |     `---`                      |
| 1                 | `.entry-title`                              |     `0.7em`             |      `---`           |      `---`                     |
|                      | `.newspack-post-subtitle`     |   `0.8em`          |   `0.7em`         |         `---`                  |
|                      | `.entry-wrapper p`                  |   `0.8em`            |   `0.7em`         |       `---`            |
|                      | `.entry-wrapper .more-link`     |    `0.8em`          |   `0.7em`         |      `---`          |
|                      | `.entry-meta`                            |    `0.8em`            |   `0.7em`         |    `---`                 |

</details>

### How to test the changes in this Pull Request:

1. Create a post with ten Content Loop blocks, one using each type scale. You can also copy-paste this starter code:

<details>
<summary>Testing blocks</summary>

```
<!-- wp:newspack-blocks/homepage-articles {"showReadMore":true,"showCategory":true,"postLayout":"grid","mediaPosition":"left","typeScale":1,"sectionHeader":"1","showSubtitle":true} /-->

<!-- wp:newspack-blocks/homepage-articles {"showReadMore":true,"showCategory":true,"postLayout":"grid","mediaPosition":"left","typeScale":2,"sectionHeader":"2","showSubtitle":true} /-->

<!-- wp:newspack-blocks/homepage-articles {"showReadMore":true,"showCategory":true,"postLayout":"grid","mediaPosition":"left","typeScale":3,"sectionHeader":"3","showSubtitle":true} /-->

<!-- wp:newspack-blocks/homepage-articles {"showReadMore":true,"showCategory":true,"postLayout":"grid","mediaPosition":"left","sectionHeader":"4","showSubtitle":true} /-->

<!-- wp:newspack-blocks/homepage-articles {"showReadMore":true,"showImage":false,"showCategory":true,"postLayout":"grid","mediaPosition":"left","typeScale":5,"sectionHeader":"5","showSubtitle":true} /-->

<!-- wp:newspack-blocks/homepage-articles {"showReadMore":true,"showImage":false,"showCategory":true,"postLayout":"grid","mediaPosition":"left","typeScale":6,"sectionHeader":"6","showSubtitle":true} /-->

<!-- wp:newspack-blocks/homepage-articles {"showReadMore":true,"showImage":false,"showCategory":true,"postLayout":"grid","mediaPosition":"left","typeScale":7,"sectionHeader":"7","showSubtitle":true} /-->

<!-- wp:newspack-blocks/homepage-articles {"showReadMore":true,"showImage":false,"showCategory":true,"postLayout":"grid","columns":2,"postsToShow":2,"mediaPosition":"left","typeScale":8,"sectionHeader":"8","showSubtitle":true} /-->

<!-- wp:newspack-blocks/homepage-articles {"showReadMore":true,"showImage":false,"showCategory":true,"columns":2,"postsToShow":1,"mediaPosition":"left","typeScale":9,"sectionHeader":"9","showSubtitle":true} /-->

<!-- wp:newspack-blocks/homepage-articles {"showReadMore":true,"showImage":false,"showCategory":true,"columns":2,"postsToShow":1,"mediaPosition":"left","typeScale":10,"sectionHeader":"10","showSubtitle":true} /-->
```
</details>

2. Edit a few posts to make sure you have a good distribution of posts with the Newspack Article Subtitle visible.
3. Apply this PR and run `npm run build`.
4. Compare the editor font sizing against the front-end -- make sure to check the different breakpoints. The exact `px` value may not line up based on the editor's base font size, but the `em` size should; this will line up with current behaviour, which is also relative. 
5. If you're not using one already, switch the site to a block theme.
6. Edit one of the Templates/Template parts, and add a Content Loop block. Switch the block to the 'Grid' layout, and make sure that at least one of the visible posts has a featured image. 
7. Confirm that the images don't exceed the available space (there's some examples of this issue [here](https://github.com/Automattic/newspack-blocks/pull/1920)).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
