### PR TITLE
fix: make sure orders processed through Link get the correct Thank You screen

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1590,7 +1590,7 @@ final class Modal_Checkout {
 		// Get express_payment_type in a way that works for both Stripe and WooPayments.
 		$express_payment_info = isset( $_POST['express_payment_type'] ) ? sanitize_text_field( wp_unslash( $_POST['express_payment_type'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 
-		$is_express_checkout = ! empty( $express_payment_info ) && in_array( $express_payment_info, [ 'apple_pay', 'google_pay', 'payment_request_api' ], true );  // Validate payment request types: https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/payment-methods/class-wc-stripe-payment-request.php#L557-L586.
+		$is_express_checkout = ! empty( $express_payment_info ) && in_array( $express_payment_info, [ 'apple_pay', 'google_pay', 'payment_request_api', 'link' ], true );  // Validate payment request types: https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/payment-methods/class-wc-stripe-payment-request.php#L557-L586.
 
 		if ( $is_express_checkout ) {
 			$referrer = isset( $_SERVER['HTTP_REFERER'] ) ? \esc_url_raw( \wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

This PR adds `link` to our array of express payment processors so successful transaction pass the 'is_modal_checkout()` check and show the Thank You message.

See NPPM-2437

### How to test the changes in this Pull Request:

1. Set up a test site running Stripe Gateway in Test Mode.
2. Under WooCommerce > Settings > Payments > Stripe, enable Link as an express payment form. 
3. Set up a checkout button with a product to test -- you want to be able to run repeated transaction as the same person, so make sure it's not a restricted subscription.
4. In an incognito window, make a purchase. Fill in the usual `4242 4242 4242 4242` number. When the Link information panel opens, enter `(201) 555-0123` as the phone number. If you're not purchasing a subscription product, make sure to save your payment information:

<img width="652" height="798" alt="CleanShot 2025-12-08 at 14 08 14" src="https://github.com/user-attachments/assets/637a6064-62ec-4f7f-a323-bfaaf9dbfd46" />

5. Complete the purchase.
6. Refresh the page and start another transaction as the same user, but this time pick Link as the payment option.
7. You'll get prompted to enter a code - enter `000 000`:

<img width="650" height="965" alt="CleanShot 2025-12-08 at 14 10 27" src="https://github.com/user-attachments/assets/94d81404-50c6-46ec-99b4-180344f99c96" />

8. Note that the transaction appears to stick - if you unhide the spinner/loader in the modal you'll see the non-Newspack normal success message is displaying:

<img width="654" height="631" alt="CleanShot 2025-12-08 at 14 12 14" src="https://github.com/user-attachments/assets/af402b2c-b838-491b-ab7d-f7c105feed41" />

9. Apply this PR.
10. Rerun steps 4 through 7 - you can use the same incognito window so your test Link information is already saved.
11. Confirm you get the normal Thank You message.

Bonus test - make sure Link still throws failed transaction errors when needed:
1. Start a new incognito window and repeat the steps starting at 4, but using the credit card number `4000 0000 0000 0341` - this is the number from Stripe that will let you add it without validating it, but will cause transactions to fail. 
2. Add the phone number `(201) 555-0123` again, and save your payment information if needed.
3. Note you get an error about the payment not going through.
4. Refresh the page and start one more new transaction and this time, pick Link, which should have saved your bad number. When prompted, enter the code `000 000` again. You may also be added to renter your CBC code, etc.
5. Confirm you get a payment failed message: 

<img width="678" height="410" alt="CleanShot 2025-12-08 at 14 23 06" src="https://github.com/user-attachments/assets/e217e50a-6be5-447c-8271-0225d1ef0c26" />


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
