### PR TITLE
fix(checkout-button): action hook for hidden fields

### DIFF
--- a/src/blocks/checkout-button/view.php
+++ b/src/blocks/checkout-button/view.php
@@ -108,6 +108,15 @@ function render_callback( $attributes ) {
 		$hidden_fields .= $after_success_url ? '<input type="hidden" name="after_success_url" value="' . esc_attr( $after_success_url ) . '" />' : '';
 	}
 
+	ob_start();
+	/**
+	 * Fires when generating hidden fields for the checkout button.
+	 *
+	 * @param array $attributes Block attributes.
+	 */
+	do_action( 'newspack_blocks_checkout_button_hidden_fields', $attributes );
+	$hidden_fields .= ob_get_clean();
+
 	// Generate the form.
 	if ( function_exists( 'wc_get_product' ) ) {
 		$product = wc_get_product( $product_id );

--- a/src/modal-checkout/analytics/ga4/pagination.js
+++ b/src/modal-checkout/analytics/ga4/pagination.js
@@ -21,6 +21,7 @@ export const managePagination = ( action = 'continue' ) => {
 		referrer,
 		variation_id = '',
 		gate_post_id = '',
+		newspack_popup_id = '',
 	} = getProductDetails( 'modal-checkout-product-details' );
 
 	const params = {
@@ -41,6 +42,11 @@ export const managePagination = ( action = 'continue' ) => {
 	// If this checkout started from a content gate, add the gate ID to the payload.
 	if ( gate_post_id ) {
 		params.gate_post_id = gate_post_id;
+	}
+
+	// If this checkout started from a campaign prompt, add the popup ID to the payload.
+	if ( newspack_popup_id ) {
+		params.newspack_popup_id = newspack_popup_id;
 	}
 
 	const payload = getEventPayload( action, params );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements an action hook for custom hidden inputs for the Checkout Button block.

### How to test the changes in this Pull Request:

Instructions at https://github.com/Automattic/newspack-popups/pull/1441

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
