### PR TITLE
Adjust cache handling for feeds to prevent content loop showing in feeds

### DIFF
--- a/includes/class-newspack-blocks-caching.php
+++ b/includes/class-newspack-blocks-caching.php
@@ -139,6 +139,7 @@ class Newspack_Blocks_Caching {
 	 *
 	 * The tradeoff is that occasionally the current post may show up in an article block on a post.
 	 * Archives should all use a global cache group, because there is nothing that would need de-duplication.
+	 * Feeds have their own cache group because some blocks have (e.g. content loop) have different markup in feeds vs. site frontend.
 	 *
 	 * @return string Cache group.
 	 */
@@ -150,6 +151,8 @@ class Newspack_Blocks_Caching {
 				return sprintf( self::CACHE_GROUP . '-post-%d', get_the_ID() );
 			}
 			return self::CACHE_GROUP;
+		} elseif ( is_feed() ) {
+			return self::CACHE_GROUP . '-feed';
 		} else {
 			return self::CACHE_GROUP;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes an interesting edge case bug I ran across.

1. [We purposely don't render anything for the content loop block in RSS feeds](https://github.com/Automattic/newspack-blocks/blob/33dbedf726aa28837452bb2ee343ddf7a5b0e1c7/src/blocks/homepage-articles/view.php#L224-L227)
2. The block caching bypasses the render block function if a block has cached output
3. So, if a content loop block was cached, the full block markup would get included in the feed.

It's fine for this to go out in the normal releases -- it doesn't need to be a hotfix.

### How to test the changes in this Pull Request:

1. You'll need a site with object cache. You'll want [a logged-out window or to disable this check](https://github.com/Automattic/newspack-blocks/blob/33dbedf726aa28837452bb2ee343ddf7a5b0e1c7/includes/class-newspack-blocks-caching.php#L45), otherwise caching won't trigger. Also create a full-content RSS feed with our RSS enhancements feature.
2. On a single article, insert a content loop block in the post content:
<img width="876" alt="Screenshot 2025-04-21 at 12 14 02 PM" src="https://github.com/user-attachments/assets/c3c9f508-d786-4582-a38a-c4d55809207b" />
3. Refresh the page a time or two to make sure the block is cached. [You can verify by tailing the error logs if you have log level enabled](https://github.com/Automattic/newspack-blocks/blob/33dbedf726aa28837452bb2ee343ddf7a5b0e1c7/includes/class-newspack-blocks-caching.php#L164)

4. Visit the RSS feed. Observe that the block markup is included in the feed content:
<img width="1389" alt="Screenshot 2025-04-21 at 12 13 54 PM" src="https://github.com/user-attachments/assets/01b74f35-d706-4cff-a0c9-69329541bd3b" />
5. Apply this patch. Visit the RSS feed. Observe that the block markup is NOT included in the feed content:
<img width="1297" alt="Screenshot 2025-04-21 at 12 15 09 PM" src="https://github.com/user-attachments/assets/5415c2bd-44da-4d4e-b412-34fac0b91085" />
If you're using the logger, you should also see that the (empty) block content is getting cached in a feeds cache group.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
