### PR TITLE
feat: add ability to filter posts by Collection in blocks

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -226,6 +226,7 @@ class Newspack_Blocks {
 				'authors_rest_url'           => rest_url( 'newspack-blocks/v1/authors' ),
 				'assets_path'                => plugins_url( '/src/assets', NEWSPACK_BLOCKS__PLUGIN_FILE ),
 				'post_subtitle'              => get_theme_support( 'post-subtitle' ),
+				'collections_enabled'        => class_exists( '\Newspack\Optional_Modules\Collections' ) && \Newspack\Optional_Modules\Collections::is_module_active(),
 				'iframe_accepted_file_mimes' => WP_REST_Newspack_Iframe_Controller::iframe_accepted_file_mimes(),
 				'iframe_can_upload_archives' => WP_REST_Newspack_Iframe_Controller::can_upload_archives(),
 				'supports_recaptcha'         => class_exists( 'Newspack\Recaptcha' ),
@@ -616,6 +617,7 @@ class Newspack_Blocks {
 		$category_join              = isset( $attributes['categoryJoinType'] ) ? $attributes['categoryJoinType'] : 'or';
 		$tags                       = isset( $attributes['tags'] ) ? $attributes['tags'] : array();
 		$custom_taxonomies          = isset( $attributes['customTaxonomies'] ) ? $attributes['customTaxonomies'] : array();
+		$collections                = isset( $attributes['collections'] ) ? $attributes['collections'] : array();
 		$tag_exclusions             = isset( $attributes['tagExclusions'] ) ? $attributes['tagExclusions'] : array();
 		$category_exclusions        = isset( $attributes['categoryExclusions'] ) ? $attributes['categoryExclusions'] : array();
 		$custom_taxonomy_exclusions = isset( $attributes['customTaxonomyExclusions'] ) ? $attributes['customTaxonomyExclusions'] : array();
@@ -696,6 +698,38 @@ class Newspack_Blocks {
 						'taxonomy'         => $exclusion['slug'],
 						'terms'            => $exclusion['terms'],
 					];
+				}
+			}
+
+			// Handle collections filtering.
+			if ( $collections && count( $collections ) ) {
+				// Check if Collections module is active.
+				if ( class_exists( '\Newspack\Optional_Modules\Collections' ) && \Newspack\Optional_Modules\Collections::is_module_active() ) {
+					// Get the collection taxonomy terms that correspond to the selected collections.
+					$collection_terms = [];
+					foreach ( $collections as $collection_id ) {
+						$collection_post = get_post( $collection_id );
+						if ( $collection_post && 'newspack_collection' === $collection_post->post_type ) {
+							// Find the corresponding taxonomy term for this collection.
+							$terms = get_terms(
+								[
+									'taxonomy' => 'newspack_collection_taxonomy',
+									'name'     => $collection_post->post_title,
+									'fields'   => 'ids',
+								]
+							);
+							if ( ! empty( $terms ) ) {
+								$collection_terms = array_merge( $collection_terms, $terms );
+							}
+						}
+					}
+					if ( ! empty( $collection_terms ) ) {
+						$args['tax_query'][] = [
+							'taxonomy' => 'newspack_collection_taxonomy',
+							'field'    => 'term_id',
+							'terms'    => $collection_terms,
+						];
+					}
 				}
 			}
 

--- a/src/blocks/carousel/block.json
+++ b/src/blocks/carousel/block.json
@@ -47,6 +47,13 @@
 		"customTaxonomies": {
 			"type": "array"
 		},
+		"collections": {
+			"type": "array",
+			"default": [],
+			"items": {
+				"type": "integer"
+			}
+		},
 		"showDate": {
 			"type": "boolean",
 			"default": true

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -167,6 +167,7 @@ class Edit extends Component {
 			specificMode,
 			specificPosts,
 			tags,
+			collections,
 		} = attributes;
 		const classes = classnames(
 			className,
@@ -387,6 +388,8 @@ class Edit extends Component {
 								onSpecificPostsChange={ _specificPosts =>
 									setAttributes( { specificPosts: _specificPosts } )
 								}
+								collections={ collections }
+								onCollectionsChange={ value => setAttributes( { collections: value } ) }
 								postType={ postType }
 							/>
 						) }

--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -186,6 +186,13 @@
 				}
 			}
 		},
+		"collections": {
+			"type": "array",
+			"default": [],
+			"items": {
+				"type": "integer"
+			}
+		},
 		"specificPosts": {
 			"type": "array",
 			"default": [],

--- a/src/blocks/homepage-articles/edit.tsx
+++ b/src/blocks/homepage-articles/edit.tsx
@@ -298,6 +298,7 @@ class Edit extends Component< HomepageArticlesProps > {
 			tagExclusions,
 			categoryExclusions,
 			customTaxonomyExclusions,
+			collections,
 		} = attributes;
 
 		const imageSizeOptions = [
@@ -376,6 +377,8 @@ class Edit extends Component< HomepageArticlesProps > {
 						onCategoryExclusionsChange={ handleAttributeChange( 'categoryExclusions' ) }
 						customTaxonomyExclusions={ customTaxonomyExclusions }
 						onCustomTaxonomyExclusionsChange={ handleAttributeChange( 'customTaxonomyExclusions' ) }
+						collections={ collections }
+						onCollectionsChange={ handleAttributeChange( 'collections' ) }
 						postType={ postType }
 					/>
 					<ToggleControl

--- a/src/blocks/homepage-articles/utils.ts
+++ b/src/blocks/homepage-articles/utils.ts
@@ -38,6 +38,7 @@ const POST_QUERY_ATTRIBUTES = [
 	'tagExclusions',
 	'categoryExclusions',
 	'customTaxonomyExclusions',
+	'collections',
 	'postType',
 	'includedPostStatuses',
 	'deduplicate',
@@ -83,6 +84,7 @@ export const queryCriteriaFromAttributes = ( attributes: Block[ 'attributes' ] )
 		tagExclusions,
 		categoryExclusions,
 		customTaxonomyExclusions,
+		collections,
 		includedPostStatuses,
 	} = pick( attributes, POST_QUERY_ATTRIBUTES );
 
@@ -105,6 +107,7 @@ export const queryCriteriaFromAttributes = ( attributes: Block[ 'attributes' ] )
 				categoryExclusions: validateAttributeCollection( categoryExclusions ),
 				customTaxonomyExclusions,
 				customTaxonomies,
+				collections: validateAttributeCollection( collections ),
 				postType,
 				includedPostStatuses,
 			},

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -242,6 +242,44 @@ class QueryControls extends Component {
 		} );
 	};
 
+	fetchCollectionSuggestions = search => {
+		return apiFetch( {
+			path: addQueryArgs( '/newspack/v1/collections', {
+				search,
+				per_page: 20,
+			} ),
+		} ).then( function ( collections ) {
+			return collections.map( collection => ( {
+				value: collection.id,
+				label: decodeEntities( collection.title ) || __( '(no title)', 'newspack-blocks' ),
+			} ) );
+		} );
+	};
+
+	fetchSavedCollections = collectionIDs => {
+		return apiFetch( {
+			path: addQueryArgs( '/newspack/v1/collections', {
+				per_page: 100,
+				include: collectionIDs.join( ',' ),
+			} ),
+		} ).then( function ( collections ) {
+			const allCollections = collections.map( collection => ( {
+				value: collection.id,
+				label: decodeEntities( collection.title ) || __( '(no title)', 'newspack-blocks' ),
+			} ) );
+			// Look for collectionIDs that were not returned (deleted collections) and add them to the list.
+			collectionIDs.forEach( collectionID => {
+				if ( ! allCollections.find( collection => collection.value === parseInt( collectionID ) ) ) {
+					allCollections.push( {
+						value: parseInt( collectionID ),
+						label: __( 'Deleted collection', 'newspack-blocks' ),
+					} );
+				}
+			} );
+			return allCollections;
+		} );
+	};
+
 	render = () => {
 		const {
 			specificMode,
@@ -267,10 +305,13 @@ class QueryControls extends Component {
 			onCategoryExclusionsChange,
 			customTaxonomyExclusions,
 			onCustomTaxonomyExclusionsChange,
+			collections,
+			onCollectionsChange,
 			enableSpecific,
 		} = this.props;
 
 		const registeredCustomTaxonomies = window.newspack_blocks_data?.custom_taxonomies;
+		const collectionsEnabled = window.newspack_blocks_data?.collections_enabled || false;
 
 		const customTaxonomiesPrepareChange = ( taxArr, taxHandler, taxSlug, value ) => {
 			let newValue = taxArr.filter( tax => tax.slug !== taxSlug );
@@ -386,6 +427,15 @@ class QueryControls extends Component {
 								label={ __( 'Authors', 'newspack-blocks' ) }
 							/>
 						) }
+						{ onCollectionsChange && collectionsEnabled && (
+							<AutocompleteTokenField
+								tokens={ collections || [] }
+								onChange={ onCollectionsChange }
+								fetchSuggestions={ this.fetchCollectionSuggestions }
+								fetchSavedInfo={ this.fetchSavedCollections }
+								label={ __( 'Collections', 'newspack-blocks' ) }
+							/>
+						) }
 						{ onCustomTaxonomiesChange &&
 							registeredCustomTaxonomies.map( ( tax, index ) => (
 								<AutocompleteTokenField
@@ -465,6 +515,7 @@ QueryControls.defaultProps = {
 	customTaxonomies: [],
 	tagExclusions: [],
 	customTaxonomyExclusions: [],
+	collections: [],
 };
 
 export default QueryControls;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -42,6 +42,7 @@ declare global {
 		showExcerpt?: boolean;
 		showCaption?: boolean,
 		showCredit?: boolean,
+		collections?: number[];
 	};
 
 	type Block = {
@@ -112,6 +113,7 @@ declare global {
 		tagExclusions: TagId[];
 		categoryExclusions: CategoryId[];
 		customTaxonomyExclusions: Taxonomy[];
+		collections: number[];
 		className: string;
 		excerptLength: number;
 		showReadMore: boolean;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Along with https://github.com/Automattic/newspack-plugin/pull/4098, this PR adds the ability to filter the Content Loop block by Collection. This will make it possible to feature stories by collection on the homepage, or to build static individual collections pages (similar to how some publishers build static category/tag pages).

### How to test the changes in this Pull Request:

1. Apply https://github.com/Automattic/newspack-plugin/pull/4098 and this PR, and run `npm run build`. 
2. If not already, enable Collections under WP Admin > Newspack > Settings.
3. Make sure you have some Collections set up on your test site, and posts populating each of them.
4. Create a page and add a Content Loop block. In the Content panel of the right sidebar, confirm you have a Collections filter along with other options. (Collections Sections will appear either way since it's a taxonomy).

<img width="263" height="440" alt="CleanShot 2025-07-21 at 09 12 36" src="https://github.com/user-attachments/assets/0b90224a-a16b-48d5-85b8-160e0e1f757b" />

5. Type in one of your collection names; confirm you get some autocomplete behaviour. 
6. Pick the Collection; confirm your block now only shows that collection. 
7. Publish your page and confirm the correct stories appear on the front-end. 
8. Set up a post that's assigned to a Collection, and a Collection Section within that Collection.
9. In a Content Loop block, assign both the Collection and Collection Section; confirm you get the correct post.
10. Publish your page and confirm the correct stories appear on the front-end. 
11. Repeat steps 3-9 with the Content Carousel block. 
12. Disable the Collections module under WP Admin > Newspack > Settings.
13. Confirm that the Collections query is no longer available under the Content Loop and Carousel block settings.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
