### PR TITLE
fix: prevent php notice when filtering scripts

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -896,7 +896,7 @@ final class Modal_Checkout {
 				}
 			}
 			foreach ( $allowed_gateway_assets as $gateway ) {
-				if ( false !== strpos( $wp_script->src, $gateway ) ) {
+				if ( $wp_script->src !== null && false !== strpos( $wp_script->src, $gateway ) ) {
 					$allowed = true;
 					break;
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Inline scripts don't have a `src`. 

### How to test the changes in this Pull Request:

1. On `trunk`, observe a PHP Notice about misuse of `strpos` during modal checkout
2. Switch to this branch, observe no notice

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->