### PR TITLE
fix: ensure transaction total updates on Complete Transaction button for Braintree

### DIFF
--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -170,13 +170,16 @@ import { domReady } from './utils';
 					}
 				}
 
+				/**
+				 * Update Place Order button text.
+				 */
 				$( document ).on( 'updated_checkout', function() {
 					// Update "Place Order" button to include current price.
 					let processOrderText = newspackBlocksModalCheckout.labels.complete_button;
 					if ( ! processOrderText ) {
 						return;
 					}
-					if ( $( '#place_order' ).hasClass( 'button-label-updated' ) ) {
+					if ( $( '#place_order' ).has( $( 'span.cart-price' ) ) ) {
 						// Modify button text to include updated price.
 						const tree = $( '<div>' + processOrderText + '</div>' );
 						// Update the HTML in the .cart-price span with the new price, and return.
@@ -184,13 +187,9 @@ import { domReady } from './utils';
 							return this.childNodes;
 						} );
 						processOrderText = tree.html();
-						$( '#place_order' ).html( processOrderText );
-						$( '#place_order_clone' ).html( processOrderText );
-					} else {
-						// Set default button label passed from PHP.
-						$( '#place_order' ).addClass( 'button-label-updated' ).html( processOrderText );
-						$( '#place_order_clone' ).addClass( 'button-label-updated' ).html( processOrderText );
 					}
+					$( '#place_order' ).html( processOrderText );
+					$( '#place_order_clone' ).html( processOrderText );
 				} );
 
 				/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR tweaks how the modal checkout button's text is updated: rather than adding and checking for the `button-label-updated` class, it relies on whether the `span.cart-price` element exists, which would also be inserted at the same time the `button-label-updated` CSS class was added.

This is to work around an issue with the Braintree payment gateway, which seems to cause issues with the `button-label-updated` class sticking.  

While testing this I found a separate issue where the Complete Transaction dollar amount is wiped out every time you change payment methods -- this happens with any payment gateway. I'll dig into that separately!

See 1200550061930446-as-1209884963637057

### How to test the changes in this Pull Request:

1. Set up a test site with the Braintree Credit Card gateway enabled (but not Braintree PayPal).
2. Enable coupons under WooCommerce > Settings, and add at least one coupon under WooCommerce > Marketing > Coupons.
3. Edit the includes/modal-checkout.php file to add `braintree_credit_card` to the `$supported_gateways` array, or make a mini-plugin to filter them: 

```
function add_gateway( $gateways ) {
	$gateways[] = 'braintree_credit_card';
	return $gateways;
}
add_filter( 'newspack_blocks_modal_checkout_supported_gateways', 'add_gateway' );
```
4. Set up a checkout button block.
5. In an incognito window, run through a checkout with your checkout button block. 
6. On the second screen, add your coupon code and click 'Apply'. Note that the 'Complete transaction: $X.XX' dollar amount on the place order button doesn't update.
7. Click 'Apply' again, and confirm the button text does update, even though you also get an error about the coupon already being applied. 
8. Apply this PR.
9. Repeat steps 5 - 7 and confirm that the coupon is applied to the Complete Transaction button when you first click 'Apply'. 
10. Switch entirely to a different payment gateway (like Stripe) and repeat steps 5-7, making sure that your coupon is applied. Note that I found I had to fully disable the Braintree plugin to turn it off, simply toggling it off under WooCommerce > Settings > Payments did not want to stick. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
