### PR TITLE
fix(modal-checkout): price summary recurrence [NPPM-2084]

### DIFF
--- a/includes/modal-checkout/class-checkout-data.php
+++ b/includes/modal-checkout/class-checkout-data.php
@@ -206,7 +206,7 @@ final class Checkout_Data {
 		}
 
 		$product_type = self::get_product_type( $product_id );
-		$recurrence   = self::get_purchase_recurrence( $product_id );
+		$recurrence   = self::get_purchase_recurrence( $variation_id ? $variation_id : $product_id );
 
 		/**
 		 * Price summary name.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The refactor from #2121 introduced a regression to the modal checkout price summary for variable subscriptions. The recurrence was being checked only against the parent product ID, returning an incorrect value.

### How to test the changes in this Pull Request:

1. Create a variable subscription with a monthly and annually billing variations
2. Add a Checkout Button block to a page attached to the "annually" variation
3. Confirm the price summary renders the correct recurrence:

<img width="665" alt="image" src="https://github.com/user-attachments/assets/7d8c6d9b-d523-46b4-b9f2-06ef39369095" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
