### PR TITLE
feat: update styles for the Subscription Confirmation checkbox

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -193,6 +193,9 @@ final class Modal_Checkout {
 		add_action( 'wp_ajax_get_cart_total', [ __CLASS__, 'get_cart_total_js' ] );
 		add_action( 'wp_ajax_nopriv_get_cart_total', [ __CLASS__, 'get_cart_total_js' ] );
 
+		// Wrap required checkbox text in a span so it works nicely with the Newspack UI grid layout.
+		add_filter( 'woocommerce_form_field_checkbox', [ __CLASS__, 'wrap_required_checkbox_text' ], 10, 4 );
+
 		/**
 		 * Ensure that options to limit the number of subscriptions per product are respected.
 		 * Note: This is normally called only for regular checkout pages and REST API requests,
@@ -1896,6 +1899,31 @@ final class Modal_Checkout {
 		$is_donation = method_exists( 'Newspack\Donations', 'is_donation_cart' ) && \Newspack\Donations::is_donation_cart();
 		$label       = $is_donation ? self::get_modal_checkout_labels( 'donation_gift_details' ) : self::get_modal_checkout_labels( 'purchase_gift_details' );
 		return \apply_filters( 'wcsg_enable_gifting_checkbox_label', $label ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WooCommerce hooks.
+	}
+
+	/**
+	 * Wrap required checkbox text in a span so it works nicely with the Newspack UI grid layout.
+	 *
+	 * @param string $field The field HTML.
+	 * @param string $key The field key.
+	 * @param array  $args The field arguments.
+	 * @param string $value The field value.
+	 * @return string Modified field HTML.
+	 */
+	public static function wrap_required_checkbox_text( $field, $key, $args, $value ) {
+		if ( ! self::is_modal_checkout() ) {
+			return $field;
+		}
+
+		if ( ! empty( $args['required'] ) && $args['type'] === 'checkbox' ) {
+			// Wrap the label's text and required asterisk in a span.
+			$field = preg_replace(
+				'/(<label[^>]*>.*?<input[^>]*>)(.*?)(<\/label>)/s',
+				'$1<span>$2</span>$3',
+				$field
+			);
+		}
+		return $field;
 	}
 
 	/**

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -842,6 +842,8 @@
 	}
 
 
+	// Subscription confirmation checkbox
+	form .newspack-subscription-confirmation-checkbox,
 	// Automate Woo Opt in
 	form .automatewoo-optin {
 		margin: var(--newspack-ui-spacer-5, 24px) 0 0;

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -501,6 +501,9 @@ import { domReady } from './utils';
 						originalFormHandlers.forEach( handler => {
 							$form.on( 'submit', handler.handler );
 						} );
+
+						// Disable 'Place Order' button if Subscription Confirmation is required.
+						handleSubscriptionConfirmation();
 					}
 					$form.triggerHandler( 'editing_details', [ isEditingDetails ] );
 					// Scroll to top.
@@ -797,7 +800,6 @@ import { domReady } from './utils';
 				} );
 			}
 		}
-
 		// Listen to various WooCommerce events.
 		$( document.body ).on( 'updated_checkout payment_method_selected checkout_error', handleSubscriptionConfirmation );
 		// Also handle initial load.

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -764,6 +764,46 @@ import { domReady } from './utils';
 		}
 
 		/**
+		 * Block form submission when Subscription Confirmation is required.
+		 * This is enabled under Newspack > Audience > Configuration > Checkout & Payment, and only appears when there's a subscription product in the cart.
+		 */
+		function handleSubscriptionConfirmation() {
+			const $subscription_confirmation = $( '#newspack_subscription_terms_confirmation, #newspack_subscription_confirmation' );
+			if ( $subscription_confirmation.length ) {
+				const $form = $( 'form.checkout' );
+				const $buttons = $form.find( 'button#place_order, button#place_order_clone' );
+
+				// Toggle button state based on checkbox.
+				function toggleButtonState() {
+					const isChecked = $subscription_confirmation.is( ':checked' );
+					$buttons.each( ( i, el ) => {
+						$( el ).attr( 'disabled', ! isChecked );
+					} );
+				}
+
+				// Initial state.
+				toggleButtonState();
+
+				// Watch for checkbox changes.
+				$subscription_confirmation.on( 'change', toggleButtonState );
+
+				// Prevent form submission if the Subscription Confirmation or Terms & Conditions checkbox is not checked.
+				$form.on( 'submit', function( e ) {
+					if ( ! $subscription_confirmation.is( ':checked' ) ) {
+						e.preventDefault();
+						e.stopPropagation();
+						return false;
+					}
+				} );
+			}
+		}
+
+		// Listen to various WooCommerce events.
+		$( document.body ).on( 'updated_checkout payment_method_selected checkout_error', handleSubscriptionConfirmation );
+		// Also handle initial load.
+		$( document ).ready( handleSubscriptionConfirmation );
+
+		/**
 		 * Handle modal checkout error events.
 		 */
 		$( document.body ).on( 'checkout_error', function () {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR should be tested with https://github.com/Automattic/newspack-plugin/pull/3961. It adds three things: 

* It adds some styles for spacing for the Subscription Confirmation checkboxes in the modal checkout. 
* It adds a new `<span>` element when a modal checkout label is for a required field and for a checkbox form element. This is to help it play nicer with our Newspack UI styles which use grid; without it, separate HTML elements -- like required asterisk and link -- ended up following the grid.
* It adds a check to block the modal checkout from being submitted when the Subscription Confirmation or Terms & Conditions checkboxes are present but not checked. There's also regular Woo validation, but this makes the requirement a little more up front. 

See 1200550061930446-as-1208929637924603

### How to test the changes in this Pull Request:

1. Please follow the testing steps in https://github.com/Automattic/newspack-plugin/pull/3961.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
