### PR TITLE
feat(checkout-button): grouped product support

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -663,7 +663,7 @@ final class Modal_Checkout {
 		if ( ! function_exists( 'WC' ) ) {
 			return;
 		}
-		if ( ! method_exists( 'Newspack\Subscriptions_Tiers', 'render_form' ) ) {
+		if ( ! class_exists( 'Newspack\Subscriptions_Tiers' ) || ! method_exists( 'Newspack\Subscriptions_Tiers', 'render_form' ) ) {
 			return;
 		}
 

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -663,6 +663,9 @@ final class Modal_Checkout {
 		if ( ! function_exists( 'WC' ) ) {
 			return;
 		}
+		if ( ! method_exists( 'Newspack\Subscriptions_Tiers', 'render_form' ) ) {
+			return;
+		}
 
 		add_filter( 'woocommerce_subscriptions_product_price_string', [ __CLASS__, 'update_subscriptions_product_price_string' ], 10, 1 );
 		add_filter( 'formatted_woocommerce_price', [ __CLASS__, 'maybe_remove_decimal_spaces' ], 10, 1 );

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -678,17 +678,16 @@ final class Modal_Checkout {
 		$products = array_keys( self::$products );
 		foreach ( $products as $product_id ) {
 			$product = wc_get_product( $product_id );
-			if ( ! $product || ! $product->is_type( 'variable' ) ) {
+			if ( ! $product || ( ! $product->is_type( 'variable' ) && ! $product->is_type( 'grouped' ) ) ) {
 				continue;
 			}
-			$product_name = $product->get_name();
 			?>
 			<div
 				class="<?php echo esc_attr( "$class_prefix {$class_prefix}__modal-container newspack-blocks__modal-variation" ); ?>"
 				data-product-id="<?php echo esc_attr( $product_id ); ?>"
 			>
 				<div class="<?php echo esc_attr( "{$class_prefix}__modal-container__overlay" ); ?>"></div>
-				<div class="<?php echo esc_attr( "{$class_prefix}__modal" ); ?>" role="dialog" aria-modal="true" aria-labelledby="newspack-modal-checkout-label">
+				<div class="<?php echo esc_attr( "{$class_prefix}__modal {$class_prefix}__modal--small" ); ?>" role="dialog" aria-modal="true" aria-labelledby="newspack-modal-checkout-label">
 					<header class="<?php echo esc_attr( "{$class_prefix}__modal__header" ); ?>">
 						<h2 id="newspack-modal-checkout-label"><?php echo esc_html( $title ); ?></h2>
 						<button class="<?php echo esc_attr( "{$class_prefix}__button {$class_prefix}__button--icon {$class_prefix}__button--ghost {$class_prefix}__modal__close" ); ?>">
@@ -699,54 +698,12 @@ final class Modal_Checkout {
 						</button>
 					</header>
 					<section class="<?php echo esc_attr( "{$class_prefix}__modal__content" ); ?>">
-						<h3><?php echo esc_html( $product_name ); ?></h3>
-						<p><?php esc_html_e( 'Select an option to continue:', 'newspack-blocks' ); ?></p>
-						<div class="<?php echo esc_attr( "{$class_prefix}__selection" ); ?>" data-product-id="<?php echo esc_attr( $product_id ); ?>">
-							<ul class="newspack-blocks__options"">
-								<?php
-								$variations = $product->get_available_variations( 'objects' );
-								foreach ( $variations as $variation ) :
-									$variation_id   = $variation->get_id();
-									$variation_name = wc_get_formatted_variation( $variation, true );
-									$price          = $variation->get_price();
-									$price_html     = $variation->get_price_html();
-
-									// Use suggested price if NYP is active and set for variation.
-									if ( \Newspack_Blocks::can_use_name_your_price() && \WC_Name_Your_Price_Helpers::is_nyp( $variation_id ) ) {
-										$price = \WC_Name_Your_Price_Helpers::get_suggested_price( $variation_id );
-										$min_price = \WC_Name_Your_Price_Helpers::get_minimum_price( $variation_id );
-										if ( ! $price && ! $min_price ) {
-											continue;
-										}
-									}
-
-									// Replace nyp price html for variations.
-									if ( class_exists( '\WC_Name_Your_Price_Helpers' ) && \WC_Name_Your_Price_Helpers::is_nyp( $variation->get_id() ) ) {
-										$price_html = str_replace( ':', '', $price_html );
-										$price_html = str_replace( '<span class="suggested-text">', '<span class="suggested-text"><span class="suggested-prefix">', $price_html );
-										$price_html = str_replace( '<span class="woocommerce-Price-amount amount">', '</span><span class="woocommerce-Price-amount amount">', $price_html );
-									}
-									?>
-									<li class="newspack-blocks__options__item"">
-										<div class="summary">
-											<span class="price"><?php echo $price_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
-										</div>
-										<div class="variation"><?php echo esc_html( $variation_name ); ?></div>
-										<form data-checkout="<?php echo esc_attr( wp_json_encode( Checkout_Data::get_checkout_data( $variation ) ) ); ?>">
-											<input type="hidden" name="newspack_checkout" value="1" />
-											<button type="submit" class="<?php echo esc_attr( "{$class_prefix}__button {$class_prefix}__button--primary" ); ?> newspack-modal-checkout-variation-selection"><?php echo esc_html( self::get_modal_checkout_labels( 'checkout_confirm_variation' ) ); ?></button>
-										</form>
-									</li>
-								<?php endforeach; ?>
-							</ul>
-						</div>
+						<?php \Newspack\Subscriptions_Tiers::render_form( $product ); ?>
 					</section>
 				</div>
 			</div>
 			<?php
 		}
-		remove_filter( 'woocommerce_subscriptions_product_price_string', [ __CLASS__, 'update_subscriptions_product_price_string' ], 10, 1 );
-		remove_filter( 'formatted_woocommerce_price', [ __CLASS__, 'maybe_remove_decimal_spaces' ], 10, 1 );
 	}
 
 	/**

--- a/includes/modal-checkout/class-checkout-data.php
+++ b/includes/modal-checkout/class-checkout-data.php
@@ -14,9 +14,9 @@ final class Checkout_Data {
 	/**
 	 * Get price string for the price summary card to render in auth flow.
 	 *
-	 * @param string $name      The name.
-	 * @param string $price     The price. Optional. If not provided, the price string will contain 0.
-	 * @param string $frequency The frequency. Optional. If not provided, the price will be treated as a one-time payment.
+	 * @param string $name       The name.
+	 * @param string $price      The price. Optional. If not provided, the price string will contain 0.
+	 * @param string $frequency  The frequency. Optional. If not provided, the price will be treated as a one-time payment.
 	 * @param int    $product_id Product ID to get additional subscription details. Optional.
 	 *
 	 * @return string The price string.

--- a/src/blocks/checkout-button/view.php
+++ b/src/blocks/checkout-button/view.php
@@ -149,6 +149,7 @@ function render_callback( $attributes ) {
 
 		$checkout_data = Checkout_Data::get_checkout_data( $product );
 		$checkout_data['is_variable'] = $is_variable;
+		$checkout_data['is_grouped']  = $product->is_type( 'grouped' );
 
 		$form = sprintf(
 			'<form data-checkout="%1$s">%2$s %3$s</form>',

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -662,7 +662,7 @@ domReady( () => {
 	 */
 	document
 		.querySelectorAll(
-			'.wpbnbd.wpbnbd--platform-wc, .wp-block-newspack-blocks-checkout-button'
+			'.wpbnbd.wpbnbd--platform-wc, .wp-block-newspack-blocks-checkout-button, .newspack-blocks__modal-variation'
 		)
 		.forEach( element => {
 			const forms = element.querySelectorAll( 'form' );

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -282,7 +282,7 @@ domReady( () => {
 		} );
 
 		// Trigger variation modal if variation is not selected.
-		if ( checkoutData.is_variable && ! checkoutData.variation_id ) {
+		if ( checkoutData.is_grouped || ( checkoutData.is_variable && ! checkoutData.variation_id ) ) {
 			const variationModal = [ ...variationModals ].find(
 				modal => modal.dataset.productId === checkoutData.product_id
 			);
@@ -662,7 +662,7 @@ domReady( () => {
 	 */
 	document
 		.querySelectorAll(
-			'.wpbnbd.wpbnbd--platform-wc, .wp-block-newspack-blocks-checkout-button, .newspack-blocks__modal-variation'
+			'.wpbnbd.wpbnbd--platform-wc, .wp-block-newspack-blocks-checkout-button'
 		)
 		.forEach( element => {
 			const forms = element.querySelectorAll( 'form' );

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -263,7 +263,7 @@ domReady( () => {
 			Object.keys( checkoutData ).forEach( key => {
 				const existingInputs = form.querySelectorAll( 'input[name="' +  key + '"]' );
 				if ( 0 === existingInputs.length ) {
-					form.appendChild( createHiddenInput( key, checkoutData[ key ] ) );
+					form.prepend( createHiddenInput( key, checkoutData[ key ] ) );
 				}
 			} );
 		}
@@ -298,7 +298,7 @@ domReady( () => {
 						].forEach( afterSuccessParam => {
 							const existingInputs = singleVariationForm.querySelectorAll( 'input[name="' +  afterSuccessParam + '"]' );
 							if ( 0 === existingInputs.length ) {
-								singleVariationForm.appendChild( createHiddenInput( afterSuccessParam, checkoutData[ afterSuccessParam ] ) );
+								singleVariationForm.prepend( createHiddenInput( afterSuccessParam, checkoutData[ afterSuccessParam ] ) );
 							}
 						} );
 
@@ -309,7 +309,7 @@ domReady( () => {
 							Object.keys( data ).forEach( key => {
 								const existingInputs = singleVariationForm.querySelectorAll( 'input[name="' +  key + '"]' );
 								if ( 0 === existingInputs.length ) {
-									singleVariationForm.appendChild( createHiddenInput( key, data[ key ] ) );
+									singleVariationForm.prepend( createHiddenInput( key, data[ key ] ) );
 								}
 							} );
 						}
@@ -668,7 +668,7 @@ domReady( () => {
 			const forms = element.querySelectorAll( 'form' );
 			forms.forEach( form => {
 				if ( ! newspackBlocksModal.has_unsupported_payment_gateway ) {
-					form.appendChild( modalCheckoutHiddenInput.cloneNode() );
+					form.prepend( modalCheckoutHiddenInput.cloneNode() );
 				}
 				form.target = IFRAME_NAME;
 				form.addEventListener( 'submit', handleCheckoutFormSubmit );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds support for [Grouped Products](https://woocommerce.com/document/managing-products/add-product/#adding-a-grouped-product) and deprecates the variation modal to use a unified "subscription tiers" modal from newpack plugin.

## Grouped Product

<img width="446" height="538" alt="image" src="https://github.com/user-attachments/assets/4eddb482-4cb0-471a-972c-a8692555f59d" />

## Variable Subscription

<img width="454" height="489" alt="image" src="https://github.com/user-attachments/assets/961fd96f-ca3a-46a0-bf37-3d9cf3f5ccd0" />


### How to test the changes in this Pull Request:

1. Checkout this branch and https://github.com/Automattic/newspack-plugin/pull/4164
2. Create the following Woo products:
   1. 2 variable subscriptions with frequency as the variable attribute (monthly/yearlypatron and member)
   2. A "grouped product" linking the 2 variable subscriptions
3. Add 2 checkout button blocks to page, one for the grouped product and the other for one of the variable subscriptions
4. Make sure **not to select a variation** in the variable subscription button block so the variation can be selected by the reader
5. Open the page and click the grouped product button
6. Confirm it renders as the image above
7. Navigate the frequency tabs and the available options
8. Select and continue
9. Close the checkout and confirm the modal reopens
10. Select again and continue
11. Go through the flow entire and confirm it works without issues
12. Click the variable subscription button and go through the entire flow
13. Confirm it also works without issues

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
