### PR TITLE
fix(modal-checkout): show transaction details for subscription renewals

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1390,9 +1390,16 @@ final class Modal_Checkout {
 				return true;
 			}
 		}
+
 		if ( class_exists( 'WC_Subscriptions_Cart' ) && \WC_Subscriptions_Cart::cart_contains_subscription() ) {
 			return true;
 		}
+
+		// Show details if the cart contains a subscription renewal.
+		if ( function_exists( 'wcs_cart_contains_renewal' ) && \wcs_cart_contains_renewal() ) {
+			return true;
+		}
+
 		return false;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When renewing a recurring subscription product, the modal checkout should show `Transaction details` so the user can review them. This works when the original purchase opted to cover the transaction fees ([line 1367](https://github.com/Automattic/newspack-blocks/blob/trunk/includes/class-modal-checkout.php#L1367)), but has not been displaying when the original purchase did not cover the transaction fees.

This PR fixes this by adding an additional check for wcs_cart_contains_renewal() to show transaction details.

`NPPM-2613`


### How to test the changes in this Pull Request:

1. In an incognito window, purchase a recurring donation product, and **do not cover** the transaction fees.
2. Navigate to My Account > Subscriptions, and view the subscription you just purchased
3. Click `Renew Now`
4. In the modal checkout that opens, note that the `Transaction details` is missing (screenshot below)
5. Also, check the "I'd like to cover the $x.xx transaction fee ..." checkbox. The `Transaction details` will still be missing.

<img width="655" height="574" alt="CleanShot 2026-02-12 at 13 10 10-1" src="https://github.com/user-attachments/assets/6284caf6-7818-4f7b-811a-06661e54b0b1" />
<br><br>

6. **Now Apply this PR**
7. Back on your My Account > Subscriptions page, click to `Renew now` once again
8. You should see the `Transaction details` now (screenshot below)
9. Also, check the "I'd like to cover the $x.xx transaction fee ..." checkbox and you'll still see the `Transaction details`

<img width="650" height="608" alt="CleanShot 2026-02-12 at 13 11 43-1" src="https://github.com/user-attachments/assets/0bad3253-4851-43bc-9df6-7f1ca89d1483" />
<br><br>

10. For a regression check, please repeat the process — purchase a new recurring donation, but this time check to cover the transaction fees from the start.
11. Return to the My Account > Subscriptions page, click to `Renew now` one last time.
12. You should see the `Transaction details` still.
13. Check/uncheck the "I'd like to cover the transaction fees" and you will continue to see the `transaction details`


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?


