### PR TITLE
fix: correct RTL styles for the Content Loop

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -261,12 +261,14 @@ class Newspack_Blocks {
 
 		$editor_style = plugins_url( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'editor.css', NEWSPACK_BLOCKS__PLUGIN_FILE );
 
+		$handle = 'newspack-blocks-editor';
 		wp_enqueue_style(
-			'newspack-blocks-editor',
+			$handle,
 			$editor_style,
 			array(),
 			NEWSPACK_BLOCKS__VERSION
 		);
+		wp_style_add_data( $handle, 'rtl', 'replace' );
 	}
 
 	/**

--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -240,7 +240,7 @@
 		},
 		"textAlign": {
 			"type": "string",
-			"default": "left"
+			"default": ""
 		},
 		"includedPostStatuses": {
 			"type": "array",

--- a/src/blocks/homepage-articles/view.scss
+++ b/src/blocks/homepage-articles/view.scss
@@ -509,6 +509,28 @@
 	}
 }
 
+[dir="rtl"] {
+	.wpnbha {
+		&.has-text-align-right {
+			.cat-links,
+			.entry-meta,
+			.entry-sponsors,
+			.sponsor-logos {
+				justify-content: flex-start;
+			}
+		}
+
+		&.has-text-align-left {
+			.cat-links,
+			.entry-meta,
+			.entry-sponsors,
+			.sponsor-logos {
+				justify-content: flex-end;
+			}
+		}
+	}
+}
+
 /*
 	Some really rough font sizing.
  */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes some RTL display issues with the Content Loop block by tweaking the styles, and removing the 'Left' text alignment CSS class from being added by default. This mirrors other blocks like paragraphs, which have an empty text alignment state, but can be set to align their text left, right, and centre, and then back to 'none' by clicking the currently selected alignment.

Closes NPPM-2146.

### How to test the changes in this Pull Request:

1. Apply this PR.
2. Add a Content Loop block to the editor, and click on the text alignment button in the block toolbar; confirm none of the options are selected. Prior to this PR, 'Left' would be selected:

<img width="664" height="228" alt="CleanShot 2025-09-24 at 17 16 22" src="https://github.com/user-attachments/assets/4f844d67-b616-440b-960b-de006abf9916" />

3. Try selecting Left, and then clicking it again -- confirm that it "turns off" when you click it a second time. For bonus points, confirm that there isn't a `.has-text-align-` CSS class on the block.
4. Set up some Content Loop blocks on your homepage.
    * All blocks should include all post meta.
    * There should be a set to represent each image alignment style (top, left/right, and behind), with all four text alignments: none, left, centre, and right. You can also copy this test content into the editor for a quick start:

<details><summary>Test HTML</summary>

```
<!-- wp:paragraph -->
<p>This is a paragraph with no alignment.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"align":"left"} -->
<p class="has-text-align-left">This is a paragraph with left alignment.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"align":"right"} -->
<p class="has-text-align-right">This is a paragraph with right alignment.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"align":"center"} -->
<p class="has-text-align-center">This is a paragraph with centre alignment.</p>
<!-- /wp:paragraph -->

<!-- wp:newspack-blocks/homepage-articles {"showCategory":true,"postLayout":"grid","sectionHeader":"CL with No Alignment","showSubtitle":true} /-->

<!-- wp:newspack-blocks/homepage-articles {"showCategory":true,"postLayout":"grid","sectionHeader":"CL with Left Alignment","showSubtitle":true,"textAlign":"left"} /-->

<!-- wp:newspack-blocks/homepage-articles {"showCategory":true,"postLayout":"grid","sectionHeader":"CL with Center Alignment","showSubtitle":true,"textAlign":"center"} /-->

<!-- wp:newspack-blocks/homepage-articles {"showCategory":true,"postLayout":"grid","sectionHeader":"CL with Right Alignment","showSubtitle":true,"textAlign":"right"} /-->

<!-- wp:newspack-blocks/homepage-articles {"showCategory":true,"postLayout":"grid","columns":2,"postsToShow":2,"mediaPosition":"left","typeScale":2,"imageScale":1,"sectionHeader":"CL with No Alignment","showSubtitle":true} /-->

<!-- wp:newspack-blocks/homepage-articles {"showCategory":true,"postLayout":"grid","columns":2,"postsToShow":2,"mediaPosition":"left","typeScale":2,"imageScale":1,"sectionHeader":"CL with Left Alignment","showSubtitle":true,"textAlign":"left"} /-->

<!-- wp:newspack-blocks/homepage-articles {"showCategory":true,"postLayout":"grid","columns":2,"postsToShow":2,"mediaPosition":"left","typeScale":2,"imageScale":1,"sectionHeader":"CL with Centre Alignment","showSubtitle":true,"textAlign":"center"} /-->

<!-- wp:newspack-blocks/homepage-articles {"showCategory":true,"postLayout":"grid","columns":2,"postsToShow":2,"mediaPosition":"left","typeScale":2,"imageScale":1,"sectionHeader":"CL with Right Alignment","showSubtitle":true,"textAlign":"right"} /-->

<!-- wp:newspack-blocks/homepage-articles {"imageShape":"uncropped","minHeight":40,"showCategory":true,"postLayout":"grid","columns":2,"postsToShow":2,"mediaPosition":"behind","typeScale":2,"imageScale":1,"sectionHeader":"CL with No Alignment","showSubtitle":true} /-->

<!-- wp:newspack-blocks/homepage-articles {"imageShape":"uncropped","minHeight":40,"showCategory":true,"postLayout":"grid","columns":2,"postsToShow":2,"mediaPosition":"behind","typeScale":2,"imageScale":1,"sectionHeader":"CL with Left Alignment","showSubtitle":true,"textAlign":"left"} /-->

<!-- wp:newspack-blocks/homepage-articles {"imageShape":"uncropped","minHeight":40,"showCategory":true,"postLayout":"grid","columns":2,"postsToShow":2,"mediaPosition":"behind","typeScale":2,"imageScale":1,"sectionHeader":"CL with Centre Alignment","showSubtitle":true,"textAlign":"center"} /-->

<!-- wp:newspack-blocks/homepage-articles {"imageShape":"uncropped","minHeight":40,"showCategory":true,"postLayout":"grid","columns":2,"postsToShow":2,"mediaPosition":"behind","typeScale":2,"imageScale":1,"sectionHeader":"CL with Right Alignment","showSubtitle":true,"textAlign":"right"} /-->
```
</details>

5. View on the front-end and confirm things look as expected, primarily checking for text alignments. The "no alignment" and "left alignment" blocks should have everything aligned left; the centre and right aligned blocks should match their names.
6. Navigate to WP Admin > Settings > General, and change the language to a RTL language like Arabic. 
7. View the blocks again in the editor and on the front-end. The order of some elements will be flipped, but the text alignments should be respected:
    * The "no alignment" and "right alignment" blocks should be aligned right
    * The "left alignment" and "centre alignment" blocks should respect that setting.
    * While the order may be off, the spacing should not - make sure there's a logical space between the avatar and byline, the byline and date, etc...).
 
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
