### PR TITLE
feat(author-profile): allow spacer and separator blocks

### DIFF
--- a/src/blocks/author-profile/edit.js
+++ b/src/blocks/author-profile/edit.js
@@ -220,7 +220,7 @@ const NESTED_TEMPLATE = [
 				{
 					className: 'author-profile-content-column',
 					templateLock: false,
-					allowedBlocks: [ 'core/heading', 'core/paragraph', 'newspack/author-profile-social' ],
+					allowedBlocks: [ 'core/heading', 'core/paragraph', 'core/separator', 'core/spacer', 'newspack/author-profile-social' ],
 					style: {
 						spacing: {
 							blockGap: 'var:preset|spacing|20',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds `core/spacer` and `core/separator` to the allowed blocks in the nested Author Profile content column, giving publishers more layout flexibility when customizing the author profile template.

Reference: https://github.com/Automattic/newspack-plugin/pull/4448#issuecomment-3945874388

Closes NPPD-1270.

### How to test the changes in this Pull Request:

1. Open the Site Editor and navigate to any template that uses the Author Profile block in nested/v2 mode.
2. Click into the content column of an Author Profile block (the column with the name, bio, etc.).
3. Use the block inserter (+ button) and verify that **Spacer** and **Separator** blocks are now available.
4. Insert a Spacer and a Separator between author fields and confirm they render correctly in both the editor and the frontend.
5. Verify that no other unexpected block types appear in the inserter for that column.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?