### PR TITLE
fix: show updated date if later than published

### DIFF
--- a/src/blocks/homepage-articles/templates/article.php
+++ b/src/blocks/homepage-articles/templates/article.php
@@ -225,7 +225,7 @@ call_user_func(
 					endif;
 					if ( $show_date ) :
 						$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
-						if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) :
+						if ( get_the_time( 'U' ) < get_the_modified_time( 'U' ) ) :
 							$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
 						endif;
 						printf(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When a scheduled post is published, the modified date still stores the date when the last modification was made, making it earlier than the published date.

When rendering the dates, we are echoing the the updated date if it's different than the published date. The correct behavior should be to display it only if the modified date is more recent than the published date.

### How to test the changes in this Pull Request:

1. Schedule a post and wait it be published
2. Make it display in a Content Loop block
3. Visit the post/page with the block and inspect the source code
4. Confirm that on `trunk` you see a older date on the `updated` entry.
5. On this branch you should not see the `updated` entry.
6. Make a modification to the post and save. Confirm you see the `updated` entry as expected in the source code.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
