### PR TITLE
fix(donate-block): handle decimals in custom amount input

### DIFF
--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-frequency-based.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-frequency-based.php
@@ -140,6 +140,10 @@ class Newspack_Blocks_Donate_Renderer_Frequency_Based extends Newspack_Blocks_Do
 
 		$configuration = self::get_configuration( $attributes );
 
+		// Calculate the value for the "step" property of the custom amount donation value `input` element.
+		$decimals = get_option( 'woocommerce_price_num_decimals', 2 );
+		$input_element_step = '0.' . str_repeat( '0', $decimals - 1 ) . '1';
+
 		ob_start();
 
 		/**
@@ -200,6 +204,7 @@ class Newspack_Blocks_Donate_Renderer_Frequency_Based extends Newspack_Blocks_Do
 											name='donation_value_<?php echo esc_attr( $frequency_slug ); ?>_untiered'
 											value='<?php echo esc_attr( $amount ); ?>'
 											id='newspack-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-untiered-input'
+											step='<?php echo esc_attr( $input_element_step ); ?>'
 										/>
 									</div>
 									<?php else : ?>
@@ -305,6 +310,7 @@ class Newspack_Blocks_Donate_Renderer_Frequency_Based extends Newspack_Blocks_Do
 														min='<?php echo esc_attr( $configuration['minimumDonation'] ); ?>'
 														name='donation_value_<?php echo esc_attr( $frequency_slug ); ?>_other'
 														id='newspack-tier-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-other-input'
+														step='<?php echo esc_attr( $input_element_step ); ?>'
 													/>
 												</div>
 												<?php

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-frequency-based.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-frequency-based.php
@@ -141,8 +141,11 @@ class Newspack_Blocks_Donate_Renderer_Frequency_Based extends Newspack_Blocks_Do
 		$configuration = self::get_configuration( $attributes );
 
 		// Calculate the value for the "step" property of the custom amount donation value `input` element.
-		$decimals = get_option( 'woocommerce_price_num_decimals', 2 );
-		$input_element_step = '0.' . str_repeat( '0', $decimals - 1 ) . '1';
+		$thousand_separator = get_option( 'woocommerce_price_thousand_sep', false );
+		if ( $thousand_separator !== '.' ) {
+			$decimals = get_option( 'woocommerce_price_num_decimals', 2 );
+			$input_element_step = '0.' . str_repeat( '0', $decimals - 1 ) . '1';
+		}
 
 		ob_start();
 

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-frequency-based.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-frequency-based.php
@@ -146,6 +146,7 @@ class Newspack_Blocks_Donate_Renderer_Frequency_Based extends Newspack_Blocks_Do
 			$decimals = get_option( 'woocommerce_price_num_decimals', 2 );
 			$input_element_step = '0.' . str_repeat( '0', $decimals - 1 ) . '1';
 		}
+		$input_element_step = '1';
 
 		ob_start();
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds decimals handling to the custom value of the Donate block. 

### How to test the changes in this Pull Request:

1. On `trunk`, load a page with a Donate block and choose a custom amount. Input a value with decimals – e.g. `10.23`, and observe it won't pass browser validation
2. Switch to this branch, try again, observe that a value with decimals (using a `.`!) is accepted
3. In WooCommerce settings, change the value of the "Currency options" -> "Number of decimals" and observe the form is validated accordingly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209683142184116