### PR TITLE
feat(modal-checkout): change subscription payment method

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -2153,18 +2153,26 @@ final class Modal_Checkout {
 	 * @return string Post checkout success message text.
 	 */
 	public static function get_post_checkout_success_text() {
-		if ( ! class_exists( '\Newspack\Reader_Activation' ) || ! \Newspack\Reader_Activation::is_enabled() ) {
-			return sprintf(
-				// Translators: %s is the site name.
-				__( 'Thank you for supporting %s. Your transaction was completed successfully.', 'newspack-blocks' ),
-				get_option( 'blogname' )
-			);
+		$text = sprintf(
+			// Translators: %s is the site name.
+			__( 'Thank you for supporting %s. Your transaction was completed successfully.', 'newspack-blocks' ),
+			get_option( 'blogname' )
+		);
+
+		if ( class_exists( '\Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) {
+			if ( ! self::is_registration_required() && self::is_checkout_registration() ) {
+				$text = \Newspack\Reader_Activation::get_post_checkout_registration_success_text();
+			} else {
+				$text = \Newspack\Reader_Activation::get_post_checkout_success_text();
+			}
 		}
-		if ( ! self::is_registration_required() && self::is_checkout_registration() ) {
-			return \Newspack\Reader_Activation::get_post_checkout_registration_success_text();
-		} else {
-			return \Newspack\Reader_Activation::get_post_checkout_success_text();
-		}
+
+		/**
+		 * Filters the post checkout success message text.
+		 *
+		 * @param string $text The post checkout success message text.
+		 */
+		return apply_filters( 'newspack_modal_checkout_success_text', $text );
 	}
 }
 Modal_Checkout::init();

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1049,7 +1049,7 @@ final class Modal_Checkout {
 			<link rel="profile" href="https://gmpg.org/xfn/11" />
 			<?php wp_head(); ?>
 		</head>
-		<body class="<?php echo esc_attr( "$class_prefix {$class_prefix}__modal__content" ); ?>" id="newspack_modal_checkout_container">
+		<body <?php body_class( "$class_prefix {$class_prefix}__modal__content" ); ?> id="newspack_modal_checkout_container">
 			<?php
 			if ( is_checkout() || is_order_received_page() ) {
 				echo do_shortcode( '[woocommerce_checkout]' );
@@ -1196,6 +1196,7 @@ final class Modal_Checkout {
 			$custom_templates['global/form-login.php']       = 'src/modal-checkout/templates/thankyou.php';
 			$custom_templates['checkout/form-checkout.php']  = 'src/modal-checkout/templates/form-checkout.php';
 			$custom_templates['checkout/payment-method.php'] = 'src/modal-checkout/templates/payment-method.php';
+			$custom_templates['checkout/form-change-payment-method.php'] = 'src/modal-checkout/templates/form-change-payment-method.php';
 			$custom_templates['checkout/thankyou.php']       = 'src/modal-checkout/templates/thankyou.php';
 		}
 

--- a/includes/modal-checkout/class-change-payment-gateway.php
+++ b/includes/modal-checkout/class-change-payment-gateway.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Subscriptions Change Payment Gateway integration for the Modal Checkout.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Blocks\Modal_Checkout;
+
+use Newspack_Blocks\Modal_Checkout;
+
+
+/**
+ * Change Payment Gateway integration class.
+ */
+final class Change_Payment_Gateway {
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'remove_filters' ] );
+		add_filter( 'newspack_modal_checkout_success_text', [ __CLASS__, 'get_success_text' ] );
+		add_filter( 'newspack_modal_checkout_data', [ __CLASS__, 'get_checkout_data' ] );
+	}
+
+	/**
+	 * Remove some WooCommerce Subscriptions filters for the modal checkout.
+	 */
+	public static function remove_filters() {
+		if ( ! Modal_Checkout::is_modal_checkout() ) {
+			return;
+		}
+
+		// Remove the custom return URL filter so it renders modal checkout's
+		// "Thank You" template.
+		remove_filter( 'woocommerce_get_return_url', 'WC_Subscriptions_Change_Payment_Gateway::get_return_url', 11 );
+	}
+
+	/**
+	 * Use WooCommerce Subscriptions' success notice for the change payment
+	 * method form.
+	 *
+	 * @param string $text The success text.
+	 *
+	 * @return string The success text.
+	 */
+	public static function get_success_text( $text ) {
+		if ( ! isset( $_GET['action_type'] ) || 'change_payment_method' !== $_GET['action_type'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return $text;
+		}
+
+		$notices = wc_get_notices( 'success' );
+		wc_clear_notices();
+
+		return implode(
+			'<br>',
+			array_map(
+				function( $notice ) {
+					return $notice['notice'];
+				},
+				$notices
+			)
+		);
+	}
+
+	/**
+	 * Modify the checkout data for the change payment method action.
+	 *
+	 * @param array $data The checkout data.
+	 *
+	 * @return array The checkout data.
+	 */
+	public static function get_checkout_data( $data ) {
+		if ( $data['action_type'] !== 'change_payment_method' ) {
+			return $data;
+		}
+
+		// The original order may contain gate or prompt post IDs, which are not
+		// relevant for this action and should be removed to avoid confusion.
+		unset( $data['gate_post_id'] );
+		unset( $data['prompt_post_id'] );
+
+		return $data;
+	}
+}
+Change_Payment_Gateway::init();

--- a/includes/modal-checkout/class-checkout-data.php
+++ b/includes/modal-checkout/class-checkout-data.php
@@ -123,6 +123,9 @@ final class Checkout_Data {
 				$action_type = 'donation';
 			}
 		}
+		if ( isset( $_GET['action_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$action_type = sanitize_text_field( wp_unslash( $_GET['action_type'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		}
 		return $action_type;
 	}
 
@@ -190,7 +193,12 @@ final class Checkout_Data {
 			$amount       = $cart_item['data']->get_price();
 			$referrer     = $cart_item['referer'] ?? '';
 		} elseif ( $source instanceof \WC_Order ) {
-			$order        = $source;
+			// If order as actually a subscription object, we need to get the original order.
+			if ( $source instanceof \WC_Subscription ) {
+				$order = $source->get_parent();
+			} else {
+				$order = $source;
+			}
 			$order_items  = $order->get_items();
 			$order_item   = reset( $order_items ); // Use only the first item in the order.
 			$product_id   = $order_item->get_product_id();
@@ -282,6 +290,12 @@ final class Checkout_Data {
 			$data['newspack_popup_id'] = $newspack_popup_id;
 		}
 
-		return $data;
+		/**
+		 * Filters the checkout data.
+		 *
+		 * @param array $data The checkout data.
+		 * @param \WC_Product|\WC_Product_Variation|\WC_Cart|\WC_Order $source Product, product variation, cart or order object.
+		 */
+		return apply_filters( 'newspack_modal_checkout_data', $data, $source );
 	}
 }

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -22,6 +22,7 @@ require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'includes/class-newspack-blocks-api.p
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'includes/class-newspack-blocks-patterns.php';
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'includes/class-newspack-blocks-caching.php';
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'includes/modal-checkout/class-checkout-data.php';
+require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'includes/modal-checkout/class-change-payment-gateway.php';
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'includes/class-modal-checkout.php';
 
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'includes/plugins/class-the-events-calendar.php';

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -921,12 +921,12 @@
 	 */
 	/* stylelint-disable-next-line selector-id-pattern */
 	#order_review {
-		.payment_methods {
-			margin: 0 0 var(--newspack-ui-spacer-5, 24px);
-			padding: 0;
+		.wc_payment_methods {
 			.wc_payment_method:only-child {
 				> label {
-					display: none;
+					background: transparent;
+					border-color: transparent;
+					padding: 0;
 				}
 			}
 		}

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -901,7 +901,7 @@
 		}
 	}
 
-	.woocommerce .woocommerce-notices-wrapper {
+	.woocommerce .woocommerce-notices-wrapper:not(:empty) {
 		margin-bottom: var(--newspack-ui-spacer-5, 24px);
 		margin-top: 0;
 	}
@@ -914,5 +914,27 @@
 	/* stylelint-disable-next-line selector-id-pattern */
 	#address_rdi_field {
 		display: none;
+	}
+
+	/**
+	 * Change Payment Method form.
+	 */
+	/* stylelint-disable-next-line selector-id-pattern */
+	#order_review {
+		.payment_methods {
+			margin: 0 0 var(--newspack-ui-spacer-5, 24px);
+			padding: 0;
+			.wc_payment_method:only-child {
+				> label {
+					display: none;
+				}
+			}
+		}
+		.update-all-subscriptions-payment-method-wrap {
+			label {
+				font-weight: normal;
+				font-size: var(--newspack-ui-font-size-xs, 14px);
+			}
+		}
 	}
 }

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -72,7 +72,8 @@ import { domReady } from './utils';
 				const $form = $( 'form.checkout' );
 
 				if ( ! $form.length ) {
-					console.warn( 'Form is not available' ); // eslint-disable-line no-console
+					console.warn( 'Checkout form is not available' ); // eslint-disable-line no-console
+					setReady();
 					return;
 				}
 

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -800,6 +800,8 @@ domReady( () => {
 	 * Open the modal checkout.
 	 *
 	 * @param {Object}   options                    Modal checkout options object.
+	 * @param {string}   options.url                The URL to open the modal checkout on.
+	 *                                              If not provided, the default checkout URL will be used.
 	 * @param {string}   options.title              The title to set for the modal.
 	 * @param {string}   options.actionType         The action type to set for the modal.
 	 * @param {Object}   options.afterSuccess       The after success configuration object.
@@ -807,6 +809,7 @@ domReady( () => {
 	 * @param {Function} options.onClose            The callback to call when the modal is closed.
 	 */
 	window.newspackOpenModalCheckout = ( {
+		url = null,
 		title = null,
 		actionType = null,
 		afterSuccess = {},
@@ -823,7 +826,21 @@ domReady( () => {
 		/**
 		 * Start with the default checkout URL.
 		 */
-		const url = new URL( newspackBlocksModal.checkout_url );
+		 url = new URL( url || newspackBlocksModal.checkout_url );
+
+		/**
+		 * For integration purposes, remove `my_account_checkout` from the URL if it exists.
+		 */
+		if ( url.searchParams.has( 'my_account_checkout' ) ) {
+			url.searchParams.delete( 'my_account_checkout' );
+		}
+
+		/**
+		 * Add `modal_checkout` to the URL if it doesn't exist.
+		 */
+		if ( ! url.searchParams.has( 'modal_checkout' ) ) {
+			url.searchParams.set( 'modal_checkout', '1' );
+		}
 
 		/**
 		 * Custom action type configuration.

--- a/src/modal-checkout/templates/form-change-payment-method.php
+++ b/src/modal-checkout/templates/form-change-payment-method.php
@@ -12,7 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 ?>
-<form id="order_review" class="checkout" method="post">
+<form id="order_review" method="post" target="_parent">
+
 	<div id="payment">
 		<?php
 		if ( $subscription->has_payment_gateway() ) {
@@ -28,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		if ( $available_gateways ) :
 			?>
-			<ul class="wc_payment_methods payment_methods methods">
+			<ul class="payment_methods methods">
 				<?php
 
 				if ( count( $available_gateways ) ) {
@@ -37,9 +38,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 				foreach ( $available_gateways as $gateway ) :
 					$supports_payment_method_changes = WC_Subscriptions_Change_Payment_Gateway::can_update_all_subscription_payment_methods( $gateway, $subscription );
-					include 'payment-method.php';
-				endforeach;
-				?>
+					?>
+					<li class="wc_payment_method payment_method_<?php echo esc_attr( $gateway->id ); ?>">
+						<input id="payment_method_<?php echo esc_attr( $gateway->id ); ?>" type="radio" class="input-radio <?php echo $supports_payment_method_changes ? 'supports-payment-method-changes' : ''; ?>" name="payment_method" value="<?php echo esc_attr( $gateway->id ); ?>" <?php checked( $gateway->chosen, true ); ?> data-order_button_text="<?php echo esc_attr( apply_filters( 'wcs_gateway_change_payment_button_text', $pay_order_button_text, $gateway ) ); ?>"/>
+						<label for="payment_method_<?php echo esc_attr( $gateway->id ); ?>"><?php echo esc_html( $gateway->get_title() ); ?><?php echo wp_kses_post( $gateway->get_icon() ); ?></label>
+						<?php
+						if ( $gateway->has_fields() || $gateway->get_description() ) {
+							echo '<div class="payment_box payment_method_' . esc_attr( $gateway->id ) . '" style="display:none;">';
+							$gateway->payment_fields();
+							echo '</div>';
+						}
+						?>
+					</li>
+				<?php endforeach; ?>
 			</ul>
 		<?php else : ?>
 			<div class="woocommerce-error">
@@ -74,14 +85,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			<?php
 			echo wp_kses(
-				apply_filters( 'woocommerce_change_payment_button_html', '<input type="submit" class="button alt' . esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ) . '" id="place_order" value="' . esc_attr( $pay_order_button_text ) . '" data-value="' . esc_attr( $pay_order_button_text ) . '" />' ),
+				apply_filters( 'woocommerce_change_payment_button_html', '<button type="submit" class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide button alt' . esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ) . '" id="place_order">' . esc_html( $pay_order_button_text ) . '</button>' ),
 				array(
-					'input' => array(
-						'type'       => array(),
-						'class'      => array(),
-						'id'         => array(),
-						'value'      => array(),
-						'data-value' => array(),
+					'button' => array(
+						'type'  => array(),
+						'class' => array(),
+						'id'    => array(),
 					),
 				)
 			);

--- a/src/modal-checkout/templates/form-change-payment-method.php
+++ b/src/modal-checkout/templates/form-change-payment-method.php
@@ -29,28 +29,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		if ( $available_gateways ) :
 			?>
-			<ul class="payment_methods methods">
+			<ul class="wc_payment_methods payment_methods methods">
 				<?php
 
 				if ( count( $available_gateways ) ) {
 					current( $available_gateways )->set_current();
 				}
 
-				foreach ( $available_gateways as $gateway ) :
-					$supports_payment_method_changes = WC_Subscriptions_Change_Payment_Gateway::can_update_all_subscription_payment_methods( $gateway, $subscription );
-					?>
-					<li class="wc_payment_method payment_method_<?php echo esc_attr( $gateway->id ); ?>">
-						<input id="payment_method_<?php echo esc_attr( $gateway->id ); ?>" type="radio" class="input-radio <?php echo $supports_payment_method_changes ? 'supports-payment-method-changes' : ''; ?>" name="payment_method" value="<?php echo esc_attr( $gateway->id ); ?>" <?php checked( $gateway->chosen, true ); ?> data-order_button_text="<?php echo esc_attr( apply_filters( 'wcs_gateway_change_payment_button_text', $pay_order_button_text, $gateway ) ); ?>"/>
-						<label for="payment_method_<?php echo esc_attr( $gateway->id ); ?>"><?php echo esc_html( $gateway->get_title() ); ?><?php echo wp_kses_post( $gateway->get_icon() ); ?></label>
-						<?php
-						if ( $gateway->has_fields() || $gateway->get_description() ) {
-							echo '<div class="payment_box payment_method_' . esc_attr( $gateway->id ) . '" style="display:none;">';
-							$gateway->payment_fields();
-							echo '</div>';
-						}
-						?>
-					</li>
-				<?php endforeach; ?>
+				foreach ( $available_gateways as $gateway ) {
+					require 'payment-method.php';
+				}
+
+				?>
 			</ul>
 		<?php else : ?>
 			<div class="woocommerce-error">

--- a/src/modal-checkout/templates/form-change-payment-method.php
+++ b/src/modal-checkout/templates/form-change-payment-method.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 ?>
-<form id="order_review" method="post" target="_parent">
+<form id="order_review" method="post">
 
 	<div id="payment">
 		<?php

--- a/src/modal-checkout/templates/form-change-payment-method.php
+++ b/src/modal-checkout/templates/form-change-payment-method.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Pay for order form displayed after a customer has clicked the "Change Payment method" button
+ * next to a subscription on their My Account page.
+ *
+ * To be rendered in the modal checkout.
+ *
+ * @package Newspack_Blocks
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+?>
+<form id="order_review" class="checkout" method="post">
+	<div id="payment">
+		<?php
+		if ( $subscription->has_payment_gateway() ) {
+			$pay_order_button_text = _x( 'Change payment method', 'text on button on checkout page', 'woocommerce-subscriptions' );
+		} else {
+			$pay_order_button_text = _x( 'Add payment method', 'text on button on checkout page', 'woocommerce-subscriptions' );
+		}
+
+		$pay_order_button_text     = apply_filters( 'woocommerce_change_payment_button_text', $pay_order_button_text );
+		$customer_subscription_ids = WCS_Customer_Store::instance()->get_users_subscription_ids( $subscription->get_customer_id() );
+		$payment_gateways_handler  = WC_Subscriptions_Core_Plugin::instance()->get_gateways_handler_class();
+		$available_gateways        = WC()->payment_gateways->get_available_payment_gateways();
+
+		if ( $available_gateways ) :
+			?>
+			<ul class="wc_payment_methods payment_methods methods">
+				<?php
+
+				if ( count( $available_gateways ) ) {
+					current( $available_gateways )->set_current();
+				}
+
+				foreach ( $available_gateways as $gateway ) :
+					$supports_payment_method_changes = WC_Subscriptions_Change_Payment_Gateway::can_update_all_subscription_payment_methods( $gateway, $subscription );
+					include 'payment-method.php';
+				endforeach;
+				?>
+			</ul>
+		<?php else : ?>
+			<div class="woocommerce-error">
+				<p> <?php echo esc_html( apply_filters( 'woocommerce_no_available_payment_methods_message', __( 'Sorry, it seems no payment gateways support changing the recurring payment method. Please contact us if you require assistance or to make alternate arrangements.', 'woocommerce-subscriptions' ) ) ); ?></p>
+			</div>
+		<?php endif; ?>
+
+		<?php if ( $available_gateways ) : ?>
+			<?php if ( count( $customer_subscription_ids ) > 1 && $payment_gateways_handler::one_gateway_supports( 'subscription_payment_method_change_admin' ) ) : ?>
+			<span class="update-all-subscriptions-payment-method-wrap">
+				<?php
+				// translators: $1: opening <strong> tag, $2: closing </strong> tag.
+				$label = sprintf( esc_html__( 'Use this payment method for %1$sall%2$s of my current subscriptions', 'woocommerce-subscriptions' ), '<strong>', '</strong>' );
+
+				woocommerce_form_field(
+					'update_all_subscriptions_payment_method',
+					array(
+						'type'     => 'checkbox',
+						'class'    => array( 'form-row-wide' ),
+						'label'    => $label,
+						'required' => true, // Making the field required to help make it more prominent on the page.
+						'default'  => apply_filters( 'wcs_update_all_subscriptions_payment_method_checked', true ),
+					)
+				);
+				?>
+			</span>
+			<?php endif; ?>
+		<div class="form-row">
+			<?php wp_nonce_field( 'wcs_change_payment_method', '_wcsnonce', true, true ); ?>
+
+			<?php do_action( 'woocommerce_subscriptions_change_payment_before_submit' ); ?>
+
+			<?php
+			echo wp_kses(
+				apply_filters( 'woocommerce_change_payment_button_html', '<input type="submit" class="button alt' . esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ) . '" id="place_order" value="' . esc_attr( $pay_order_button_text ) . '" data-value="' . esc_attr( $pay_order_button_text ) . '" />' ),
+				array(
+					'input' => array(
+						'type'       => array(),
+						'class'      => array(),
+						'id'         => array(),
+						'value'      => array(),
+						'data-value' => array(),
+					),
+				)
+			);
+			?>
+
+			<?php do_action( 'woocommerce_subscriptions_change_payment_after_submit' ); ?>
+
+			<input type="hidden" name="woocommerce_change_payment" value="<?php echo esc_attr( $subscription->get_id() ); ?>" />
+		</div>
+		<?php endif; ?>
+
+	</div>
+
+</form>

--- a/src/modal-checkout/templates/payment-method.php
+++ b/src/modal-checkout/templates/payment-method.php
@@ -9,11 +9,15 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
+$supports_payment_method_changes = false;
+if ( ! empty( $subscription ) ) {
+	$supports_payment_method_changes = WC_Subscriptions_Change_Payment_Gateway::can_update_all_subscription_payment_methods( $gateway, $subscription );
+}
 ?>
 
 <li class="wc_payment_method payment_method_<?php echo esc_attr( $gateway->id ); ?>">
 	<label class="newspack-ui__input-card" for="payment_method_<?php echo esc_attr( $gateway->id ); ?>">
-		<input id="payment_method_<?php echo esc_attr( $gateway->id ); ?>" type="radio" class="input-radio" name="payment_method" value="<?php echo esc_attr( $gateway->id ); ?>" <?php checked( $gateway->chosen, true ); ?> data-order_button_text="<?php echo esc_attr( $gateway->order_button_text ); ?>" />
+		<input id="payment_method_<?php echo esc_attr( $gateway->id ); ?>" type="radio" class="input-radio <?php echo $supports_payment_method_changes ? 'supports-payment-method-changes' : ''; ?>" name="payment_method" value="<?php echo esc_attr( $gateway->id ); ?>" <?php checked( $gateway->chosen, true ); ?> data-order_button_text="<?php echo esc_attr( $gateway->order_button_text ); ?>" />
 		<span>
 			<?php echo $gateway->get_title(); /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?> <?php echo $gateway->get_icon(); /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?>
 			<?php if ( $gateway->has_fields() || $gateway->get_description() ) : ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Integrate the modal checkout with WooCommerce Subscriptions' ability to change a subscription payment method.

The new `src/modal-checkout/templates/form-change-payment-method.php` was copied from WooCommerce Subscriptions, with slight changes so it doesn't render the summary table:

| Original | Modified |
| --- | --- |
| <img width="1233" alt="image" src="https://github.com/user-attachments/assets/3d476461-af0c-49f4-89ed-fcb4968209bc" /> | <img width="610" alt="image" src="https://github.com/user-attachments/assets/586901f4-e8c2-4a56-9c2d-d7f0e6e22d73" /> |

A new `newspack_modal_checkout_success_text` filter is being introduced so the `Change_Payment_Gateway` integration class can implement the success message according to Woo Subscriptions' response.

Further details and instructions at https://github.com/Automattic/newspack-plugin/pull/4016

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
