### PR TITLE
Fix/donate block formatting

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -1504,6 +1504,10 @@ class Newspack_Blocks {
 			$currency_symbol     = function_exists( 'get_woocommerce_currency_symbol' ) ? \get_woocommerce_currency_symbol() : '&#36;';
 			$wc_formatted_amount = '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">' . $currency_symbol . '</span>AMOUNT_PLACEHOLDER</bdi></span> FREQUENCY_PLACEHOLDER';
 		} else {
+			// If it's a float but with no decimal value, treat it as an int.
+			if ( is_float( $amount ) && floor( $amount ) == $amount ) {
+				$amount = (int) $amount;
+			}
 			// Format the amount with currency symbol and separators.
 			$amount_string = \wc_price(
 				$amount,

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
@@ -40,7 +40,7 @@ abstract class Newspack_Blocks_Donate_Renderer_Base {
 	 *
 	 * @param array $attributes Block attributes.
 	 */
-	public static function get_configuration( $attributes ) {
+	public static function get_configuration( $attributes = [] ) {
 		$attributes_hash = md5( wp_json_encode( $attributes ) );
 		if ( isset( self::$configurations_cache[ $attributes_hash ] ) ) {
 			return self::$configurations_cache[ $attributes_hash ];

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
@@ -148,7 +148,7 @@ abstract class Newspack_Blocks_Donate_Renderer_Base {
 		if ( isset( $configuration['minimumDonation'] ) ) {
 			foreach ( $configuration['amounts'] as $frequency => $amounts ) {
 				foreach ( $amounts as $index => $amount ) {
-					$configuration['amounts'][ $frequency ][ $index ] = max( $configuration['minimumDonation'], $amount );
+					$configuration['amounts'][ $frequency ][ $index ] = max( (float) $configuration['minimumDonation'], $amount );
 				}
 			}
 		}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -27,6 +27,9 @@ function newspack_blocks_manually_load_plugin() {
 }
 tests_add_filter( 'muplugins_loaded', 'newspack_blocks_manually_load_plugin' );
 
+// Print errors to stdout.
+ini_set( 'error_log', 'php://stdout' ); // phpcs:ignore WordPress.PHP.IniSet.Risky
+
 // Load the composer autoloader.
 require_once __DIR__ . '/../vendor/autoload.php';
 

--- a/tests/test-donate-block.php
+++ b/tests/test-donate-block.php
@@ -1,0 +1,92 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Class DonateBlockTest
+ *
+ * @package Newspack_Blocks
+ */
+
+/**
+ * Mock WooCommerce functions for testing.
+ */
+if ( ! function_exists( 'wc_price' ) ) {
+	/**
+	 * Mock wc_price function.
+	 *
+	 * @param float $price The price to format.
+	 * @param array $args Formatting arguments.
+	 * @return string Formatted price.
+	 */
+	function wc_price( $price, $args = [] ) {
+		$decimals = isset( $args['decimals'] ) ? $args['decimals'] : 2;
+		$formatted_price = number_format( $price, $decimals );
+		return '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">$</span>' . $formatted_price . '</bdi></span>';
+	}
+}
+
+if ( ! function_exists( 'get_woocommerce_currency_symbol' ) ) {
+	/**
+	 * Mock get_woocommerce_currency_symbol function.
+	 *
+	 * @return string Currency symbol.
+	 */
+	function get_woocommerce_currency_symbol() {
+		return '$';
+	}
+}
+
+if ( ! function_exists( 'wcs_price_string' ) ) {
+	/**
+	 * Mock wcs_price_string function for subscriptions.
+	 *
+	 * @param array $args Price string arguments.
+	 * @return string Formatted subscription price string.
+	 */
+	function wcs_price_string( $args ) {
+		$recurring_amount = isset( $args['recurring_amount'] ) ? $args['recurring_amount'] : '';
+		$period = isset( $args['subscription_period'] ) ? $args['subscription_period'] : 'month';
+
+		if ( 'day' === $period ) {
+			return $recurring_amount;
+		}
+
+		return $recurring_amount . ' / ' . $period;
+	}
+}
+
+/**
+ * Donate Block.
+ */
+class DonateBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
+	/**
+	 * Test the amount formatting.
+	 */
+	public function test_donate_block_amount_formatting() {
+		$expected_format_wrapper = '<span class="wpbnbd__tiers__amount__value"><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">$</span>%s</bdi></span></span>';
+
+		$this->assertEquals(
+			sprintf( $expected_format_wrapper, '25' ),
+			Newspack_Blocks::get_formatted_amount( 25, 'once' )
+		);
+		$this->assertEquals(
+			sprintf( $expected_format_wrapper, '1,000' ),
+			Newspack_Blocks::get_formatted_amount( 1000, 'once' )
+		);
+
+		// Test float amounts.
+		$formatted_float = Newspack_Blocks::get_formatted_amount( 25.50, 'once' );
+		$this->assertEquals(
+			sprintf( $expected_format_wrapper, '25.50' ),
+			Newspack_Blocks::get_formatted_amount( 25.5, 'once' )
+		);
+
+		// Test zero amount.
+		$formatted_zero = Newspack_Blocks::get_formatted_amount( 0, 'once' );
+		$this->assertIsString( $formatted_zero );
+
+		// Returning placeholder format.
+		$this->assertEquals(
+			$with_placeholder = Newspack_Blocks::get_formatted_amount(),
+			'<span class="wpbnbd__tiers__amount__value"><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">$</span>AMOUNT_PLACEHOLDER</bdi></span> FREQUENCY_PLACEHOLDER</span>'
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes handling of minimum value for the Donate block.

### How to test the changes in this Pull Request:

1. On `trunk`
1. Use this configuration for a Donate block:

```
<!-- wp:newspack-blocks/donate {"className":"is-style-modern","manual":true,"amounts":{"once":[25,50,500,20],"month":[15,25,50,15],"year":[50,500,800,180]},"disabledFrequencies":{"once":true,"month":false,"year":false},"defaultFrequency":"year","buttonColor":"#ffb243","minimumDonation":"15","layoutOption":"tiers","tiersBasedOptions":[{"heading":"","description":"","buttonText":"Select","recommendLabel":""},{"heading":"","description":"","buttonText":"Select","recommendLabel":""},{"heading":"","description":"","buttonText":"Select","recommendLabel":"Premium"}]} /-->
```

3. Observe the issue with decimals:

<img width="224" alt="image" src="https://github.com/user-attachments/assets/803d5f19-a82c-4514-acd6-9e6937775a32" />

5. Switch to this branch, observe the issue gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->