### PR TITLE
fix(checkout-button): editor width settings

### DIFF
--- a/src/blocks/checkout-button/edit.scss
+++ b/src/blocks/checkout-button/edit.scss
@@ -30,21 +30,38 @@
 }
 
 .wp-block-newspack-blocks-checkout-button {
-	[data-align="center"] & {
-		display: flex;
-		flex-direction: column;
-	}
-	&__button {
-		width: auto;
+	display: flex;
 
-		[data-align="full"] &,
-		[data-align="wide"] & {
+	&.alignwide,
+	&.alignfull {
+		div {
 			width: 100%;
 		}
-		[data-align="center"] & {
+	}
+	&.aligncenter {
+		flex-direction: column;
+
+		div {
 			margin-left: auto;
 			margin-right: auto;
 		}
+	}
+
+	&.wp-block-button__width-25 &__button {
+		width: 25%;
+	}
+	&.wp-block-button__width-50 &__button {
+		width: 50%;
+	}
+	&.wp-block-button__width-75 &__button {
+		width: 75%;
+	}
+	&.wp-block-button__width-100 &__button {
+		width: 100%;
+	}
+
+	&__button {
+		width: auto;
 	}
 }
 

--- a/src/blocks/checkout-button/view.scss
+++ b/src/blocks/checkout-button/view.scss
@@ -7,7 +7,6 @@
 	}
 	&.aligncenter {
 		form {
-			display: flex;
 			flex-direction: column;
 		}
 		button {
@@ -27,6 +26,10 @@
 	}
 	&.wp-block-button__width-100 button {
 		width: 100%;
+	}
+
+	form {
+		display: flex;
 	}
 
 	.wp-block-button__link {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The various width settings are currently not working (alignwide, 100%, 75% etc...) in the editor. This PR fixes it.

Before:

![before](https://github.com/user-attachments/assets/ab920ab7-6773-418e-ad01-e16f34be628d)

After:

![after](https://github.com/user-attachments/assets/e8ff4223-e9f9-4a69-92aa-fa5c0f51e6a2)

### How to test the changes in this Pull Request:

1. Add a checkout button to a page, try to edit width (nothing happens)
2. Switch to this branch
3. Try again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
