### PR TITLE
feat: display authors present in custom bylines

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -760,12 +760,14 @@ class Newspack_Blocks {
 	}
 
 	/**
-	 * Prepare an array of authors, taking presence of CoAuthors Plus into account.
+	 * Prepare an array of authors, taking presence of custom byline and CoAuthors Plus into account.
 	 *
 	 * @return array Array of WP_User objects.
 	 */
 	public static function prepare_authors() {
-		if ( function_exists( 'coauthors_posts_links' ) && ! empty( get_coauthors() ) ) {
+		if ( class_exists( 'Newspack\Bylines' ) && Newspack\Bylines::is_enabled() ) {
+			return Newspack\Bylines::authors_on_byline();
+		} elseif ( function_exists( 'coauthors_posts_links' ) && ! empty( get_coauthors() ) ) {
 			$authors = get_coauthors();
 			foreach ( $authors as $author ) {
 				$author->avatar = coauthors_get_avatar( $author, 48 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Is adds a conditional check to `Newspack_Blocks::prepare_authors()` to check if custom bylines are in use, and then it returns an array of authors that are present on the custom byline online, not all authors from coauthors plus.

### How to test the changes in this Pull Request:

1. Look at a page where an article block is in use
2. Set a custom byline to one or more of the articles being displayed
3. Compare if the authors present in the custom byline are the ones that are being displayed in the block

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
