### PR TITLE
feat(checkout-button): add justification support

### DIFF
--- a/src/blocks/checkout-button/block.json
+++ b/src/blocks/checkout-button/block.json
@@ -99,7 +99,16 @@
 			"__experimentalDefaultControls": {
 				"radius": true
 			}
-		}
+		},
+		"layout": {
+		  "default": {
+		    "type": "flex"
+      },
+      "allowJustification": true,
+      "allowVerticalAlignment": false,
+      "allowOrientation": false,
+      "allowSwitching": false
+    }
 	},
 	"styles": [
 		{

--- a/src/blocks/checkout-button/edit.js
+++ b/src/blocks/checkout-button/edit.js
@@ -207,7 +207,7 @@ function ProductControl( props ) {
 
 function CheckoutButtonEdit( props ) {
 	const { attributes, setAttributes, className } = props;
-	const { placeholder, style, text, product, price, variation, width } = attributes;
+	const { placeholder, style, text, product, price, variation, width, layout } = attributes;
 
 	const [ productData, setProductData ] = useState( {} );
 	const [ variations, setVariations ] = useState( [] );
@@ -266,6 +266,7 @@ function CheckoutButtonEdit( props ) {
 	const colorProps = useColorProps( attributes );
 	const spacingProps = useSpacingProps( attributes );
 	const blockProps = useBlockProps();
+
 	return (
 		<>
 			<div
@@ -274,6 +275,7 @@ function CheckoutButtonEdit( props ) {
 					[ `wp-block-button` ]: true,
 					[ `has-custom-font-size` ]: blockProps.style.fontSize,
 					[ `has-custom-width wp-block-button__width-${ width }` ]: width,
+					[ `has-custom-justification wp-block-button__justification-${ layout?.justifyContent }` ]: layout?.justifyContent,
 				} ) }
 			>
 				<RichText
@@ -302,7 +304,7 @@ function CheckoutButtonEdit( props ) {
 					identifier="text"
 				/>
 			</div>
-			<InspectorControls>
+			<InspectorControls group="settings">
 				<PanelBody title={ __( 'Product', 'newspack-blocks' ) }>
 					<ProductControl
 						value={ product }
@@ -391,7 +393,7 @@ function CheckoutButtonEdit( props ) {
 					</PanelBody>
 				) }
 			</InspectorControls>
-			<InspectorControls>
+			<InspectorControls group="settings">
 				<WidthPanel selectedWidth={ width } setAttributes={ setAttributes } />
 			</InspectorControls>
 		</>

--- a/src/blocks/checkout-button/edit.scss
+++ b/src/blocks/checkout-button/edit.scss
@@ -63,5 +63,18 @@
 	&__button {
 		width: auto;
 	}
+
+	&.wp-block-button__justification-center {
+		justify-content: center;
+	}
+	&.wp-block-button__justification-left {
+		justify-content: flex-start;
+	}
+	&.wp-block-button__justification-right {
+		justify-content: flex-end;
+	}
+	&.wp-block-button__justification-space-between {
+		justify-content: space-between;
+	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds justification support to the checkout button block to be more inline with how the regular button block works:

![Screenshot 2025-09-12 at 16 08 20](https://github.com/user-attachments/assets/95a84945-99a1-46c5-9396-edbcc6bcf9ae)

While working on https://github.com/Automattic/newspack-plugin/pull/4176 I noticed the checkout button block doesn't support justification like the regular button block does.

### How to test the changes in this Pull Request:

1. Add a checkout button to any page or post
2. Notice the justification settings in both the block controls and the sidebar
3. Select different justification settings and confirm the button moves in the editor
4. Save the different settings and view on the front end

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
