### PR TITLE
fix(homepage-articles): revert #2123

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -232,40 +232,22 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 		return;
 	}
 
-	// If the block is rendered in wp_kses_post() call, ensure the `time` tag is allowed.
-	\add_filter(
-		'wp_kses_allowed_html',
-		function( $tags ) {
-			$tags['time'] = [
-				'class'    => true,
-				'datetime' => true,
-			];
-			return $tags;
-		}
-	);
-
 	// Gather all Homepage Articles blocks on the page and output only the needed CSS.
-	// This CSS will be printed in the document head once.
+	// This CSS will be printed along with the first found block markup.
 	global $newspack_blocks_hpb_all_blocks;
-	static $has_enqueued_styles = false;
-
+	$inline_style_html = '';
 	if ( ! is_array( $newspack_blocks_hpb_all_blocks ) ) {
 		$newspack_blocks_hpb_all_blocks = newspack_blocks_retrieve_homepage_articles_blocks(
 			parse_blocks( get_the_content() ),
 			$block_name
 		);
-		$all_used_attrs = newspack_blocks_collect_all_attribute_values( array_column( $newspack_blocks_hpb_all_blocks, 'attrs' ) );
-
-		if ( ! $has_enqueued_styles ) {
-			$css_string = newspack_blocks_get_homepage_articles_css_string( $all_used_attrs );
-
-			// Enqueue CSS in head instead of adding inline to block content.
-			wp_register_style( 'newspack-blocks-homepage-articles-inline', false, [], \NEWSPACK_BLOCKS__VERSION );
-			wp_enqueue_style( 'newspack-blocks-homepage-articles-inline' );
-			wp_add_inline_style( 'newspack-blocks-homepage-articles-inline', $css_string );
-
-			$has_enqueued_styles = true;
-		}
+		$all_used_attrs                 = newspack_blocks_collect_all_attribute_values( array_column( $newspack_blocks_hpb_all_blocks, 'attrs' ) );
+		$css_string                     = newspack_blocks_get_homepage_articles_css_string( $all_used_attrs );
+		ob_start();
+		?>
+			<style id="newspack-blocks-inline-css" type="text/css"><?php echo esc_html( $css_string ); ?></style>
+		<?php
+		$inline_style_html = ob_get_clean();
 	}
 
 	// This will let the FSE plugin know we need CSS/JS now.
@@ -380,6 +362,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 		class="<?php echo esc_attr( $classes ); ?>"
 		style="<?php echo esc_attr( $styles ); ?>"
 		>
+		<?php echo $inline_style_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 		<div data-posts data-current-post-id="<?php the_ID(); ?>">
 			<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
 				<h2 class="article-section-title">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

p1748973619796749-slack-C015W6BES8J

Reverts #2123.

The solution doesn't interact well with block caching. When blocks are cached, the block render callback is never called, and the inline styles are never enqueued.

### How to test the changes in this Pull Request:

1. While on release, visit your site anonymously and confirm that when blocks are cached, the `newspack-blocks-homepage-articles-inline` style tag is not added to the markup
2. Checkout this branch, refresh and confirm the inline styles are rendered as expected (as part of the block markup)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
