### PR TITLE
fix: update stripe express checkout divider

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -857,7 +857,8 @@
 	// Express checkout dividers.
 	// This is being replaced with JavaScript so it can be styled correctly.
 	#wcpay-express-checkout-button-separator,
-	#wc-stripe-payment-request-button-separator {
+	#wc-stripe-payment-request-button-separator,
+	#wc-stripe-express-checkout-button-separator {
 		display: none !important; // !important needed to override inline styles.
 
 		&[style*="display:none"] + .newspack-ui__word-divider {

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -63,7 +63,7 @@ import { domReady } from './utils';
 		} else {
 			function init() {
 				// If present, update the markup used for the WooPayments express checkout divider.
-				$( '#wcpay-express-checkout-button-separator, #wc-stripe-payment-request-button-separator' ).after(
+				$( '#wcpay-express-checkout-button-separator, #wc-stripe-payment-request-button-separator, #wc-stripe-express-checkout-button-separator' ).after(
 					'<div class="newspack-ui__word-divider">' + newspackBlocksModalCheckout.divider_text + '</div>'
 				);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Make sure we also target `#wc-stripe-express-checkout-button-separator`

__Before:__

![1-bfr](https://github.com/user-attachments/assets/66086d60-e35c-4f9f-8f16-22a9963461d5)

__After:__

![2-aftr](https://github.com/user-attachments/assets/42583b3a-91dd-4490-80a4-b3f1f2532785)

### How to test the changes in this Pull Request:

1. Enable stripe express checkout
2. Notice the separator "Or" that looks unstyled on a product page when trying to checkout
3. Switch to this branch
4. Refresh modal

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
