### PR TITLE
fix: revert render modal checkout with filtered supported gateways (#2240)

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -200,7 +200,6 @@ final class Modal_Checkout {
 
 		// Wrap required checkbox text in a span so it works nicely with the Newspack UI grid layout.
 		add_filter( 'woocommerce_form_field_checkbox', [ __CLASS__, 'wrap_required_checkbox_text' ], 10, 4 );
-		add_filter( 'woocommerce_available_payment_gateways', [ __CLASS__, 'filter_available_payment_gateways' ] );
 
 		/**
 		 * Ensure that options to limit the number of subscriptions per product are respected.
@@ -268,43 +267,21 @@ final class Modal_Checkout {
 	}
 
 	/**
-	 * Filter available payment gateways to only supported ones in modal checkout.
-	 *
-	 * @param array $available_gateways Available payment gateways.
-	 *
-	 * @return array Filtered available payment gateways.
-	 */
-	public static function filter_available_payment_gateways( $available_gateways ) {
-		if ( ! self::is_modal_checkout() ) {
-			return $available_gateways;
-		}
-
-		$supported_gateways = self::get_supported_payment_gateways();
-		foreach ( $available_gateways as $id => $gateway ) {
-			if ( ! in_array( $id, $supported_gateways, true ) ) {
-				unset( $available_gateways[ $id ] );
-			}
-		}
-
-		return $available_gateways;
-	}
-
-	/**
 	 * Whether any available payment gateways are not suppored in modal checkout.
 	 *
 	 * @return boolean
 	 */
-	public static function has_supported_payment_gateway() {
-		$supported_gateways = self::get_supported_payment_gateways();
-		$available_gateways = function_exists( 'WC' ) ? \WC()->payment_gateways->get_available_payment_gateways() : [];
-		$has_supported      = false;
+	public static function has_unsupported_payment_gateway() {
+		$supported_gateways          = self::get_supported_payment_gateways();
+		$available_gateways          = function_exists( 'WC' ) ? \WC()->payment_gateways->get_available_payment_gateways() : [];
+		$unsupported_payment_gateway = false;
 		foreach ( $available_gateways as $id => $gateway ) {
-			if ( in_array( $id, $supported_gateways, true ) ) {
-				$has_supported = true;
+			if ( ! in_array( $id, $supported_gateways, true ) ) {
+				$unsupported_payment_gateway = true;
 				break;
 			}
 		}
-		return $has_supported;
+		return $unsupported_payment_gateway;
 	}
 
 	/**
@@ -413,7 +390,7 @@ final class Modal_Checkout {
 			$query_args['referer_categories'] = implode( ',', $referer_categories );
 		}
 
-		if ( self::has_supported_payment_gateway() ) {
+		if ( ! self::has_unsupported_payment_gateway() ) {
 			$query_args['modal_checkout'] = 1;
 		}
 
@@ -981,13 +958,13 @@ final class Modal_Checkout {
 			'newspack-blocks-modal',
 			'newspackBlocksModal',
 			[
-				'ajax_url'                      => admin_url( 'admin-ajax.php' ),
-				'checkout_registration_flag'    => self::CHECKOUT_REGISTRATION_FLAG,
-				'newspack_class_prefix'         => self::get_class_prefix(),
-				'is_registration_required'      => self::is_registration_required(),
-				'has_supported_payment_gateway' => self::has_supported_payment_gateway(),
-				'checkout_url'                  => remove_query_arg( 'my_account_checkout', add_query_arg( 'modal_checkout', '1', wc_get_checkout_url() ) ),
-				'labels'                        => [
+				'ajax_url'                        => admin_url( 'admin-ajax.php' ),
+				'checkout_registration_flag'      => self::CHECKOUT_REGISTRATION_FLAG,
+				'newspack_class_prefix'           => self::get_class_prefix(),
+				'is_registration_required'        => self::is_registration_required(),
+				'has_unsupported_payment_gateway' => self::has_unsupported_payment_gateway(),
+				'checkout_url'                    => remove_query_arg( 'my_account_checkout', add_query_arg( 'modal_checkout', '1', wc_get_checkout_url() ) ),
+				'labels'                          => [
 					'auth_modal_title'     => self::get_modal_checkout_labels( 'auth_modal_title' ),
 					'checkout_modal_title' => self::get_modal_checkout_labels( 'checkout_modal_title' ),
 					'register_modal_title' => self::get_modal_checkout_labels( 'register_modal_title' ),
@@ -1112,7 +1089,7 @@ final class Modal_Checkout {
 	 * @return string
 	 */
 	public static function woocommerce_get_return_url( $url, $order ) {
-		if ( ! self::is_modal_checkout() || ! self::has_supported_payment_gateway() ) {
+		if ( ! self::is_modal_checkout() || self::has_unsupported_payment_gateway() ) {
 			return $url;
 		}
 

--- a/src/blocks/checkout-button/view.php
+++ b/src/blocks/checkout-button/view.php
@@ -103,7 +103,7 @@ function render_callback( $attributes ) {
 
 	// Generate hidden fields for the form.
 	$hidden_fields = '<input type="hidden" name="newspack_checkout" value="1" />';
-	if ( Modal_Checkout::has_supported_payment_gateway() ) {
+	if ( ! Modal_Checkout::has_unsupported_payment_gateway() ) {
 		$hidden_fields .= $after_success_behavior ? '<input type="hidden" name="after_success_behavior" value="' . esc_attr( $after_success_behavior ) . '" />' : '';
 		$hidden_fields .= $after_success_button_label ? '<input type="hidden" name="after_success_button_label" value="' . esc_attr( $after_success_button_label ) . '" />' : '';
 		$hidden_fields .= $after_success_url ? '<input type="hidden" name="after_success_url" value="' . esc_attr( $after_success_url ) . '" />' : '';

--- a/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
+++ b/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
@@ -203,7 +203,7 @@ abstract class Newspack_Blocks_Donate_Renderer_Base {
 			<input type='hidden' name='frequency_ids' value='<?php echo esc_attr( wp_json_encode( $donate_child_ids ) ); ?>' />
 		<?php
 
-		if ( \Newspack_Blocks\Modal_Checkout::has_supported_payment_gateway() ) {
+		if ( ! \Newspack_Blocks\Modal_Checkout::has_unsupported_payment_gateway() ) {
 			foreach ( [ [ 'afterSuccessBehavior', 'after_success_behavior' ], [ 'afterSuccessButtonLabel', 'after_success_button_label' ], [ 'afterSuccessURL', 'after_success_url' ] ] as $attribute ) {
 				$attribute_name = $attribute[0];
 				$param_name     = $attribute[1];

--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -193,7 +193,7 @@ domReady( () => {
 	 */
 	const emptyCart = async () => {
 		const body = new FormData();
-		if ( newspackBlocksModal.has_supported_payment_gateway ) {
+		if ( ! newspackBlocksModal.has_unsupported_payment_gateway ) {
 			body.append( 'modal_checkout', '1' );
 		}
 		body.append( 'action', 'abandon_modal_checkout' );
@@ -229,7 +229,7 @@ domReady( () => {
 	 * @param {Event} ev
 	 */
 	const handleCheckoutFormSubmit = ev => {
-		const isModalCheckout = newspackBlocksModal.has_supported_payment_gateway;
+		const isModalCheckout = ! newspackBlocksModal.has_unsupported_payment_gateway;
 		if ( ! isModalCheckout ) {
 			ev.preventDefault();
 		}
@@ -679,7 +679,7 @@ domReady( () => {
 		.forEach( element => {
 			const forms = element.querySelectorAll( 'form' );
 			forms.forEach( form => {
-				if ( newspackBlocksModal.has_supported_payment_gateway ) {
+				if ( ! newspackBlocksModal.has_unsupported_payment_gateway ) {
 					form.prepend( modalCheckoutHiddenInput.cloneNode() );
 				}
 				form.target = IFRAME_NAME;


### PR DESCRIPTION
This reverts commit ba74667f28f674eb028dd1dc613e6b3c90206efa.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Reverts changes from #2240, which we determined aren't needed at this time.

### How to test the changes in this Pull Request:

Confirm that the changes from #2240 are reverted.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
