### PR TITLE
fix(modal-checkout): skip newsletter signup on subscription switch

### DIFF
--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -498,6 +498,8 @@ domReady( () => {
 		);
 		const hasNewsletterPopup = document?.querySelector( '.newspack-newsletters-signup-modal' );
 
+		const checkoutData = getCheckoutData( container?.querySelector( '#modal-checkout-product-details' ) );
+
 		// Empty cart if checkout is not complete.
 		if ( ! container?.checkoutComplete ) {
 			emptyCart();
@@ -546,7 +548,7 @@ domReady( () => {
 				inCheckoutIntent = false;
 			};
 
-			if ( window?.newspackReaderActivation?.openNewslettersSignupModal ) {
+			if ( checkoutData.action_type !== 'subscription_switch' && window?.newspackReaderActivation?.openNewslettersSignupModal ) {
 				window.newspackReaderActivation.openNewslettersSignupModal( {
 					onSuccess: handleCheckoutComplete,
 					onError: handleCheckoutComplete,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The post-checkout newsletter signup modal shouldn't render when subscription switching.

While working on this change, I also found a bug when getting the action type on post-checkout. The checkout data source can also be a `WC_Order`, which was not considered in `get_action_type()`. This PR also fixes this issue.

### How to test the changes in this Pull Request:

1. Setup a primary subscription product (Audience -> Subscriptions)
2. In a fresh session, go through the update subscription link flow
3. Purchase the subscription and confirm you get the newsletter signup
4. Access the link again and go through the **upgrade flow**
5. Confirm you don't get the newsletter signup modal at the end

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
