### PR TITLE
fix: account for core woocommerce subscriptions gifting

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1294,7 +1294,7 @@ final class Modal_Checkout {
 		if (
 			1 === count( array_values( $cart_items ) ) &&
 			method_exists( 'WCS_Gifting', 'email_belongs_to_current_user' ) &&
-			method_exists( 'WCS_Gifting', 'update_cart_item_key' ) &&
+			method_exists( 'WCS_Gifting', 'update_cart_item_recipient' ) &&
 			method_exists( 'WCSG_Cart', 'is_giftable_item' )
 		) {
 			$is_gift   = ! empty( filter_input( INPUT_POST, 'newspack_wcsg_is_gift', FILTER_SANITIZE_SPECIAL_CHARS ) );
@@ -1307,7 +1307,7 @@ final class Modal_Checkout {
 
 				// If no errors, attach the recipient's email address to the subscription item.
 				if ( $is_valid_email ) {
-					\WCS_Gifting::update_cart_item_key( $cart_item, $cart_item_key, $recipient_email );
+					\WCS_Gifting::update_cart_item_recipient( $cart_item, $cart_item_key, $recipient_email );
 				} else {
 					$notice = $self_gifting
 						? __( 'Please enter someone else\' email address to receive this gift.', 'newspack-blocks' )


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2341/this-is-a-gift-checkbox-not-working-on-modal

This PR uses the newly merged gifting logic within subscriptions gifting. Previously our code depended on [the WC Subscriptions Gifting extension which has been retired](https://woocommerce.com/document/subscriptions-gifting/). As a result, our modal checkout gifting checkbox no longer worked.

![Screenshot 2025-10-27 at 12 59 57](https://github.com/user-attachments/assets/a2a2528d-3433-4f8d-9c9d-e42c1b662793)

### How to test the changes in this Pull Request:

Before testing, also checkout the following plugin PR https://github.com/Automattic/newspack-plugin/pull/4257

1. As a reader, purchase a giftable subscription for another recipient (check the gifting box and input another email address)
2. As admin, verify the subscription was correctly purchased for the gifting recipient

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
