### PR TITLE
feat: add hooks around the content loop's content

### DIFF
--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -86,7 +86,15 @@ call_user_func(
 		<?php endif; ?>
 
 		<div class="entry-wrapper">
-			<?php do_action( 'newspack_blocks_content_loop_entry_wrapper_start', $post_id, $attributes ); ?>
+			<?php
+			/**
+			 * Fires at the beginning of the entry wrapper for each article in the homepage articles block.
+			 *
+			 * @param int   $post_id    The current post ID.
+			 * @param array $attributes The block attributes array.
+			 */
+			do_action( 'newspack_blocks_content_loop_entry_wrapper_start', $post_id, $attributes );
+			?>
 			<?php if ( ! empty( $sponsors ) || ( $attributes['showCategory'] ) ) : ?>
 
 				<div class="cat-links <?php if ( ! empty( $sponsors ) ) : ?>sponsor-label<?php endif; // phpcs:ignore Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace ?>">
@@ -148,6 +156,12 @@ call_user_func(
 				</div>
 			<?php endif; ?>
 			<?php
+			/**
+			 * Fires before the main content (excerpt or full content) for each article in the homepage articles block.
+			 *
+			 * @param int   $post_id    The current post ID.
+			 * @param array $attributes The block attributes array.
+			 */
 			do_action( 'newspack_blocks_content_loop_content_start', $post_id, $attributes );
 			if ( $attributes['showExcerpt'] && ! $attributes['showFullContent'] ) :
 				the_excerpt();
@@ -155,7 +169,14 @@ call_user_func(
 			if ( $attributes['showFullContent'] && ! $attributes['showExcerpt'] ) :
 				the_content();
 			endif;
+			/**
+			 * Fires after the main content (excerpt or full content) for each article in the homepage articles block.
+			 *
+			 * @param int   $post_id    The current post ID.
+			 * @param array $attributes The block attributes array.
+			 */
 			do_action( 'newspack_blocks_content_loop_content_end', $post_id, $attributes );
+
 			if ( $post_link && ! $attributes['showFullContent'] && $attributes['showReadMore'] ) :
 				?>
 				<a class="more-link" href="<?php echo esc_url( $post_link ); ?>" rel="bookmark">
@@ -251,7 +272,15 @@ call_user_func(
 					?>
 				</div><!-- .entry-meta -->
 			<?php endif; ?>
-			<?php do_action( 'newspack_blocks_content_loop_entry_wrapper_end', $post_id, $attributes ); ?>
+			<?php
+			/**
+			 * Fires at the end of the entry wrapper for each article in the homepage articles block.
+			 *
+			 * @param int   $post_id    The current post ID.
+			 * @param array $attributes The block attributes array.
+			 */
+			do_action( 'newspack_blocks_content_loop_entry_wrapper_end', $post_id, $attributes );
+			?>
 		</div><!-- .entry-wrapper -->
 	</article>
 

--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -86,6 +86,7 @@ call_user_func(
 		<?php endif; ?>
 
 		<div class="entry-wrapper">
+			<?php do_action( 'newspack_blocks_content_loop_entry_wrapper_start', $post_id, $attributes ); ?>
 			<?php if ( ! empty( $sponsors ) || ( $attributes['showCategory'] ) ) : ?>
 
 				<div class="cat-links <?php if ( ! empty( $sponsors ) ) : ?>sponsor-label<?php endif; // phpcs:ignore Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace ?>">
@@ -147,12 +148,14 @@ call_user_func(
 				</div>
 			<?php endif; ?>
 			<?php
+			do_action( 'newspack_blocks_content_loop_content_start', $post_id, $attributes );
 			if ( $attributes['showExcerpt'] && ! $attributes['showFullContent'] ) :
 				the_excerpt();
 			endif;
 			if ( $attributes['showFullContent'] && ! $attributes['showExcerpt'] ) :
 				the_content();
 			endif;
+			do_action( 'newspack_blocks_content_loop_content_end', $post_id, $attributes );
 			if ( $post_link && ! $attributes['showFullContent'] && $attributes['showReadMore'] ) :
 				?>
 				<a class="more-link" href="<?php echo esc_url( $post_link ); ?>" rel="bookmark">
@@ -248,6 +251,7 @@ call_user_func(
 					?>
 				</div><!-- .entry-meta -->
 			<?php endif; ?>
+			<?php do_action( 'newspack_blocks_content_loop_entry_wrapper_end', $post_id, $attributes ); ?>
 		</div><!-- .entry-wrapper -->
 	</article>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds four hooks around the content in the Content Loop articles: at the start and end of the 'entry-wrapper' (the div that holds all the text in each article), and before and after where the_excerpt/the_content gets output. 

### How to test the changes in this Pull Request:

1. Apply this PR. 
2. Try adding stuff to the posts using the hooks, like:
```
function test_the_block_hooks( $post_id, $attributes ) {
    echo '<div>THIS IS THE END</div>';
}
add_action( 'newspack_blocks_content_loop_content_end', 'test_the_block_hooks', 10, 2 );
```
3. Confirm that your additions show up on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
