### PR TITLE
fix: make sure five column border layout works

### DIFF
--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -744,7 +744,7 @@
 		&.columns-5 article:nth-of-type(5n),
 		&.columns-6 article:nth-of-type(6n) {
 			border: 0;
-			padding-right: 0;
+			padding-right: 0 !important; // to overide the :not(:last-of-type) for .columns-5.
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue where, if you paired the Content Loop 5 column layout with the border style, it would incorrectly display as four columns. This was because of an issue with CSS specificity -- on tablet-sized screens and up, the last article in each row should have no right padding, but just for the 5 column layout, [this selector](https://github.com/Automattic/newspack-blocks/blob/f692662e317bb52141669b64d1decb3d94cc6883/src/blocks/homepage-articles/view.scss#L713) ended up being too "strong" for [this one](https://github.com/Automattic/newspack-blocks/blob/f692662e317bb52141669b64d1decb3d94cc6883/src/blocks/homepage-articles/view.scss#L744) to overpower it.

The 2 and 4 column layouts share the same selector, but they were fine because the last article is never an odd-numbered article, unlike the 5 column layout.

See 1200550061930446-as-1207679012622027

### How to test the changes in this Pull Request:

1. Set up a page with 6 Content Loop blocks, all set to show 5 columns with at least 6 posts showing in each. Set it up so you have two version of the block with each of the three different column gap options, one of each with borders enabled, and one of each with borders off. Or you can just copy this test content: 

<details>
<summary>Test blocks</summary>

```
<!-- wp:newspack-blocks/homepage-articles {"className":"is-style-borders","showExcerpt":false,"showDate":false,"showAuthor":false,"postLayout":"grid","columns":5,"postsToShow":7,"typeScale":2,"sectionHeader":"With Borders - Gap Large"} /-->

<!-- wp:newspack-blocks/homepage-articles {"className":"is-style-borders","showExcerpt":false,"showDate":false,"showAuthor":false,"postLayout":"grid","columns":5,"colGap":2,"postsToShow":7,"typeScale":2,"sectionHeader":"With Borders - Gap Medium"} /-->

<!-- wp:newspack-blocks/homepage-articles {"className":"is-style-borders","showExcerpt":false,"showDate":false,"showAuthor":false,"postLayout":"grid","columns":5,"colGap":1,"postsToShow":7,"typeScale":2,"sectionHeader":"With Borders - Gap Small"} /-->

<!-- wp:newspack-blocks/homepage-articles {"className":"is-style-default","showExcerpt":false,"showDate":false,"showAuthor":false,"postLayout":"grid","columns":5,"postsToShow":7,"typeScale":2,"sectionHeader":"No borders - Gap Large"} /-->

<!-- wp:newspack-blocks/homepage-articles {"className":"is-style-default","showExcerpt":false,"showDate":false,"showAuthor":false,"postLayout":"grid","columns":5,"colGap":2,"postsToShow":7,"typeScale":2,"sectionHeader":"No borders - Gap Medium"} /-->

<!-- wp:newspack-blocks/homepage-articles {"className":"is-style-default","showExcerpt":false,"showDate":false,"showAuthor":false,"postLayout":"grid","columns":5,"colGap":1,"postsToShow":7,"typeScale":2,"sectionHeader":"No borders - Gap Small"} /-->
```

</details>

2. View on the front-end and in the editor - note that the five column layout isn't working when the borders are on -- the fifth article in each line wraps to the next one:

![CleanShot 2025-03-12 at 13 46 36](https://github.com/user-attachments/assets/eb8cc81f-b97d-4b2c-8fcd-ab0e6b88cf6a)

3. Apply the PR and run `npm run build`.
4. Confirm that all the columns display as expected (with 5 per line until you run out of posts).

![CleanShot 2025-03-12 at 13 47 35](https://github.com/user-attachments/assets/de84c523-b71b-42bd-a9f4-d38667b7ef83)


5. Test on different screen sizes to make sure the articles wrap properly -- for the five column layout, when there's an uneven number of posts per line (like when you hit the tablet screen and there's only one on the last line), it should take up the full width:

![CleanShot 2025-03-12 at 13 47 52](https://github.com/user-attachments/assets/b78f11b5-22f8-4fd8-9c9b-e627563af6b3)

6. Edit the page to change up the columns-per-block. Retest on the front and in the editor just to confirm the padding change doesn't negatively impact any of the blocks (this should only affect blocks with the border style). 


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
