### PR TITLE
fix: the warning generated by get_term_classes because the category might be null

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -839,14 +839,18 @@ class Newspack_Blocks {
 		$tags = get_the_terms( $post_id, 'post_tag' );
 		if ( ! empty( $tags ) ) {
 			foreach ( $tags as $tag ) {
-				$classes[] = 'tag-' . $tag->slug;
+				if ( ! empty( $tag->slug ) ) {
+					$classes[] = 'tag-' . $tag->slug;
+				}
 			}
 		}
 
 		$categories = get_the_terms( $post_id, 'category' );
 		if ( ! empty( $categories ) ) {
 			foreach ( $categories as $cat ) {
-				$classes[] = 'category-' . $cat->slug;
+				if ( ! empty( $cat->slug ) ) {
+					$classes[] = 'category-' . $cat->slug;
+				}
 			}
 		}
 
@@ -854,7 +858,9 @@ class Newspack_Blocks {
 			$terms = get_the_terms( $post_id, $tax['slug'] );
 			if ( ! empty( $terms ) ) {
 				foreach ( $terms as $term ) {
-					$classes[] = $term->taxonomy . '-' . $term->slug;
+					if ( ! empty( $term->taxonomy ) && ! empty( $term->slug ) ) {
+						$classes[] = $term->taxonomy . '-' . $term->slug;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes p1745618925471759-slack-CRWCHQGUB
Related to https://github.com/Automattic/jetpack/pull/43271

Fix the warning Warning: Attempt to read property "slug" on null generated by the get_term_classes function. You can see the error from logstash on Slack.

### How to test the changes in this Pull Request:

1. Weirdly, I cannot reproduce the issue even if I access the same request URL from the log...
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
