### PR TITLE
fix: clarify NRH dependency for Campaign ID sidebar attribute

### DIFF
--- a/src/blocks/donate/edit/index.tsx
+++ b/src/blocks/donate/edit/index.tsx
@@ -423,17 +423,19 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 						label={ __( 'Button Color', 'newspack-blocks' ) }
 					/>
 				</PanelBody>
-				<PanelBody title={ __( 'Campaign', 'newspack-blocks' ) } initialOpen={ false }>
-					<TextControl
-						label={ __( 'Campaign ID', 'newspack-blocks' ) }
-						value={ attributes.campaign || '' }
-						onChange={ ( value: string ) =>
-							setAttributes( {
-								campaign: value,
-							} )
-						}
-					/>
-				</PanelBody>
+				{ settings.platform === 'nrh' && (
+					<PanelBody title={ __( 'News Revenue Hub Settings', 'newspack-blocks' ) } initialOpen={ false }>
+						<TextControl
+							label={ __( 'Campaign ID', 'newspack-blocks' ) }
+							value={ attributes.campaign || '' }
+							onChange={ ( value: string ) =>
+								setAttributes( {
+									campaign: value,
+								} )
+							}
+						/>
+					</PanelBody>
+				) }
 				{ window.newspack_blocks_data.supports_recaptcha && (
 					<PanelBody title={ __( 'Spam protection', 'newspack' ) }>
 						<p>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Renames the Donate block's "Campaign" sidebar panel to "News Revenue Hub Settings" and hides it unless the active platform is NRH, to clarify the purpose of this block attribute.

Closes NPPM-2244.

### How to test the changes in this Pull Request:

1. On `trunk`, add a Donate block to a post/page and add a Campaign ID value to it. Save.
2. Check out this branch.
3. In **Audience > Configuration > Checkout & Payment**, set your reader revenue platform to something other than News Revenue Hub.
4. Edit the existing Donate block and add a new Donate block to a post or page. Confirm that there's no "Campaign" or "News Revenue Hub Settings" sidebar panel when the Donate block is selected.
5. Set your reader revenue platform to News Revenue Hub.
6. Edit the existing Donate block and add a new one, and confirm that the "News Revenue Hub Settings" panel appears and can still be edited and saved after refreshing the editor. Confirm that the Donate block you created in step 1 still has the same Campaign ID you entered when you last saved it.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
