### PR TITLE
fix: run update_checkout on loading page 2 for physical products

### DIFF
--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -560,6 +560,10 @@ import { domReady, onCheckoutPlaceOrderProcessing } from './utils';
 						handleSubscriptionConfirmation();
 					}
 					$form.triggerHandler( 'editing_details', [ isEditingDetails ] );
+					// When transitioning to step 2, trigger update_checkout just in case for shipping totals.
+					if ( ! isEditingDetails ) {
+						$( document.body ).trigger( 'update_checkout' );
+					}
 					// Scroll to top.
 					window.scroll( { top: 0, left: 0, behavior: 'smooth' } );
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

There's a weird edge case where the Transaction Details don't update with shipping costs if you're purchasing a physical product through the modal checkout. This PR fixes that.

### How to test the changes in this Pull Request:

1. If you haven't already, under WooCommerce > Settings > Shipping > Shipping Zones, add a shipping Zone (like Everywhere, for a flat rate).
2. Set up a physical product in WooCommerce (not virtual or download-able)
3. Set up a modal checkout button block with this product
4. In an incognito window, run though a checkout; on the second screen, note you don't have Transaction Details (or if your physical product is also a subscription product, note that when you open Transaction details they're greyed out, and don't include your shipping costs).
5. Apply this PR and run `npm run build`.
6. In a fully new incognito window, retest step 4 (if you do it in the same session, the issue "fixes" itself sometimes).
7. Confirm that the Transaction details show, and include your shipping information.
8. Repeat the steps with a new physical product -- if your original product was a simple product, test with a physical subscription product, or vis versa. Run each test in a new incognito window.
9. Repeat the testing with a couple other products: 
     * a regular virtual subscription product (should show the Transaction details because it's recurring)
     * a recurring donation, and opt in to cover the fees as the reader (should show the Transaction details because it's recurring, and include the transaction fee)
     * a one-time donation, and opt in to cover the fees as a reader (shouldn't have the Transaction details initially, but the label should appear when you opt to cover the fees, and include them in the total in the table)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
