### PR TITLE
fix: add a max-width to the Content Carousel block [NPPM-2391]

### DIFF
--- a/src/blocks/carousel/editor.scss
+++ b/src/blocks/carousel/editor.scss
@@ -1,6 +1,10 @@
 @use "newspack-colors" as np-colors;
 @use "../../shared/sass/placeholder";
 
+.wp-block:has(> .wpnbpc) {
+	max-width: 100%;
+}
+
 .wp-block-newspack-blocks-carousel {
 	.swiper-wrapper {
 		height: auto;
@@ -43,6 +47,7 @@
 		margin-right: 1.5em;
 	}
 }
+
 .editor-block-list__layout .editor-block-list__block .wpnbpc .entry-title a,
 .editor-block-list__layout .editor-block-list__block .wpnbpc .entry-meta .byline a {
 	color: inherit;

--- a/src/blocks/carousel/view.scss
+++ b/src/blocks/carousel/view.scss
@@ -6,6 +6,7 @@
 .wp-block-newspack-blocks-carousel {
 	position: relative;
 	margin-top: 0;
+	max-width: 100%;
 
 	article {
 		max-width: 100%;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a max-width to the Content Carousel block. In themes like Twenty Twenty Five, nesting this block inside of a Stack block causes it to render humongous; the Newspack Theme has some styles that mask this in the editor, but it's an issue on the front end on top of being an issue in both the editor and front-end on WP.com

Closes #2250

### How to test the changes in this Pull Request:

1. On a test site running Twenty Twenty Five, create a page.
2. Add a stack block, and inside of that stack block add a Content Carousel block.
3. Observe that the carousel is blowing out the right side, both in the editor and on the front-end:

<img width="1433" height="1116" alt="CleanShot 2025-11-13 at 12 56 00" src="https://github.com/user-attachments/assets/0e92c59f-cd6b-40a6-a3e8-d1e248f7ab9d" />

4. Apply the PR and run `npm run build`.
5. Confirm that the Content Carousel is now contained by the Stack block width, both in the editor and on the front-end:

<img width="1442" height="751" alt="CleanShot 2025-11-13 at 12 54 50" src="https://github.com/user-attachments/assets/0b1cef25-0793-457f-bdbd-504c292403f1" />

7. Switch to the Newspack Theme and just make sure this didn't introduce any regressions; compare how the block looks in this branch vs. trunk.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
