### PR TITLE
fix(modal-checkout): restore iframe visibility on resize observer

### DIFF
--- a/src/modal-checkout/modal.js
+++ b/src/modal-checkout/modal.js
@@ -515,6 +515,7 @@ domReady( () => {
 			// Match iframe and modal content heights to avoid inner iframe scollbar.
 			modalContent.style.height = iframeHeight + 'px';
 			iframe.style.height = iframeHeight + 'px';
+			iframe.style.visibility = 'visible';
 		}
 	} );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Restores the visibility style property in case it was hidden by the height check.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
