### PR TITLE
feat(content-loop): use generic terminology for static mode labels and help text

### DIFF
--- a/languages/newspack-blocks-de_DE.po
+++ b/languages/newspack-blocks-de_DE.po
@@ -739,7 +739,7 @@ msgid "Mode"
 msgstr ""
 
 #: dist/editor.js:1 src/components/query-controls.js:297
-msgid "The block will display only the specifically selected post(s)."
+msgid "The block will display only the specifically selected content."
 msgstr ""
 
 #: dist/editor.js:1 src/components/query-controls.js:298
@@ -755,8 +755,8 @@ msgid "Static"
 msgstr ""
 
 #: dist/editor.js:1 src/components/query-controls.js:312
-msgid "Posts"
-msgstr "Beiträge"
+msgid "Content"
+msgstr "Inhalt"
 
 #: dist/editor.js:1 src/components/query-controls.js:313
 msgid ""
@@ -1604,7 +1604,7 @@ msgid "Grid"
 msgstr ""
 
 #: dist/editor.js:41
-msgid "Allow duplicate stories"
+msgid "Allow duplicate content"
 msgstr ""
 
 #: dist/editor.js:41

--- a/languages/newspack-blocks-es_ES.po
+++ b/languages/newspack-blocks-es_ES.po
@@ -731,7 +731,7 @@ msgid "Mode"
 msgstr ""
 
 #: dist/editor.js:1 src/components/query-controls.js:297
-msgid "The block will display only the specifically selected post(s)."
+msgid "The block will display only the specifically selected content."
 msgstr ""
 
 #: dist/editor.js:1 src/components/query-controls.js:298
@@ -747,7 +747,7 @@ msgid "Static"
 msgstr ""
 
 #: dist/editor.js:1 src/components/query-controls.js:312
-msgid "Posts"
+msgid "Content"
 msgstr ""
 
 #: dist/editor.js:1 src/components/query-controls.js:313
@@ -1596,7 +1596,7 @@ msgid "Grid"
 msgstr ""
 
 #: dist/editor.js:41
-msgid "Allow duplicate stories"
+msgid "Allow duplicate content"
 msgstr ""
 
 #: dist/editor.js:41

--- a/languages/newspack-blocks-fr_BE.po
+++ b/languages/newspack-blocks-fr_BE.po
@@ -730,7 +730,7 @@ msgid "Mode"
 msgstr ""
 
 #: dist/editor.js:1 src/components/query-controls.js:297
-msgid "The block will display only the specifically selected post(s)."
+msgid "The block will display only the specifically selected content."
 msgstr ""
 
 #: dist/editor.js:1 src/components/query-controls.js:298
@@ -746,7 +746,7 @@ msgid "Static"
 msgstr ""
 
 #: dist/editor.js:1 src/components/query-controls.js:312
-msgid "Posts"
+msgid "Content"
 msgstr ""
 
 #: dist/editor.js:1 src/components/query-controls.js:313
@@ -1595,7 +1595,7 @@ msgid "Grid"
 msgstr ""
 
 #: dist/editor.js:41
-msgid "Allow duplicate stories"
+msgid "Allow duplicate content"
 msgstr ""
 
 #: dist/editor.js:41

--- a/languages/newspack-blocks-nb_NO.po
+++ b/languages/newspack-blocks-nb_NO.po
@@ -729,7 +729,7 @@ msgid "Mode"
 msgstr ""
 
 #: dist/editor.js:1 src/components/query-controls.js:297
-msgid "The block will display only the specifically selected post(s)."
+msgid "The block will display only the specifically selected content."
 msgstr ""
 
 #: dist/editor.js:1 src/components/query-controls.js:298
@@ -745,7 +745,7 @@ msgid "Static"
 msgstr ""
 
 #: dist/editor.js:1 src/components/query-controls.js:312
-msgid "Posts"
+msgid "Content"
 msgstr ""
 
 #: dist/editor.js:1 src/components/query-controls.js:313
@@ -1594,7 +1594,7 @@ msgid "Grid"
 msgstr ""
 
 #: dist/editor.js:41
-msgid "Allow duplicate stories"
+msgid "Allow duplicate content"
 msgstr ""
 
 #: dist/editor.js:41

--- a/languages/newspack-blocks-pt_PT.po
+++ b/languages/newspack-blocks-pt_PT.po
@@ -729,7 +729,7 @@ msgid "Mode"
 msgstr ""
 
 #: dist/editor.js:1 src/components/query-controls.js:297
-msgid "The block will display only the specifically selected post(s)."
+msgid "The block will display only the specifically selected content."
 msgstr ""
 
 #: dist/editor.js:1 src/components/query-controls.js:298
@@ -745,8 +745,8 @@ msgid "Static"
 msgstr ""
 
 #: dist/editor.js:1 src/components/query-controls.js:312
-msgid "Posts"
-msgstr "Posts"
+msgid "Content"
+msgstr ""
 
 #: dist/editor.js:1 src/components/query-controls.js:313
 msgid ""
@@ -1161,7 +1161,7 @@ msgstr ""
 #: dist/editor.js:8 dist/editor.js:47 src/blocks/carousel/index.js:39
 #: src/blocks/homepage-articles/index.js:41
 msgid "posts"
-msgstr "posts"
+msgstr ""
 
 #: dist/editor.js:8 dist/editor.js:47 src/blocks/carousel/index.js:40
 #: src/blocks/homepage-articles/index.js:42
@@ -1594,7 +1594,7 @@ msgid "Grid"
 msgstr ""
 
 #: dist/editor.js:41
-msgid "Allow duplicate stories"
+msgid "Allow duplicate content"
 msgstr ""
 
 #: dist/editor.js:41

--- a/languages/newspack-blocks.pot
+++ b/languages/newspack-blocks.pot
@@ -741,7 +741,7 @@ msgstr ""
 
 #: dist/editor.js:1
 #: src/components/query-controls.js:297
-msgid "The block will display only the specifically selected post(s)."
+msgid "The block will display only the specifically selected content."
 msgstr ""
 
 #: dist/editor.js:1
@@ -761,7 +761,7 @@ msgstr ""
 
 #: dist/editor.js:1
 #: src/components/query-controls.js:312
-msgid "Posts"
+msgid "Content"
 msgstr ""
 
 #: dist/editor.js:1
@@ -1797,7 +1797,7 @@ msgid "Grid"
 msgstr ""
 
 #: dist/editor.js:41
-msgid "Allow duplicate stories"
+msgid "Allow duplicate content"
 msgstr ""
 
 #: dist/editor.js:41

--- a/src/blocks/homepage-articles/edit.tsx
+++ b/src/blocks/homepage-articles/edit.tsx
@@ -287,7 +287,7 @@ class Edit extends Component< HomepageArticlesProps > {
 						postType={ postType }
 					/>
 					<ToggleControl
-						label={ __( 'Allow duplicate stories', 'newspack-blocks' ) }
+						label={ __( 'Allow duplicate content', 'newspack-blocks' ) }
 						help={ __( "Exclude this block from the page's deduplication logic.", 'newspack-blocks' ) }
 						checked={ ! attributes.deduplicate }
 						onChange={ ( value: boolean ) => setAttributes( { deduplicate: ! value } ) }

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -294,7 +294,7 @@ class QueryControls extends Component {
 						isBlock
 						help={
 							specificMode
-								? __( 'The block will display only the specifically selected post(s).', 'newspack-blocks' )
+								? __( 'The block will display only the specifically selected content.', 'newspack-blocks' )
 								: __( 'The block will display content based on the filtering settings below.', 'newspack-blocks' )
 						}
 						__next40pxDefaultSize
@@ -309,8 +309,8 @@ class QueryControls extends Component {
 						onChange={ onSpecificPostsChange }
 						fetchSuggestions={ this.fetchPostSuggestions }
 						fetchSavedInfo={ this.fetchSavedPosts }
-						label={ __( 'Posts', 'newspack-blocks' ) }
-						help={ __( 'Begin typing any word in a post title. Click on an autocomplete result to select it.', 'newspack-blocks' ) }
+						label={ __( 'Content', 'newspack-blocks' ) }
+						help={ __( 'Begin typing any word in a title. Click on an autocomplete result to select it.', 'newspack-blocks' ) }
 					/>
 				) : (
 					<>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates the Content Loop block to use more generic language in Static mode. Replaces “posts” and “stories” with “content” across labels and help text to better reflect the range of selectable post types (e.g., Pages, Listings, Collections). This ensures consistent and accurate terminology throughout the interface.

Closes https://linear.app/a8c/issue/DSGNEWS-48/content-loop-static-post-labels

### How to test the changes in this Pull Request:

1. Add a content loop block to a page, switch to "Static" mode, notice labels for posts selection, mode description, deduplication
2. Switch to this branch, refresh editor
3. Notice new labels

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
