### PR TITLE
fix(modal-checkout): apply newspack-ui styles to subscription confirmation checkbox

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -809,38 +809,41 @@
 				margin-top: 0;
 			}
 		}
+	}
 
-		p.form-row {
-			background: var(--newspack-ui-color-neutral-5, #f7f7f7);
-			border-color: var(--newspack-ui-color-border, #ddd);
-			box-shadow: none;
-			font-size: var(--newspack-ui-font-size-xs, 14px);
-			line-height: var(--newspack-ui-line-height-xs, 1.4286);
-			margin-top: var(--newspack-ui-spacer-5, 24px);
-			padding: var(--newspack-ui-spacer-5, 24px);
+	// Subscriptions confirmation checkbox
+	// stylelint-disable-next-line selector-id-pattern
+	p#newspack_subscription_confirmation_field,
+	//Terms and Conditions checkbox
+	.woocommerce-terms-and-conditions-wrapper > p.form-row {
+		background: var(--newspack-ui-color-neutral-5, #f7f7f7);
+		border-color: var(--newspack-ui-color-border, #ddd);
+		box-shadow: none;
+		font-size: var(--newspack-ui-font-size-xs, 14px);
+		line-height: var(--newspack-ui-line-height-xs, 1.4286);
+		margin-top: var(--newspack-ui-spacer-5, 24px);
+		padding: var(--newspack-ui-spacer-5, 24px);
 
-			label {
-				display: flex !important; // to override grid on more generic labels with checkboxes.
-				justify-content: flex-start;
-				align-items: center;
-				height: 20px;
-				margin: 0;
-				padding: 0;
-				gap: 0;
+		label {
+			display: flex !important; // to override grid on more generic labels with checkboxes.
+			justify-content: flex-start;
+			align-items: center;
+			height: 20px;
+			margin: 0;
+			padding: 0;
+			gap: 0;
 
-				input {
-					margin: 0 var(--newspack-ui-spacer-2, 12px) 0 0;
-				}
-				// Override checkout form terms and condition text.
-				.woocommerce-terms-and-conditions-checkbox-text {
-					font-size: var(--newspack-ui-font-size-xs, 14px);
-					line-height: var(--newspack-ui-line-height-xs, 1.4286);
-					margin-bottom: 0;
-				}
+			> input {
+				margin: 0 var(--newspack-ui-spacer-2, 12px) 0 0;
+			}
+
+			> span {
+				font-size: var(--newspack-ui-font-size-xs, 14px);
+				line-height: var(--newspack-ui-line-height-xs, 1.4286);
+				margin-bottom: 0;
 			}
 		}
 	}
-
 
 	// Subscription confirmation checkbox
 	form .newspack-subscription-confirmation-checkbox,


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2191/modal-checkout-termsconditions-and-subscription-checkboxes

This PR applies newspack ui styles to the subscription confirmation checkbox in modal checkout:

![Screenshot 2025-08-26 at 16 30 48](https://github.com/user-attachments/assets/c3feb08d-b268-4c15-9da5-1547e19b82ec)

### How to test the changes in this Pull Request:

1. As admin, enable terms and conditions in checkout by going to Appearance > Customizer > WooCommerce > Checkout and setting a Terms and conditions page/add terms and conditions text
2. Enable subscription confirmation checkbox by going to Audience > Configuration > Checkout & Payment > Subscription
3. As a reader, trigger modal checkout for any subscription product or donation
4. Confirm the subscription confirmation checkbox matches the styling of the terms and conditions checkbox as pictured above

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
