### PR TITLE
fix: correct checkout button block width in WP 6.8

### DIFF
--- a/src/blocks/checkout-button/edit.scss
+++ b/src/blocks/checkout-button/edit.scss
@@ -35,6 +35,8 @@
 		flex-direction: column;
 	}
 	&__button {
+		width: auto;
+
 		[data-align="full"] &,
 		[data-align="wide"] & {
 			width: 100%;

--- a/src/blocks/checkout-button/view.scss
+++ b/src/blocks/checkout-button/view.scss
@@ -28,4 +28,9 @@
 	&.wp-block-button__width-100 button {
 		width: 100%;
 	}
+
+	.wp-block-button__link {
+		display: inline-block;
+		width: auto;
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

There's a couple button block styling changes coming in WordPress 6.8 that negatively impact the Checkout Button block. This PR should fix that!

### How to test the changes in this Pull Request:

1. On a site running WP 6.7.2, add a few different checkout button blocks to a page, including:
    * One with a default width/alignment
    * One each with different width setting (100%, 75%, 50%, and 25%)
    * One each with different alignments (centred and wide). Overall you should get a page that looks like this:

![CleanShot 2025-03-25 at 14 56 53](https://github.com/user-attachments/assets/f67dc7e5-0e76-45ab-9183-374888fd6313)

2. Switch the site to the latest RC of WP 6.8 (you can do this by installing the [Beta Tester plugin](https://wordpress.org/plugins/wordpress-beta-tester/), switching the settings to "Bleeding edge" and "Beta/RC Only", and upgrading your site under WP Admin > Dashboard > Updates).
3. Refresh your page - the button with the default settings and the button that's centred should now be full width:

![CleanShot 2025-03-25 at 15 01 51](https://github.com/user-attachments/assets/96c49c3b-bfda-4d6b-8cb8-6d9a07b921ef)

4. Apply this PR and run `npm run build`.
5. Confirm that the buttons now match the original screenshot from 6.7.2 on the front end and in the editor:

![CleanShot 2025-03-25 at 15 04 17](https://github.com/user-attachments/assets/43523160-eb7d-4c08-8622-28a9f9a9c345)

6. Roll back your site to WP 6.7.2 (if you're using the Beta Tester plugin, you can do this on the WP Admin > Dashboard > Updates screen again, by clicking 'Re-install version 6.7.2'). 
7. Confirm the CSS changes don't actually change anything for WP 6.7.2 on the front-end and in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
