### PR TITLE
fix(homepage-articles): add styles outside of the block markup

### DIFF
--- a/includes/class-newspack-blocks-caching.php
+++ b/includes/class-newspack-blocks-caching.php
@@ -212,6 +212,10 @@ class Newspack_Blocks_Caching {
 		if ( ! self::should_cache_block( $block_data ) ) {
 			return $block_html;
 		}
+
+		// Equeue the styles needed to render the blocks.
+		newspack_blocks_enqueue_block_homepage_articles_styles();
+
 		if ( ! self::$can_serve_all_blocks_from_cache ) {
 			return $block_html;
 		}

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -214,6 +214,25 @@ function newspack_blocks_get_homepage_articles_css_string( $attrs ) {
 }
 
 /**
+ * Gather all Homepage Articles blocks on the page and output only the needed CSS.
+ */
+function newspack_blocks_enqueue_block_homepage_articles_styles() {
+	global $newspack_blocks_hpb_all_blocks;
+	if ( ! is_array( $newspack_blocks_hpb_all_blocks ) ) {
+		$block_name = apply_filters( 'newspack_blocks_block_name', 'newspack-blocks/homepage-articles' );
+		$newspack_blocks_hpb_all_blocks = newspack_blocks_retrieve_homepage_articles_blocks(
+			parse_blocks( get_the_content() ),
+			$block_name
+		);
+		$all_used_attrs = newspack_blocks_collect_all_attribute_values( array_column( $newspack_blocks_hpb_all_blocks, 'attrs' ) );
+		$css_string = newspack_blocks_get_homepage_articles_css_string( $all_used_attrs );
+		wp_register_style( 'newspack-blocks-homepage-articles-inline', false, [], \NEWSPACK_BLOCKS__VERSION );
+		wp_enqueue_style( 'newspack-blocks-homepage-articles-inline' );
+		wp_add_inline_style( 'newspack-blocks-homepage-articles-inline', $css_string );
+	}
+}
+
+/**
  * Renders the `newspack-blocks/homepage-posts` block on server.
  *
  * @param array $attributes The block attributes.
@@ -230,24 +249,6 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	$article_query = new WP_Query( Newspack_Blocks::build_articles_query( $attributes, $block_name ) );
 	if ( ! $article_query->have_posts() ) {
 		return;
-	}
-
-	// Gather all Homepage Articles blocks on the page and output only the needed CSS.
-	// This CSS will be printed along with the first found block markup.
-	global $newspack_blocks_hpb_all_blocks;
-	$inline_style_html = '';
-	if ( ! is_array( $newspack_blocks_hpb_all_blocks ) ) {
-		$newspack_blocks_hpb_all_blocks = newspack_blocks_retrieve_homepage_articles_blocks(
-			parse_blocks( get_the_content() ),
-			$block_name
-		);
-		$all_used_attrs                 = newspack_blocks_collect_all_attribute_values( array_column( $newspack_blocks_hpb_all_blocks, 'attrs' ) );
-		$css_string                     = newspack_blocks_get_homepage_articles_css_string( $all_used_attrs );
-		ob_start();
-		?>
-			<style id="newspack-blocks-inline-css" type="text/css"><?php echo esc_html( $css_string ); ?></style>
-		<?php
-		$inline_style_html = ob_get_clean();
 	}
 
 	// This will let the FSE plugin know we need CSS/JS now.
@@ -362,7 +363,6 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 		class="<?php echo esc_attr( $classes ); ?>"
 		style="<?php echo esc_attr( $styles ); ?>"
 		>
-		<?php echo $inline_style_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 		<div data-posts data-current-post-id="<?php the_ID(); ?>">
 			<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
 				<h2 class="article-section-title">

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -263,6 +263,8 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 		}
 	);
 
+	newspack_blocks_enqueue_block_homepage_articles_styles();
+
 	// This will let the FSE plugin know we need CSS/JS now.
 	do_action( 'newspack_blocks_render_homepage_articles' );
 

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -251,6 +251,18 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 		return;
 	}
 
+	// If the block is rendered in wp_kses_post() call, ensure the `time` tag is allowed.
+	\add_filter(
+		'wp_kses_allowed_html',
+		function( $tags ) {
+			$tags['time'] = [
+				'class'    => true,
+				'datetime' => true,
+			];
+			return $tags;
+		}
+	);
+
 	// This will let the FSE plugin know we need CSS/JS now.
 	do_action( 'newspack_blocks_render_homepage_articles' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The HPB aka Content Loop block was rendering it's styles inline, in a `<style>` tag. That did not jive with how the Tabs block (or maybe some other blocks, too) render content nested in inner blocks. To be on the safe side, this PR moves the styles rendering to the document head.

This is a re-implementation of #2123 after it had to be reverted in #2139. The issue with the original approach was that the enqueueing of the CSS was done only if the block was not cached. This resulted in an experience in which the first request would get the the CSS enqueued, but the subsequent requests would not, because the HTML was served from cache and thus the `newspack_blocks_render_block_homepage_articles` function (enqueueing the CSS) was bypassed. 

### How to test the changes in this Pull Request:

1. Insert the Content Loop block on a page
2. Ensure a post with multiple authors is included – the styles for multiple authors are among those concerned here
3. Set the type scale of the block to the maximum value
4. Observe the post with multiple authors it rendered as expected
5. `wp config set NEWSPACK_LOG_LEVEL 2`, so that HPB caching is logged
6. Reload the page a few times and observe that the block is served from cache, but the styles persist

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210279806949908