### PR TITLE
fix: iframe Editor Compatibility

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -207,7 +207,7 @@ class Newspack_Blocks {
 	/**
 	 * Enqueue block scripts and styles for editor.
 	 */
-	public static function enqueue_block_editor_assets() {
+	public static function enqueue_block_assets() {
 		$script_data = static::script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'editor.js' );
 
 		if ( $script_data ) {

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -131,6 +131,10 @@ class Newspack_Blocks {
 	 * Enqueue placeholder blocks assets.
 	 */
 	public static function enqueue_placeholder_blocks_assets() {
+		if ( ! is_admin() ) {
+			// In non-editor environment, do nothing.
+			return;
+		}
 		$script_data = self::script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'placeholder_blocks.js' );
 		if ( $script_data ) {
 			wp_enqueue_script(
@@ -208,8 +212,11 @@ class Newspack_Blocks {
 	 * Enqueue block scripts and styles for editor.
 	 */
 	public static function enqueue_block_assets() {
+		if ( ! is_admin() ) {
+			// In non-editor environment, do nothing.
+			return;
+		}
 		$script_data = static::script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'editor.js' );
-
 		if ( $script_data ) {
 			wp_enqueue_script(
 				'newspack-blocks-editor',
@@ -260,7 +267,6 @@ class Newspack_Blocks {
 		}
 
 		$editor_style = plugins_url( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'editor.css', NEWSPACK_BLOCKS__PLUGIN_FILE );
-
 		$handle = 'newspack-blocks-editor';
 		wp_enqueue_style(
 			$handle,

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -83,7 +83,7 @@ add_action( 'rest_api_init', 'newspack_iframe_block_register_rest_routes' );
 Newspack_Blocks::manage_view_scripts();
 add_action( 'enqueue_block_assets', array( 'Newspack_Blocks', 'enqueue_block_assets' ) );
 add_action( 'enqueue_block_assets', array( 'Newspack_Blocks', 'enqueue_placeholder_blocks_assets' ), 9999 );
-add_action( 'wp_enqueue_scripts', array( 'Newspack_Blocks', 'enqueue_block_styles_assets' ) );
+add_action( 'enqueue_block_assets', array( 'Newspack_Blocks', 'enqueue_block_styles_assets' ) );
 
 /**
  * Load language files

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -81,8 +81,8 @@ function newspack_iframe_block_register_rest_routes() { // phpcs:ignore WordPres
 add_action( 'rest_api_init', 'newspack_iframe_block_register_rest_routes' );
 
 Newspack_Blocks::manage_view_scripts();
-add_action( 'enqueue_block_editor_assets', array( 'Newspack_Blocks', 'enqueue_block_editor_assets' ) );
-add_action( 'enqueue_block_editor_assets', array( 'Newspack_Blocks', 'enqueue_placeholder_blocks_assets' ), 9999 );
+add_action( 'enqueue_block_assets', array( 'Newspack_Blocks', 'enqueue_block_assets' ) );
+add_action( 'enqueue_block_assets', array( 'Newspack_Blocks', 'enqueue_placeholder_blocks_assets' ), 9999 );
 add_action( 'wp_enqueue_scripts', array( 'Newspack_Blocks', 'enqueue_block_styles_assets' ) );
 
 /**

--- a/src/blocks/author-list/block.json
+++ b/src/blocks/author-list/block.json
@@ -1,7 +1,8 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
 	"name": "author-list",
 	"category": "newspack",
-	"apiVersion": 3,
 	"attributes": {
 		"className": {
 			"type": "string",

--- a/src/blocks/author-list/edit.js
+++ b/src/blocks/author-list/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { BlockControls, InspectorControls } from '@wordpress/block-editor';
+import { BlockControls, InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
 	BaseControl,
 	CheckboxControl,
@@ -24,7 +24,7 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { Fragment, useEffect, useState } from '@wordpress/element';
+import { Fragment, useEffect, useRef, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { columns as columnsIcon, pencil, listView, pullLeft, pullRight } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
@@ -48,8 +48,8 @@ const AuthorList = ( { attributes, clientId, setAttributes } ) => {
 	const [ error, setError ] = useState( null );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ maxItemsToSuggest, setMaxItemsToSuggest ] = useState( 0 );
-	const canUseCAP = Boolean( window.newspack_blocks_data?.can_use_cap );
-	const editableRoles = window.newspack_blocks_data?.editable_roles;
+	const [ canUseCAP, setCanUseCAP ] = useState( false );
+	const [ editableRoles, setEditableRoles ] = useState( [] );
 	const separators = [];
 	const {
 		authorRoles,
@@ -68,10 +68,27 @@ const AuthorList = ( { attributes, clientId, setAttributes } ) => {
 		avatarHideDefault,
 	} = attributes;
 	const isColumns = 'columns' === layout;
+	const ref = useRef();
 
 	useEffect( () => {
 		getAuthors();
 	}, [ authorRoles, authorType, avatarHideDefault, exclude, excludeEmpty ] );
+
+	// Handle global newspack_blocks_data availability in iframe editor.
+	// See https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/block-migration-for-iframe-editor-compatibility/#document-and-window.
+	useEffect( () => {
+		const { ownerDocument } = ref.current || {};
+		const { defaultView } = ownerDocument || {};
+		if ( defaultView ) {
+			setCanUseCAP( Boolean( defaultView.newspack_blocks_data?.can_use_cap ) );
+			setEditableRoles( defaultView.newspack_blocks_data?.editable_roles || [] );
+		}
+	}, [] );
+
+	const blockProps = useBlockProps( {
+		className: classnames( attributes.className, 'wp-block-newspack-blocks-author-list' ),
+		ref,
+	} );
 
 	const getAuthors = async () => {
 		setError( null );
@@ -363,7 +380,7 @@ const AuthorList = ( { attributes, clientId, setAttributes } ) => {
 					/>
 				</BlockControls>
 			) }
-			<div className={ classnames( attributes.className, 'wp-block-newspack-blocks-author-list' ) }>
+			<div { ...blockProps }>
 				{ ! isLoading && ! error && authors && Array.isArray( authors ) && (
 					<>
 						{ isColumns && showSeparators && separatorSections ? (

--- a/src/blocks/author-list/edit.js
+++ b/src/blocks/author-list/edit.js
@@ -24,7 +24,7 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { Fragment, useEffect, useRef, useState } from '@wordpress/element';
+import { Fragment, useEffect, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { columns as columnsIcon, pencil, listView, pullLeft, pullRight } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
@@ -48,8 +48,9 @@ const AuthorList = ( { attributes, clientId, setAttributes } ) => {
 	const [ error, setError ] = useState( null );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ maxItemsToSuggest, setMaxItemsToSuggest ] = useState( 0 );
-	const [ canUseCAP, setCanUseCAP ] = useState( false );
-	const [ editableRoles, setEditableRoles ] = useState( [] );
+	const canUseCAP = Boolean( window?.newspack_blocks_data?.can_use_cap );
+	const editableRoles = window?.newspack_blocks_data?.editable_roles || [];
+
 	const separators = [];
 	const {
 		authorRoles,
@@ -68,26 +69,13 @@ const AuthorList = ( { attributes, clientId, setAttributes } ) => {
 		avatarHideDefault,
 	} = attributes;
 	const isColumns = 'columns' === layout;
-	const ref = useRef();
 
 	useEffect( () => {
 		getAuthors();
 	}, [ authorRoles, authorType, avatarHideDefault, exclude, excludeEmpty ] );
 
-	// Handle global newspack_blocks_data availability in iframe editor.
-	// See https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/block-migration-for-iframe-editor-compatibility/#document-and-window.
-	useEffect( () => {
-		const { ownerDocument } = ref.current || {};
-		const { defaultView } = ownerDocument || {};
-		if ( defaultView ) {
-			setCanUseCAP( Boolean( defaultView.newspack_blocks_data?.can_use_cap ) );
-			setEditableRoles( defaultView.newspack_blocks_data?.editable_roles || [] );
-		}
-	}, [] );
-
 	const blockProps = useBlockProps( {
 		className: classnames( attributes.className, 'wp-block-newspack-blocks-author-list' ),
-		ref,
 	} );
 
 	const getAuthors = async () => {

--- a/src/blocks/author-list/index.js
+++ b/src/blocks/author-list/index.js
@@ -37,6 +37,7 @@ authorCustomFields.forEach( field => {
 } );
 
 export const settings = {
+	...metadata,
 	title,
 	icon: {
 		src: listView,

--- a/src/blocks/author-list/index.js
+++ b/src/blocks/author-list/index.js
@@ -20,7 +20,7 @@ import edit from './edit';
 import './editor.scss';
 import './view.scss';
 import metadata from './block.json';
-const { name, attributes, category } = metadata;
+const { name, attributes, apiVersion, category } = metadata;
 
 // Name must be exported separately.
 export { name };
@@ -37,20 +37,20 @@ authorCustomFields.forEach( field => {
 } );
 
 export const settings = {
-	...metadata,
+	apiVersion,
 	title,
 	icon: {
 		src: listView,
 		foreground: colors[ 'primary-400' ],
 	},
+	attributes,
+	category,
 	keywords: [ __( 'author', 'newspack-blocks' ), __( 'profile', 'newspack-blocks' ) ],
 	description: __( 'Display a list of author profile cards.', 'newspack-blocks' ),
 	styles: [
 		{ name: 'default', label: _x( 'Default', 'block style', 'newspack-blocks' ), isDefault: true },
 		{ name: 'center', label: _x( 'Centered', 'block style', 'newspack-blocks' ) },
 	],
-	attributes,
-	category,
 	supports: {
 		html: false,
 		default: '',

--- a/src/blocks/author-list/view.php
+++ b/src/blocks/author-list/view.php
@@ -27,6 +27,7 @@ function newspack_blocks_register_author_list() {
 	register_block_type(
 		'newspack-blocks/' . $block_json['name'],
 		[
+			'api_version'     => $block_json['apiVersion'],
 			'attributes'      => $block_json['attributes'],
 			'render_callback' => 'newspack_blocks_render_block_author_list',
 		]

--- a/src/blocks/author-profile/block.json
+++ b/src/blocks/author-profile/block.json
@@ -1,4 +1,6 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
 	"name": "author-profile",
 	"category": "newspack",
 	"apiVersion": 3,

--- a/src/blocks/author-profile/block.json
+++ b/src/blocks/author-profile/block.json
@@ -3,7 +3,6 @@
 	"apiVersion": 3,
 	"name": "author-profile",
 	"category": "newspack",
-	"apiVersion": 3,
 	"usesContext": [ "postId", "postType" ],
 	"attributes": {
 		"className": {

--- a/src/blocks/author-profile/edit.js
+++ b/src/blocks/author-profile/edit.js
@@ -711,7 +711,6 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 					) }
 				</PanelBody>
 			) }
-<<<<<<< HEAD
 		</InspectorControls>
 	);
 

--- a/src/blocks/author-profile/edit.js
+++ b/src/blocks/author-profile/edit.js
@@ -360,7 +360,6 @@ const getPlaceholderAuthor = ( socialIconSvgs = {} ) => {
 };
 
 const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
-	const blockProps = useBlockProps();
 	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
 
 	// ALL HOOKS MUST BE CALLED UNCONDITIONALLY (React rules of hooks)

--- a/src/blocks/author-profile/edit.js
+++ b/src/blocks/author-profile/edit.js
@@ -389,6 +389,7 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 		avatarHideDefault,
 		showEmptyBio,
 	} = attributes;
+	const blockProps = useBlockProps();
 
 	// Get post ID from block context or editor
 	const editorPostId = useSelect( select => select( 'core/editor' )?.getCurrentPostId?.(), [] );
@@ -710,6 +711,7 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 					) }
 				</PanelBody>
 			) }
+<<<<<<< HEAD
 		</InspectorControls>
 	);
 

--- a/src/blocks/author-profile/index.js
+++ b/src/blocks/author-profile/index.js
@@ -38,7 +38,7 @@ authorCustomFields.forEach( field => {
 } );
 
 export const settings = {
-	apiVersion: metadata.apiVersion,
+	...metadata,
 	title,
 	icon: {
 		src: postAuthor,

--- a/src/blocks/author-profile/index.js
+++ b/src/blocks/author-profile/index.js
@@ -7,7 +7,7 @@ import colors from 'newspack-colors';
  * WordPress dependencies
  */
 import { InnerBlocks } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { postAuthor } from '@wordpress/icons';
 
 /**
@@ -21,7 +21,7 @@ import edit from './edit';
 import './editor.scss';
 import './view.scss';
 import metadata from './block.json';
-const { name, attributes, category } = metadata;
+const { name, attributes, apiVersion, category } = metadata;
 
 // Name must be exported separately.
 export { name };
@@ -38,16 +38,20 @@ authorCustomFields.forEach( field => {
 } );
 
 export const settings = {
-	...metadata,
+	apiVersion,
 	title,
 	icon: {
 		src: postAuthor,
 		foreground: colors[ 'primary-400' ],
 	},
-	keywords: [ __( 'author', 'newspack-blocks' ), __( 'profile', 'newspack-blocks' ) ],
-	description: __( 'Display an author profile card.', 'newspack-blocks' ),
 	attributes,
 	category,
+	keywords: [ __( 'author', 'newspack-blocks' ), __( 'profile', 'newspack-blocks' ) ],
+	description: __( 'Display an author profile card.', 'newspack-blocks' ),
+	styles: [
+		{ name: 'default', label: _x( 'Default', 'block style', 'newspack-blocks' ), isDefault: true },
+		{ name: 'center', label: _x( 'Centered', 'block style', 'newspack-blocks' ) },
+	],
 	supports: {
 		html: false,
 		default: '',

--- a/src/blocks/author-profile/view.php
+++ b/src/blocks/author-profile/view.php
@@ -89,7 +89,7 @@ function newspack_blocks_register_author_profile() {
 	register_block_type(
 		'newspack-blocks/' . $block_json['name'],
 		[
-			'api_version'     => $block_json['apiVersion'],
+			'api_version'      => $block_json['apiVersion'],
 			'attributes'       => $block_json['attributes'],
 			'render_callback'  => 'newspack_blocks_render_block_author_profile',
 			'uses_context'     => $block_json['usesContext'] ?? [],

--- a/src/blocks/author-profile/view.php
+++ b/src/blocks/author-profile/view.php
@@ -89,6 +89,7 @@ function newspack_blocks_register_author_profile() {
 	register_block_type(
 		'newspack-blocks/' . $block_json['name'],
 		[
+			'api_version'     => $block_json['apiVersion'],
 			'attributes'       => $block_json['attributes'],
 			'render_callback'  => 'newspack_blocks_render_block_author_profile',
 			'uses_context'     => $block_json['usesContext'] ?? [],

--- a/src/blocks/carousel/block.json
+++ b/src/blocks/carousel/block.json
@@ -1,7 +1,8 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
 	"name": "carousel",
 	"category": "newspack",
-	"apiVersion": 3,
 	"attributes": {
 		"className": {
 			"type": "string",

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -10,10 +10,10 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { InspectorControls } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 import { dateI18n, __experimentalGetSettings } from '@wordpress/date';
-import { Component, createRef, Fragment, RawHTML } from '@wordpress/element';
+import { Component, createRef, Fragment, RawHTML, useRef } from '@wordpress/element';
 import {
 	PanelBody,
 	Placeholder,
@@ -50,7 +50,6 @@ class Edit extends Component {
 		this.btnPauseRef = createRef();
 		this.btnNextRef = createRef();
 		this.btnPrevRef = createRef();
-		this.carouselRef = createRef();
 		this.paginationRef = createRef();
 
 		this.state = {
@@ -64,7 +63,7 @@ class Edit extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const isVisible = 0 < this.carouselRef.current.offsetWidth && 0 < this.carouselRef.current.offsetHeight;
+		const isVisible = 0 < this.props.carouselRef.current.offsetWidth && 0 < this.props.carouselRef.current.offsetHeight;
 
 		// Bail early if the component is hidden.
 		if ( ! isVisible ) {
@@ -108,8 +107,8 @@ class Edit extends Component {
 			const { aspectRatio, autoplay, delay, slidesPerView } = this.props.attributes;
 			const swiperInstance = createSwiper(
 				{
-					block: this.carouselRef.current, // Editor uses the same wrapper for block and swiper container.
-					container: this.carouselRef.current,
+					block: this.props.carouselRef.current, // Editor uses the same wrapper for block and swiper container.
+					container: this.props.carouselRef.current,
 					next: this.btnNextRef.current,
 					prev: this.btnPrevRef.current,
 					play: this.btnPlayRef.current,
@@ -134,7 +133,7 @@ class Edit extends Component {
 	}
 
 	render() {
-		const { attributes, className, setAttributes, latestPosts, isUIDisabled } = this.props;
+		const { attributes, setAttributes, latestPosts, isUIDisabled, blockProps } = this.props;
 		const {
 			aspectRatio,
 			authors,
@@ -161,8 +160,7 @@ class Edit extends Component {
 			tags,
 		} = attributes;
 		const classes = classnames(
-			className,
-			'wp-block-newspack-blocks-carousel', // Default to make styles work for third-party consumers.
+			blockProps.className,
 			'wpnbpc', // Shortened version of the default classname.
 			'slides-per-view-' + slidesPerView,
 			'swiper',
@@ -206,113 +204,6 @@ class Edit extends Component {
 
 		return (
 			<Fragment>
-				<div className={ classes } ref={ this.carouselRef }>
-					{ hasNoPosts && (
-						<Placeholder className="component-placeholder__align-center">
-							<div style={ { margin: 'auto' } }>{ __( 'Sorry, no posts were found.' ) }</div>
-						</Placeholder>
-					) }
-					{ ( ! this.state.swiperInitialized || ! latestPosts ) && (
-						<Placeholder icon={ <Spinner /> } className="component-placeholder__align-center" />
-					) }
-					{ latestPosts && (
-						<Fragment>
-							{ autoplay && (
-								<Fragment>
-									<button className="swiper-button swiper-button-pause" ref={ this.btnPauseRef } />
-									<button className="swiper-button swiper-button-play" ref={ this.btnPlayRef } />
-								</Fragment>
-							) }
-							<div className="swiper-wrapper">
-								{ latestPosts.map( post => (
-									<article
-										className={ `post-has-image swiper-slide ${ post.post_type } ${ post.newspack_article_classes || '' }` }
-										key={ post.id }
-									>
-										{ getPostStatusLabel( post ) }
-										<figure className="post-thumbnail">
-											<a href="#" rel="bookmark">
-												{ post.newspack_featured_image_src ? (
-													<img
-														className={ `image-fit-${ imageFit }` }
-														src={ post.newspack_featured_image_src.large }
-														alt=""
-													/>
-												) : (
-													<div className="wp-block-newspack-blocks-carousel__placeholder" />
-												) }
-											</a>
-										</figure>
-										{ ( post.newspack_post_sponsors ||
-											showCategory ||
-											showTitle ||
-											showAuthor ||
-											showDate ||
-											showCaption ||
-											showCredit ) && (
-											<div className="entry-wrapper">
-												{ ( post.newspack_post_sponsors || ( showCategory && 0 < post.newspack_category_info.length ) ) && (
-													<div className={ 'cat-links' + ( post.newspack_post_sponsors ? ' sponsor-label' : '' ) }>
-														{ post.newspack_post_sponsors && (
-															<span className="flag">{ post.newspack_post_sponsors[ 0 ].flag }</span>
-														) }
-														{ showCategory &&
-															( ! post.newspack_post_sponsors || post.newspack_sponsors_show_categories ) && (
-																<RawHTML>{ decodeEntities( post.newspack_category_info ) }</RawHTML>
-															) }
-													</div>
-												) }
-												{ showTitle && (
-													<h3 className="entry-title">
-														<a href="#">{ decodeEntities( post.title.rendered.trim() ) }</a>
-													</h3>
-												) }
-												<div className="entry-meta">
-													{ post.newspack_post_sponsors && (
-														<span
-															className={ `entry-sponsors ${
-																post.newspack_sponsors_show_author ? 'plus-author' : ''
-															}` }
-														>
-															{ formatSponsorLogos( post.newspack_post_sponsors ) }
-															{ formatSponsorByline( post.newspack_post_sponsors ) }
-														</span>
-													) }
-													{ showAuthor &&
-														! post.newspack_listings_hide_author &&
-														( ! post.newspack_post_sponsors || post.newspack_sponsors_show_author ) && (
-															<RawHTML className="byline-container">{ getBylineHTML( post, showAvatar ) }</RawHTML>
-														) }
-													{ showDate && (
-														<time className="entry-date published" key="pub-date">
-															{ dateI18n( dateFormat, post.date ) }
-														</time>
-													) }
-													{ ( showCaption || showCredit ) && post.newspack_featured_image_caption && (
-														<div
-															className="entry-caption"
-															dangerouslySetInnerHTML={ {
-																__html: post.newspack_featured_image_caption,
-															} }
-														/>
-													) }
-												</div>
-											</div>
-										) }
-									</article>
-								) ) }
-							</div>
-							{ ! hasNoPosts && ! hasOnePost && (
-								<>
-									<button className="swiper-button swiper-button-prev" ref={ this.btnPrevRef } />
-									<button className="swiper-button swiper-button-next" ref={ this.btnNextRef } />
-									<div className="swiper-pagination swiper-pagination-bullets" ref={ this.paginationRef } />
-								</>
-							) }
-						</Fragment>
-					) }
-				</div>
-
 				<InspectorControls>
 					<PanelBody title={ __( 'Settings', 'newspack-blocks' ) } className="newspack-block__panel is-content">
 						{ postsToShow && (
@@ -456,9 +347,124 @@ class Edit extends Component {
 					<PostTypesPanel attributes={ attributes } setAttributes={ setAttributes } />
 					<PostStatusesPanel attributes={ attributes } setAttributes={ setAttributes } />
 				</InspectorControls>
+				<div { ...blockProps }>
+					<div className={ classes } ref={ this.props.carouselRef }>
+						{ hasNoPosts && (
+							<Placeholder className="component-placeholder__align-center">
+								<div style={ { margin: 'auto' } }>{ __( 'Sorry, no posts were found.' ) }</div>
+							</Placeholder>
+						) }
+						{ ( ! this.state.swiperInitialized || ! latestPosts ) && (
+							<Placeholder icon={ <Spinner /> } className="component-placeholder__align-center" />
+						) }
+						{ latestPosts && (
+							<Fragment>
+								{ autoplay && (
+									<Fragment>
+										<button className="swiper-button swiper-button-pause" ref={ this.btnPauseRef } />
+										<button className="swiper-button swiper-button-play" ref={ this.btnPlayRef } />
+									</Fragment>
+								) }
+								<div className="swiper-wrapper">
+									{ latestPosts.map( post => (
+										<article
+											className={ `post-has-image swiper-slide ${ post.post_type } ${ post.newspack_article_classes || '' }` }
+											key={ post.id }
+										>
+											{ getPostStatusLabel( post ) }
+											<figure className="post-thumbnail">
+												<a href="#" rel="bookmark">
+													{ post.newspack_featured_image_src ? (
+														<img
+															className={ `image-fit-${ imageFit }` }
+															src={ post.newspack_featured_image_src.large }
+															alt=""
+														/>
+													) : (
+														<div className="wp-block-newspack-blocks-carousel__placeholder" />
+													) }
+												</a>
+											</figure>
+											{ ( post.newspack_post_sponsors ||
+												showCategory ||
+												showTitle ||
+												showAuthor ||
+												showDate ||
+												showCaption ||
+												showCredit ) && (
+												<div className="entry-wrapper">
+													{ ( post.newspack_post_sponsors ||
+														( showCategory && 0 < post.newspack_category_info.length ) ) && (
+														<div className={ 'cat-links' + ( post.newspack_post_sponsors ? ' sponsor-label' : '' ) }>
+															{ post.newspack_post_sponsors && (
+																<span className="flag">{ post.newspack_post_sponsors[ 0 ].flag }</span>
+															) }
+															{ showCategory &&
+																( ! post.newspack_post_sponsors || post.newspack_sponsors_show_categories ) && (
+																	<RawHTML>{ decodeEntities( post.newspack_category_info ) }</RawHTML>
+																) }
+														</div>
+													) }
+													{ showTitle && (
+														<h3 className="entry-title">
+															<a href="#">{ decodeEntities( post.title.rendered.trim() ) }</a>
+														</h3>
+													) }
+													<div className="entry-meta">
+														{ post.newspack_post_sponsors && (
+															<span
+																className={ `entry-sponsors ${
+																	post.newspack_sponsors_show_author ? 'plus-author' : ''
+																}` }
+															>
+																{ formatSponsorLogos( post.newspack_post_sponsors ) }
+																{ formatSponsorByline( post.newspack_post_sponsors ) }
+															</span>
+														) }
+														{ showAuthor &&
+															! post.newspack_listings_hide_author &&
+															( ! post.newspack_post_sponsors || post.newspack_sponsors_show_author ) && (
+																<RawHTML className="byline-container">{ getBylineHTML( post, showAvatar ) }</RawHTML>
+															) }
+														{ showDate && (
+															<time className="entry-date published" key="pub-date">
+																{ dateI18n( dateFormat, post.date ) }
+															</time>
+														) }
+														{ ( showCaption || showCredit ) && post.newspack_featured_image_caption && (
+															<div
+																className="entry-caption"
+																dangerouslySetInnerHTML={ {
+																	__html: post.newspack_featured_image_caption,
+																} }
+															/>
+														) }
+													</div>
+												</div>
+											) }
+										</article>
+									) ) }
+								</div>
+								{ ! hasNoPosts && ! hasOnePost && (
+									<>
+										<button className="swiper-button swiper-button-prev" ref={ this.btnPrevRef } />
+										<button className="swiper-button swiper-button-next" ref={ this.btnNextRef } />
+										<div className="swiper-pagination swiper-pagination-bullets" ref={ this.paginationRef } />
+									</>
+								) }
+							</Fragment>
+						) }
+					</div>
+				</div>
 			</Fragment>
 		);
 	}
 }
 
-export default compose( [ withSelect( postsBlockSelector ), withDispatch( postsBlockDispatch ) ] )( Edit );
+const EditWithBlockProps = props => {
+	const carouselRef = useRef();
+	const blockProps = useBlockProps();
+	return <Edit { ...props } blockProps={ blockProps } carouselRef={ carouselRef } />;
+};
+
+export default compose( [ withSelect( postsBlockSelector ), withDispatch( postsBlockDispatch ) ] )( EditWithBlockProps );

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -347,114 +347,111 @@ class Edit extends Component {
 					<PostTypesPanel attributes={ attributes } setAttributes={ setAttributes } />
 					<PostStatusesPanel attributes={ attributes } setAttributes={ setAttributes } />
 				</InspectorControls>
-				<div { ...blockProps }>
-					<div className={ classes } ref={ this.props.carouselRef }>
-						{ hasNoPosts && (
-							<Placeholder className="component-placeholder__align-center">
-								<div style={ { margin: 'auto' } }>{ __( 'Sorry, no posts were found.' ) }</div>
-							</Placeholder>
-						) }
-						{ ( ! this.state.swiperInitialized || ! latestPosts ) && (
-							<Placeholder icon={ <Spinner /> } className="component-placeholder__align-center" />
-						) }
-						{ latestPosts && (
-							<Fragment>
-								{ autoplay && (
-									<Fragment>
-										<button className="swiper-button swiper-button-pause" ref={ this.btnPauseRef } />
-										<button className="swiper-button swiper-button-play" ref={ this.btnPlayRef } />
-									</Fragment>
-								) }
-								<div className="swiper-wrapper">
-									{ latestPosts.map( post => (
-										<article
-											className={ `post-has-image swiper-slide ${ post.post_type } ${ post.newspack_article_classes || '' }` }
-											key={ post.id }
-										>
-											{ getPostStatusLabel( post ) }
-											<figure className="post-thumbnail">
-												<a href="#" rel="bookmark">
-													{ post.newspack_featured_image_src ? (
-														<img
-															className={ `image-fit-${ imageFit }` }
-															src={ post.newspack_featured_image_src.large }
-															alt=""
-														/>
-													) : (
-														<div className="wp-block-newspack-blocks-carousel__placeholder" />
-													) }
-												</a>
-											</figure>
-											{ ( post.newspack_post_sponsors ||
-												showCategory ||
-												showTitle ||
-												showAuthor ||
-												showDate ||
-												showCaption ||
-												showCredit ) && (
-												<div className="entry-wrapper">
-													{ ( post.newspack_post_sponsors ||
-														( showCategory && 0 < post.newspack_category_info.length ) ) && (
-														<div className={ 'cat-links' + ( post.newspack_post_sponsors ? ' sponsor-label' : '' ) }>
-															{ post.newspack_post_sponsors && (
-																<span className="flag">{ post.newspack_post_sponsors[ 0 ].flag }</span>
-															) }
-															{ showCategory &&
-																( ! post.newspack_post_sponsors || post.newspack_sponsors_show_categories ) && (
-																	<RawHTML>{ decodeEntities( post.newspack_category_info ) }</RawHTML>
-																) }
-														</div>
-													) }
-													{ showTitle && (
-														<h3 className="entry-title">
-															<a href="#">{ decodeEntities( post.title.rendered.trim() ) }</a>
-														</h3>
-													) }
-													<div className="entry-meta">
+				<div { ...blockProps } className={ classes } ref={ this.props.carouselRef }>
+					{ hasNoPosts && (
+						<Placeholder className="component-placeholder__align-center">
+							<div style={ { margin: 'auto' } }>{ __( 'Sorry, no posts were found.' ) }</div>
+						</Placeholder>
+					) }
+					{ ( ! this.state.swiperInitialized || ! latestPosts ) && (
+						<Placeholder icon={ <Spinner /> } className="component-placeholder__align-center" />
+					) }
+					{ latestPosts && (
+						<Fragment>
+							{ autoplay && (
+								<Fragment>
+									<button className="swiper-button swiper-button-pause" ref={ this.btnPauseRef } />
+									<button className="swiper-button swiper-button-play" ref={ this.btnPlayRef } />
+								</Fragment>
+							) }
+							<div className="swiper-wrapper">
+								{ latestPosts.map( post => (
+									<article
+										className={ `post-has-image swiper-slide ${ post.post_type } ${ post.newspack_article_classes || '' }` }
+										key={ post.id }
+									>
+										{ getPostStatusLabel( post ) }
+										<figure className="post-thumbnail">
+											<a href="#" rel="bookmark">
+												{ post.newspack_featured_image_src ? (
+													<img
+														className={ `image-fit-${ imageFit }` }
+														src={ post.newspack_featured_image_src.large }
+														alt=""
+													/>
+												) : (
+													<div className="wp-block-newspack-blocks-carousel__placeholder" />
+												) }
+											</a>
+										</figure>
+										{ ( post.newspack_post_sponsors ||
+											showCategory ||
+											showTitle ||
+											showAuthor ||
+											showDate ||
+											showCaption ||
+											showCredit ) && (
+											<div className="entry-wrapper">
+												{ ( post.newspack_post_sponsors || ( showCategory && 0 < post.newspack_category_info.length ) ) && (
+													<div className={ 'cat-links' + ( post.newspack_post_sponsors ? ' sponsor-label' : '' ) }>
 														{ post.newspack_post_sponsors && (
-															<span
-																className={ `entry-sponsors ${
-																	post.newspack_sponsors_show_author ? 'plus-author' : ''
-																}` }
-															>
-																{ formatSponsorLogos( post.newspack_post_sponsors ) }
-																{ formatSponsorByline( post.newspack_post_sponsors ) }
-															</span>
+															<span className="flag">{ post.newspack_post_sponsors[ 0 ].flag }</span>
 														) }
-														{ showAuthor &&
-															! post.newspack_listings_hide_author &&
-															( ! post.newspack_post_sponsors || post.newspack_sponsors_show_author ) && (
-																<RawHTML className="byline-container">{ getBylineHTML( post, showAvatar ) }</RawHTML>
+														{ showCategory &&
+															( ! post.newspack_post_sponsors || post.newspack_sponsors_show_categories ) && (
+																<RawHTML>{ decodeEntities( post.newspack_category_info ) }</RawHTML>
 															) }
-														{ showDate && (
-															<time className="entry-date published" key="pub-date">
-																{ dateI18n( dateFormat, post.date ) }
-															</time>
-														) }
-														{ ( showCaption || showCredit ) && post.newspack_featured_image_caption && (
-															<div
-																className="entry-caption"
-																dangerouslySetInnerHTML={ {
-																	__html: post.newspack_featured_image_caption,
-																} }
-															/>
-														) }
 													</div>
+												) }
+												{ showTitle && (
+													<h3 className="entry-title">
+														<a href="#">{ decodeEntities( post.title.rendered.trim() ) }</a>
+													</h3>
+												) }
+												<div className="entry-meta">
+													{ post.newspack_post_sponsors && (
+														<span
+															className={ `entry-sponsors ${
+																post.newspack_sponsors_show_author ? 'plus-author' : ''
+															}` }
+														>
+															{ formatSponsorLogos( post.newspack_post_sponsors ) }
+															{ formatSponsorByline( post.newspack_post_sponsors ) }
+														</span>
+													) }
+													{ showAuthor &&
+														! post.newspack_listings_hide_author &&
+														( ! post.newspack_post_sponsors || post.newspack_sponsors_show_author ) && (
+															<RawHTML className="byline-container">{ getBylineHTML( post, showAvatar ) }</RawHTML>
+														) }
+													{ showDate && (
+														<time className="entry-date published" key="pub-date">
+															{ dateI18n( dateFormat, post.date ) }
+														</time>
+													) }
+													{ ( showCaption || showCredit ) && post.newspack_featured_image_caption && (
+														<div
+															className="entry-caption"
+															dangerouslySetInnerHTML={ {
+																__html: post.newspack_featured_image_caption,
+															} }
+														/>
+													) }
 												</div>
-											) }
-										</article>
-									) ) }
-								</div>
-								{ ! hasNoPosts && ! hasOnePost && (
-									<>
-										<button className="swiper-button swiper-button-prev" ref={ this.btnPrevRef } />
-										<button className="swiper-button swiper-button-next" ref={ this.btnNextRef } />
-										<div className="swiper-pagination swiper-pagination-bullets" ref={ this.paginationRef } />
-									</>
-								) }
-							</Fragment>
-						) }
-					</div>
+											</div>
+										) }
+									</article>
+								) ) }
+							</div>
+							{ ! hasNoPosts && ! hasOnePost && (
+								<>
+									<button className="swiper-button swiper-button-prev" ref={ this.btnPrevRef } />
+									<button className="swiper-button swiper-button-next" ref={ this.btnNextRef } />
+									<div className="swiper-pagination swiper-pagination-bullets" ref={ this.paginationRef } />
+								</>
+							) }
+						</Fragment>
+					) }
 				</div>
 			</Fragment>
 		);

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -28,6 +28,7 @@ export { name };
 export const title = __( 'Content Carousel', 'newspack-blocks' );
 
 export const settings = {
+	...metadata,
 	title,
 	icon: {
 		src: icon,

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -20,7 +20,7 @@ import edit from './edit';
 import './view.scss';
 import './editor.scss';
 import metadata from './block.json';
-const { name, attributes, category } = metadata;
+const { name, attributes, apiVersion, category } = metadata;
 
 // Name must be exported separately.
 export { name };
@@ -28,7 +28,7 @@ export { name };
 export const title = __( 'Content Carousel', 'newspack-blocks' );
 
 export const settings = {
-	...metadata,
+	apiVersion,
 	title,
 	icon: {
 		src: icon,

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -304,6 +304,7 @@ function newspack_blocks_register_carousel() {
 		apply_filters(
 			'newspack_blocks_block_args',
 			array(
+				'api_version'     => 3,
 				'attributes'      => array(
 					'className'        => array(
 						'type' => 'string',

--- a/src/blocks/donate/block.json
+++ b/src/blocks/donate/block.json
@@ -1,7 +1,8 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
 	"name": "donate",
 	"category": "newspack",
-	"apiVersion": 3,
 	"attributes": {
 		"className": {
 			"type": "string"

--- a/src/blocks/donate/edit/FrequencyBasedLayout.tsx
+++ b/src/blocks/donate/edit/FrequencyBasedLayout.tsx
@@ -19,11 +19,11 @@ import { FREQUENCIES } from '../consts';
 import type { ComponentProps, DonationFrequencySlug } from '../types';
 import { updateBlockClassName, getFormData } from '../view';
 
-const FrequencyBasedLayout = ( props: { isTiered: boolean } & ComponentProps ) => {
+const FrequencyBasedLayout = ( props: { canUseNameYourPrice: boolean; isTiered: boolean } & ComponentProps ) => {
 	// Unique identifier to prevent collisions with other Donate blocks' labels.
 	const uid = useMemo( () => Math.random().toString( 16 ).slice( 2 ), [] );
 
-	const { attributes, settings, amounts, availableFrequencies, setAttributes } = props;
+	const { attributes, settings, amounts, availableFrequencies, setAttributes, canUseNameYourPrice } = props;
 
 	const formRef = useRef< HTMLFormElement >( null );
 
@@ -69,7 +69,6 @@ const FrequencyBasedLayout = ( props: { isTiered: boolean } & ComponentProps ) =
 	}, [ attributes.defaultFrequency ] );
 
 	const [ selectedFrequency, setSelectedFrequency ] = useState( attributes.defaultFrequency );
-	const canUseNameYourPrice = window.newspack_blocks_data?.can_use_name_your_price;
 	const renderFrequencySelect = ( frequencySlug: DonationFrequencySlug ) => (
 		<>
 			<input

--- a/src/blocks/donate/edit/index.tsx
+++ b/src/blocks/donate/edit/index.tsx
@@ -40,8 +40,7 @@ import RedirectAfterSuccess from '../../../components/redirect-after-success';
 
 const TIER_LABELS = [ __( 'Low-tier', 'newspack-blocks' ), __( 'Mid-tier', 'newspack-blocks' ), __( 'High-tier', 'newspack-blocks' ) ];
 
-const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
-	const blockProps = useBlockProps();
+const Edit = ( { attributes, setAttributes }: EditProps ) => {
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ error, setError ] = useState( '' );
 
@@ -100,6 +99,7 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 			.finally( () => setIsLoading( false ) );
 	}, [] );
 
+	const blockProps = useBlockProps();
 	if ( error.length ) {
 		return (
 			<div { ...blockProps }>
@@ -136,11 +136,14 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 		);
 	}
 
-	const canUseNameYourPrice = window.newspack_blocks_data?.can_use_name_your_price;
+	const canUseNameYourPrice = window?.newspack_blocks_data?.can_use_name_your_price;
 	const isManual = attributes.manual && canUseNameYourPrice;
 	const isTiered = isManual ? attributes.tiered : settings.tiered;
 	const isTierBasedLayoutEnabled = isTiered && attributes.layoutOption === 'tiers';
 	const tierLayoutStyle = attributes.tierStyle;
+	const hasRecaptcha = window?.newspack_blocks_data?.has_recaptcha;
+	const supportsRecaptcha = window?.newspack_blocks_data?.supports_recaptcha;
+	const recaptchaURL = window?.newspack_blocks_data?.recaptcha_url || '';
 
 	const amounts = isManual ? attributes.amounts : settings.amounts;
 
@@ -148,8 +151,9 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 		isManual ? ! attributes.disabledFrequencies[ slug ] : ! settings.disabledFrequencies[ slug ]
 	);
 
+	let { className } = attributes;
 	// Editor bug – initially, the default style is selected, but the class not applied.
-	if ( className?.indexOf( 'is-style' ) === -1 ) {
+	if ( className.indexOf( 'is-style' ) === -1 ) {
 		className += ' is-style-default';
 	}
 	if ( ! canUseNameYourPrice ) {
@@ -389,16 +393,16 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 						/>
 					</PanelBody>
 				) }
-				{ window.newspack_blocks_data.supports_recaptcha && (
+				{ supportsRecaptcha && (
 					<PanelBody title={ __( 'Spam protection', 'newspack' ) }>
 						<p>
 							{ sprintf(
 								// translators: %s is either 'enabled' or 'disabled'.
 								__( 'reCAPTCHA is currently %s.', 'newspack' ),
-								window.newspack_blocks_data.has_recaptcha ? __( 'enabled', 'newspack' ) : __( 'disabled', 'newspack' )
+								hasRecaptcha ? __( 'enabled', 'newspack' ) : __( 'disabled', 'newspack' )
 							) }
 						</p>
-						{ ! window.newspack_blocks_data.has_recaptcha && (
+						{ ! hasRecaptcha && (
 							<p>
 								{ __(
 									"It's highly recommended that you enable reCAPTCHA protection to prevent spambots from using this form!",
@@ -407,7 +411,7 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 							</p>
 						) }
 						<p>
-							<a href={ window.newspack_blocks_data.recaptcha_url }>{ __( 'Configure your reCAPTCHA settings.', 'newspack' ) }</a>
+							<a href={ recaptchaURL }>{ __( 'Configure your reCAPTCHA settings.', 'newspack' ) }</a>
 						</p>
 					</PanelBody>
 				) }
@@ -415,19 +419,24 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 					<RedirectAfterSuccess setAttributes={ setAttributes } attributes={ attributes } />
 				</PanelBody>
 			</InspectorControls>
+			{ isTierBasedLayoutEnabled && (
+				<BlockControls>
+					<Toolbar controls={ tiersLayoutControls } />
+				</BlockControls>
+			) }
 			<div { ...blockProps }>
 				{ isTierBasedLayoutEnabled ? (
-					<>
-						<div className={ getWrapperClassNames() }>
-							<TierBasedLayout { ...componentProps } amounts={ displayedAmounts } />
-						</div>
-						<BlockControls>
-							<Toolbar controls={ tiersLayoutControls } />
-						</BlockControls>
-					</>
+					<div className={ getWrapperClassNames() }>
+						<TierBasedLayout { ...componentProps } amounts={ displayedAmounts } />
+					</div>
 				) : (
 					<div className={ getWrapperClassNames( [ isTiered ? 'tiered' : 'untiered' ] ) }>
-						<FrequencyBasedLayout isTiered={ isTiered } { ...componentProps } amounts={ displayedAmounts } />
+						<FrequencyBasedLayout
+							isTiered={ isTiered }
+							canUseNameYourPrice={ canUseNameYourPrice }
+							amounts={ displayedAmounts }
+							{ ...componentProps }
+						/>
 					</div>
 				) }
 			</div>

--- a/src/blocks/donate/edit/index.tsx
+++ b/src/blocks/donate/edit/index.tsx
@@ -140,7 +140,7 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 	);
 
 	// Editor bug – initially, the default style is selected, but the class not applied.
-	if ( className.indexOf( 'is-style' ) === -1 ) {
+	if ( className?.indexOf( 'is-style' ) === -1 ) {
 		className += ' is-style-default';
 	}
 	if ( ! canUseNameYourPrice ) {

--- a/src/blocks/donate/edit/index.tsx
+++ b/src/blocks/donate/edit/index.tsx
@@ -151,7 +151,7 @@ const Edit = ( { attributes, setAttributes }: EditProps ) => {
 		isManual ? ! attributes.disabledFrequencies[ slug ] : ! settings.disabledFrequencies[ slug ]
 	);
 
-	let { className } = attributes;
+	let className = attributes?.className || '';
 	// Editor bug – initially, the default style is selected, but the class not applied.
 	if ( className.indexOf( 'is-style' ) === -1 ) {
 		className += ' is-style-default';
@@ -424,22 +424,20 @@ const Edit = ( { attributes, setAttributes }: EditProps ) => {
 					<Toolbar controls={ tiersLayoutControls } />
 				</BlockControls>
 			) }
-			<div { ...blockProps }>
-				{ isTierBasedLayoutEnabled ? (
-					<div className={ getWrapperClassNames() }>
-						<TierBasedLayout { ...componentProps } amounts={ displayedAmounts } />
-					</div>
-				) : (
-					<div className={ getWrapperClassNames( [ isTiered ? 'tiered' : 'untiered' ] ) }>
-						<FrequencyBasedLayout
-							isTiered={ isTiered }
-							canUseNameYourPrice={ canUseNameYourPrice }
-							amounts={ displayedAmounts }
-							{ ...componentProps }
-						/>
-					</div>
-				) }
-			</div>
+			{ isTierBasedLayoutEnabled ? (
+				<div { ...blockProps } className={ classNames( blockProps.className, getWrapperClassNames() ) }>
+					<TierBasedLayout { ...componentProps } amounts={ displayedAmounts } />
+				</div>
+			) : (
+				<div { ...blockProps } className={ classNames( blockProps.className, getWrapperClassNames( [ isTiered ? 'tiered' : 'untiered' ] ) ) }>
+					<FrequencyBasedLayout
+						isTiered={ isTiered }
+						canUseNameYourPrice={ canUseNameYourPrice }
+						amounts={ displayedAmounts }
+						{ ...componentProps }
+					/>
+				</div>
+			) }
 		</Fragment>
 	);
 };

--- a/src/blocks/donate/edit/index.tsx
+++ b/src/blocks/donate/edit/index.tsx
@@ -23,7 +23,7 @@ import {
 	Button,
 	Notice,
 } from '@wordpress/components';
-import { BlockControls, ColorPaletteControl, InspectorControls } from '@wordpress/block-editor';
+import { BlockControls, ColorPaletteControl, InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { isEmpty, pick } from 'lodash';
 import { Icon, formatListBullets, grid } from '@wordpress/icons';
 
@@ -41,6 +41,7 @@ import RedirectAfterSuccess from '../../../components/redirect-after-success';
 const TIER_LABELS = [ __( 'Low-tier', 'newspack-blocks' ), __( 'Mid-tier', 'newspack-blocks' ), __( 'High-tier', 'newspack-blocks' ) ];
 
 const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
+	const blockProps = useBlockProps();
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ error, setError ] = useState( '' );
 
@@ -101,30 +102,38 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 
 	if ( error.length ) {
 		return (
-			<Placeholder icon="warning" label={ __( 'Error', 'newspack-blocks' ) } instructions={ error }>
-				<ExternalLink href="/wp-admin/admin.php?page=newspack-audience#/payment">
-					{ __( 'Go to checkout & payment settings to troubleshoot.', 'newspack-blocks' ) }
-				</ExternalLink>
-			</Placeholder>
+			<div { ...blockProps }>
+				<Placeholder icon="warning" label={ __( 'Error', 'newspack-blocks' ) } instructions={ error }>
+					<ExternalLink href="/wp-admin/admin.php?page=newspack-audience#/payment">
+						{ __( 'Go to checkout & payment settings to troubleshoot.', 'newspack-blocks' ) }
+					</ExternalLink>
+				</Placeholder>
+			</div>
 		);
 	}
 
 	if ( settings.platform === 'other' ) {
 		return (
-			<Placeholder
-				icon="warning"
-				label={ __( 'The Donate block will not be rendered.', 'newspack-blocks' ) }
-				instructions={ __( 'The Reader Revenue platform is set to "other".', 'newspack-blocks' ) }
-			>
-				<ExternalLink href="/wp-admin/admin.php?page=newspack-audience#/payment">
-					{ __( 'Go to checkout & payment settings to update the platform.', 'newspack-blocks' ) }
-				</ExternalLink>
-			</Placeholder>
+			<div { ...blockProps }>
+				<Placeholder
+					icon="warning"
+					label={ __( 'The Donate block will not be rendered.', 'newspack-blocks' ) }
+					instructions={ __( 'The Reader Revenue platform is set to "other".', 'newspack-blocks' ) }
+				>
+					<ExternalLink href="/wp-admin/admin.php?page=newspack-audience#/payment">
+						{ __( 'Go to checkout & payment settings to update the platform.', 'newspack-blocks' ) }
+					</ExternalLink>
+				</Placeholder>
+			</div>
 		);
 	}
 
 	if ( isLoading ) {
-		return <Placeholder icon={ <Spinner /> } className="component-placeholder__align-center" />;
+		return (
+			<div { ...blockProps }>
+				<Placeholder icon={ <Spinner /> } className="component-placeholder__align-center" />
+			</div>
+		);
 	}
 
 	const canUseNameYourPrice = window.newspack_blocks_data?.can_use_name_your_price;
@@ -200,22 +209,7 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 	);
 
 	return (
-		<>
-			{ isTierBasedLayoutEnabled ? (
-				<>
-					<div className={ getWrapperClassNames() }>
-						<TierBasedLayout { ...componentProps } amounts={ displayedAmounts } />
-					</div>
-					<BlockControls>
-						<Toolbar controls={ tiersLayoutControls } />
-					</BlockControls>
-				</>
-			) : (
-				<div className={ getWrapperClassNames( [ isTiered ? 'tiered' : 'untiered' ] ) }>
-					<FrequencyBasedLayout isTiered={ isTiered } { ...componentProps } amounts={ displayedAmounts } />
-				</div>
-			) }
-
+		<Fragment>
 			<InspectorControls>
 				<PanelBody title={ __( 'Layout', 'newspack-blocks' ) }>
 					{ canUseNameYourPrice && (
@@ -421,7 +415,23 @@ const Edit = ( { attributes, setAttributes, className }: EditProps ) => {
 					<RedirectAfterSuccess setAttributes={ setAttributes } attributes={ attributes } />
 				</PanelBody>
 			</InspectorControls>
-		</>
+			<div { ...blockProps }>
+				{ isTierBasedLayoutEnabled ? (
+					<>
+						<div className={ getWrapperClassNames() }>
+							<TierBasedLayout { ...componentProps } amounts={ displayedAmounts } />
+						</div>
+						<BlockControls>
+							<Toolbar controls={ tiersLayoutControls } />
+						</BlockControls>
+					</>
+				) : (
+					<div className={ getWrapperClassNames( [ isTiered ? 'tiered' : 'untiered' ] ) }>
+						<FrequencyBasedLayout isTiered={ isTiered } { ...componentProps } amounts={ displayedAmounts } />
+					</div>
+				) }
+			</div>
+		</Fragment>
 	);
 };
 

--- a/src/blocks/donate/index.js
+++ b/src/blocks/donate/index.js
@@ -23,7 +23,7 @@ import metadata from './block.json';
 import './styles/editor.scss';
 import './styles/view.scss';
 
-const { name, attributes, category, supports } = metadata;
+const { name, attributes, apiVersion, category, supports } = metadata;
 
 // Name must be exported separately.
 export { name };
@@ -31,7 +31,7 @@ export { name };
 export const title = __( 'Donate', 'newspack-blocks' );
 
 export const settings = {
-	...metadata,
+	apiVersion,
 	title,
 	icon: {
 		src: icon,

--- a/src/blocks/donate/index.js
+++ b/src/blocks/donate/index.js
@@ -31,6 +31,7 @@ export { name };
 export const title = __( 'Donate', 'newspack-blocks' );
 
 export const settings = {
+	...metadata,
 	title,
 	icon: {
 		src: icon,

--- a/src/blocks/donate/view.php
+++ b/src/blocks/donate/view.php
@@ -19,6 +19,7 @@ function newspack_blocks_register_donate() {
 	register_block_type(
 		'newspack-blocks/' . $block_json['name'],
 		[
+			'api_version'     => $block_json['apiVersion'],
 			'attributes'      => $block_json['attributes'],
 			'render_callback' => 'Newspack_Blocks_Donate_Renderer::render',
 			'supports'        => $block_json['supports'],

--- a/src/blocks/homepage-articles/block.json
+++ b/src/blocks/homepage-articles/block.json
@@ -1,7 +1,8 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
 	"name": "homepage-articles",
 	"category": "newspack",
-	"apiVersion": 3,
 	"attributes": {
 		"className": {
 			"type": "string",

--- a/src/blocks/homepage-articles/edit.tsx
+++ b/src/blocks/homepage-articles/edit.tsx
@@ -23,7 +23,7 @@ import { aspectLandscape, aspectPortrait, aspectSquare } from 'newspack-icons';
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Component, Fragment, RawHTML } from '@wordpress/element';
-import { BlockControls, InspectorControls, PanelColorSettings, RichText, withColors, AlignmentControl } from '@wordpress/block-editor';
+import { BlockControls, InspectorControls, PanelColorSettings, RichText, withColors, AlignmentControl, useBlockProps } from '@wordpress/block-editor';
 import {
 	PanelBody,
 	Placeholder,
@@ -549,7 +549,7 @@ class Edit extends Component< HomepageArticlesProps > {
 		 * Constants
 		 */
 
-		const { attributes, className, setAttributes, isSelected, latestPosts, textColor, error } = this.props;
+		const { attributes, setAttributes, isSelected, latestPosts, textColor, error, blockProps } = this.props;
 
 		const {
 			showImage,
@@ -570,7 +570,7 @@ class Edit extends Component< HomepageArticlesProps > {
 			textAlign,
 		} = attributes;
 
-		const classes = classNames( className, {
+		const classes = classNames( blockProps.className, {
 			'is-grid': postLayout === 'grid',
 			'show-image': showImage,
 			[ `columns-${ columns }` ]: postLayout === 'grid',
@@ -658,7 +658,23 @@ class Edit extends Component< HomepageArticlesProps > {
 
 		return (
 			<Fragment>
+				<BlockControls>
+					<Toolbar>
+						<AlignmentControl
+							value={ textAlign }
+							onChange={ ( nextAlign: string ) => {
+								setAttributes( { textAlign: nextAlign } );
+							} }
+						/>
+					</Toolbar>
+					<Toolbar controls={ blockControls } />
+					{ showImage && <Toolbar controls={ blockControlsImages } /> }
+					{ showImage && <Toolbar controls={ blockControlsImageShape } /> }
+				</BlockControls>
+				<InspectorControls>{ this.renderInspectorControls() }</InspectorControls>
+				<InspectorControls group="styles">{ this.renderStylesInspectorControls() }</InspectorControls>
 				<div
+					{ ...blockProps }
 					className={ classes }
 					style={ {
 						color: textColor.color,
@@ -684,46 +700,35 @@ class Edit extends Component< HomepageArticlesProps > {
 
 						{ latestPosts && latestPosts.map( post => this.renderPost( post ) ) }
 					</div>
-				</div>
 
-				{ ! specificMode && latestPosts && moreButton && ! isBlogPrivate() && (
-					/*
-					 * The "More" button option is hidden for private sites, so we should
-					 * also hide the button in case it was previously enabled.
-					 */
-					<div className="wpnbha__wp-block-button__wrapper">
-						<div className="wp-block-button">
-							<RichText
-								placeholder={ __( 'Load more posts', 'newspack-blocks' ) }
-								value={ moreButtonText }
-								onChange={ ( value: string ) => setAttributes( { moreButtonText: value } ) }
-								className="wp-block-button__link"
-								allowedFormats={ [] }
-							/>
+					{ ! specificMode && latestPosts && moreButton && ! isBlogPrivate() && (
+						/*
+						 * The "More" button option is hidden for private sites, so we should
+						 * also hide the button in case it was previously enabled.
+						 */
+						<div className="wpnbha__wp-block-button__wrapper">
+							<div className="wp-block-button">
+								<RichText
+									placeholder={ __( 'Load more posts', 'newspack-blocks' ) }
+									value={ moreButtonText }
+									onChange={ ( value: string ) => setAttributes( { moreButtonText: value } ) }
+									className="wp-block-button__link"
+									allowedFormats={ [] }
+								/>
+							</div>
 						</div>
-					</div>
-				) }
-
-				<BlockControls>
-					<Toolbar>
-						<AlignmentControl
-							value={ textAlign }
-							onChange={ ( nextAlign: string ) => {
-								setAttributes( { textAlign: nextAlign } );
-							} }
-						/>
-					</Toolbar>
-					<Toolbar controls={ blockControls } />
-					{ showImage && <Toolbar controls={ blockControlsImages } /> }
-					{ showImage && <Toolbar controls={ blockControlsImageShape } /> }
-				</BlockControls>
-				<InspectorControls>{ this.renderInspectorControls() }</InspectorControls>
-				<InspectorControls group="styles">{ this.renderStylesInspectorControls() }</InspectorControls>
+					) }
+				</div>
 			</Fragment>
 		);
 	}
 }
 
+const EditWithBlockProps = ( props: any ) => {
+	const blockProps = useBlockProps();
+	return <Edit { ...props } blockProps={ blockProps } />;
+};
+
 export default compose( [ withColors( { textColor: 'color' } ), withSelect( postsBlockSelector ), withDispatch( postsBlockDispatch ) ] as any )(
-	Edit
+	EditWithBlockProps
 );

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -22,7 +22,7 @@ import edit from './edit';
 import './editor.scss';
 import './view.scss';
 import metadata from './block.json';
-const { name, attributes, category } = metadata;
+const { name, attributes, apiVersion, category } = metadata;
 
 // Name must be exported separately.
 export { name };
@@ -30,7 +30,7 @@ export { name };
 export const title = __( 'Content Loop', 'newspack-blocks' );
 
 export const settings = {
-	...metadata,
+	apiVersion,
 	title,
 	icon: {
 		src: icon,

--- a/src/blocks/homepage-articles/index.js
+++ b/src/blocks/homepage-articles/index.js
@@ -30,6 +30,7 @@ export { name };
 export const title = __( 'Content Loop', 'newspack-blocks' );
 
 export const settings = {
+	...metadata,
 	title,
 	icon: {
 		src: icon,

--- a/src/blocks/homepage-articles/view.php
+++ b/src/blocks/homepage-articles/view.php
@@ -440,6 +440,7 @@ function newspack_blocks_register_homepage_articles() {
 		apply_filters(
 			'newspack_blocks_block_args',
 			array(
+				'api_version'     => $block['apiVersion'],
 				'attributes'      => $block['attributes'],
 				'render_callback' => 'newspack_blocks_render_block_homepage_articles',
 				'supports'        => [],

--- a/src/blocks/iframe/block.json
+++ b/src/blocks/iframe/block.json
@@ -1,7 +1,8 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
 	"name": "iframe",
 	"category": "newspack",
-	"apiVersion": 3,
 	"attributes": {
 		"className": {
 			"type": "string",

--- a/src/blocks/iframe/edit.js
+++ b/src/blocks/iframe/edit.js
@@ -7,7 +7,7 @@ import { iframe as icon } from 'newspack-icons';
  * WordPress dependencies
  */
 import { Fragment, useState } from '@wordpress/element';
-import { InspectorControls, BlockControls } from '@wordpress/block-editor';
+import { InspectorControls, BlockControls, useBlockProps } from '@wordpress/block-editor';
 import {
 	PanelBody,
 	ToggleControl,
@@ -27,6 +27,7 @@ import apiFetch from '@wordpress/api-fetch';
 import IframePlaceholder from './iframe-placeholder';
 
 const IframeEdit = ( { attributes, setAttributes } ) => {
+	const blockProps = useBlockProps();
 	const label = __( 'Iframe', 'block title' );
 	const { mode, src, archiveFolder, isFullScreen, height, width } = attributes;
 	const [ showPreview, setShowPreview ] = useState( true );
@@ -156,39 +157,6 @@ const IframeEdit = ( { attributes, setAttributes } ) => {
 
 	return (
 		<Fragment>
-			{ isFullScreen && (
-				<Notice status="warning" className="wp-block-newspack-blocks-iframe-notice" isDismissible={ false }>
-					{ __( 'This block will take over the page content.', 'newspack-blocks' ) }
-				</Notice>
-			) }
-			{ src && showPreview ? (
-				<div className="iframe-container">
-					<FocusableIframe
-						title={ __( 'Newspack embedded iframe', 'newspack-blocks' ) }
-						src={ 'document' === mode ? `https://docs.google.com/gview?embedded=true&url=${ encodeURIComponent( src ) }` : src }
-						style={ {
-							width: isFullScreen ? '100vw' : width,
-							height: isFullScreen ? '100vh' : height,
-							maxWidth: '100%',
-							maxHeight: '100%',
-							pointerEvents: 'none',
-						} }
-					/>
-				</div>
-			) : (
-				<IframePlaceholder
-					icon={ icon }
-					label={ label }
-					src={ src }
-					onSelectURL={ embedURL }
-					onSelectMedia={ setIframeArchiveFromMedia }
-					isUploadingArchive={ isUploadingArchive }
-					archiveFolder={ archiveFolder }
-					uploadIframeArchive={ uploadIframeArchive }
-					error={ error }
-				/>
-			) }
-
 			<BlockControls>
 				<Toolbar controls={ src && iframeControls } />
 			</BlockControls>
@@ -223,6 +191,40 @@ const IframeEdit = ( { attributes, setAttributes } ) => {
 					</Fragment>
 				</PanelBody>
 			</InspectorControls>
+			<div { ...blockProps }>
+				{ isFullScreen && (
+					<Notice status="warning" className="wp-block-newspack-blocks-iframe-notice" isDismissible={ false }>
+						{ __( 'This block will take over the page content.', 'newspack-blocks' ) }
+					</Notice>
+				) }
+				{ src && showPreview ? (
+					<div className="iframe-container">
+						<FocusableIframe
+							title={ __( 'Newspack embedded iframe', 'newspack-blocks' ) }
+							src={ 'document' === mode ? `https://docs.google.com/gview?embedded=true&url=${ encodeURIComponent( src ) }` : src }
+							style={ {
+								width: isFullScreen ? '100vw' : width,
+								height: isFullScreen ? '100vh' : height,
+								maxWidth: '100%',
+								maxHeight: '100%',
+								pointerEvents: 'none',
+							} }
+						/>
+					</div>
+				) : (
+					<IframePlaceholder
+						icon={ icon }
+						label={ label }
+						src={ src }
+						onSelectURL={ embedURL }
+						onSelectMedia={ setIframeArchiveFromMedia }
+						isUploadingArchive={ isUploadingArchive }
+						archiveFolder={ archiveFolder }
+						uploadIframeArchive={ uploadIframeArchive }
+						error={ error }
+					/>
+				) }
+			</div>
 		</Fragment>
 	);
 };

--- a/src/blocks/iframe/index.js
+++ b/src/blocks/iframe/index.js
@@ -28,6 +28,7 @@ export const title = __( 'Iframe', 'newspack-blocks' );
 export { name };
 
 export const settings = {
+	...metadata,
 	title,
 	icon: {
 		src: icon,

--- a/src/blocks/iframe/index.js
+++ b/src/blocks/iframe/index.js
@@ -15,7 +15,7 @@ import { __ } from '@wordpress/i18n';
  */
 import edit from './edit';
 import metadata from './block.json';
-const { name, attributes, category } = metadata;
+const { name, attributes, apiVersion, category } = metadata;
 
 /**
  * Style dependencies - will load in editor
@@ -28,7 +28,7 @@ export const title = __( 'Iframe', 'newspack-blocks' );
 export { name };
 
 export const settings = {
-	...metadata,
+	apiVersion,
 	title,
 	icon: {
 		src: icon,

--- a/src/blocks/iframe/view.php
+++ b/src/blocks/iframe/view.php
@@ -30,6 +30,7 @@ function newspack_blocks_register_iframe() {
 	register_block_type(
 		'newspack-blocks/' . $block_json['name'],
 		[
+			'api_version'     => $block_json['apiVersion'],
 			'attributes'      => $block_json['attributes'],
 			'render_callback' => 'newspack_blocks_render_block_iframe',
 		]

--- a/src/blocks/video-playlist/edit.js
+++ b/src/blocks/video-playlist/edit.js
@@ -5,7 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { Component, Fragment } from '@wordpress/element';
 import { Notice, Placeholder, Spinner, PanelBody } from '@wordpress/components';
-import { InspectorControls } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { addQueryArgs } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
 
@@ -187,19 +187,6 @@ class Edit extends Component {
 
 		return (
 			<Fragment>
-				<div>
-					{ ( isLoading || '' === embed ) && this.renderPlaceholder() }
-					{ ! ( isLoading || '' === embed ) && (
-						<div className="wpbnbvp-preview">
-							<div dangerouslySetInnerHTML={ { __html: embed } } />
-						</div>
-					) }
-					{ ! isLoading && (
-						<div className="wpbnbvp__overlay">
-							<Warning />
-						</div>
-					) }
-				</div>
 				<InspectorControls>
 					<PanelBody title={ __( 'Settings', 'newspack-blocks' ) } initialOpen={ true }>
 						<Notice status="warning" isDismissible={ false }>
@@ -207,9 +194,29 @@ class Edit extends Component {
 						</Notice>
 					</PanelBody>
 				</InspectorControls>
+				<div { ...this.props.blockProps }>
+					<div>
+						{ ( isLoading || '' === embed ) && this.renderPlaceholder() }
+						{ ! ( isLoading || '' === embed ) && (
+							<div className="wpbnbvp-preview">
+								<div dangerouslySetInnerHTML={ { __html: embed } } />
+							</div>
+						) }
+						{ ! isLoading && (
+							<div className="wpbnbvp__overlay">
+								<Warning />
+							</div>
+						) }
+					</div>
+				</div>
 			</Fragment>
 		);
 	}
 }
 
-export default Edit;
+const EditWithBlockProps = props => {
+	const blockProps = useBlockProps();
+	return <Edit { ...props } blockProps={ blockProps } />;
+};
+
+export default EditWithBlockProps;

--- a/src/blocks/video-playlist/index.js
+++ b/src/blocks/video-playlist/index.js
@@ -23,6 +23,8 @@ export const name = 'youtube-video-playlist';
 export const title = __( 'YouTube Video Playlist (DEPRECATED)', 'newspack-blocks' );
 
 export const settings = {
+	$schema: 'https://schemas.wp.org/trunk/block.json',
+	apiVersion: 3,
 	title,
 	icon: {
 		src: icon,

--- a/src/blocks/video-playlist/index.js
+++ b/src/blocks/video-playlist/index.js
@@ -23,7 +23,6 @@ export const name = 'youtube-video-playlist';
 export const title = __( 'YouTube Video Playlist (DEPRECATED)', 'newspack-blocks' );
 
 export const settings = {
-	$schema: 'https://schemas.wp.org/trunk/block.json',
 	apiVersion: 3,
 	title,
 	icon: {

--- a/src/blocks/video-playlist/view.php
+++ b/src/blocks/video-playlist/view.php
@@ -26,6 +26,7 @@ function newspack_blocks_register_video_playlist() {
 	register_block_type(
 		'newspack-blocks/youtube-video-playlist',
 		array(
+			'api_version'     => 3,
 			'attributes'      => array(
 				'className'    => array(
 					'type' => 'string',

--- a/src/setup/placeholder-blocks.js
+++ b/src/setup/placeholder-blocks.js
@@ -57,6 +57,8 @@ function registerPlaceholderBlock( blockName, { title, description, icon, messag
 		);
 	};
 	registerBlockType( blockName, {
+		$schema: 'https://schemas.wp.org/trunk/block.json',
+		apiVersion: 3,
 		title,
 		description,
 		icon,

--- a/src/setup/placeholder-blocks.js
+++ b/src/setup/placeholder-blocks.js
@@ -57,7 +57,6 @@ function registerPlaceholderBlock( blockName, { title, description, icon, messag
 		);
 	};
 	registerBlockType( blockName, {
-		$schema: 'https://schemas.wp.org/trunk/block.json',
 		apiVersion: 3,
 		title,
 		description,


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2583/newspack-blocks-iframe-editor-compatibility

### How to test the changes in this Pull Request:

1. Ensure ONLY the main plugin, blocks, newsletters, and popups are the only Newspack extensions active and are all on the `fix/iframe-editor-compatibility` branch.
2. Smoke test blocks in the editor + frontend (You can find a list in the linked linear issue)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
