### PR TITLE
feat: better error messages for limited products

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1533,7 +1533,7 @@ final class Modal_Checkout {
 	 * @return string
 	 */
 	public static function get_subscription_limited_message_any() {
-		return __( "You're already a subscriber! You can only have one subscription at a time. If you wish to renew an expired subscription, please Sign In and visit the subscriptions page on your account.", 'newspack-blocks' );
+		return __( "You're already a subscriber! You can only have one subscription at a time. If you wish to renew an expired subscription, please sign in and visit the subscriptions page on your account.", 'newspack-blocks' );
 	}
 
 	/**

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1515,7 +1515,7 @@ final class Modal_Checkout {
 	}
 
 	/**
-	 * Alternative error message to show when limiting a subscription product's purchase.
+	 * Alternative error message to show when limiting a subscription product's purchase to only one active subscription.
 	 *
 	 * @return string
 	 */
@@ -1528,6 +1528,15 @@ final class Modal_Checkout {
 	}
 
 	/**
+	 * Alternative error message to show when limiting a subscription product's purchase to one of any status.
+	 *
+	 * @return string
+	 */
+	public static function get_subscription_limited_message_any() {
+		return __( "You're already a subscriber! You can only have one subscription at a time. If you wish to renew an expired subscription, please Sign In and visit the subscriptions page on your account.", 'newspack-blocks' );
+	}
+
+	/**
 	 * Filters the error message shown when a product can't be added to the cart.
 	 *
 	 * @param string     $message Message.
@@ -1537,9 +1546,15 @@ final class Modal_Checkout {
 	 */
 	public static function woocommerce_cart_product_cannot_be_purchased_message( $message, $product_data ) {
 		if ( method_exists( 'WCS_Limiter', 'is_purchasable' ) ) {
-			$product = \wc_get_product( $product_data->get_id() );
+			$product            = \wc_get_product( $product_data->get_id() );
+			$product_limitation = wcs_get_product_limitation( $product->get_id() );
+
 			if ( ! \WCS_Limiter::is_purchasable( false, $product ) ) {
-				$message = self::get_subscription_limited_message();
+				if ( 'active' === $product_limitation ) {
+					$message = self::get_subscription_limited_message();
+				} else {
+					$message = self::get_subscription_limited_message_any();
+				}
 			}
 		}
 
@@ -2111,8 +2126,10 @@ final class Modal_Checkout {
 		$id_from_email = self::get_user_id_from_email();
 		if ( $id_from_email ) {
 			$is_limited_for_user = wcs_is_product_limited_for_user( $product, $id_from_email );
+			$product_limitation  = wcs_get_product_limitation( $product->get_id() );
+			$callback = 'active' === $product_limitation ? 'get_subscription_limited_message' : 'get_subscription_limited_message_any';
 			if ( $is_limited_for_user ) {
-				add_filter( 'woocommerce_cart_item_removed_message', [ __CLASS__, 'get_subscription_limited_message' ], 10, 2 );
+				add_filter( 'woocommerce_cart_item_removed_message', [ __CLASS__, $callback ], 10, 2 );
 			}
 		}
 		return $is_limited_for_user;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Improves the error message when a user tries to buy a subscription they already have. Currently, the error message only covers the scenario that subscriptions are limited to one active sub per user. This PR also adds a message when the limitation is one of any status.

### How to test the changes in this Pull Request:

1. Setup a subscription
2. As a reader, buy that subscription via our checkout modal
3. As an admin, edit the Product, in the Advanced tab, in the  "Limit subscription" option, set it to "Limit to one active subscription"
4. In a new window, try to buy the subscription again with the same email used on step 2. Confirm you see the existing error message:

<img width="741" height="139" alt="image" src="https://github.com/user-attachments/assets/4d6cd6d6-71d7-4647-a206-1e0d86fa43cb" />

5.  As an admin, edit the Product, in the Advanced tab, in the  "Limit subscription" option, set it to "Limit to one of any status"
6. In a new window, try to buy the subscription again with the same email used on step 2. Confirm you see the new error message:

<img width="584" height="135" alt="image" src="https://github.com/user-attachments/assets/9d6bad08-0fba-44d0-94b6-f911511045f6" />


7. Does the new message looks good? Any suggestions to the copy?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
