### PR TITLE
fix(modal-checkout): account for signup fee in price summary

### DIFF
--- a/includes/modal-checkout/class-checkout-data.php
+++ b/includes/modal-checkout/class-checkout-data.php
@@ -30,13 +30,15 @@ final class Checkout_Data {
 			if ( $frequency && $frequency !== 'once' ) {
 				// Get additional subscription details if product_id is provided.
 				$subscription_interval = 1;
-				$trial_length = 0;
-				$trial_period = '';
+				$trial_length          = 0;
+				$trial_period          = '';
+				$initial_amount        = 0;
 
 				if ( $product_id ) {
 					$subscription_interval = get_post_meta( $product_id, '_subscription_period_interval', true );
 					$trial_length = get_post_meta( $product_id, '_subscription_trial_length', true );
 					$trial_period = get_post_meta( $product_id, '_subscription_trial_period', true );
+					$initial_amount = get_post_meta( $product_id, '_subscription_sign_up_fee', true );
 
 					if ( empty( $subscription_interval ) ) {
 						$subscription_interval = 1;
@@ -52,6 +54,7 @@ final class Checkout_Data {
 							'use_per_slash'         => true,
 							'trial_length'          => $trial_length,
 							'trial_period'          => $trial_period,
+							'initial_amount'        => $initial_amount,
 						]
 					)
 				);

--- a/includes/modal-checkout/class-checkout-data.php
+++ b/includes/modal-checkout/class-checkout-data.php
@@ -64,7 +64,16 @@ final class Checkout_Data {
 		}
 
 		// translators: 1 is the name of the item. 2 is the price of the item.
-		return sprintf( __( '%1$s: %2$s', 'newspack-blocks' ), $name, $price );
+		$price_summary = sprintf( __( '%1$s: %2$s', 'newspack-blocks' ), $name, $price );
+
+		/**
+		 * Filters the price summary string that appears in modal checkout.
+		 *
+		 * @param string $price_summary The formatted price summary string.
+		 *
+		 * @return string The filtered price summary string.
+		 */
+		return apply_filters( 'newspack_modal_checkout_price_summary', $price_summary );
 	}
 
 	/**

--- a/includes/modal-checkout/class-checkout-data.php
+++ b/includes/modal-checkout/class-checkout-data.php
@@ -70,10 +70,11 @@ final class Checkout_Data {
 		 * Filters the price summary string that appears in modal checkout.
 		 *
 		 * @param string $price_summary The formatted price summary string.
+		 * @param string $product_id    The product ID, if available.
 		 *
 		 * @return string The filtered price summary string.
 		 */
-		return apply_filters( 'newspack_modal_checkout_price_summary', $price_summary );
+		return apply_filters( 'newspack_modal_checkout_price_summary', $price_summary, $product_id );
 	}
 
 	/**

--- a/languages/newspack-blocks-de_DE.po
+++ b/languages/newspack-blocks-de_DE.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Newspack Blocks\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/project\n"
-"POT-Creation-Date: 2025-08-11T17:13:27+00:00\n"
+"POT-Creation-Date: 2025-08-11T19:44:30+00:00\n"
 "PO-Revision-Date: 2024-08-30 08:45-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -138,7 +138,7 @@ msgstr ""
 #. translators: 1: Checkout button confirmation text. 2: Order total.
 #. translators: 1 is the name of the item. 2 is the price of the item.
 #: includes/class-modal-checkout.php:1630
-#: includes/modal-checkout/class-checkout-data.php:64
+#: includes/modal-checkout/class-checkout-data.php:67
 #, php-format
 msgid "%1$s: %2$s"
 msgstr ""
@@ -298,7 +298,7 @@ msgstr ""
 msgid " per "
 msgstr ""
 
-#: includes/modal-checkout/class-checkout-data.php:242 dist/editor.js:35
+#: includes/modal-checkout/class-checkout-data.php:255 dist/editor.js:35
 #: src/blocks/donate/index.js:25
 msgid "Donate"
 msgstr "Spenden"

--- a/languages/newspack-blocks-es_ES.po
+++ b/languages/newspack-blocks-es_ES.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Newspack Blocks 1.0.0-alpha.20\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/project\n"
-"POT-Creation-Date: 2025-08-11T17:13:27+00:00\n"
+"POT-Creation-Date: 2025-08-11T19:44:30+00:00\n"
 "PO-Revision-Date: 2024-08-30 08:45-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -128,7 +128,7 @@ msgstr ""
 #. translators: 1: Checkout button confirmation text. 2: Order total.
 #. translators: 1 is the name of the item. 2 is the price of the item.
 #: includes/class-modal-checkout.php:1630
-#: includes/modal-checkout/class-checkout-data.php:64
+#: includes/modal-checkout/class-checkout-data.php:67
 #, php-format
 msgid "%1$s: %2$s"
 msgstr ""
@@ -288,7 +288,7 @@ msgstr ""
 msgid " per "
 msgstr ""
 
-#: includes/modal-checkout/class-checkout-data.php:242 dist/editor.js:35
+#: includes/modal-checkout/class-checkout-data.php:255 dist/editor.js:35
 #: src/blocks/donate/index.js:25
 msgid "Donate"
 msgstr ""

--- a/languages/newspack-blocks-fr_BE.po
+++ b/languages/newspack-blocks-fr_BE.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Newspack Blocks 1.0.0-alpha.25\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/project\n"
-"POT-Creation-Date: 2025-08-11T17:13:27+00:00\n"
+"POT-Creation-Date: 2025-08-11T19:44:30+00:00\n"
 "PO-Revision-Date: 2024-08-30 08:46-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -128,7 +128,7 @@ msgstr ""
 #. translators: 1: Checkout button confirmation text. 2: Order total.
 #. translators: 1 is the name of the item. 2 is the price of the item.
 #: includes/class-modal-checkout.php:1630
-#: includes/modal-checkout/class-checkout-data.php:64
+#: includes/modal-checkout/class-checkout-data.php:67
 #, php-format
 msgid "%1$s: %2$s"
 msgstr ""
@@ -288,7 +288,7 @@ msgstr ""
 msgid " per "
 msgstr ""
 
-#: includes/modal-checkout/class-checkout-data.php:242 dist/editor.js:35
+#: includes/modal-checkout/class-checkout-data.php:255 dist/editor.js:35
 #: src/blocks/donate/index.js:25
 msgid "Donate"
 msgstr ""

--- a/languages/newspack-blocks-nb_NO.po
+++ b/languages/newspack-blocks-nb_NO.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Newspack Blocks 1.0.0-alpha.20\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/project\n"
-"POT-Creation-Date: 2025-08-11T17:13:27+00:00\n"
+"POT-Creation-Date: 2025-08-11T19:44:30+00:00\n"
 "PO-Revision-Date: 2024-08-30 08:46-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -128,7 +128,7 @@ msgstr ""
 #. translators: 1: Checkout button confirmation text. 2: Order total.
 #. translators: 1 is the name of the item. 2 is the price of the item.
 #: includes/class-modal-checkout.php:1630
-#: includes/modal-checkout/class-checkout-data.php:64
+#: includes/modal-checkout/class-checkout-data.php:67
 #, php-format
 msgid "%1$s: %2$s"
 msgstr ""
@@ -288,7 +288,7 @@ msgstr ""
 msgid " per "
 msgstr ""
 
-#: includes/modal-checkout/class-checkout-data.php:242 dist/editor.js:35
+#: includes/modal-checkout/class-checkout-data.php:255 dist/editor.js:35
 #: src/blocks/donate/index.js:25
 msgid "Donate"
 msgstr ""

--- a/languages/newspack-blocks-pt_PT.po
+++ b/languages/newspack-blocks-pt_PT.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Newspack Blocks 1.0.0-alpha.25\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/project\n"
-"POT-Creation-Date: 2025-08-11T17:13:27+00:00\n"
+"POT-Creation-Date: 2025-08-11T19:44:30+00:00\n"
 "PO-Revision-Date: 2024-08-30 08:46-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -128,7 +128,7 @@ msgstr ""
 #. translators: 1: Checkout button confirmation text. 2: Order total.
 #. translators: 1 is the name of the item. 2 is the price of the item.
 #: includes/class-modal-checkout.php:1630
-#: includes/modal-checkout/class-checkout-data.php:64
+#: includes/modal-checkout/class-checkout-data.php:67
 #, php-format
 msgid "%1$s: %2$s"
 msgstr ""
@@ -288,7 +288,7 @@ msgstr ""
 msgid " per "
 msgstr ""
 
-#: includes/modal-checkout/class-checkout-data.php:242 dist/editor.js:35
+#: includes/modal-checkout/class-checkout-data.php:255 dist/editor.js:35
 #: src/blocks/donate/index.js:25
 msgid "Donate"
 msgstr "Doação"

--- a/languages/newspack-blocks.pot
+++ b/languages/newspack-blocks.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-08-11T17:13:27+00:00\n"
+"POT-Creation-Date: 2025-08-11T19:44:30+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: newspack-blocks\n"
@@ -125,7 +125,7 @@ msgstr ""
 #. translators: 1: Checkout button confirmation text. 2: Order total.
 #. translators: 1 is the name of the item. 2 is the price of the item.
 #: includes/class-modal-checkout.php:1630
-#: includes/modal-checkout/class-checkout-data.php:64
+#: includes/modal-checkout/class-checkout-data.php:67
 #, php-format
 msgid "%1$s: %2$s"
 msgstr ""
@@ -283,7 +283,7 @@ msgstr ""
 msgid " per "
 msgstr ""
 
-#: includes/modal-checkout/class-checkout-data.php:242
+#: includes/modal-checkout/class-checkout-data.php:255
 #: dist/editor.js:35
 #: src/blocks/donate/index.js:25
 msgid "Donate"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
 				"fetch-mock-jest": "^1.5.1",
 				"html-entities": "^2.6.0",
 				"identity-obj-proxy": "^3.0.0",
-				"lint-staged": "^16.1.2",
+				"lint-staged": "^16.1.4",
 				"newspack-components": "^3.1.0",
 				"newspack-scripts": "^5.5.2",
 				"postcss-scss": "^4.0.9"
@@ -17974,9 +17974,9 @@
 			}
 		},
 		"node_modules/lint-staged": {
-			"version": "16.1.2",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.1.2.tgz",
-			"integrity": "sha512-sQKw2Si2g9KUZNY3XNvRuDq4UJqpHwF0/FQzZR2M7I5MvtpWvibikCjUVJzZdGE0ByurEl3KQNvsGetd1ty1/Q==",
+			"version": "16.1.4",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.1.4.tgz",
+			"integrity": "sha512-xy7rnzQrhTVGKMpv6+bmIA3C0yET31x8OhKBYfvGo0/byeZ6E0BjGARrir3Kg/RhhYHutpsi01+2J5IpfVoueA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -17984,7 +17984,7 @@
 				"commander": "^14.0.0",
 				"debug": "^4.4.1",
 				"lilconfig": "^3.1.3",
-				"listr2": "^8.3.3",
+				"listr2": "^9.0.1",
 				"micromatch": "^4.0.8",
 				"nano-spawn": "^1.0.2",
 				"pidtree": "^0.6.0",
@@ -18014,9 +18014,9 @@
 			}
 		},
 		"node_modules/listr2": {
-			"version": "8.3.3",
-			"resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
-			"integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.1.tgz",
+			"integrity": "sha512-SL0JY3DaxylDuo/MecFeiC+7pedM0zia33zl0vcjgwcq1q1FWWF1To9EIauPbl8GbMCU0R2e0uJ8bZunhYKD2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -18028,7 +18028,7 @@
 				"wrap-ansi": "^9.0.0"
 			},
 			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/load-json-file": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"fetch-mock-jest": "^1.5.1",
 		"html-entities": "^2.6.0",
 		"identity-obj-proxy": "^3.0.0",
-		"lint-staged": "^16.1.2",
+		"lint-staged": "^16.1.4",
 		"newspack-components": "^3.1.0",
 		"newspack-scripts": "^5.5.2",
 		"postcss-scss": "^4.0.9"


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2164/checkout-price-summary-error-verbiage-not-reflecting-sign-up-fees

This PR fixes an issue where the price summary didn't include the sign up fee. This PR also adds a filter to the `get_price_summary` method.

### How to test the changes in this Pull Request:

1. Create a subscription product, add a sign up fee AND a free trial period
2. Create a checkout button block and assign the subscription product.
3. As a reader, trigger modal checkout by clicking the button
4. Verify the sign up fee is included in the price summary

![Screenshot 2025-08-11 at 14 58 52](https://github.com/user-attachments/assets/96d58e24-d703-4ef0-ae14-bf64b3eca979)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
