### PR TITLE
feat: replace buttongroup with togglegroupcontrol

### DIFF
--- a/src/blocks/author-list/edit.js
+++ b/src/blocks/author-list/edit.js
@@ -5,8 +5,6 @@ import apiFetch from '@wordpress/api-fetch';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
 import {
 	BaseControl,
-	Button,
-	ButtonGroup,
 	CheckboxControl,
 	Notice,
 	PanelBody,
@@ -19,6 +17,10 @@ import {
 	Toolbar,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalUnitControl as UnitControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { Fragment, useEffect, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -262,94 +264,71 @@ const AuthorList = ( { attributes, clientId, setAttributes } ) => {
 							postTypeLabel={ __( 'author', 'newspack-blocks' ) }
 							postTypeLabelPlural={ __( 'authors', 'newspack-blocks' ) }
 							selectedItems={ exclude }
+							__next40pxDefaultSize
 						/>
 					</PanelRow>
 				</PanelBody>
 				<PanelBody title={ __( 'Author Profile Settings', 'newspack-blocks' ) }>
-					<BaseControl
-						label={ __( 'Text Size', 'newspack-blocks' ) }
-						id="newspack-blocks__text-size-control"
-					>
-						<PanelRow>
-							<ButtonGroup
-								id="newspack-blocks__text-size-control-buttons"
-								aria-label={ __( 'Text Size', 'newspack-blocks' ) }
-							>
-								{ textSizeOptions.map( option => {
-									const isCurrent = textSize === option.value;
-									return (
-										<Button
-											isPrimary={ isCurrent }
-											aria-pressed={ isCurrent }
-											aria-label={ option.label }
-											key={ option.value }
-											onClick={ () => setAttributes( { textSize: option.value } ) }
-										>
-											{ option.shortName }
-										</Button>
-									);
-								} ) }
-							</ButtonGroup>
-						</PanelRow>
-					</BaseControl>
+				<ToggleGroupControl
+					label={ __( 'Text Size', 'newspack-blocks' ) }
+					value={ textSize }
+					onChange={ value => setAttributes( { textSize: value } ) }
+					isBlock
+					__next40pxDefaultSize
+				>
+					{ textSizeOptions.map( option => (
+						<ToggleGroupControlOption
+							key={ option.value }
+							label={ option.shortName }
+							value={ option.value }
+						/>
+					) ) }
+				</ToggleGroupControl>
 					<AuthorDisplaySettings attributes={ attributes } setAttributes={ setAttributes } />
 				</PanelBody>
-				<PanelBody title={ __( 'Avatar Settings', 'newspack-blocks' ) }>
-					<PanelRow>
-						<ToggleControl
-							label={ __( 'Display avatar', 'newspack-blocks' ) }
-							checked={ showAvatar }
-							onChange={ () => setAttributes( { showAvatar: ! showAvatar } ) }
-						/>
-					</PanelRow>
+				<PanelBody title={ __( 'Avatar', 'newspack-blocks' ) }>
+					<ToggleControl
+						label={ __( 'Display avatar', 'newspack-blocks' ) }
+						checked={ showAvatar }
+						onChange={ () => setAttributes( { showAvatar: ! showAvatar } ) }
+					/>
 					{ showAvatar && (
-						<PanelRow>
-							<ToggleControl
-								label={ __( 'Hide default avatar', 'newspack-blocks' ) }
-								checked={ avatarHideDefault }
-								onChange={ () => setAttributes( { avatarHideDefault: ! avatarHideDefault } ) }
-							/>
-						</PanelRow>
+						<ToggleControl
+							label={ __( 'Hide default avatar', 'newspack-blocks' ) }
+							checked={ avatarHideDefault }
+							onChange={ () => setAttributes( { avatarHideDefault: ! avatarHideDefault } ) }
+						/>
 					) }
 					{ showAvatar && (
-						<BaseControl
+						<ToggleGroupControl
 							label={ __( 'Avatar Size', 'newspack-blocks' ) }
-							id="newspack-blocks__avatar-size-control"
+							value={ avatarSize }
+							onChange={ value => setAttributes( { avatarSize: value } ) }
+							isBlock
+							__next40pxDefaultSize
 						>
-							<PanelRow>
-								<ButtonGroup
-									id="newspack-blocks__avatar-size-control-buttons"
-									aria-label={ __( 'Avatar Size', 'newspack-blocks' ) }
-								>
-									{ avatarSizeOptions.map( option => {
-										const isCurrent = avatarSize === option.value;
-										return (
-											<Button
-												isPrimary={ isCurrent }
-												aria-pressed={ isCurrent }
-												aria-label={ option.label }
-												key={ option.value }
-												onClick={ () => setAttributes( { avatarSize: option.value } ) }
-											>
-												{ option.shortName }
-											</Button>
-										);
-									} ) }
-								</ButtonGroup>
-							</PanelRow>
-						</BaseControl>
+							{ avatarSizeOptions.map( option => (
+								<ToggleGroupControlOption
+									key={ option.value }
+									label={ option.shortName }
+									value={ option.value }
+								/>
+							) ) }
+						</ToggleGroupControl>
 					) }
 					{ showAvatar && (
 						<PanelRow>
 							<UnitControl
-								label={ __( 'Avatar border radius', 'newspack-blocks' ) }
+								label={ __( 'Border radius', 'newspack-blocks' ) }
+								aria-label={ __( 'Avatar border radius', 'newspack-blocks' ) }
 								labelPosition="edge"
-								__unstableInputWidth="80px"
 								units={ units }
 								value={ avatarBorderRadius }
 								onChange={ value =>
 									setAttributes( { avatarBorderRadius: 0 > parseFloat( value ) ? '0' : value } )
 								}
+								__next40pxDefaultSize
+								__unstableInputWidth="80px"
 							/>
 						</PanelRow>
 					) }
@@ -360,7 +339,7 @@ const AuthorList = ( { attributes, clientId, setAttributes } ) => {
 					<Toolbar
 						controls={ [
 							{
-								icon: <Icon icon={ listView } />,
+								icon: listView,
 								title: __( 'List', 'newspack-blocks' ),
 								isActive: 'list' === layout,
 								onClick: () => {
@@ -368,7 +347,7 @@ const AuthorList = ( { attributes, clientId, setAttributes } ) => {
 								},
 							},
 							{
-								icon: <Icon icon={ columnsIcon } />,
+								icon: columnsIcon,
 								title: __( 'Columns', 'newspack-blocks' ),
 								isActive: isColumns,
 								onClick: () => {
@@ -381,13 +360,13 @@ const AuthorList = ( { attributes, clientId, setAttributes } ) => {
 						<Toolbar
 							controls={ [
 								{
-									icon: <Icon icon={ pullLeft } />,
+									icon: pullLeft,
 									title: __( 'Show avatar on left', 'newspack-blocks' ),
 									isActive: avatarAlignment === 'left',
 									onClick: () => setAttributes( { avatarAlignment: 'left' } ),
 								},
 								{
-									icon: <Icon icon={ pullRight } />,
+									icon: pullRight,
 									title: __( 'Show avatar on right', 'newspack-blocks' ),
 									isActive: avatarAlignment === 'right',
 									onClick: () => setAttributes( { avatarAlignment: 'right' } ),
@@ -398,7 +377,7 @@ const AuthorList = ( { attributes, clientId, setAttributes } ) => {
 					<Toolbar
 						controls={ [
 							{
-								icon: <Icon icon={ edit } />,
+								icon: edit,
 								title: __( 'Edit selection', 'newspack-blocks' ),
 								onClick: () => {
 									setAttributes( { authorId: 0 } );

--- a/src/blocks/author-list/edit.js
+++ b/src/blocks/author-list/edit.js
@@ -25,7 +25,6 @@ import {
 import { Fragment, useEffect, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import {
-	Icon,
 	columns as columnsIcon,
 	edit,
 	listView,
@@ -301,7 +300,8 @@ const AuthorList = ( { attributes, clientId, setAttributes } ) => {
 					) }
 					{ showAvatar && (
 						<ToggleGroupControl
-							label={ __( 'Avatar Size', 'newspack-blocks' ) }
+							label={ __( 'Size', 'newspack-blocks' ) }
+							aria-label={ __( 'Avatar size', 'newspack-blocks' ) }
 							value={ avatarSize }
 							onChange={ value => setAttributes( { avatarSize: value } ) }
 							isBlock
@@ -317,20 +317,18 @@ const AuthorList = ( { attributes, clientId, setAttributes } ) => {
 						</ToggleGroupControl>
 					) }
 					{ showAvatar && (
-						<PanelRow>
-							<UnitControl
-								label={ __( 'Border radius', 'newspack-blocks' ) }
-								aria-label={ __( 'Avatar border radius', 'newspack-blocks' ) }
-								labelPosition="edge"
-								units={ units }
-								value={ avatarBorderRadius }
-								onChange={ value =>
-									setAttributes( { avatarBorderRadius: 0 > parseFloat( value ) ? '0' : value } )
-								}
-								__next40pxDefaultSize
-								__unstableInputWidth="80px"
-							/>
-						</PanelRow>
+						<UnitControl
+							label={ __( 'Border radius', 'newspack-blocks' ) }
+							aria-label={ __( 'Avatar border radius', 'newspack-blocks' ) }
+							labelPosition="edge"
+							units={ units }
+							value={ avatarBorderRadius }
+							onChange={ value =>
+								setAttributes( { avatarBorderRadius: 0 > parseFloat( value ) ? '0' : value } )
+							}
+							__next40pxDefaultSize
+							__unstableInputWidth="80px"
+						/>
 					) }
 				</PanelBody>
 			</InspectorControls>
@@ -454,7 +452,7 @@ const AuthorList = ( { attributes, clientId, setAttributes } ) => {
 				) }
 				{ ( ! authors || isLoading ) && (
 					<Placeholder
-						icon={ <Icon icon={ listView } /> }
+						icon={ listView }
 						label={ __( 'Author List', 'newspack-blocks' ) }
 					>
 						{ error && (

--- a/src/blocks/author-profile/edit.js
+++ b/src/blocks/author-profile/edit.js
@@ -4,22 +4,22 @@
 import apiFetch from '@wordpress/api-fetch';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
 import {
-	BaseControl,
-	Button,
-	ButtonGroup,
 	Notice,
 	PanelBody,
-	PanelRow,
 	Placeholder,
 	Spinner,
 	ToggleControl,
 	Toolbar,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalUnitControl as UnitControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
-import { Icon, edit, postAuthor, pullLeft, pullRight } from '@wordpress/icons';
+import { edit, postAuthor, pullLeft, pullRight } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -211,92 +211,67 @@ const AuthorProfile = ( { attributes, setAttributes } ) => {
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Author Profile Settings', 'newspack-blocks' ) }>
-					<BaseControl
-						label={ __( 'Text Size', 'newspack-blocks' ) }
-						id="newspack-blocks__text-size-control"
-					>
-						<PanelRow>
-							<ButtonGroup
-								id="newspack-blocks__text-size-control-buttons"
-								aria-label={ __( 'Text Size', 'newspack-blocks' ) }
-							>
-								{ textSizeOptions.map( option => {
-									const isCurrent = textSize === option.value;
-									return (
-										<Button
-											isPrimary={ isCurrent }
-											aria-pressed={ isCurrent }
-											aria-label={ option.label }
-											key={ option.value }
-											onClick={ () => setAttributes( { textSize: option.value } ) }
-										>
-											{ option.shortName }
-										</Button>
-									);
-								} ) }
-							</ButtonGroup>
-						</PanelRow>
-					</BaseControl>
+				<ToggleGroupControl
+					label={ __( 'Text Size', 'newspack-blocks' ) }
+					value={ textSize }
+					onChange={ value => setAttributes( { textSize: value } ) }
+					isBlock
+					__next40pxDefaultSize
+				>
+					{ textSizeOptions.map( option => (
+						<ToggleGroupControlOption
+							key={ option.value }
+							label={ option.shortName }
+							value={ option.value }
+						/>
+					) ) }
+				</ToggleGroupControl>
 					<AuthorDisplaySettings attributes={ attributes } setAttributes={ setAttributes } />
 				</PanelBody>
-				<PanelBody title={ __( 'Avatar Settings', 'newspack-blocks' ) }>
-					<PanelRow>
+				<PanelBody title={ __( 'Avatar', 'newspack-blocks' ) }>
+					<ToggleControl
+						label={ __( 'Display avatar', 'newspack-blocks' ) }
+						checked={ showAvatar }
+						onChange={ () => setAttributes( { showAvatar: ! showAvatar } ) }
+					/>
+					{ showAvatar && (
 						<ToggleControl
-							label={ __( 'Display avatar', 'newspack-blocks' ) }
-							checked={ showAvatar }
-							onChange={ () => setAttributes( { showAvatar: ! showAvatar } ) }
+							label={ __( 'Hide default avatar', 'newspack-blocks' ) }
+							checked={ avatarHideDefault }
+							onChange={ () => setAttributes( { avatarHideDefault: ! avatarHideDefault } ) }
 						/>
-					</PanelRow>
-					{ showAvatar && (
-						<PanelRow>
-							<ToggleControl
-								label={ __( 'Hide default avatar', 'newspack-blocks' ) }
-								checked={ avatarHideDefault }
-								onChange={ () => setAttributes( { avatarHideDefault: ! avatarHideDefault } ) }
-							/>
-						</PanelRow>
 					) }
 					{ showAvatar && (
-						<BaseControl
-							label={ __( 'Avatar size', 'newspack-blocks' ) }
-							id="newspack-blocks__avatar-size-control"
+						<ToggleGroupControl
+							label={ __( 'Size', 'newspack-blocks' ) }
+							aria-label={ __( 'Avatar size', 'newspack-blocks' ) }
+							value={ avatarSize }
+							onChange={ value => setAttributes( { avatarSize: value } ) }
+							isBlock
+							__next40pxDefaultSize
 						>
-							<PanelRow>
-								<ButtonGroup
-									id="newspack-blocks__avatar-size-control-buttons"
-									aria-label={ __( 'Avatar size', 'newspack-blocks' ) }
-								>
-									{ avatarSizeOptions.map( option => {
-										const isCurrent = avatarSize === option.value;
-										return (
-											<Button
-												isPrimary={ isCurrent }
-												aria-pressed={ isCurrent }
-												aria-label={ option.label }
-												key={ option.value }
-												onClick={ () => setAttributes( { avatarSize: option.value } ) }
-											>
-												{ option.shortName }
-											</Button>
-										);
-									} ) }
-								</ButtonGroup>
-							</PanelRow>
-						</BaseControl>
+							{ avatarSizeOptions.map( option => (
+								<ToggleGroupControlOption
+									key={ option.value }
+									label={ option.shortName }
+									value={ option.value }
+								/>
+							) ) }
+						</ToggleGroupControl>
 					) }
 					{ showAvatar && (
-						<PanelRow>
-							<UnitControl
-								label={ __( 'Avatar border radius', 'newspack-blocks' ) }
-								labelPosition="edge"
-								__unstableInputWidth="80px"
-								units={ units }
-								value={ avatarBorderRadius }
-								onChange={ value =>
-									setAttributes( { avatarBorderRadius: 0 > parseFloat( value ) ? '0' : value } )
-								}
-							/>
-						</PanelRow>
+						<UnitControl
+							label={ __( 'Border radius', 'newspack-blocks' ) }
+							aria-label={ __( 'Avatar border radius', 'newspack-blocks' ) }
+							labelPosition="edge"
+							__next40pxDefaultSize
+							__unstableInputWidth="80px"
+							units={ units }
+							value={ avatarBorderRadius }
+							onChange={ value =>
+								setAttributes( { avatarBorderRadius: 0 > parseFloat( value ) ? '0' : value } )
+							}
+						/>
 					) }
 				</PanelBody>
 			</InspectorControls>
@@ -306,13 +281,13 @@ const AuthorProfile = ( { attributes, setAttributes } ) => {
 						<Toolbar
 							controls={ [
 								{
-									icon: <Icon icon={ pullLeft } />,
+									icon: pullLeft,
 									title: __( 'Show avatar on left', 'newspack-blocks' ),
 									isActive: avatarAlignment === 'left',
 									onClick: () => setAttributes( { avatarAlignment: 'left' } ),
 								},
 								{
-									icon: <Icon icon={ pullRight } />,
+									icon: pullRight,
 									title: __( 'Show avatar on right', 'newspack-blocks' ),
 									isActive: avatarAlignment === 'right',
 									onClick: () => setAttributes( { avatarAlignment: 'right' } ),
@@ -323,7 +298,7 @@ const AuthorProfile = ( { attributes, setAttributes } ) => {
 					<Toolbar
 						controls={ [
 							{
-								icon: <Icon icon={ edit } />,
+								icon: edit,
 								title: __( 'Edit selection', 'newspack-blocks' ),
 								onClick: () => {
 									setAttributes( { authorId: 0 } );
@@ -339,7 +314,7 @@ const AuthorProfile = ( { attributes, setAttributes } ) => {
 			) : (
 				<Placeholder
 					className="newspack-blocks-author-profile"
-					icon={ <Icon icon={ postAuthor } /> }
+					icon={ postAuthor }
 					label={ __( 'Author Profile', 'newspack-blocks' ) }
 				>
 					{ error && (

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -15,14 +15,15 @@ import { InspectorControls } from '@wordpress/block-editor';
 import { dateI18n, __experimentalGetSettings } from '@wordpress/date';
 import { Component, createRef, Fragment, RawHTML } from '@wordpress/element';
 import {
-	BaseControl,
-	Button,
-	ButtonGroup,
 	PanelBody,
 	Placeholder,
 	RangeControl,
 	Spinner,
 	ToggleControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
@@ -357,7 +358,7 @@ class Edit extends Component {
 				</div>
 
 				<InspectorControls>
-					<PanelBody title={ __( 'Content', 'newspack-blocks' ) } className='newspack-block__panel is-content'>
+					<PanelBody title={ __( 'Settings', 'newspack-blocks' ) } className='newspack-block__panel is-content'>
 						{ postsToShow && (
 							<QueryControls
 								numberOfItems={ postsToShow }
@@ -440,33 +441,26 @@ class Edit extends Component {
 						) }
 					</PanelBody>
 					<PanelBody title={ __( 'Featured Image', 'newspack-blocks' ) } className="newspack-block__panel">
-					<BaseControl
+						<ToggleGroupControl
 							label={ __( 'Aspect ratio', 'newspack-blocks' ) }
 							help={ __(
 								'All slides will share the same aspect ratio, for consistency.',
 								'newspack-blocks'
 							) }
-							id="newspack-blocks__aspect-ratio-control"
-							className="newspack-block__button-group"
+							value={ String( aspectRatio ) }
+							onChange={ value => setAttributes( { aspectRatio: parseFloat( value ) } ) }
+							isBlock
+							__next40pxDefaultSize
 						>
-							<ButtonGroup>
-								{ aspectRatioOptions.map( option => {
-									const isCurrent = aspectRatio === option.value;
-									return (
-										<Button
-											isPrimary={ isCurrent }
-											aria-pressed={ isCurrent }
-											aria-label={ option.label }
-											key={ option.value }
-											onClick={ () => setAttributes( { aspectRatio: option.value } ) }
-										>
-											{ option.shortName }
-										</Button>
-									);
-								} ) }
-							</ButtonGroup>
-						</BaseControl>
-						<BaseControl
+							{ aspectRatioOptions.map( option => (
+								<ToggleGroupControlOption
+									key={ option.value }
+									label={ option.shortName }
+									value={ String( option.value ) }
+								/>
+							) ) }
+						</ToggleGroupControl>
+						<ToggleGroupControl
 							label={ __( 'Fit', 'newspack-blocks' ) }
 							help={
 								'cover' === imageFit
@@ -478,28 +472,14 @@ class Edit extends Component {
 										'newspack-blocks'
 									)
 							}
-							id="newspack-blocks__blocks__image-fit-control"
-							className="newspack-block__button-group"
+							value={ imageFit }
+							onChange={ value => setAttributes( { imageFit: value } ) }
+							isBlock
+							__next40pxDefaultSize
 						>
-							<ButtonGroup>
-								<Button
-									isPrimary={ 'cover' === imageFit }
-									aria-pressed={ 'cover' === imageFit }
-									aria-label={ __( 'Cover', 'newspack-blocks' ) }
-									onClick={ () => setAttributes( { imageFit: 'cover' } ) }
-								>
-									{ __( 'Cover', 'newspack-blocks' ) }
-								</Button>
-								<Button
-									isPrimary={ 'contain' === imageFit }
-									aria-pressed={ 'contain' === imageFit }
-									aria-label={ __( 'Contain', 'newspack-blocks' ) }
-									onClick={ () => setAttributes( { imageFit: 'contain' } ) }
-								>
-									{ __( 'Contain', 'newspack-blocks' ) }
-								</Button>
-							</ButtonGroup>
-						</BaseControl>
+							<ToggleGroupControlOption label={ __( 'Cover', 'newspack-blocks' ) } value="cover" />
+							<ToggleGroupControlOption label={ __( 'Contain', 'newspack-blocks' ) } value="contain" />
+						</ToggleGroupControl>
 						<ToggleControl
 							label={ __( 'Show caption', 'newspack-blocks' ) }
 							checked={ showCaption }

--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -27,8 +27,11 @@ import {
 	SelectControl,
 	FormTokenField,
 	Button,
-	ButtonGroup,
 	Spinner,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
@@ -58,7 +61,7 @@ function getNYP( product ) {
 	};
 }
 
-function WidthPanel( { selectedWidth, setAttributes } ) {
+function WidthControl( { selectedWidth, setAttributes } ) {
 	function handleChange( newWidth ) {
 		// Check if we are toggling the width off
 		const width = selectedWidth === newWidth ? undefined : newWidth;
@@ -68,22 +71,21 @@ function WidthPanel( { selectedWidth, setAttributes } ) {
 	}
 
 	return (
-		<PanelBody title={ __( 'Width settings', 'newspack-blocks' ) }>
-			<ButtonGroup aria-label={ __( 'Button width', 'newspack-blocks' ) }>
-				{ [ 25, 50, 75, 100 ].map( widthValue => {
-					return (
-						<Button
-							key={ widthValue }
-							size="small"
-							variant={ widthValue === selectedWidth ? 'primary' : undefined }
-							onClick={ () => handleChange( widthValue ) }
-						>
-							{ widthValue }%
-						</Button>
-					);
-				} ) }
-			</ButtonGroup>
-		</PanelBody>
+		<ToggleGroupControl
+			label={ __( 'Width', 'newspack-blocks' ) }
+			value={ selectedWidth ? String( selectedWidth ) : undefined }
+			onChange={ value => handleChange( parseFloat( value ) ) }
+			isBlock
+			__next40pxDefaultSize
+		>
+			{ [ 25, 50, 75, 100 ].map( widthValue => (
+				<ToggleGroupControlOption
+					key={ widthValue }
+					label={ `${ widthValue }%` }
+					value={ String( widthValue ) }
+				/>
+			) ) }
+		</ToggleGroupControl>
 	);
 }
 
@@ -161,19 +163,24 @@ function ProductControl( props ) {
 		return <Spinner />;
 	}
 	return (
-		<div className="newspack-checkout-button__product-field">
+		<div className="newspack-checkout-button__product-field" style={ { marginBottom: '16px' } }>
 			{ selected && ! isChanging ? (
 				<>
 					<BaseControl
-						className="newspack-checkout-button__product-field__selected"
-						help={ __( 'Click to change the selected product', 'newspack-blocks' ) }
+						label={ __( 'Product', 'newspack-blocks' ) }
+						id="selected-product-control"
 					>
+						<TextControl
+							value={ selected.name }
+							__next40pxDefaultSize
+							disabled
+						/>
 						<Button
-							isSecondary
+							variant="link"
 							onClick={ () => setIsChanging( true ) }
 							aria-label={ __( 'Change the selected product', 'newspack-blocks' ) }
 						>
-							{ selected.name }
+							{ __( 'Edit', 'newspack-blocks' ) }
 						</Button>
 					</BaseControl>
 					{ props.children }
@@ -185,16 +192,20 @@ function ProductControl( props ) {
 							placeholder={
 								props.placeholder || __( 'Type to search for a product…', 'newspack-blocks' )
 							}
-							label={ __( 'Select a product', 'newspack-blocks' ) }
+							label={ __( 'Product', 'newspack-blocks' ) }
 							maxLength={ 1 }
 							onChange={ onChange }
 							onInputChange={ handleInputChange }
 							suggestions={ Object.values( suggestions ) }
+							__next40pxDefaultSize
 						/>
 						{ inFlight && <Spinner /> }
 					</div>
 					{ selected && (
-						<Button isSecondary onClick={ () => setIsChanging( false ) }>
+						<Button
+							variant="link"
+							onClick={ () => setIsChanging( false ) }
+						>
 							{ __( 'Cancel', 'newspack-blocks' ) }
 						</Button>
 					) }
@@ -303,7 +314,7 @@ function CheckoutButtonEdit( props ) {
 				/>
 			</div>
 			<InspectorControls>
-				<PanelBody title={ __( 'Product', 'newspack-blocks' ) }>
+				<PanelBody title={ __( 'Settings', 'newspack-blocks' ) }>
 					<ProductControl
 						value={ product }
 						price={ price }
@@ -351,6 +362,7 @@ function CheckoutButtonEdit( props ) {
 							</>
 						) }
 					</ProductControl>
+					<WidthControl selectedWidth={ width } setAttributes={ setAttributes } />
 				</PanelBody>
 				<PanelBody title={ __( 'After purchase', 'newspack-blocks' ) }>
 					<RedirectAfterSuccess setAttributes={ setAttributes } attributes={ attributes } />
@@ -387,12 +399,10 @@ function CheckoutButtonEdit( props ) {
 							min={ parseFloat( nyp.minPrice ) || null }
 							max={ parseFloat( nyp.maxPrice ) || null }
 							onChange={ value => setAttributes( { price: value } ) }
+							__next40pxDefaultSize
 						/>
 					</PanelBody>
 				) }
-			</InspectorControls>
-			<InspectorControls>
-				<WidthPanel selectedWidth={ width } setAttributes={ setAttributes } />
 			</InspectorControls>
 		</>
 	);

--- a/src/blocks/checkout-button/edit.scss
+++ b/src/blocks/checkout-button/edit.scss
@@ -2,13 +2,6 @@
 
 .newspack-checkout-button {
 	&__product-field {
-		&__selected {
-			.components-button {
-				display: block;
-				width: 100%;
-				text-align: left;
-			}
-		}
 		&__error {
 			color: colors.$color__error;
 			font-size: 0.9em;
@@ -22,9 +15,12 @@
 			position: relative;
 			.components-spinner {
 				position: absolute;
-				top: 2em;
+				top: 12px;
 				right: 0;
 			}
+		}
+		.components-base-control {
+			margin: 0;
 		}
 	}
 }

--- a/src/blocks/homepage-articles/edit.tsx
+++ b/src/blocks/homepage-articles/edit.tsx
@@ -423,8 +423,12 @@ class Edit extends Component< HomepageArticlesProps > {
 					<ToggleGroupControl
 						label={ __( 'Text', 'newspack-blocks' ) }
 						value={ ( () => {
-							if ( showFullContent ) return 'full';
-							if ( showExcerpt ) return 'excerpt';
+							if ( showFullContent ) {
+								return 'full';
+							}
+							if ( showExcerpt ) {
+								return 'excerpt';
+							}
 							return 'none';
 						} )() }
 						onChange={ ( value: string ) => {

--- a/src/blocks/homepage-articles/edit.tsx
+++ b/src/blocks/homepage-articles/edit.tsx
@@ -32,9 +32,6 @@ import {
 	AlignmentControl,
 } from '@wordpress/block-editor';
 import {
-	BaseControl,
-	Button,
-	ButtonGroup,
 	PanelBody,
 	Path,
 	Placeholder,
@@ -44,6 +41,10 @@ import {
 	Toolbar,
 	ToggleControl,
 	TextControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
@@ -347,7 +348,7 @@ class Edit extends Component< HomepageArticlesProps > {
 						/>
 					</PanelBody>
 				) }
-				<PanelBody title={ __( 'Content', 'newspack-blocks' ) } className="newspack-block__panel is-content">
+				<PanelBody title={ __( 'Settings', 'newspack-blocks' ) } className="newspack-block__panel is-content">
 					<QueryControls
 						numberOfItems={ postsToShow }
 						onNumberOfItemsChange={ ( _postsToShow: number ) =>
@@ -419,50 +420,26 @@ class Edit extends Component< HomepageArticlesProps > {
 					) }
 				</PanelBody>
 				<PanelBody title={ __( 'Display', 'newspack-blocks' ) } className="newspack-block__panel">
-					<BaseControl
+					<ToggleGroupControl
 						label={ __( 'Text', 'newspack-blocks' ) }
-						id="newspack-block__content-display"
-						className="newspack-block__button-group"
+						value={ ( () => {
+							if ( showFullContent ) return 'full';
+							if ( showExcerpt ) return 'excerpt';
+							return 'none';
+						} )() }
+						onChange={ ( value: string ) => {
+							setAttributes( {
+								showExcerpt: value === 'excerpt',
+								showFullContent: value === 'full'
+							} );
+						} }
+						isBlock
+						__next40pxDefaultSize
 					>
-						<ButtonGroup>
-							<Button
-								variant={ ! showExcerpt && ! showFullContent && 'primary' }
-								aria-pressed={ ! showExcerpt && ! showFullContent }
-								onClick={ () => {
-									setAttributes( {
-										showExcerpt: false,
-										showFullContent: false
-									} )
-								} }
-							>
-								{ __( 'None', 'newspack-blocks' ) }
-							</Button>
-							<Button
-								variant={ showExcerpt && ! showFullContent && 'primary' }
-								aria-pressed={ showExcerpt && ! showFullContent }
-								onClick={ () => {
-									setAttributes( {
-										showExcerpt: ! showExcerpt,
-										showFullContent: showFullContent ? false : showFullContent
-									} )
-								} }
-							>
-								{ __( 'Excerpt', 'newspack-blocks' ) }
-							</Button>
-							<Button
-								variant={ ! showExcerpt && showFullContent && 'primary' }
-								aria-pressed={ ! showExcerpt && showFullContent }
-								onClick={ () => {
-									setAttributes( {
-										showFullContent: ! showFullContent,
-										showExcerpt: showExcerpt ? false : showExcerpt
-									} )
-								} }
-							>
-								{ __( 'Full Post', 'newspack-blocks' ) }
-							</Button>
-						</ButtonGroup>
-					</BaseControl>
+						<ToggleGroupControlOption label={ __( 'None', 'newspack-blocks' ) } value="none" />
+						<ToggleGroupControlOption label={ __( 'Excerpt', 'newspack-blocks' ) } value="excerpt" />
+						<ToggleGroupControlOption label={ __( 'Full Post', 'newspack-blocks' ) } value="full" />
+					</ToggleGroupControl>
 					{ showExcerpt && (
 						<RangeControl
 							label={ __( 'Max number of words in excerpt', 'newspack-blocks' ) }
@@ -528,28 +505,22 @@ class Edit extends Component< HomepageArticlesProps > {
 								checked={ mobileStack }
 								onChange={ () => setAttributes( { mobileStack: ! mobileStack } ) }
 							/>
-							<BaseControl
+							<ToggleGroupControl
 								label={ __( 'Size', 'newspack-blocks' ) }
-								id="newspack-block__featured-image-size"
-								className="newspack-block__button-group"
+								value={ String( imageScale ) }
+								onChange={ ( value: string ) => setAttributes( { imageScale: parseInt( value ) } ) }
+								isBlock
+								__next40pxDefaultSize
 							>
-								<ButtonGroup>
-									{ imageSizeOptions.map( option => {
-										const isCurrent = imageScale === option.value;
-										return (
-											<Button
-												variant={ isCurrent && 'primary' }
-												aria-pressed={ isCurrent }
-												aria-label={ option.label }
-												key={ option.value }
-												onClick={ () => setAttributes( { imageScale: option.value } ) }
-											>
-												{ option.shortName }
-											</Button>
-										);
-									} ) }
-								</ButtonGroup>
-							</BaseControl>
+								{ imageSizeOptions.map( option => (
+									<ToggleGroupControlOption
+										key={ option.value }
+										label={ option.shortName }
+										title={ option.label }
+										value={ String( option.value ) }
+									/>
+								) ) }
+							</ToggleGroupControl>
 						</>
 					) }
 					{ showImage && mediaPosition === 'behind' && (

--- a/src/blocks/homepage-articles/editor.scss
+++ b/src/blocks/homepage-articles/editor.scss
@@ -197,23 +197,6 @@
 			}
 		}
 	}
-
-	&__button-group {
-		flex: 0 0 100%;
-
-		.components-base-control__label {
-			width: 100%;
-		}
-
-		.components-button-group {
-			display: grid;
-			grid-template-columns: repeat(auto-fit, minmax(40px, 1fr));
-
-			button {
-				justify-content: center;
-			}
-		}
-	}
 }
 
 .components-base-control__field:empty {

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -5,11 +5,13 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import {
 	BaseControl,
-	Button,
-	ButtonGroup,
 	CheckboxControl,
 	SelectControl,
-	QueryControls as BasicQueryControls
+	QueryControls as BasicQueryControls,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
@@ -286,33 +288,29 @@ class QueryControls extends Component {
 		return (
 			<>
 				{ enableSpecific && (
-					<BaseControl
+					<ToggleGroupControl
 						label={ __( 'Mode', 'newspack-blocks' ) }
-						id="newspack-block__loop-type"
-						className="newspack-block__button-group"
-						help={ specificMode ? (
-							__( 'The block will display only the specifically selected post(s).', 'newspack-blocks' )
-						) : (
-							__( 'The block will display content based on the filtering settings below.', 'newspack-blocks' )
-						) }
+						value={ specificMode ? 'specific' : 'dynamic' }
+						onChange={ value => {
+							if ( value === 'specific' ) {
+								onSpecificModeChange();
+							} else {
+								onLoopModeChange();
+							}
+						} }
+						isBlock
+						help={
+							specificMode ? (
+								__( 'The block will display only the specifically selected post(s).', 'newspack-blocks' )
+							) : (
+								__( 'The block will display content based on the filtering settings below.', 'newspack-blocks' )
+							)
+						}
+						__next40pxDefaultSize
 					>
-						<ButtonGroup>
-							<Button
-								variant={ ! specificMode && 'primary' }
-								aria-pressed={ ! specificMode }
-								onClick={ onLoopModeChange }
-							>
-								{ __( 'Dynamic', 'newspack-blocks' ) }
-							</Button>
-							<Button
-								variant={ specificMode && 'primary' }
-								aria-pressed={ specificMode }
-								onClick={ onSpecificModeChange }
-							>
-								{ __( 'Static', 'newspack-blocks' ) }
-							</Button>
-						</ButtonGroup>
-					</BaseControl>
+						<ToggleGroupControlOption label={ __( 'Dynamic', 'newspack-blocks' ) } value="dynamic" />
+						<ToggleGroupControlOption label={ __( 'Static', 'newspack-blocks' ) } value="specific" />
+					</ToggleGroupControl>
 				) }
 				{ specificMode ? (
 					<AutocompleteTokenField

--- a/src/components/redirect-after-success.tsx
+++ b/src/components/redirect-after-success.tsx
@@ -30,11 +30,13 @@ const RedirectAfterSuccess = ( { attributes, setAttributes }: Props ) => (
 			onChange={ ( value: string ) => {
 				setAttributes( { afterSuccessBehavior: value.toString() } );
 			} }
+			__next40pxDefaultSize
 		/>
 		<TextControl
 			label={ __( 'Button Label', 'newspack-blocks' ) }
 			value={ attributes.afterSuccessButtonLabel || '' }
 			onChange={ ( value: string ) => setAttributes( { afterSuccessButtonLabel: value } ) }
+			__next40pxDefaultSize
 		/>
 		{ attributes.afterSuccessBehavior === 'custom' && (
 			<TextControl
@@ -42,6 +44,7 @@ const RedirectAfterSuccess = ( { attributes, setAttributes }: Props ) => (
 				placeholder={ __( 'https://example.com', 'newspack-blocks' ) }
 				value={ attributes.afterSuccessURL || '' }
 				onChange={ ( value: string ) => setAttributes( { afterSuccessURL: value } ) }
+				__next40pxDefaultSize
 			/>
 		) }
 	</>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR replaces the "custom" and complex `BaseControl`–`ButtonGroup` (now deprecated)–`Button` combo with a simpler (experimental) approach with a `ToggleGroupControl` (and `ToggleGroupControlOption`).

This follows a similar component available with Core's Query Loop block for example.

_Before:_
<img width="562" height="2016" alt="" src="https://github.com/user-attachments/assets/868814f9-de3b-4673-a944-fd7fdee425e7" />

_After:_
<img width="562" height="1454" alt="" src="https://github.com/user-attachments/assets/3e31278b-0e0b-41fb-b886-880bb704a168" />

### How to test the changes in this Pull Request:

1. (on `trunk`) Open the editor, create a new page, add a Content Loop block and a Content Carousel block.
2. Save the page and visit front-end
3. Switch to this branch
4. Refresh your editor and check if all the settings work, make some changes and save
5. Check front-end

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
