### PR TITLE
fix: add space to donate block label in editor

### DIFF
--- a/src/blocks/donate/utils.ts
+++ b/src/blocks/donate/utils.ts
@@ -49,11 +49,12 @@ export const getFrequencyLabel = ( frequencySlug: DonationFrequencySlug, hideOnc
 		? hideOnceLabel
 			? ''
 			: __( 'once', 'newspack-blocks' )
-		: ' ' + sprintf(
+		: ' ' +
+		sprintf(
 				// Translators: %s is the frequency (e.g. per month, per year).
 				_x( 'per %s', 'per `Frequency`', 'newspack-blocks' ),
 				frequencySlug
-		  );
+		);
 };
 
 export const getFormattedAmount = ( amount: number, withCurrency = false ) => {

--- a/src/blocks/donate/utils.ts
+++ b/src/blocks/donate/utils.ts
@@ -54,7 +54,7 @@ export const getFrequencyLabel = ( frequencySlug: DonationFrequencySlug, hideOnc
 					// Translators: %s is the frequency (e.g. per month, per year).
 					_x( 'per %s', 'per `Frequency`', 'newspack-blocks' ),
 					frequencySlug
-				) + ' ';
+				);
 };
 
 export const getFormattedAmount = ( amount: number, withCurrency = false ) => {

--- a/src/blocks/donate/utils.ts
+++ b/src/blocks/donate/utils.ts
@@ -49,7 +49,7 @@ export const getFrequencyLabel = ( frequencySlug: DonationFrequencySlug, hideOnc
 		? hideOnceLabel
 			? ''
 			: __( 'once', 'newspack-blocks' )
-		: sprintf(
+		: ' ' + sprintf(
 				// Translators: %s is the frequency (e.g. per month, per year).
 				_x( 'per %s', 'per `Frequency`', 'newspack-blocks' ),
 				frequencySlug

--- a/src/blocks/donate/utils.ts
+++ b/src/blocks/donate/utils.ts
@@ -50,11 +50,11 @@ export const getFrequencyLabel = ( frequencySlug: DonationFrequencySlug, hideOnc
 			? ''
 			: __( 'once', 'newspack-blocks' )
 		: ' ' +
-		sprintf(
-				// Translators: %s is the frequency (e.g. per month, per year).
-				_x( 'per %s', 'per `Frequency`', 'newspack-blocks' ),
-				frequencySlug
-		);
+				sprintf(
+					// Translators: %s is the frequency (e.g. per month, per year).
+					_x( 'per %s', 'per `Frequency`', 'newspack-blocks' ),
+					frequencySlug
+				) + ' ';
 };
 
 export const getFormattedAmount = ( amount: number, withCurrency = false ) => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I noticed this while working on something else:

The Donate block has a new per month/per year frequency text in the "Other" field label, but there's no space before this label in the editor. This PR fixes that.

### How to test the changes in this Pull Request:

1. Add the Donate block to the editor and pick the Monthly or Annually tab; adjust it so you can see the 'Other' field, and note the text:

<img width="830" height="269" alt="CleanShot 2026-01-06 at 10 44 18" src="https://github.com/user-attachments/assets/edffdffc-2430-4313-ae30-75225907f447" />

2. Apply this PR and run `npm run build`.
3. Refresh the editor and confirm the text is properly spaced:

<img width="827" height="266" alt="CleanShot 2026-01-06 at 10 46 18" src="https://github.com/user-attachments/assets/b6d9ee99-9f59-44ca-91f4-f35568d3ff44" />


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
