### PR TITLE
chore(notice): check null on amount

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -1427,7 +1427,7 @@ class Newspack_Blocks {
 	 */
 	public static function get_formatted_amount( $amount = null, $frequency = null, $hide_once_label = false ) {
 		if ( ! function_exists( 'wc_price' ) || ( method_exists( 'Newspack\Donations', 'is_platform_wc' ) && ! \Newspack\Donations::is_platform_wc() ) ) {
-			if ( 0 === $amount ) {
+			if ( empty( $amount ) ) {
 				return false;
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

This one fixes a PHP notice that was bugging me. The check was for `0` even though the default arg is `null`.

`PHP Deprecated:  NumberFormatter::formatCurrency(): Passing null to parameter #1 ($amount) of type float is deprecated in /Users/ckj/Dev/_code/repos/newspack-blocks/includes/class-newspack-blocks.php on line 1437
`

### How to test the changes in this Pull Request:

Before switching to the branch:
1. Make sure you have PHP notices on
2. Edit any post and see the notice.

Now switch to the branch and repeat the steps. There should be no notice this time.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
