### PR TITLE
fix: content loop load more for custom taxs

### DIFF
--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -323,19 +323,6 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 		$styles = 'color: ' . $attributes['customTextColor'] . ';';
 	}
 
-	// Handle custom taxonomies.
-	if ( isset( $attributes['customTaxonomies'] ) ) {
-		$custom_taxes = $attributes['customTaxonomies'];
-		unset( $attributes['customTaxonomies'] );
-		if ( is_array( $custom_taxes ) && ! empty( $custom_taxes ) ) {
-			foreach ( $custom_taxes as $tax ) {
-				if ( ! empty( $tax['slug'] ) && ! empty( $tax['terms'] ) ) {
-					$attributes[ $tax['slug'] ] = $tax['terms'];
-				}
-			}
-		}
-	}
-
 	$articles_rest_url = add_query_arg(
 		array_merge(
 			map_deep(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

NPPM-2373

Fixes the "load more" button in the content Loop block for Custom taxonomies.

When you add a block that has a filter for custom taxonomies like Brands, and a "Load more posts" button, when you click the button, the posts that are loaded do not respect the filter for the custom taxonomy.

### How to test the changes in this Pull Request:

This basically reverts part of the changes introduced in https://github.com/Automattic/newspack-blocks/pull/1454

It seems safe to just remove it, as the `$attributes` var is only being used to build the "more posts" link and in the templates. The link is what was broken, and the templates don't look for custom taxonomies for anything... I have no idea why I added this code in the first place.

1. Perform all the tests described in https://github.com/Automattic/newspack-blocks/pull/1454
2. Add a block with the option to "Show Load More posts button"  ON and a filter by BRAND
3. Visit the block on the front end and make sure the posts that are loaded respect the Brand filter.
4. Also run the same test for the Infinite Scroll option

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
