### PR TITLE
Avoid warning newspack blocks api accessing attachment images

### DIFF
--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -38,7 +38,7 @@ class Newspack_Blocks_API {
 			$landscape_size,
 			false
 		);
-		$featured_image_set['landscape'] = $feat_img_array_landscape[0] ?? null;;
+		$featured_image_set['landscape'] = $feat_img_array_landscape[0] ?? null;
 
 		// Portrait image.
 		$portrait_size = Newspack_Blocks::image_size_for_orientation( 'portrait' );
@@ -48,7 +48,7 @@ class Newspack_Blocks_API {
 			$portrait_size,
 			false
 		);
-		$featured_image_set['portrait'] = $feat_img_array_portrait[0] ?? null;;
+		$featured_image_set['portrait'] = $feat_img_array_portrait[0] ?? null;
 
 		// Square image.
 		$square_size = Newspack_Blocks::image_size_for_orientation( 'square' );
@@ -58,7 +58,7 @@ class Newspack_Blocks_API {
 			$square_size,
 			false
 		);
-		$featured_image_set['square'] = $feat_img_array_square[0] ?? null;;
+		$featured_image_set['square'] = $feat_img_array_square[0] ?? null;
 
 		// Uncropped image.
 		$uncropped_size = 'newspack-article-block-uncropped';
@@ -68,7 +68,7 @@ class Newspack_Blocks_API {
 			$uncropped_size,
 			false
 		);
-		$featured_image_set['uncropped'] = $feat_img_array_uncropped[0] ?? null;;
+		$featured_image_set['uncropped'] = $feat_img_array_uncropped[0] ?? null;
 
 		return $featured_image_set;
 	}

--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -28,7 +28,7 @@ class Newspack_Blocks_API {
 			'large',
 			false
 		);
-		$featured_image_set['large'] = $feat_img_array_large[0];
+		$featured_image_set['large'] = $feat_img_array_large[0] ?? null;
 
 		// Landscape image.
 		$landscape_size = Newspack_Blocks::image_size_for_orientation( 'landscape' );
@@ -38,7 +38,7 @@ class Newspack_Blocks_API {
 			$landscape_size,
 			false
 		);
-		$featured_image_set['landscape'] = $feat_img_array_landscape[0];
+		$featured_image_set['landscape'] = $feat_img_array_landscape[0] ?? null;;
 
 		// Portrait image.
 		$portrait_size = Newspack_Blocks::image_size_for_orientation( 'portrait' );
@@ -48,7 +48,7 @@ class Newspack_Blocks_API {
 			$portrait_size,
 			false
 		);
-		$featured_image_set['portrait'] = $feat_img_array_portrait[0];
+		$featured_image_set['portrait'] = $feat_img_array_portrait[0] ?? null;;
 
 		// Square image.
 		$square_size = Newspack_Blocks::image_size_for_orientation( 'square' );
@@ -58,7 +58,7 @@ class Newspack_Blocks_API {
 			$square_size,
 			false
 		);
-		$featured_image_set['square'] = $feat_img_array_square[0];
+		$featured_image_set['square'] = $feat_img_array_square[0] ?? null;;
 
 		// Uncropped image.
 		$uncropped_size = 'newspack-article-block-uncropped';
@@ -68,7 +68,7 @@ class Newspack_Blocks_API {
 			$uncropped_size,
 			false
 		);
-		$featured_image_set['uncropped'] = $feat_img_array_uncropped[0];
+		$featured_image_set['uncropped'] = $feat_img_array_uncropped[0] ?? null;;
 
 		return $featured_image_set;
 	}


### PR DESCRIPTION




### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Add checks to avoid warnings when accessing the attachment `image_src` in the newspack blocks API..
This was caught in jetpack-alerts slack channel p1741335065431469-slack-C034JEXD1RD and I created https://github.com/Automattic/jetpack/pull/42290 in the jetpack mono repo. 
But @arthur791004 pointed out that the code in the jetpack monorepo is copied from here.
### How to test the changes in this Pull Request:

Code Review should suffice

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
