### PR TITLE
fix: better handle deleted terms

### DIFF
--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -125,49 +125,75 @@ class QueryControls extends Component {
 		);
 	};
 	fetchSavedCategories = categoryIDs => {
-		return apiFetch( {
-			path: addQueryArgs( '/wp/v2/categories', {
+		return apiFetch({
+			path: addQueryArgs('/wp/v2/categories', {
 				per_page: 100,
 				_fields: 'id,name',
-				include: categoryIDs.join( ',' ),
-			} ),
-		} ).then( function ( categories ) {
-			return categories.map( category => ( {
+				include: categoryIDs.join(','),
+			}),
+		}).then(function (categories) {
+			const allCats = categories.map(category => ({
 				value: category.id,
-				label: decodeEntities( category.name ) || __( '(no title)', 'newspack-blocks' ),
-			} ) );
-		} );
+				label:
+					decodeEntities(category.name) ||
+					__('(no title)', 'newspack-blocks'),
+			}));
+			// Look for categoryIDs that were not returned (deleted categories) and add them to the list.
+			categoryIDs.forEach(catID => {
+				if (!allCats.find(cat => cat.value === parseInt(catID))) {
+					allCats.push({
+						value: parseInt(catID),
+						label: __('Deleted category', 'newspack-blocks'),
+					});
+				}
+			});
+			return allCats;
+		});
 	};
 
 	fetchTagSuggestions = search => {
-		return apiFetch( {
-			path: addQueryArgs( '/wp/v2/tags', {
+		return apiFetch({
+			path: addQueryArgs('/wp/v2/tags', {
 				search,
 				per_page: 20,
 				_fields: 'id,name',
 				orderby: 'count',
 				order: 'desc',
-			} ),
-		} ).then( function ( tags ) {
-			return tags.map( tag => ( {
+			}),
+		}).then(function (tags) {
+			return tags.map(tag => ({
 				value: tag.id,
-				label: decodeEntities( tag.name ) || __( '(no title)', 'newspack-blocks' ),
-			} ) );
-		} );
+				label:
+					decodeEntities(tag.name) ||
+					__('(no title)', 'newspack-blocks'),
+			}));
+		});
 	};
 	fetchSavedTags = tagIDs => {
-		return apiFetch( {
-			path: addQueryArgs( '/wp/v2/tags', {
+		return apiFetch({
+			path: addQueryArgs('/wp/v2/tags', {
 				per_page: 100,
 				_fields: 'id,name',
-				include: tagIDs.join( ',' ),
-			} ),
-		} ).then( function ( tags ) {
-			return tags.map( tag => ( {
+				include: tagIDs.join(','),
+			}),
+		}).then(function (tags) {
+			const allTags = tags.map(tag => ({
 				value: tag.id,
-				label: decodeEntities( tag.name ) || __( '(no title)', 'newspack-blocks' ),
-			} ) );
-		} );
+				label:
+					decodeEntities(tag.name) ||
+					__('(no title)', 'newspack-blocks'),
+			}));
+			// Look for tagIDs that were not returned (deleted tags) and add them to the list.
+			tagIDs.forEach(tagID => {
+				if (!allTags.find(tag => tag.value === parseInt(tagID))) {
+					allTags.push({
+						value: parseInt(tagID),
+						label: __('Deleted tag', 'newspack-blocks'),
+					});
+				}
+			});
+			return allTags;
+		});
 	};
 
 	fetchCustomTaxonomiesSuggestions = ( taxSlug, search ) => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When a category or tag is deleted, the block might still be filtering by it, but nothing is displayed in its settings. If you want to clean up and remove that filter from the block, the only way to do it is to go through the source code.

Usually when a publisher deletes a category they don't realize it impacts the block. They see a block returning no posts and they can't tell why that's happening. They open the editor and the filter is clear. There's no easy way to fix the issue.

This PR adds a "deleted category/tag" placeholder to surface the issue and allow the editor to fix it.

Cleaning this up on the fly would be too expensive. And magically fixing this when loading the Editor could not work very well because the user would not have any visual feedback of what just happened and therefore not even click the save button.

### How to test the changes in this Pull Request:

1. Add a Content Loop block and filter by category
2. Delete the category (alternatively, you can just edit the source code and modify the filter to a category ID that doesn't exist)
3. refresh the editor and see that you see the "deleted category" placeholder
4. Confirm that you can delete and save the block and that you will see posts again.
5. Repeat it with tags


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
