### PR TITLE
fix: make sure RTL styles are loaded

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -315,14 +315,16 @@ class Newspack_Blocks {
 	 * Enqueue block styles stylesheet.
 	 */
 	public static function enqueue_block_styles_assets() {
-		$style_path = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'block_styles' . ( is_rtl() ? '-rtl' : '' ) . '.css';
+		$style_path = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'block_styles.css';
 		if ( file_exists( NEWSPACK_BLOCKS__PLUGIN_DIR . $style_path ) ) {
+			$handle = 'newspack-blocks-block-styles-stylesheet';
 			wp_enqueue_style(
-				'newspack-blocks-block-styles-stylesheet',
+				$handle,
 				plugins_url( $style_path, NEWSPACK_BLOCKS__PLUGIN_FILE ),
 				array(),
 				NEWSPACK_BLOCKS__VERSION
 			);
+			wp_style_add_data( $handle, 'rtl', 'replace' );
 		}
 	}
 
@@ -334,18 +336,20 @@ class Newspack_Blocks {
 	public static function enqueue_view_assets( $type ) {
 		$style_path = apply_filters(
 			'newspack_blocks_enqueue_view_assets',
-			NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view' . ( is_rtl() ? '-rtl' : '' ) . '.css',
+			NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view.css',
 			$type,
 			is_rtl()
 		);
 
 		if ( file_exists( NEWSPACK_BLOCKS__PLUGIN_DIR . $style_path ) ) {
+			$handle = "newspack-blocks-{$type}";
 			wp_enqueue_style(
-				"newspack-blocks-{$type}",
+				$handle,
 				plugins_url( $style_path, NEWSPACK_BLOCKS__PLUGIN_FILE ),
 				array(),
 				NEWSPACK_BLOCKS__VERSION
 			);
+			wp_style_add_data( $handle, 'rtl', 'replace' );
 		}
 		$script_data = static::script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view.js' );
 		if ( $script_data ) {

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -315,7 +315,7 @@ class Newspack_Blocks {
 	 * Enqueue block styles stylesheet.
 	 */
 	public static function enqueue_block_styles_assets() {
-		$style_path = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'block_styles' . ( is_rtl() ? '.rtl' : '' ) . '.css';
+		$style_path = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'block_styles' . ( is_rtl() ? '-rtl' : '' ) . '.css';
 		if ( file_exists( NEWSPACK_BLOCKS__PLUGIN_DIR . $style_path ) ) {
 			wp_enqueue_style(
 				'newspack-blocks-block-styles-stylesheet',
@@ -334,7 +334,7 @@ class Newspack_Blocks {
 	public static function enqueue_view_assets( $type ) {
 		$style_path = apply_filters(
 			'newspack_blocks_enqueue_view_assets',
-			NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css',
+			NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view' . ( is_rtl() ? '-rtl' : '' ) . '.css',
 			$type,
 			is_rtl()
 		);

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer.php
@@ -70,13 +70,14 @@ class Newspack_Blocks_Donate_Renderer {
 		wp_script_add_data( $handle, 'async', true );
 
 		if ( $has_css ) {
-			$style_path = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $filename . ( is_rtl() ? '-rtl' : '' ) . '.css';
+			$style_path = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $filename . '.css';
 			wp_enqueue_style(
 				$handle,
 				plugins_url( $style_path, NEWSPACK_BLOCKS__PLUGIN_FILE ),
 				[],
 				NEWSPACK_BLOCKS__VERSION
 			);
+			wp_style_add_data( $handle, 'rtl', 'replace' );
 		}
 	}
 

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer.php
@@ -70,7 +70,7 @@ class Newspack_Blocks_Donate_Renderer {
 		wp_script_add_data( $handle, 'async', true );
 
 		if ( $has_css ) {
-			$style_path = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $filename . ( is_rtl() ? '.rtl' : '' ) . '.css';
+			$style_path = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $filename . ( is_rtl() ? '-rtl' : '' ) . '.css';
 			wp_enqueue_style(
 				$handle,
 				plugins_url( $style_path, NEWSPACK_BLOCKS__PLUGIN_FILE ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This hotfix fixes the file name the plugin checks for the RTL CSS files - it was looking for files with a `.rtl.css` suffix, but the blocks are actually generating these styles with an `-rtl.css` suffix.

(I did this as a hotfix because it's having a rather noticeable effect on a site currently in staging). 

### How to test the changes in this Pull Request:

1. Set up some Content Loop blocks with obvious styles, like aligning the images right or left. 
2. Switch your site language to an RTL language (like Farsi), and note that the images are stacked, not aligned left or right.
3. Apply this PR.
4. Confirm the Content Loop block is now displaying correctly.
5. Switch back to an LTR language and confirm things look right.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
