### PR TITLE
fix: remove current page deduplication from logic when deduplication is disabled (NPPM-2130)

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -636,9 +636,7 @@ class Newspack_Blocks {
 			$args['orderby']        = 'post__in';
 		} else {
 			$args['posts_per_page'] = $posts_to_show;
-			if ( ! self::should_deduplicate_block( $attributes ) ) {
-				$args['post__not_in'] = [ get_the_ID() ]; // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_post__not_in
-			} else {
+			if ( self::should_deduplicate_block( $attributes ) ) {
 				if ( count( $newspack_blocks_all_specific_posts_ids ) ) {
 					$args['post__not_in'] = $newspack_blocks_all_specific_posts_ids; // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_post__not_in
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adjusts the query behaviour of the Content Loop block when deduplication is disabled.

Currently when deduplication is on, the block query will:
* Will check if a post has appeared before on the page; if yes, skip it.
* WIll add any posts that appear in the block to the list to check for the other blocks, so those stories don't appear again.
* Will check the current post/page and exclude it from appearing in the block.

And when deduplication is disabled, the block query:
* Will not check if if a post has appeared before on the page, it will show it anyway.
* Will not add any posts that appear in the block to the list to check for other blocks - so those stories can appear in subsequent blocks, even if they have deduplication on.
* Will check the current post/page and exclude it from appearing in the block.

That last bit is a little strange in application.

We often add a Content Loop block to a sidebar to show the latest posts and leave deduplication on -- in that case, it's really helpful that it doesn't show the current page. But when we disable deduplication, it's usually a really specific use case: you may want a story to appear a couple times on the homepage, or want it to appear in more than one CTA on the page, or a CTA that ignores other blocks on a page.

One real-life example where this may cause issues now is if we want to use the current Collection in CTAs for publishers: even when deduplication is disabled, if you go to the Collections landing page, the CTAs will show the previous issue.

This PR removes the check for the current post/page for content loop blocks where deduplication is disabled. It seems very low risk -- I can't think of a single case where a site would need to leverage this setting combination (having deduplication off but also needing to skip the current post/page in the block. I'm open to feedback on that, though!

### How to test the changes in this Pull Request:

1. On your site, add a Content Loop block in the below header and above footer widget areas. For both, set them to show one story, and disable deduplication.
2. On the homepage, add a Content Loop block and leave deduplication on. Check the front-end, and confirm you essentially have the same version of the same story three times: below the header, in the content, and above the footer.
3. Click any one of those stories to go to the single view of this post.
4. Note that the below header and above footer widgets now show a different story but only on this post.
5. Apply this PR.
6. Refresh the post and confirm the two widget areas now show the same post. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
