### PR TITLE
fix: update how we check for the express checkout in the is_modal check

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1615,9 +1615,10 @@ final class Modal_Checkout {
 	 * Is this transaction using an express checkout method?
 	 */
 	public static function is_express_checkout() {
-		// Express checkout payment requests are separate requests, so they won't have the modal checkout flag. We'll have to check the HTTP_REFERER instead.
-		$express_payment_info = filter_input( INPUT_POST, 'express_payment_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
-		$is_express_checkout = ! empty( $express_payment_info ) && in_array( $express_payment_info, [ 'apple_pay', 'google_pay', 'payment_request_api' ], true ); // Validate payment request types: https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/payment-methods/class-wc-stripe-payment-request.php#L557-L586.
+		// Get express_payment_type in a way that works for both Stripe and WooPayments.
+		$express_payment_info = isset( $_POST['express_payment_type'] ) ? sanitize_text_field( wp_unslash( $_POST['express_payment_type'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+
+		$is_express_checkout = ! empty( $express_payment_info ) && in_array( $express_payment_info, [ 'apple_pay', 'google_pay', 'payment_request_api' ], true );  // Validate payment request types: https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/payment-methods/class-wc-stripe-payment-request.php#L557-L586.
 
 		if ( $is_express_checkout ) {
 			$referrer = isset( $_SERVER['HTTP_REFERER'] ) ? \esc_url_raw( \wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1111,13 +1111,29 @@ final class Modal_Checkout {
 	 * Get after success button params.
 	 */
 	private static function get_after_success_params() {
-		return array_filter(
-			[
-				'after_success_behavior'     => isset( $_REQUEST['after_success_behavior'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['after_success_behavior'] ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				'after_success_url'          => isset( $_REQUEST['after_success_url'] ) ? sanitize_url( wp_unslash( $_REQUEST['after_success_url'] ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				'after_success_button_label' => isset( $_REQUEST['after_success_button_label'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['after_success_button_label'] ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			]
-		);
+		// Express checkout payment requests are separate requests, so they won't have the after_success attributes. We'll have to check the HTTP_REFERER instead.
+		if ( self::is_express_checkout() ) {
+			$referrer = isset( $_SERVER['HTTP_REFERER'] ) ? \esc_url_raw( \wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			if ( $referrer ) {
+				$referrer_query = \wp_parse_url( $referrer, PHP_URL_QUERY );
+				\wp_parse_str( $referrer_query, $referrer_query_params );
+				return array_filter(
+					[
+						'after_success_behavior'     => isset( $referrer_query_params['after_success_behavior'] ) ? sanitize_text_field( wp_unslash( $referrer_query_params['after_success_behavior'] ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+						'after_success_url'          => isset( $referrer_query_params['after_success_url'] ) ? sanitize_url( wp_unslash( $referrer_query_params['after_success_url'] ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+						'after_success_button_label' => isset( $referrer_query_params['after_success_button_label'] ) ? sanitize_text_field( wp_unslash( $referrer_query_params['after_success_button_label'] ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+					]
+				);
+			}
+		} else {
+			return array_filter(
+				[
+					'after_success_behavior'     => isset( $_REQUEST['after_success_behavior'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['after_success_behavior'] ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+					'after_success_url'          => isset( $_REQUEST['after_success_url'] ) ? sanitize_url( wp_unslash( $_REQUEST['after_success_url'] ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+					'after_success_button_label' => isset( $_REQUEST['after_success_button_label'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['after_success_button_label'] ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				]
+			);
+		}
 	}
 
 	/**
@@ -1162,7 +1178,6 @@ final class Modal_Checkout {
 		if ( isset( $_REQUEST[ self::CHECKOUT_REGISTRATION_FLAG ] ) && $_REQUEST[ self::CHECKOUT_REGISTRATION_FLAG ] ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 			$args[ self::CHECKOUT_REGISTRATION_FLAG ] = '1';
 		}
-
 		return add_query_arg(
 			$args,
 			$url
@@ -1589,6 +1604,17 @@ final class Modal_Checkout {
 			$is_modal_checkout = strpos( $_REQUEST['post_data'], 'modal_checkout=1' ) !== false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		}
 
+		if ( self::is_express_checkout() ) {
+			$is_modal_checkout = true;
+		}
+
+		return $is_modal_checkout;
+	}
+
+	/**
+	 * Is this transaction using an express checkout method?
+	 */
+	public static function is_express_checkout() {
 		// Express checkout payment requests are separate requests, so they won't have the modal checkout flag. We'll have to check the HTTP_REFERER instead.
 		$express_payment_info = filter_input( INPUT_POST, 'express_payment_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$is_express_checkout = ! empty( $express_payment_info ) && in_array( $express_payment_info, [ 'apple_pay', 'google_pay', 'payment_request_api' ], true ); // Validate payment request types: https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/payment-methods/class-wc-stripe-payment-request.php#L557-L586.
@@ -1599,12 +1625,11 @@ final class Modal_Checkout {
 				$referrer_query = \wp_parse_url( $referrer, PHP_URL_QUERY );
 				\wp_parse_str( $referrer_query, $referrer_query_params );
 				if ( isset( $referrer_query_params['modal_checkout'] ) && $referrer_query_params['modal_checkout'] ) {
-					$is_modal_checkout = true;
+					return true;
 				}
 			}
 		}
-
-		return $is_modal_checkout;
+		return false;
 	}
 
 	/**

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1589,9 +1589,10 @@ final class Modal_Checkout {
 			$is_modal_checkout = strpos( $_REQUEST['post_data'], 'modal_checkout=1' ) !== false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		}
 
-		// Express checkout payment requests are separate requests, so they won't have the modal checkout flag. We'll have to check the HTTP_REFERER insteaad.
-		$payment_request_type = filter_input( INPUT_POST, 'payment_request_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
-		$is_express_checkout  = ! empty( $payment_request_type ) && in_array( $payment_request_type, [ 'apple_pay', 'google_pay', 'payment_request_api' ], true ); // Validate payment request types: https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/payment-methods/class-wc-stripe-payment-request.php#L529-L548.
+		// Express checkout payment requests are separate requests, so they won't have the modal checkout flag. We'll have to check the HTTP_REFERER instead.
+		$express_payment_info = filter_input( INPUT_POST, 'express_payment_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$is_express_checkout = ! empty( $express_payment_info ) && in_array( $express_payment_info, [ 'apple_pay', 'google_pay', 'payment_request_api' ], true ); // Validate payment request types: https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/payment-methods/class-wc-stripe-payment-request.php#L557-L586.
+
 		if ( $is_express_checkout ) {
 			$referrer = isset( $_SERVER['HTTP_REFERER'] ) ? \esc_url_raw( \wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			if ( $referrer ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The check in the `is_modal_checkout` function to determine whether a customer is using an express payment type (like Google Pay or Apple Pay) is failing for some reason -- `payment_request_type` isn't returning anything.

This PR updates the check to look for `express_payment_type` in the `$_POST` instead, as well as makes sure we're passing the `after_success` params to the success modal when using an express checkout. This should now work for both Stripe and WooPayments express payment options. 

As always, any feedback about how I went about this is very welcome!  

### How to test the changes in this Pull Request:

1. Set up a test site with WooCommerce Stripe Gateway, and enable Google Pay/Apple Pay.
2. Set up a checkout button block to test with.
3. In an incognito window, try running through a checkout and pick Google Pay or Apple Pay (I tested primarily with Google Pay because Apple Pay was giving me a hard time about not finding my phone). Complete the transaction.
4. Note that instead of the normal 'Transaction Successful' message, you get a frankenmodal showing the default WooCommerce Order Received message inside of the Newspack modal checkout:

<img src="https://github.com/user-attachments/assets/827cdb9d-c785-4cfc-9148-e09bb64193c7" width="400">

5. Apply this PR.
6. Repeat steps 3 and 4 and confirm that you get the regular success message.
7. Try testing with a test credit card number and confirm that still works as expected.
8. Edit your checkout button block and change the after success behaviour to go to a different page, and change the button text. 
9. Repeat steps 3 and 4 and confirm your success modal shows your customizations.

![CleanShot 2025-04-16 at 12 12 56](https://github.com/user-attachments/assets/8e9487a7-bd92-4ef2-9ae0-21910d0f38c8)

10. Under Newspack > Audience > Configuration, enable "Present newsletter signup after checkout and registration".
11. Test and confirm the Newsletters modal is shown as expected. 
12. Go to your Shop page and run a regular transaction with the regular checkout. Use the express checkout option. Confirm that displays the regular "Order Received" page.
13. Go to WooCommerce > Settings > Payments, and switch Stripe Gateway for WooCommerce Payments with Google Pay/Apple Pay enabled.
14. Repeat testing the different cases:
* An express checkout with regular modal checkout with no customizations or newsletters enabled.
* A regular checkout (with a text credit card number)
* An express checkout with a modal checkout with the after success behaviour and button label customized.
* An express checkout with amodal checkout with newsletters enabled.
* An express checkout with the standard WooCommerce checkout (from the /shop page).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209931644868966