### PR TITLE
fix: don’t show trial info in modal checkout if not applicable

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1829,7 +1829,7 @@ final class Modal_Checkout {
 	 *
 	 * @return false|int User ID if found by email address, false otherwise.
 	 */
-	private static function get_user_id_from_email() {
+	public static function get_user_id_from_email() {
 		$billing_email = filter_input( INPUT_POST, 'billing_email', FILTER_SANITIZE_EMAIL );
 		if ( $billing_email ) {
 			$customer = \get_user_by( 'email', $billing_email );

--- a/includes/modal-checkout/class-checkout-data.php
+++ b/includes/modal-checkout/class-checkout-data.php
@@ -26,7 +26,7 @@ final class Checkout_Data {
 			$price = '0';
 		}
 
-		if ( function_exists( 'wcs_price_string' ) && function_exists( 'wc_price' ) ) {
+		if ( function_exists( 'wcs_price_string' ) && function_exists( 'wc_price' ) && function_exists( 'wc_get_product' ) && class_exists( 'WC_Subscriptions_Product' ) ) {
 			if ( $frequency && $frequency !== 'once' ) {
 				// Get additional subscription details if product_id is provided.
 				$subscription_interval = 1;
@@ -35,10 +35,11 @@ final class Checkout_Data {
 				$initial_amount        = 0;
 
 				if ( $product_id ) {
-					$subscription_interval = get_post_meta( $product_id, '_subscription_period_interval', true );
-					$trial_length = get_post_meta( $product_id, '_subscription_trial_length', true );
-					$trial_period = get_post_meta( $product_id, '_subscription_trial_period', true );
-					$initial_amount = get_post_meta( $product_id, '_subscription_sign_up_fee', true );
+					$product = wc_get_product( $product_id );
+					$subscription_interval = \WC_Subscriptions_Product::get_interval( $product );
+					$trial_length = \WC_Subscriptions_Product::get_trial_length( $product );
+					$trial_period = \WC_Subscriptions_Product::get_trial_period( $product );
+					$initial_amount = \WC_Subscriptions_Product::get_sign_up_fee( $product );
 
 					if ( empty( $subscription_interval ) ) {
 						$subscription_interval = 1;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Related https://github.com/Automattic/newspack-plugin/pull/4287. If a user who already purchased a free trial tries to purchase the same product, they shouldn't be able to get a free trial. This PR ensures that in that scenario, the checkout modal won't show the free trial info in the product info or transaction details.

Closes NPPM-2302.

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-plugin/pull/4287.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
