### PR TITLE
fix(author-block): classname application

### DIFF
--- a/src/blocks/author-profile/edit.js
+++ b/src/blocks/author-profile/edit.js
@@ -302,7 +302,7 @@ const AuthorProfile = ( { attributes, setAttributes } ) => {
 			</InspectorControls>
 			{ author && (
 				<BlockControls>
-					{ showAvatar && 'is-style-center' !== attributes.className && (
+					{ showAvatar && ! attributes.className?.includes( 'is-style-center' ) && (
 						<Toolbar
 							controls={ [
 								{

--- a/src/blocks/author-profile/single-author.js
+++ b/src/blocks/author-profile/single-author.js
@@ -62,7 +62,7 @@ export const SingleAuthor = ( { author, attributes } ) => {
 				'wp-block-newspack-blocks-author-profile',
 				'avatar-' + avatarAlignment,
 				'text-size-' + textSize,
-				{ 'is-style-center': 'is-style-center' === attributes.className }
+				attributes.className
 			) }
 		>
 			{ showAvatar && author.avatar && (


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes how `className` attribute is applied to the block.

Closes NPPM-2126

### How to test the changes in this Pull Request:

1. On `trunk`, add Author Profile block, make it centered, and add another classname in "Additional CSS class(es)" sidebar panel
2. Observe the centering is not applied in the editor
3. Switch to this branch, observe it's fixed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->