### PR TITLE
feat(content-loop): support custom bylines

### DIFF
--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -74,57 +74,6 @@ class Newspack_Blocks_API {
 	}
 
 	/**
-	 * Get author info for the rest field.
-	 *
-	 * @param array $object_info The object info.
-	 * @return array Author data.
-	 */
-	public static function newspack_blocks_get_author_info( $object_info ) {
-		$authors = [];
-		if ( class_exists( 'Newspack\Bylines' ) && Newspack\Bylines::is_enabled() ) {
-			$authors = Newspack\Bylines::get_post_byline_authors();
-		}
-
-		if ( empty( $authors ) && function_exists( 'get_coauthors' ) ) {
-			$authors = get_coauthors();
-		}
-
-		$author_data = [];
-		foreach ( $authors as $author ) {
-			$author_avatar = coauthors_get_avatar( $author, 48 );
-			$author_link   = null;
-
-			if ( function_exists( 'coauthors_posts_links' ) ) {
-				$author_link = get_author_posts_url( $author->ID, $author->user_nicename );
-			}
-			$author_data[] = array(
-				/* Get the author name */
-				'display_name' => esc_html( $author->display_name ),
-				/* Get the author avatar */
-				'avatar'       => wp_kses_post( $author_avatar ),
-				/* Get the author ID */
-				'id'           => $author->ID,
-				/* Get the author Link */
-				'author_link'  => $author_link,
-			);
-		}
-
-		if ( empty( $author_data ) ) {
-			$author_data[] = array(
-				/* Get the author name */
-				'display_name' => get_the_author_meta( 'display_name', $object_info['author'] ),
-				/* Get the author avatar */
-				'avatar'       => get_avatar( $object_info['author'], 48 ),
-				/* Get the author ID */
-				'id'           => $object_info['author'],
-				/* Get the author Link */
-				'author_link'  => get_author_posts_url( $object_info['author'] ),
-			);
-		}
-		return $author_data;
-	}
-
-	/**
 	 * Get primary category for the rest field.
 	 *
 	 * @param array $object_info The object info.
@@ -310,9 +259,9 @@ class Newspack_Blocks_API {
 			];
 
 			$sponsors = Newspack_Blocks::get_all_sponsors( $post->ID );
+			$author_info = Newspack_Blocks::prepare_authors();
 			$add_ons  = [
 				'newspack_article_classes'          => Newspack_Blocks::get_term_classes( $data['id'] ),
-				'newspack_author_info'              => self::newspack_blocks_get_author_info( $data ),
 				'newspack_category_info'            => self::newspack_blocks_get_primary_category( $data ),
 				'newspack_featured_image_caption'   => Newspack_Blocks::get_image_caption( $data['featured_media'], $attributes['showCaption'], $attributes['showCredit'] ),
 				'newspack_featured_image_src'       => self::newspack_blocks_get_image_src( $data ),
@@ -320,15 +269,12 @@ class Newspack_Blocks_API {
 				'newspack_post_sponsors'            => self::newspack_blocks_sponsor_info( $data ),
 				'newspack_sponsors_show_author'     => Newspack_Blocks::newspack_display_sponsors_and_authors( $sponsors ),
 				'newspack_sponsors_show_categories' => Newspack_Blocks::newspack_display_sponsors_and_categories( $sponsors ),
+				'newspack_post_avatars'             => \newspack_blocks_format_avatars( $author_info ),
+				'newspack_post_byline'              => \newspack_blocks_format_byline( $author_info ),
 				'post_status'                       => $post->post_status,
 				'post_type'                         => $post->post_type,
 				'post_link'                         => Newspack_Blocks::get_post_link( $post->ID ),
 			];
-
-			if ( class_exists( 'Newspack\Bylines' ) && Newspack\Bylines::is_enabled() ) {
-				$add_ons['newspack_byline_authors'] = Newspack\Bylines::get_post_byline_authors();
-				$add_ons['newspack_byline'] = Newspack\Bylines::output_byline_on_post( false );
-			}
 
 			// Support Newspack Listings hide author/publish date options.
 			if ( class_exists( 'Newspack_Listings\Core' ) ) {

--- a/includes/class-newspack-blocks-api.php
+++ b/includes/class-newspack-blocks-api.php
@@ -80,30 +80,36 @@ class Newspack_Blocks_API {
 	 * @return array Author data.
 	 */
 	public static function newspack_blocks_get_author_info( $object_info ) {
-		$author_data = [];
+		$authors = [];
+		if ( class_exists( 'Newspack\Bylines' ) && Newspack\Bylines::is_enabled() ) {
+			$authors = Newspack\Bylines::get_post_byline_authors();
+		}
 
-		if ( function_exists( 'coauthors_posts_links' ) && ! empty( get_coauthors() ) ) :
+		if ( empty( $authors ) && function_exists( 'get_coauthors' ) ) {
 			$authors = get_coauthors();
+		}
 
-			foreach ( $authors as $author ) {
-				$author_avatar = coauthors_get_avatar( $author, 48 );
-				$author_link   = null;
+		$author_data = [];
+		foreach ( $authors as $author ) {
+			$author_avatar = coauthors_get_avatar( $author, 48 );
+			$author_link   = null;
 
-				if ( function_exists( 'coauthors_posts_links' ) ) {
-					$author_link = get_author_posts_url( $author->ID, $author->user_nicename );
-				}
-				$author_data[] = array(
-					/* Get the author name */
-					'display_name' => esc_html( $author->display_name ),
-					/* Get the author avatar */
-					'avatar'       => wp_kses_post( $author_avatar ),
-					/* Get the author ID */
-					'id'           => $author->ID,
-					/* Get the author Link */
-					'author_link'  => $author_link,
-				);
+			if ( function_exists( 'coauthors_posts_links' ) ) {
+				$author_link = get_author_posts_url( $author->ID, $author->user_nicename );
 			}
-		else :
+			$author_data[] = array(
+				/* Get the author name */
+				'display_name' => esc_html( $author->display_name ),
+				/* Get the author avatar */
+				'avatar'       => wp_kses_post( $author_avatar ),
+				/* Get the author ID */
+				'id'           => $author->ID,
+				/* Get the author Link */
+				'author_link'  => $author_link,
+			);
+		}
+
+		if ( empty( $author_data ) ) {
 			$author_data[] = array(
 				/* Get the author name */
 				'display_name' => get_the_author_meta( 'display_name', $object_info['author'] ),
@@ -114,9 +120,7 @@ class Newspack_Blocks_API {
 				/* Get the author Link */
 				'author_link'  => get_author_posts_url( $object_info['author'] ),
 			);
-		endif;
-
-		/* Return the author data */
+		}
 		return $author_data;
 	}
 
@@ -320,6 +324,11 @@ class Newspack_Blocks_API {
 				'post_type'                         => $post->post_type,
 				'post_link'                         => Newspack_Blocks::get_post_link( $post->ID ),
 			];
+
+			if ( class_exists( 'Newspack\Bylines' ) && Newspack\Bylines::is_enabled() ) {
+				$add_ons['newspack_byline_authors'] = Newspack\Bylines::get_post_byline_authors();
+				$add_ons['newspack_byline'] = Newspack\Bylines::output_byline_on_post( false );
+			}
 
 			// Support Newspack Listings hide author/publish date options.
 			if ( class_exists( 'Newspack_Listings\Core' ) ) {

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -775,14 +775,21 @@ class Newspack_Blocks {
 	 * @return array Array of WP_User objects.
 	 */
 	public static function prepare_authors() {
-		if ( function_exists( 'coauthors_posts_links' ) && ! empty( get_coauthors() ) ) {
+		$authors = [];
+		if ( class_exists( 'Newspack\Bylines' ) && Newspack\Bylines::is_enabled() ) {
+			$authors = Newspack\Bylines::get_post_byline_authors();
+		}
+		if ( empty( $authors ) && function_exists( 'coauthors_posts_links' ) && ! empty( get_coauthors() ) ) {
 			$authors = get_coauthors();
+		}
+		if ( ! empty( $authors ) ) {
 			foreach ( $authors as $author ) {
 				$author->avatar = coauthors_get_avatar( $author, 48 );
 				$author->url    = get_author_posts_url( $author->ID, $author->user_nicename );
 			}
 			return $authors;
 		}
+
 		$id = get_the_author_meta( 'ID' );
 		return array(
 			(object) array(

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -793,34 +793,38 @@ class Newspack_Blocks {
 	/**
 	 * Prepare an array of authors, taking presence of CoAuthors Plus into account.
 	 *
-	 * @return array Array of WP_User objects.
+	 * @return object[] Array of user objects.
 	 */
 	public static function prepare_authors() {
 		$authors = [];
-		if ( class_exists( 'Newspack\Bylines' ) && Newspack\Bylines::is_enabled() ) {
-			$authors = Newspack\Bylines::get_post_byline_authors();
-		}
-		if ( empty( $authors ) && function_exists( 'coauthors_posts_links' ) && ! empty( get_coauthors() ) ) {
+
+		if ( function_exists( 'get_coauthors' ) ) {
 			$authors = get_coauthors();
-		}
-		if ( ! empty( $authors ) ) {
 			foreach ( $authors as $author ) {
 				$author->avatar = coauthors_get_avatar( $author, 48 );
 				$author->url    = get_author_posts_url( $author->ID, $author->user_nicename );
 			}
-			return $authors;
 		}
 
-		$id = get_the_author_meta( 'ID' );
-		return array(
-			(object) array(
-				'ID'            => $id,
-				'avatar'        => get_avatar( $id, 48 ),
-				'url'           => get_author_posts_url( $id ),
-				'user_nicename' => get_the_author(),
-				'display_name'  => get_the_author_meta( 'display_name' ),
-			),
-		);
+		if ( empty( $authors ) ) {
+			$id = get_the_author_meta( 'ID' );
+			$authors = array(
+				(object) array(
+					'ID'            => $id,
+					'avatar'        => get_avatar( $id, 48 ),
+					'url'           => get_author_posts_url( $id ),
+					'user_nicename' => get_the_author(),
+					'display_name'  => get_the_author_meta( 'display_name' ),
+				),
+			);
+		}
+
+		/**
+		 * Filters the authors array.
+		 *
+		 * @param object[] $authors Array of user objects.
+		 */
+		return apply_filters( 'newspack_blocks_post_authors', $authors );
 	}
 
 	/**

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -35,8 +35,7 @@ import QueryControls from '../../components/query-controls';
 import { PostTypesPanel, PostStatusesPanel } from '../../components/editor-panels';
 import createSwiper from './create-swiper';
 import {
-	formatAvatars,
-	formatByline,
+	getBylineHTML,
 	formatSponsorLogos,
 	formatSponsorByline,
 	getPostStatusLabel,
@@ -320,14 +319,10 @@ class Edit extends Component {
 														</span>
 													) }
 													{ showAuthor &&
-														showAvatar &&
-														( ! post.newspack_post_sponsors ||
-															post.newspack_sponsors_show_author ) &&
-														formatAvatars( post.newspack_author_info ) }
-													{ showAuthor &&
-														( ! post.newspack_post_sponsors ||
-															post.newspack_sponsors_show_author ) &&
-														formatByline( post.newspack_author_info ) }
+														! post.newspack_listings_hide_author &&
+														( ! post.newspack_post_sponsors || post.newspack_sponsors_show_author ) &&
+														<RawHTML className="byline-container">{ getBylineHTML( post, showAvatar ) }</RawHTML>
+													}
 													{ showDate && (
 														<time className="entry-date published" key="pub-date">
 															{ dateI18n( dateFormat, post.date ) }

--- a/src/blocks/carousel/editor.scss
+++ b/src/blocks/carousel/editor.scss
@@ -33,6 +33,14 @@
 			visibility: hidden;
 		}
 	}
+
+	// Work around RawHTML `<div />` encapsulation.
+	.entry-meta div.byline-container {
+		display: inline;
+		display: flex;
+		align-items: center;
+		margin-right: 1.5em;
+	}
 }
 .editor-block-list__layout .editor-block-list__block .wpnbpc .entry-title a,
 .editor-block-list__layout .editor-block-list__block .wpnbpc .entry-meta .byline a {

--- a/src/blocks/homepage-articles/edit.tsx
+++ b/src/blocks/homepage-articles/edit.tsx
@@ -6,8 +6,7 @@
 import QueryControls from '../../components/query-controls';
 import { postsBlockSelector, postsBlockDispatch, isBlogPrivate, shouldReflow } from './utils';
 import {
-	formatAvatars,
-	formatByline,
+	getBylineHTML,
 	formatSponsorLogos,
 	formatSponsorByline,
 	getPostStatusLabel,
@@ -236,14 +235,9 @@ class Edit extends Component< HomepageArticlesProps > {
 
 						{ showAuthor &&
 							! post.newspack_listings_hide_author &&
-							showAvatar &&
 							( ! post.newspack_post_sponsors || post.newspack_sponsors_show_author ) &&
-							formatAvatars( post.newspack_author_info ) }
-
-						{ showAuthor &&
-							! post.newspack_listings_hide_author &&
-							( ! post.newspack_post_sponsors || post.newspack_sponsors_show_author ) &&
-							formatByline( post ) }
+							<RawHTML className="byline-container">{ getBylineHTML( post, showAvatar ) }</RawHTML>
+						}
 
 						{ showDate && ! post.newspack_listings_hide_publish_date && (
 							<time className="entry-date published" key="pub-date">

--- a/src/blocks/homepage-articles/edit.tsx
+++ b/src/blocks/homepage-articles/edit.tsx
@@ -243,7 +243,7 @@ class Edit extends Component< HomepageArticlesProps > {
 						{ showAuthor &&
 							! post.newspack_listings_hide_author &&
 							( ! post.newspack_post_sponsors || post.newspack_sponsors_show_author ) &&
-							formatByline( post.newspack_author_info ) }
+							formatByline( post ) }
 
 						{ showDate && ! post.newspack_listings_hide_publish_date && (
 							<time className="entry-date published" key="pub-date">

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -30,18 +30,22 @@
 		flex-wrap: wrap;
 		align-items: center;
 		margin-top: 0.5em;
+		// Work around RawHTML `<div />` encapsulation.
+		div.byline-container {
+			display: inline;
+			display: flex;
+			align-items: center;
+			margin-right: 1.5em;
+		}
 	}
 
 	.cat-links {
 		font-size: variables.$font__size-xs;
 	}
 
-	span.avatar {
+	.entry-meta .avatar {
 		display: inline-block;
 		margin-right: 0.5em;
-		div {
-			display: inline;
-		}
 	}
 
 	/* Article excerpt */

--- a/src/blocks/homepage-articles/utils.ts
+++ b/src/blocks/homepage-articles/utils.ts
@@ -176,14 +176,13 @@ const generatePreviewPost = ( id: PostId ) => {
 			rendered: __( 'Post Title', 'newspack-blocks' ),
 		},
 		newspack_article_classes: 'type-post',
-		newspack_author_info: [
-			{
-				display_name: __( 'Author Name', 'newspack-blocks' ),
-				avatar: `<div style="background: #e8e8e8;width: 40px;height: 40px;display: block;overflow: hidden;border-radius: 50%; max-width: 100%; max-height: 100%;"></div>`,
-				id: 1,
-				author_link: '/',
-			},
-		],
+		newspack_post_avatars: `<div style="background: #e8e8e8;width: 40px;height: 40px;display: block;overflow: hidden;border-radius: 50%; max-width: 100%; max-height: 100%;" class="avatar"></div>`,
+		newspack_post_byline: `<span class="byline">
+			<span class="author-prefix">${ __( 'by', 'newspack-blocks' ) }</span>
+			<span class="author vcard">
+				<a class="url fn n" href="/">Author Name</a>
+			</span>
+		</span>`,
 		newspack_category_info: __( 'Category', 'newspack-blocks' ),
 		newspack_featured_image_caption: __( 'Featured image caption', 'newspack-blocks' ),
 		newspack_featured_image_src: {

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -467,18 +467,11 @@ function newspack_blocks_format_avatars( $author_info ) {
 /**
  * Renders byline markup.
  *
- * @param array $author_info Author info array.
+ * @param object[] $author_info Author info array.
  *
  * @return string Returns byline markup.
  */
 function newspack_blocks_format_byline( $author_info ) {
-	if ( class_exists( 'Newspack\Bylines' ) && Newspack\Bylines::is_enabled() ) {
-		$custom_byline = Newspack\Bylines::output_byline_on_post( false );
-		if ( $custom_byline ) {
-			return $custom_byline;
-		}
-	}
-
 	$index    = -1;
 	$elements = array_merge(
 		[
@@ -507,7 +500,15 @@ function newspack_blocks_format_byline( $author_info ) {
 		)
 	);
 
-	return implode( '', $elements );
+	$byline = implode( '', $elements );
+
+	/**
+	 * Filters the byline markup.
+	 *
+	 * @param string   $byline      Byline markup.
+	 * @param objcet[] $author_info Author info array.
+	 */
+	return apply_filters( 'newspack_blocks_post_byline', $byline, $author_info );
 }
 
 /**

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -472,6 +472,13 @@ function newspack_blocks_format_avatars( $author_info ) {
  * @return string Returns byline markup.
  */
 function newspack_blocks_format_byline( $author_info ) {
+	if ( class_exists( 'Newspack\Bylines' ) && Newspack\Bylines::is_enabled() ) {
+		$custom_byline = Newspack\Bylines::output_byline_on_post( false );
+		if ( $custom_byline ) {
+			return $custom_byline;
+		}
+	}
+
 	$index    = -1;
 	$elements = array_merge(
 		[

--- a/src/shared/js/utils.js
+++ b/src/shared/js/utils.js
@@ -13,25 +13,31 @@ export const formatAvatars = authorInfo =>
 		</span>
 	) );
 
-export const formatByline = authorInfo => (
-	<span className="byline">
-		<span className="author-prefix">{ _x( 'by', 'post author', 'newspack-blocks' ) }</span>{ ' ' }
-		{ authorInfo.reduce( ( accumulator, author, index ) => {
-			return [
-				...accumulator,
-				<span className="author vcard" key={ author.id }>
-					<a className="url fn n" href={ author.author_link }>
-						{ author.display_name }
-					</a>
-				</span>,
-				index < authorInfo.length - 2 && ', ',
-				authorInfo.length > 1 &&
-					index === authorInfo.length - 2 &&
-					_x( ' and ', 'post author', 'newspack-blocks' ),
-			];
-		}, [] ) }
-	</span>
-);
+export const formatByline = post => {
+	if ( post.newspack_byline ) {
+		return <RawHTML>{ post.newspack_byline }</RawHTML>;
+	}
+	const authorInfo = post.newspack_author_info;
+	return (
+		<span className="byline">
+			<span className="author-prefix">{ _x( 'by', 'post author', 'newspack-blocks' ) }</span>{ ' ' }
+			{ authorInfo.reduce( ( accumulator, author, index ) => {
+				return [
+					...accumulator,
+					<span className="author vcard" key={ author.id }>
+						<a className="url fn n" href={ author.author_link }>
+							{ author.display_name }
+						</a>
+					</span>,
+					index < authorInfo.length - 2 && ', ',
+					authorInfo.length > 1 &&
+						index === authorInfo.length - 2 &&
+						_x( ' and ', 'post author', 'newspack-blocks' ),
+				];
+			}, [] ) }
+		</span>
+	);
+};
 
 export const formatSponsorLogos = sponsorInfo => (
 	<span className="sponsor-logos">

--- a/src/shared/js/utils.js
+++ b/src/shared/js/utils.js
@@ -2,41 +2,14 @@
  * WordPress dependencies
  */
 import { _x, __ } from '@wordpress/i18n';
-import { RawHTML, Fragment } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 
-export const formatAvatars = authorInfo =>
-	authorInfo.map( author => (
-		<span className="avatar author-avatar" key={ author.id }>
-			<a className="url fn n" href={ author.author_link }>
-				<RawHTML>{ author.avatar }</RawHTML>
-			</a>
-		</span>
-	) );
-
-export const formatByline = post => {
-	if ( post.newspack_byline ) {
-		return <RawHTML>{ post.newspack_byline }</RawHTML>;
+export const getBylineHTML = ( post, showAvatar = false ) => {
+	const byline = '<span class="byline">' + post.newspack_post_byline + '</span>';
+	if ( showAvatar && post.newspack_post_avatars ) {
+		return post.newspack_post_avatars + byline;
 	}
-	const authorInfo = post.newspack_author_info;
-	return (
-		<span className="byline">
-			<span className="author-prefix">{ _x( 'by', 'post author', 'newspack-blocks' ) }</span>{ ' ' }
-			{ authorInfo.reduce( ( accumulator, author, index ) => {
-				return [
-					...accumulator,
-					<span className="author vcard" key={ author.id }>
-						<a className="url fn n" href={ author.author_link }>
-							{ author.display_name }
-						</a>
-					</span>,
-					index < authorInfo.length - 2 && ', ',
-					authorInfo.length > 1 &&
-						index === authorInfo.length - 2 &&
-						_x( ' and ', 'post author', 'newspack-blocks' ),
-				];
-			}, [] ) }
-		</span>
-	);
+	return byline;
 };
 
 export const formatSponsorLogos = sponsorInfo => (

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -71,11 +71,6 @@ declare global {
 			newspack_post_subtitle: string;
 		};
 		post_link: string;
-		newspack_author_info: {
-			id: number;
-			author_link: string;
-			avatar: string;
-		}[];
 		newspack_article_classes: string;
 		newspack_featured_image_caption: string;
 		newspack_featured_image_src: {
@@ -86,6 +81,8 @@ declare global {
 			uncropped: string;
 		};
 		newspack_category_info: string;
+		newspack_post_avatars: string;
+		newspack_post_byline: string;
 		newspack_sponsors_show_categories: boolean;
 		newspack_sponsors_show_author: boolean;
 		newspack_post_sponsors?:


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implement custom byline support to the Content Loop block.

This PR also refactors how avatars and bylines are rendered in the editor for the Content Loop and Carousel blocks. It unifies the rendering strategy, passing the full markup instead of author data for react parsing. The single strategy improves extensibility and maintainability.

Supersedes #2091 

### How to test the changes in this Pull Request:

1. Checkout https://github.com/Automattic/newspack-plugin/pull/3911
2. Create a new category and publish 4 posts in this category with the following author setup:
   1. Single author with a custom byline
   3. 3 authors without custom byline
   4. 3 authors with a custom byline that only mentions 2 of them
   5. 3 authors with a custom byline **but toggled off**
6. Draft a new page and add a Content Loop block
7. Filter the block by the created category and confirm the bylines rendered as expected in the editor
8. Publish and visit the page
9. Confirm the bylines reflect the editor

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
