### PR TITLE
feat: improve express checkout handling by surfacing errors

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -985,6 +985,10 @@
 		margin-top: 0;
 	}
 
+	.woocommerce .woocommerce-notices-wrapper .woocommerce-error.newspack-ui__notice--error {
+		padding: var(--newspack-ui-spacer-2, 12px);
+	}
+
 	.modal-processing {
 		opacity: 0.5;
 	}

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -841,9 +841,16 @@ import { domReady, onCheckoutPlaceOrderProcessing } from './utils';
 					} );
 
 					observer.observe( container, { childList: true, subtree: true } );
+					return observer;
 				}
 
-				observeExpressCheckoutErrors();
+				const expressCheckoutErrorObserver = observeExpressCheckoutErrors();
+				if ( expressCheckoutErrorObserver ) {
+					const disconnect = () => expressCheckoutErrorObserver.disconnect();
+					container.addEventListener( 'checkout-complete', disconnect );
+					container.addEventListener( 'checkout-cancel', disconnect );
+					window.addEventListener( 'beforeunload', disconnect );
+				}
 			}
 			init();
 		}

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -794,6 +794,10 @@ import { domReady, onCheckoutPlaceOrderProcessing } from './utils';
 				 * the standard WooCommerce checkout_error event.
 				 */
 				function observeExpressCheckoutErrors() {
+					if ( ! container ) {
+						return;
+					}
+
 					const ERROR_HANDLED_ATTR = 'data-newspack-error-handled';
 
 					const handleExpressCheckoutError = errorNode => {
@@ -808,7 +812,13 @@ import { domReady, onCheckoutPlaceOrderProcessing } from './utils';
 					};
 
 					const isErrorNode = node => {
-						return node.classList?.contains( 'woocommerce-error' ) || node.classList?.contains( 'wc-block-components-notice-banner' );
+						if ( node.classList?.contains( 'woocommerce-error' ) ) {
+							return true;
+						}
+						if ( node.classList?.contains( 'wc-block-components-notice-banner' ) && node.classList?.contains( 'is-error' ) ) {
+							return true;
+						}
+						return false;
 					};
 
 					const observer = new MutationObserver( mutations => {
@@ -821,7 +831,7 @@ import { domReady, onCheckoutPlaceOrderProcessing } from './utils';
 									handleExpressCheckoutError( node );
 									return;
 								}
-								const nestedError = node.querySelector?.( '.woocommerce-error, .wc-block-components-notice-banner' );
+								const nestedError = node.querySelector?.( '.woocommerce-error, .wc-block-components-notice-banner.is-error' );
 								if ( nestedError ) {
 									handleExpressCheckoutError( nestedError );
 									return;
@@ -830,8 +840,7 @@ import { domReady, onCheckoutPlaceOrderProcessing } from './utils';
 						}
 					} );
 
-					const observeTarget = container || document.body;
-					observer.observe( observeTarget, { childList: true, subtree: true } );
+					observer.observe( container, { childList: true, subtree: true } );
 				}
 
 				observeExpressCheckoutErrors();

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -40,8 +40,9 @@ import { domReady, onCheckoutPlaceOrderProcessing } from './utils';
 		}
 
 		function clearNotices() {
+			$( '.woocommerce-notices-wrapper' ).empty();
 			$(
-				`.woocommerce-NoticeGroup-checkout, .${ CLASS_PREFIX }__inline-error, .woocommerce-error, .woocommerce-message, .wc-block-components-notice-banner, .woocommerce-notices-wrapper`
+				`.woocommerce-NoticeGroup-checkout, .${ CLASS_PREFIX }__inline-error, .woocommerce-error, .woocommerce-message, .wc-block-components-notice-banner`
 			).remove();
 		}
 
@@ -786,6 +787,54 @@ import { domReady, onCheckoutPlaceOrderProcessing } from './utils';
 					form.removeClass( 'modal-processing' );
 					return true;
 				}
+
+				/**
+				 * Watch for Express Checkout errors added to the checkout container.
+				 * Express Checkout (GPay/Apple Pay) uses the Store API which doesn't trigger
+				 * the standard WooCommerce checkout_error event.
+				 */
+				function observeExpressCheckoutErrors() {
+					const ERROR_HANDLED_ATTR = 'data-newspack-error-handled';
+
+					const handleExpressCheckoutError = errorNode => {
+						if ( errorNode.hasAttribute( ERROR_HANDLED_ATTR ) ) {
+							return;
+						}
+						errorNode.setAttribute( ERROR_HANDLED_ATTR, 'true' );
+
+						$( errorNode ).addClass( `${ CLASS_PREFIX }__notice ${ CLASS_PREFIX }__notice--error` );
+						container.dispatchEvent( placeOrderErrorEvent );
+						errorNode.scrollIntoView( { behavior: 'smooth', block: 'center' } );
+					};
+
+					const isErrorNode = node => {
+						return node.classList?.contains( 'woocommerce-error' ) || node.classList?.contains( 'wc-block-components-notice-banner' );
+					};
+
+					const observer = new MutationObserver( mutations => {
+						for ( const mutation of mutations ) {
+							for ( const node of mutation.addedNodes ) {
+								if ( node.nodeType !== Node.ELEMENT_NODE ) {
+									continue;
+								}
+								if ( isErrorNode( node ) ) {
+									handleExpressCheckoutError( node );
+									return;
+								}
+								const nestedError = node.querySelector?.( '.woocommerce-error, .wc-block-components-notice-banner' );
+								if ( nestedError ) {
+									handleExpressCheckoutError( nestedError );
+									return;
+								}
+							}
+						}
+					} );
+
+					const observeTarget = container || document.body;
+					observer.observe( observeTarget, { childList: true, subtree: true } );
+				}
+
+				observeExpressCheckoutErrors();
 			}
 			init();
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Express Checkout (GPay/Apple Pay) errors were failing silently in the modal checkout because they use the WooCommerce Store API, which doesn't trigger the classic `checkout_error` event that the modal relies on. Instead, the payment gateway plugin appends error elements directly to the DOM, but the modal's processing screen remains visible, and users see no feedback.

This PR adds a [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) to detect when error elements (`.woocommerce-error` or `.wc-block-components-notice-banner.is-error`) are added to the checkout container. When detected, it applies Newspack styling, dispatches the `placeOrderErrorEvent` to hide the processing screen, and scrolls the error into view. The `clearNotices()` function was also updated to preserve the `.woocommerce-notices-wrapper` container, allowing payment plugins to continue appending errors to it.

This fix applies to any error returned by the Store API checkout endpoint (`/wp-json/wc/store/v1/checkout`). For example, when a user already has an account with the same email, it returns this:

```json
{
    "code": "registration-error-email-exists",
    "message": "An account is already registered with email@example.com. Please log in or use a different email address.",
    "data": {
        "status": 400
    }
}
```
<img width="636" height="600" alt="image" src="https://github.com/user-attachments/assets/a706106e-e529-4f76-a099-a181ecd2deb9" />


Or when the billing address from GPay/Apple Pay is missing required fields:

```json
{
  "code": "woocommerce_rest_invalid_address",
  "message": "There was a problem with the provided billing address: Province is required, Postcode \/ ZIP is required",
  "data": {
    "errors": {
      "billing": [
        "Province is required",
        "Postcode \/ ZIP is required"
      ]
    },
    "status": 400
  }
}
```

Closes NPPM-2426.

### How to test the changes in this Pull Request:

1. Enable Express Checkout in WooCommerce > Settings > Payments > Stripe > Express Checkout > Enable > Customize > Enable Checkout page.
2. Ensure you have an existing WordPress account on the site with the same email as your GPay/Apple account and that you're not currently logged in (there's a check to prevent loading the checkout modal if you're logged in and subscribed).
3. Add a checkout button to a page or post, with a subscription product.
4. Open the modal checkout and attempt to pay via GPay or Apple Pay.
6. Verify the error message "An account is already registered with [email]..." is displayed, and the processing screen is hidden.
7. Test closing the modal via X button and reopening or via the Cancel button, and verify normal checkout still works.
8. Test a successful Express Checkout payment to verify it still completes normally.
9. Other issues, like the missing address fields, might not be entirely replicable with a Stripe sandboxed account, as it uses a placeholder address to not share the real account data with the site (at least on my tests with GPay).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
