### PR TITLE
feat: supress carousel block from feeds NPPM-2413

### DIFF
--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -13,6 +13,12 @@
  * @return string Returns the post content with latest posts added.
  */
 function newspack_blocks_render_block_carousel( $attributes ) {
+
+	// Don't output the block inside RSS feeds.
+	if ( is_feed() ) {
+		return;
+	}
+
 	static $newspack_blocks_carousel_id = 0;
 	global $newspack_blocks_post_id;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds the [same behavior of the Content Loop block](https://github.com/Automattic/newspack-blocks/commit/51f72ebd6a8db158bc93ea2a4ceaf2b044653944) and exclude it from feeds

### How to test the changes in this Pull Request:

1. Add a carousel block to a post
2. Make sure it works as expected both in the editor and in the frontend
3. Confirm it's no longer included in feeds

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
