### PR TITLE
fix: handle multiple responsive iframe blocks

### DIFF
--- a/src/blocks/iframe/view.js
+++ b/src/blocks/iframe/view.js
@@ -1,5 +1,49 @@
 /**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+
+/**
  * Style dependencies
  */
 
 import './view.scss';
+
+domReady( () => {
+	const iframes = Array.from( document.querySelectorAll( '.wp-block-newspack-blocks-iframe iframe' ) );
+	iframes.forEach( iframe => {
+		const timerId = setInterval( function () {
+			iframe.src = iframe.src;
+		}, 2000 );
+
+		iframe.onload = function () {
+			clearInterval( timerId );
+		};
+
+		// Add a listener for dynamic resizing if the iframe supports it.
+		window.addEventListener( 'message', function ( event ) {
+			// Reject messages from untrusted origins.
+			if ( event.origin !== new URL( iframe.src ).origin || iframe.contentWindow !== event.source ) {
+				return;
+			}
+
+			let iframeHeight = 0;
+			if ( event.data && event.data.height ) {
+				if ( typeof event.data.height === 'number' ) {
+					iframeHeight = event.data.height;
+				} else if ( typeof event.data.height === 'string' ) {
+					iframeHeight = Number( event.data.height );
+				}
+			}
+			if ( ! isNaN( iframeHeight ) && iframeHeight > 0 ) {
+				// Remove height from the iframe's parent element if needed.
+				if ( iframe.parentElement && iframe.parentElement.style.height !== 'auto' ) {
+					iframe.parentElement.style.height = 'auto';
+				}
+
+				// Set the new height dynamically.
+				iframe.style.height = iframeHeight + 'px';
+			}
+		} );
+	} );
+} );

--- a/src/blocks/iframe/view.php
+++ b/src/blocks/iframe/view.php
@@ -110,44 +110,6 @@ function newspack_blocks_get_iframe_html( $mode, $src, $height, $width, $is_full
 			></iframe>
 		</div>
 	</figure>
-
-	<script>
-		const iframe = document.getElementById("<?php echo esc_attr( $iframe_id ); ?>");
-		const timerId = setInterval( function() {
-				iframe.src = iframe.src;
-			}, 2000 );
-
-		iframe.onload = function() {
-			clearInterval(timerId);
-		}
-
-		// Add a listener for dynamic resizing if the iframe supports it.
-		window.addEventListener("message", function(event) {
-			// Reject messages from untrusted origins.
-			if (event.origin !== new URL(iframe.src).origin || iframe.contentWindow !== event.source) {
-				return; 
-			}
-
-			var iframeHeight = 0;
-			if (event.data && event.data.height){
-				if (typeof event.data.height === "number") {
-					iframeHeight = event.data.height;
-				} else if (typeof event.data.height === "string") {
-					iframeHeight = Number(event.data.height);
-				}
-			}
-			if (!isNaN(iframeHeight) && iframeHeight > 0) {
-				// Remove height from the iframe's parent element if needed.
-				if (iframe.parentElement && iframe.parentElement.style.height !== "auto") {
-					iframe.parentElement.style.height = "auto";
-				}
-
-				// Set the new height dynamically.
-				iframe.style.height = iframeHeight + "px";
-			}
-		});
-	</script>
-
 	<?php
 	return ob_get_clean();
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Hotfix to allow fix from #2209 to apply to multiple instances of the iframe block on a single page. Also moves the front-end JS into the `view.js` file so it gets the benefits of transpiling and minification from our webpack build flows.

Closes NPPM-2365.

### How to test the changes in this Pull Request:

1. Check out this branch and rebuild assets
2. In a post, add two separate iframe blocks and point them to HTML or URLs that will send `postMessage` events upon resizing. You can use this [this sample URL](https://community.bendsource.com/bend/Responsive/Components/Landing/CalendarPicksFrame.html) from #2209 for both instances for testing.
3. View the post on the front-end and resize the window enough to trigger the content inside each iframe to resize/reflow. Confirm that both iframes resize automatically to contain their content.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
