### PR TITLE
fix(donate-block): handle decimals in custom amount input, fixed

### DIFF
--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-frequency-based.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-frequency-based.php
@@ -140,6 +140,18 @@ class Newspack_Blocks_Donate_Renderer_Frequency_Based extends Newspack_Blocks_Do
 
 		$configuration = self::get_configuration( $attributes );
 
+		// Calculate the value for the "step" property of the custom amount donation value `input` element.
+		$input_element_step_attribute = '1';
+		$thousand_separator = get_option( 'woocommerce_price_thousand_sep', false );
+		$decimals = get_option( 'woocommerce_price_num_decimals', 2 );
+		if ( $thousand_separator !== '.' && $decimals > 0 ) {
+			// According to the HTML spec, a float can only use a dot (https://html.spec.whatwg.org/dev/common-microsyntaxes.html#valid-floating-point-number).
+			// Therefore, an `input[type="number"]` with a `,` decimal separator is invalid HTML.
+			// To support separators other than a dot would mean using a standard `input[type="text"]` element,
+			// with JS handling the validation and input filtering. This might be revisited in the future.
+			$input_element_step_attribute = '0.' . str_repeat( '0', $decimals - 1 ) . '1';
+		}
+
 		ob_start();
 
 		/**
@@ -200,6 +212,7 @@ class Newspack_Blocks_Donate_Renderer_Frequency_Based extends Newspack_Blocks_Do
 											name='donation_value_<?php echo esc_attr( $frequency_slug ); ?>_untiered'
 											value='<?php echo esc_attr( $amount ); ?>'
 											id='newspack-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-untiered-input'
+											step='<?php echo esc_attr( $input_element_step_attribute ); ?>'
 										/>
 									</div>
 									<?php else : ?>
@@ -305,6 +318,7 @@ class Newspack_Blocks_Donate_Renderer_Frequency_Based extends Newspack_Blocks_Do
 														min='<?php echo esc_attr( $configuration['minimumDonation'] ); ?>'
 														name='donation_value_<?php echo esc_attr( $frequency_slug ); ?>_other'
 														id='newspack-tier-<?php echo esc_attr( $frequency_slug . '-' . $uid ); ?>-other-input'
+														step='<?php echo esc_attr( $input_element_step_attribute ); ?>'
 													/>
 												</div>
 												<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

https://github.com/Automattic/newspack-blocks/pull/2074 added decimals handling to the Donate block, but it had a flaw – didn't account for WC decimals setting with value 0 – so it was reverted in https://github.com/Automattic/newspack-blocks/pull/2094. This PR reinstates it, with the 0 handling added.

### How to test the changes in this Pull Request:

1. Follow instructions from https://github.com/Automattic/newspack-blocks/pull/2074
2. Update the WC decimals setting to 0, observe it's still working as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->