### PR TITLE
Increase required log level to log content loop caching

### DIFF
--- a/includes/class-newspack-blocks-caching.php
+++ b/includes/class-newspack-blocks-caching.php
@@ -164,7 +164,7 @@ class Newspack_Blocks_Caching {
 	 * @param string $message Message to log.
 	 */
 	protected static function debug_log( $message ) {
-		if ( defined( 'NEWSPACK_LOG_LEVEL' ) && (int) NEWSPACK_LOG_LEVEL >= 2 && class_exists( 'Newspack\Logger' ) ) {
+		if ( defined( 'NEWSPACK_LOG_LEVEL' ) && (int) NEWSPACK_LOG_LEVEL >= 4 && class_exists( 'Newspack\Logger' ) ) {
 			Newspack\Logger::log( $message );
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**Note**: This is a hotfix because I want less noisy debugging more quickly :) 

This PR increases the log level to debug content loop block caching to 4 (making it the highest level so far). This is because it's super noisy and logs a ton of stuff each second on a busy site. This makes it overwhelm any other logging. Additionally, this feature has been running well for over a year, so the logging is not super necessary.

### How to test the changes in this Pull Request:

1. Add this to your wp-config: `define( 'NEWSPACK_LOG_LEVEL', 3 );` (or any number less than 3). Visit the homepage. Observe no block caching related logging.
2. Change the log level to 4 or greater. Visit your site's homepage observe a bunch of output like this in the logs:
```
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Found cached block: item np_cached_block_969b32d2d97d2b39a0b4505b1d9a2f95_7 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Checking cache for item np_cached_block_4b589b6a288ab6b66d58b71d9938c6ad_8 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Found cached block: item np_cached_block_4b589b6a288ab6b66d58b71d9938c6ad_8 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Checking cache for item np_cached_block_4a00e9bd1ece20a96f56353bc5b430a5_9 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Found cached block: item np_cached_block_4a00e9bd1ece20a96f56353bc5b430a5_9 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Checking cache for item np_cached_block_74160c673d92de0f2a9d37f92a360e15_10 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Found cached block: item np_cached_block_74160c673d92de0f2a9d37f92a360e15_10 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Checking cache for item np_cached_block_02f304162cf97c5d39456c0435b14c38_11 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Found cached block: item np_cached_block_02f304162cf97c5d39456c0435b14c38_11 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Checking cache for item np_cached_block_ae9b7b422715444281311407664eb8fb_12 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Found cached block: item np_cached_block_ae9b7b422715444281311407664eb8fb_12 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Checking cache for item np_cached_block_aedbc74b0e9d908522094e17d11323d6_13 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Found cached block: item np_cached_block_aedbc74b0e9d908522094e17d11323d6_13 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Checking cache for item np_cached_block_8bf3bb52231fd3339c3adbb3182967d7_14 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Found cached block: item np_cached_block_8bf3bb52231fd3339c3adbb3182967d7_14 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Checking cache for item np_cached_block_daebcc8704de40ed48a8313dbccf9732_15 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Found cached block: item np_cached_block_daebcc8704de40ed48a8313dbccf9732_15 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Checking cache for item np_cached_block_61257afc9325ced4c5dec77cb276d6c0_16 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Found cached block: item np_cached_block_61257afc9325ced4c5dec77cb276d6c0_16 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Checking cache for item np_cached_block_a97937608abd7fe9097dbd19c02c9e5e_17 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:43 UTC] [187165][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Found cached block: item np_cached_block_a97937608abd7fe9097dbd19c02c9e5e_17 in group newspack_blocks-post-311319
[06-Jan-2026 22:21:44 UTC] [187225][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Checking cache for item np_cached_block_ad7a889d146a6040d338d84d6bab8ef7_0 in group newspack_blocks-post-311333
[06-Jan-2026 22:21:44 UTC] [187225][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Cached data not found for item np_cached_block_ad7a889d146a6040d338d84d6bab8ef7_0 in group newspack_blocks-post-311333
[06-Jan-2026 22:21:44 UTC] [187225][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Checking cache for item np_cached_block_1d90876efa4cbb7e8cd72ee762234378_1 in group newspack_blocks-post-311333
[06-Jan-2026 22:21:44 UTC] [187225][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Cached data not found for item np_cached_block_1d90876efa4cbb7e8cd72ee762234378_1 in group newspack_blocks-post-311333
[06-Jan-2026 22:21:44 UTC] [187225][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Checking cache for item np_cached_block_e9c90d7f8f408e0e973880140ccdaacb_2 in group newspack_blocks-post-311333
[06-Jan-2026 22:21:44 UTC] [187225][NEWSPACK][Newspack_Blocks_Caching::debug_log]: Cached data not found for item np_cached_block_e9c90d7f8f408e0e973880140ccdaacb_2 in group newspack_blocks-post-311333
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
