### PR TITLE
fix(modal-checkout): handling of tiered donation block

### DIFF
--- a/includes/modal-checkout/class-checkout-data.php
+++ b/includes/modal-checkout/class-checkout-data.php
@@ -58,7 +58,7 @@ final class Checkout_Data {
 						]
 					)
 				);
-			} else {
+			} elseif ( $price !== '{{PRICE}}' ) { // Preserve placeholder for templating.
 				$price = wp_strip_all_tags( wc_price( $price ) );
 			}
 		}

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -249,7 +249,14 @@ domReady( () => {
 				customAmount = checkoutData[ `donation_value_${ frequency }` ];
 			} else {
 				donationContainer = donationTiers[ 0 ];
-				customAmount = checkoutData[ `donation_value_${ frequency }_untiered` ];
+				if ( checkoutData[ `donation_value_${ frequency }_untiered` ] ) {
+					customAmount = checkoutData[ `donation_value_${ frequency }_untiered` ];
+				} else {
+					customAmount = checkoutData[ `donation_value_${ frequency }` ];
+					if ( customAmount === 'other' ) {
+						customAmount = checkoutData[ `donation_value_${ frequency }_other` ];
+					}
+				}
 			}
 			const donationData = getCheckoutData( donationContainer );
 			for( const key in donationData ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The price summary template for non-recurring products is getting replaced with 0 when transformed by `wp_strip_all_tags( wc_price( $price ) )`. This fixes it by not transforming the price for non-recurring products.

This also fixes the checkout data handling tiered donation blocks.

### How to test the changes in this Pull Request:

1. While on release, place a tiered Donate block and make sure "Require sign in or create account before checkout" is toggled on in Audience -> Configuration -> Checkout & Payment
2. Click to donate on each frequency and confirm the modal renders $0 for one-time donations and NaN for recurring donations
3. Checkout this branch and confirm it renders the expected amount
4. Also test with "Other" amount and confirm it also renders the custom value
5. Edit the block and change it to the standard untiered frequency mode
6. Confirm there's no regression

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
