### PR TITLE
fix: avoid redeclaration of global function

### DIFF
--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -85,4 +85,3 @@ $checkout_data          = Checkout_Data::get_checkout_data( $order );
 	<?php
 endif;
 do_action( 'newpack_blocks_modal_checkout_thankyou' );
-?>

--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -29,63 +29,60 @@ if ( ! defined( 'ABSPATH' ) ) {
  * order-received.php template with an order details summary so the experience
  * matches whether or not the email address used is already associated with an
  * existing customer account.
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
  */
-function newspack_blocks_replace_login_with_order_summary() {
-	$order    = isset( $_GET['order_id'] ) ? \wc_get_order( \absint( \wp_unslash( $_GET['order_id'] ) ) ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	$key      = isset( $_GET['key'] ) ? \wc_clean( \sanitize_text_field( \wp_unslash( $_GET['key'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	$is_valid = $order && is_a( $order, 'WC_Order' ) && hash_equals( $order->get_order_key(), $key ); // Validate order key to prevent CSRF.
+$key      = isset( $_GET['key'] ) ? \wc_clean( \sanitize_text_field( \wp_unslash( $_GET['key'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$is_valid = $order && is_a( $order, 'WC_Order' ) && hash_equals( $order->get_order_key(), $key ); // Validate order key to prevent CSRF.
 
-	if ( ! $is_valid ) {
-		return;
-	}
-
-	$is_success             = ! $order->has_status( 'failed' );
-	$after_success_behavior = isset( $_GET['after_success_behavior'] ) ? \sanitize_text_field( \wp_unslash( $_GET['after_success_behavior'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	$after_success_url      = isset( $_GET['after_success_url'] ) ? esc_url( \sanitize_url( \wp_unslash( $_GET['after_success_url'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	$after_success_label    = isset( $_GET['after_success_button_label'] ) ? \sanitize_text_field( \wp_unslash( $_GET['after_success_button_label'] ) ) : \Newspack_Blocks\Modal_Checkout::get_modal_checkout_labels( 'after_success' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	$checkout_data          = Checkout_Data::get_checkout_data( $order );
-	?>
-	<div class="woocommerce-order">
-	<?php if ( $is_success ) : ?>
-		<div class="newspack-ui__box newspack-ui__box--success newspack-ui__box--text-center">
-			<span class="newspack-ui__icon newspack-ui__icon--success">
-				<?php // TODO: Replace with newspack-ui icons when available. ?>
-				<svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-					<path d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"></path>
-				</svg>
-			</span>
-			<p id="modal-checkout-product-details" data-checkout='<?php echo wp_json_encode( $checkout_data ); ?>'>
-				<strong>
-					<?php
-						echo esc_html( Modal_Checkout::get_post_checkout_success_text() );
-					?>
-				</strong>
-			</p>
-		</div>
-		<form>
-			<?php if ( $after_success_behavior ) : ?>
-				<input type="hidden" name="after_success_behavior" value="<?php echo esc_attr( $after_success_behavior ); ?>">
-			<?php endif; ?>
-			<?php if ( $after_success_behavior ) : ?>
-				<input type="hidden" name="after_success_url" value="<?php echo esc_attr( $after_success_url ); ?>">
-			<?php endif; ?>
-			<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide" id="checkout-after-success" onclick="parent.newspackCloseModalCheckout();">
-				<?php echo esc_html( $after_success_label ); ?>
-			</button>
-		</form>
-	<?php else : ?>
-		<div class="newspack-ui__box newspack-ui__box__error newspack-ui__box--text-center">
-			<p>
-				<?php esc_html_e( 'Unfortunately your order cannot be processed. Please attempt your purchase again.', 'newspack-blocks' ); ?>
-			</p>
-		</div>
-		<a href="<?php echo esc_url( $order->get_checkout_payment_url() ); ?>" class="newspack-blocks-ui__button newspack-ui__button--primary newspack-ui__button--wide"><?php esc_html_e( 'Pay', 'newspack-blocks' ); ?></a>
-		<?php if ( is_user_logged_in() ) : ?>
-			<a href="<?php echo esc_url( wc_get_page_permalink( 'myaccount' ) ); ?>" class="newspack-blocks-ui__button newspack-ui__button--ghost newspack-ui__button--wide"><?php esc_html_e( 'My account', 'newspack-blocks' ); ?></a>
-		<?php endif; ?>
-		<?php
-	endif;
-	do_action( 'newpack_blocks_modal_checkout_thankyou' );
+if ( ! $is_valid ) {
+	return;
 }
 
-newspack_blocks_replace_login_with_order_summary();
+$is_success             = ! $order->has_status( 'failed' );
+$after_success_behavior = isset( $_GET['after_success_behavior'] ) ? \sanitize_text_field( \wp_unslash( $_GET['after_success_behavior'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$after_success_url      = isset( $_GET['after_success_url'] ) ? esc_url( \sanitize_url( \wp_unslash( $_GET['after_success_url'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$after_success_label    = isset( $_GET['after_success_button_label'] ) ? \sanitize_text_field( \wp_unslash( $_GET['after_success_button_label'] ) ) : \Newspack_Blocks\Modal_Checkout::get_modal_checkout_labels( 'after_success' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$checkout_data          = Checkout_Data::get_checkout_data( $order );
+?>
+<div class="woocommerce-order">
+<?php if ( $is_success ) : ?>
+	<div class="newspack-ui__box newspack-ui__box--success newspack-ui__box--text-center">
+		<span class="newspack-ui__icon newspack-ui__icon--success">
+			<?php // TODO: Replace with newspack-ui icons when available. ?>
+			<svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<path d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"></path>
+			</svg>
+		</span>
+		<p id="modal-checkout-product-details" data-checkout='<?php echo wp_json_encode( $checkout_data ); ?>'>
+			<strong>
+				<?php
+					echo esc_html( Modal_Checkout::get_post_checkout_success_text() );
+				?>
+			</strong>
+		</p>
+	</div>
+	<form>
+		<?php if ( $after_success_behavior ) : ?>
+			<input type="hidden" name="after_success_behavior" value="<?php echo esc_attr( $after_success_behavior ); ?>">
+		<?php endif; ?>
+		<?php if ( $after_success_behavior ) : ?>
+			<input type="hidden" name="after_success_url" value="<?php echo esc_attr( $after_success_url ); ?>">
+		<?php endif; ?>
+		<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide" id="checkout-after-success" onclick="parent.newspackCloseModalCheckout();">
+			<?php echo esc_html( $after_success_label ); ?>
+		</button>
+	</form>
+<?php else : ?>
+	<div class="newspack-ui__box newspack-ui__box__error newspack-ui__box--text-center">
+		<p>
+			<?php esc_html_e( 'Unfortunately your order cannot be processed. Please attempt your purchase again.', 'newspack-blocks' ); ?>
+		</p>
+	</div>
+	<a href="<?php echo esc_url( $order->get_checkout_payment_url() ); ?>" class="newspack-blocks-ui__button newspack-ui__button--primary newspack-ui__button--wide"><?php esc_html_e( 'Pay', 'newspack-blocks' ); ?></a>
+	<?php if ( is_user_logged_in() ) : ?>
+		<a href="<?php echo esc_url( wc_get_page_permalink( 'myaccount' ) ); ?>" class="newspack-blocks-ui__button newspack-ui__button--ghost newspack-ui__button--wide"><?php esc_html_e( 'My account', 'newspack-blocks' ); ?></a>
+	<?php endif; ?>
+	<?php
+endif;
+do_action( 'newpack_blocks_modal_checkout_thankyou' );
+?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids a possible redeclaration fatal if the thankyou.php custom template is loaded more than once. Related to https://github.com/Automattic/newspack-plugin/pull/4251.

### How to test the changes in this Pull Request:

1. While on https://github.com/Automattic/newspack-plugin/pull/4251 and `trunk` of this repo, complete a modal checkout transaction on a page that renders content gates.
2. Observe a fatal error that prevents the success modal from loading: `PHP Fatal error:  Cannot redeclare Newspack_Blocks\newspack_blocks_replace_login_with_order_summary() (previously declared in /newspack-repos/newspack-blocks/src/modal-checkout/templates/thankyou.php:33) in /newspack-repos/newspack-blocks/src/modal-checkout/templates/thankyou.php on line 33`
3. Check out this branch, repeat, confirm no error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
