### PR TITLE
fix(modal-checkout): check product type to get recurrence data

### DIFF
--- a/includes/modal-checkout/class-checkout-data.php
+++ b/includes/modal-checkout/class-checkout-data.php
@@ -81,13 +81,21 @@ final class Checkout_Data {
 	 * Returns whether a product is a one time purchase, or recurring and when.
 	 *
 	 * @param string $product_id Product's ID.
+	 *
+	 * @return string The purchase recurrence.
 	 */
 	public static function get_purchase_recurrence( $product_id ) {
-		$recurrence = get_post_meta( $product_id, '_subscription_period', true );
-		if ( empty( $recurrence ) ) {
-			$recurrence = 'once';
+		if ( ! function_exists( 'wc_get_product' ) ) {
+			return 'once';
 		}
-		return $recurrence;
+		$product = \wc_get_product( $product_id );
+		if ( $product && ( $product->is_type( 'subscription' ) || $product->is_type( 'subscription_variation' ) ) ) {
+			$recurrence = get_post_meta( $product_id, '_subscription_period', true );
+			if ( ! empty( $recurrence ) ) {
+				return $recurrence;
+			}
+		}
+		return 'once';
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

p1763480732595219-slack-C01C378QWRX

Refactors the `Checkout_Data:: get_purchase_recurrence( $product_id )` method so it checks the product type before returning the recurrence value.

We've discovered that a non-subscription variable product variant may have `month` set as `_subscription_period` post meta, which will render an incorrect price summary.

### How to test the changes in this Pull Request:

1. While on release, set up a "Variable Product" with "amount" as the variation attribute
2. Add a Checkout Button targeting a variant for the product (don't forget to set a variant, the checkout button variation selection modal doesn't support non-subscription options and will show empty, see NPPD-1013)
3. Visit the page and start the modal checkout
4. Confirm you get the summary with `/ month` even though it's not a subscription product
5. Checkout this branch and refresh the page
6. Confirm the checkout no longer includes the `/ month`
7. Confirm there's no regression by triggering the modal checkout for regular and variable subscriptions, and the ` / {recurrence}` renders as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
