### PR TITLE
Support for iframe auto-resizing

### DIFF
--- a/src/blocks/iframe/view.php
+++ b/src/blocks/iframe/view.php
@@ -123,14 +123,27 @@ function newspack_blocks_get_iframe_html( $mode, $src, $height, $width, $is_full
 
 		// Add a listener for dynamic resizing if the iframe supports it.
 		window.addEventListener("message", function(event) {
-			if(event.data.height && iframe.contentWindow === event.source) {
+			// Reject messages from untrusted origins.
+			if (event.origin !== new URL(iframe.src).origin || iframe.contentWindow !== event.source) {
+				return; 
+			}
+
+			var iframeHeight = 0;
+			if (event.data && event.data.height){
+				if (typeof event.data.height === "number") {
+					iframeHeight = event.data.height;
+				} else if (typeof event.data.height === "string") {
+					iframeHeight = Number(event.data.height);
+				}
+			}
+			if (!isNaN(iframeHeight) && iframeHeight > 0) {
 				// Remove height from the iframe's parent element if needed.
-				if (iframe.parentElement) {
+				if (iframe.parentElement && iframe.parentElement.style.height !== "auto") {
 					iframe.parentElement.style.height = "auto";
 				}
 
 				// Set the new height dynamically.
-				iframe.style.height = event.data.height + "px";
+				iframe.style.height = iframeHeight + "px";
 			}
 		});
 	</script>

--- a/src/blocks/iframe/view.php
+++ b/src/blocks/iframe/view.php
@@ -121,6 +121,18 @@ function newspack_blocks_get_iframe_html( $mode, $src, $height, $width, $is_full
 			clearInterval(timerId);
 		}
 
+		// Add a listener for dynamic resizing if the iframe supports it.
+		window.addEventListener("message", function(event) {
+			if(event.data.height && iframe.contentWindow === event.source) {
+				// Remove height from the iframe's parent element if needed.
+				if (iframe.parentElement) {
+					iframe.parentElement.style.height = "auto";
+				}
+
+				// Set the new height dynamically.
+				iframe.style.height = event.data.height + "px";
+			}
+		});
 	</script>
 
 	<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes NPPD-878. This PR adds support for iframes that send resize messages from the child page to the parent page. Currently iframes have a static vertical size, and this PR lets them have dynamic vertical sizes if the embedded page supports that.

### How to test the changes in this Pull Request:

1. You can use https://community.bendsource.com/bend/Responsive/Components/Landing/CalendarPicksFrame.html as a sample URL, because these embeds definitely support the necessary messages. Before applying this PR, create an iframe block with this URL. Resize the screen to a variety of sizes. Observe that at some sizes, the contents of the iframe overflow the container of the iframe:

<img width="781" height="867" alt="Screenshot 2025-09-18 at 3 00 35 PM" src="https://github.com/user-attachments/assets/7b812d20-43c2-4e21-a74b-c2b86f9cd859" />

2. Apply this PR. Refresh the page and go through the screen sizes again. Observe that the height of the iframe changes dynamically so that it never overflows:

<img width="655" height="775" alt="Screenshot 2025-09-18 at 3 01 54 PM" src="https://github.com/user-attachments/assets/44feee62-9c44-4f2d-8c49-bf6cd130c3af" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
