### PR TITLE
fix: remove coming soon mode message from the modal checkout

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -212,6 +212,9 @@ final class Modal_Checkout {
 
 		// Remove any hooks that aren't supported by the modal checkout.
 		add_action( 'wp_loaded', [ __CLASS__, 'remove_hooks' ] );
+
+		// Exclude the modal checkout from 'Coming Soon' mode.
+		add_action( 'plugins_loaded', [ __CLASS__, 'disable_coming_soon' ] );
 	}
 
 	/**
@@ -978,6 +981,22 @@ final class Modal_Checkout {
 			$priority = has_action( $remove['hook'], $remove['callback'] );
 			remove_action( $remove['hook'], $remove['callback'], $priority );
 		}
+	}
+
+	/**
+	 * Exclude the Modal Checkout from 'Coming Soon' mode.
+	 */
+	public static function disable_coming_soon() {
+		if ( ! self::is_modal_checkout() ) {
+			return;
+		}
+		add_filter(
+			'woocommerce_coming_soon_exclude',
+			function() {
+				return true;
+			},
+			10
+		);
 	}
 
 	/**

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -215,6 +215,7 @@ final class Modal_Checkout {
 
 		// Exclude the modal checkout from 'Coming Soon' mode.
 		add_action( 'plugins_loaded', [ __CLASS__, 'disable_coming_soon' ] );
+		add_filter( 'woocommerce_coming_soon_exclude', [ __CLASS__, 'disable_coming_soon' ] );
 	}
 
 	/**
@@ -987,16 +988,7 @@ final class Modal_Checkout {
 	 * Exclude the Modal Checkout from 'Coming Soon' mode.
 	 */
 	public static function disable_coming_soon() {
-		if ( ! self::is_modal_checkout() ) {
-			return;
-		}
-		add_filter(
-			'woocommerce_coming_soon_exclude',
-			function() {
-				return true;
-			},
-			10
-		);
+		return self::is_modal_checkout();
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

If you enable WooCommerce's new 'Coming Soon' mode (which is on by default for new sites), the modal checkout will display the 'Coming Soon' message underneath the checkout form.

This PR fixes the issue by disabling Coming Soon mode in the modal (so it displays as usual). Another option could be to disable the actual checkout and only display the message, but without the header/footer (which is what happens on the regular /checkout screens).

See 1200550061930446-as-1209426735338090

### How to test the changes in this Pull Request:

1. If it's not on already, turn on "Coming Soon" mode in Woo. You can see if it's on or off by checking the badge in the top-left corner of the admin toolbar, and clicking it to change the settings if it says "Live". You can also access this setting under WP Admin > Woo > Settings > Site visibility:

![CleanShot 2025-03-05 at 09 53 00@2x](https://github.com/user-attachments/assets/e81ab4db-2976-4031-9304-97fe9721fcba)

![CleanShot 2025-03-05 at 09 55 03@2x](https://github.com/user-attachments/assets/aa0f2844-3002-4e34-8267-df41a75bf18b)

2. In an incognito window, go to the /shop page and confirm you get a full-page 'Coming Soon' message.
3. Try running through a checkout with the modal checkout and confirm you get the same message, under the form:

![CleanShot 2025-03-05 at 09 56 36@2x](https://github.com/user-attachments/assets/9c65d993-64d8-44e5-8183-ad9164705d12)

4. Apply this PR.
5. Repeat steps 2 and 3; confirm that you still get the 'Coming Soon' message on the /shop page, but not in the modal checkout. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
