### PR TITLE
fix(recaptcha): move clone button code to Newspack\Recaptcha class

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1945,22 +1945,16 @@ final class Modal_Checkout {
 	 * Add newspack ui classes to the "Place order" button html.
 	 *
 	 * @param string $html The button html.
+	 *
+	 * @return string The modified button html.
 	 */
 	public static function order_button_html( $html ) {
 		if ( ! self::is_modal_checkout() ) {
 			return $html;
 		}
 
-		$class_prefix = self::get_class_prefix();
-
+		$class_prefix      = self::get_class_prefix();
 		$newspack_ui_html = preg_replace( '/class=".*?"/', "class='{$class_prefix}__button {$class_prefix}__button--primary {$class_prefix}__button--wide'", $html );
-
-		if ( class_exists( 'Newspack\Recaptcha' ) && \Newspack\Recaptcha::can_use_captcha( 'v2' ) ) {
-			$cloned_button    = preg_replace( '/type="submit"/', 'type="button"', $newspack_ui_html );
-			$cloned_button    = preg_replace( '/id="place_order"/', '', $newspack_ui_html );
-			$cloned_button    = preg_replace( '/name=".*?"/', 'id="place_order_clone"', $newspack_ui_html );
-			$newspack_ui_html = $cloned_button . $newspack_ui_html;
-		}
 
 		return $newspack_ui_html;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Moves code to clone the Place Order button in Woo checkout templates for reCAPTCHA v2 to the `Newspack\Recaptcha` class, to keep this handling for reCAPTCHA in one place.

### How to test the changes in this Pull Request:

See testing instructions in https://github.com/Automattic/newspack-plugin/pull/3930.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
