### PR TITLE
fix: add the timezone to the Content blocks  datetime attribute

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -1386,7 +1386,21 @@ class Newspack_Blocks {
 		if ( $post === null ) {
 			$post = get_post();
 		}
-		$date           = new DateTime( $post->post_date );
+		return apply_filters( 'newspack_blocks_displayed_post_date', mysql_to_rfc3339( $post->post_date ), $post );
+	}
+
+	/**
+	 * Get post date in ISO-8601 format to be used in the datetime attribute.
+	 *
+	 * @param WP_Post $post Post object.
+	 * @return string Date string in ISO-8601 format.
+	 */
+	public static function get_datetime_post_date( $post = null ) {
+		if ( $post === null ) {
+			$post = get_post();
+		}
+		$date  = self::get_displayed_post_date( $post );
+		$date  = new DateTime( $date );
 		$date_formatted = date_i18n( 'c', $date->getTimestamp() );
 		return apply_filters( 'newspack_blocks_displayed_post_date', $date_formatted, $post );
 	}

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -1399,10 +1399,12 @@ class Newspack_Blocks {
 		if ( $post === null ) {
 			$post = get_post();
 		}
-		$date  = self::get_displayed_post_date( $post );
-		$date  = new DateTime( $date );
-		$date_formatted = date_i18n( 'c', $date->getTimestamp() );
-		return apply_filters( 'newspack_blocks_displayed_post_date', $date_formatted, $post );
+		/**
+		 * Filters the post date used for the datetime attribute.
+		 *
+		 * @param string Date string in a format appropriate for datetime attributes.
+		 */
+		return apply_filters( 'newspack_blocks_displayed_post_date', get_post_datetime( $post )->format( 'c' ), $post );
 	}
 
 	/**

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -1386,7 +1386,9 @@ class Newspack_Blocks {
 		if ( $post === null ) {
 			$post = get_post();
 		}
-		return apply_filters( 'newspack_blocks_displayed_post_date', mysql_to_rfc3339( $post->post_date ), $post );
+		$date           = new DateTime( $post->post_date );
+		$date_formatted = date_i18n( 'c', $date->getTimestamp() );
+		return apply_filters( 'newspack_blocks_displayed_post_date', $date_formatted, $post );
 	}
 
 	/**

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -238,7 +238,7 @@ call_user_func(
 									),
 								)
 							),
-							esc_attr( Newspack_Blocks::get_displayed_post_date() ),
+							esc_attr( Newspack_Blocks::get_datetime_post_date() ),
 							esc_html( Newspack_Blocks::get_formatted_displayed_post_date() ),
 							esc_attr( get_the_modified_date( DATE_W3C ) ),
 							esc_html( get_the_modified_date() )


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The theme was recently updated to use JavaScript to determine the 'time ago' date format, to avoid the caching issues that happened with a PHP-only version. This approached used the `datetime` attribute on the post date, which was missing the time zone in the Content Loop block. This PR adds it. 

### How to test the changes in this Pull Request:

1. Change your site's time zone -- preferably to a time zone ahead of yours for some time travel vibes.
2. Under Customizer > Template Settings > Post Settings, enable the 'Time ago' date format setting.
3. Publish a new post and confirm it shows the right time ago value (1-2 minutes ago) on the front end of the single post.
4. Set up a Content Loop block that will display the post, and note the publish date:

![CleanShot 2025-04-23 at 16 23 48](https://github.com/user-attachments/assets/3090c44b-e3b3-42a0-a791-a7761570c631)

5. Apply this PR.
6. Confirm that the time in the Content Loop is more accurate. For bonus points, inspect the block's date and confirm the `datetime` includes a time zone offset. 

![CleanShot 2025-04-23 at 16 24 44](https://github.com/user-attachments/assets/c805ef5b-4f93-4364-b17c-11e7ce758aaf)

7. Navigate to Customizer > Template Settings > Post Settings and disable the 'Time ago' date format setting.
8. Under Settings > General, switch the `Date Format` to 'Custom' and switch it to a format that shows the time as well (like `F j, Y g:i a`). 
9. View the Content Loop block on the front-page and confirm the time and date shown on the post matches the time and date shown on the single view of the post.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210052777025617