### PR TITLE
fix(modal-checkout): reduce gap between text and chevron

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -103,6 +103,7 @@
 					}
 
 					svg {
+						margin: 0 -8px;
 						transition: rotate 125ms ease-in-out;
 					}
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Tiny PR that reduces the gap between "Transaction details" and the chevron.

Before:
<img width="1198" height="142" alt="bfr" src="https://github.com/user-attachments/assets/3968afb8-bf15-4422-90aa-a875ec93ab44" />

After:
<img width="1192" height="138" alt="aftr" src="https://github.com/user-attachments/assets/174135b0-a46e-4447-a948-98e6a2c85d18" />

### How to test the changes in this Pull Request:

1. Checkout, notice the big gap between "Transaction details" and the chevron.
2. Switch to this branch
3. Checkout again, the gap should be much norrower now

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
