### PR TITLE
feat: add body class depending on theme type

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -85,16 +85,17 @@ class Newspack_Blocks {
 	/**
 	 * Body class.
 	 *
-	 * @param array $classes Array of body class names.
-	 * @return array Modified array of body class names.
+	 * @param string|array $classes Array or string of body class names.
+	 * @return string|array Modified array or string of body class names.
 	 */
 	public static function add_body_classes( $classes ) {
-		$block_theme = 'is-block-theme';
-
-		if ( wp_is_block_theme() && is_admin() ) {
-			$classes .= $block_theme;
-		} elseif ( wp_is_block_theme() ) {
-			$classes[] = $block_theme;
+		if ( wp_is_block_theme() ) {
+			// Handle string (admin) vs array (frontend) cases.
+			if ( is_string( $classes ) ) {
+				$classes .= ' is-block-theme ';
+			} else {
+				$classes[] = 'is-block-theme';
+			}
 		}
 
 		return $classes;

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -29,6 +29,8 @@ class Newspack_Blocks {
 		add_post_type_support( 'page', 'newspack_blocks' );
 		add_action( 'jetpack_register_gutenberg_extensions', [ __CLASS__, 'disable_jetpack_donate' ], 99 );
 		add_filter( 'the_content', [ __CLASS__, 'hide_post_content_when_iframe_block_is_fullscreen' ] );
+		add_filter( 'body_class', [ __CLASS__, 'add_body_classes' ] );
+		add_filter( 'admin_body_class', [ __CLASS__, 'add_body_classes' ] );
 
 		/**
 		 * Disable NextGEN's `C_NextGen_Shortcode_Manager`.
@@ -78,6 +80,24 @@ class Newspack_Blocks {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Body class.
+	 *
+	 * @param array $classes Array of body class names.
+	 * @return array Modified array of body class names.
+	 */
+	public static function add_body_classes( $classes ) {
+		$block_theme = 'is-block-theme';
+
+		if ( wp_is_block_theme() && is_admin() ) {
+			$classes .= $block_theme;
+		} elseif ( wp_is_block_theme() ) {
+			$classes[] = $block_theme;
+		}
+
+		return $classes;
 	}
 
 	/**

--- a/src/block-styles/core/columns/editor.scss
+++ b/src/block-styles/core/columns/editor.scss
@@ -1,7 +1,7 @@
 @use "../../../shared/sass/variables";
 @use "../../../shared/sass/mixins";
 
-body:not([class*="block-theme"]) .editor-styles-wrapper div.wp-block-columns {
+body:not(.is-block-theme) .editor-styles-wrapper div.wp-block-columns {
 	gap: 32px;
 
 	&.is-style-borders {

--- a/src/block-styles/core/columns/view.scss
+++ b/src/block-styles/core/columns/view.scss
@@ -1,7 +1,7 @@
 @use "../../../shared/sass/variables";
 @use "../../../shared/sass/mixins";
 
-body:not([class*="block-theme"]) div.wp-block-columns {
+body:not(.is-block-theme) div.wp-block-columns {
 	gap: 32px;
 
 	&.is-style-borders {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If we have a block theme active (e.g. our very own [newspack-block-theme](https://github.com/Automattic/newspack-block-theme)), this function adds an `is-block-theme` class to the body (editor and front-end).

The issue comes from the fact that some CSS was targeting the block theme using WP’s `theme-{stylesheet}` functionality. However, I’ve noticed that the `newspackstaging` environment is removing this class, and I’m not entirely sure why. In any case, this approach seems fragile, so we’re switching to using a more reliable classname to determine if it’s a block theme.

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Switch your theme to a block theme
3. Check the editor and the front-end if you see the class applied
4. Add a colums block and check if the gap (32px) is ignored and instead uses the gap defined by the block
5. Switch to a classic theme and check, you shouldn't see any specific class applied
6. And check the columns block, the gap should be 32px

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
