### PR TITLE
fix: remove styles config

### DIFF
--- a/src/blocks/author-profile/index.js
+++ b/src/blocks/author-profile/index.js
@@ -7,7 +7,7 @@ import colors from 'newspack-colors';
  * WordPress dependencies
  */
 import { InnerBlocks } from '@wordpress/block-editor';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { postAuthor } from '@wordpress/icons';
 
 /**
@@ -48,10 +48,6 @@ export const settings = {
 	category,
 	keywords: [ __( 'author', 'newspack-blocks' ), __( 'profile', 'newspack-blocks' ) ],
 	description: __( 'Display an author profile card.', 'newspack-blocks' ),
-	styles: [
-		{ name: 'default', label: _x( 'Default', 'block style', 'newspack-blocks' ), isDefault: true },
-		{ name: 'center', label: _x( 'Centered', 'block style', 'newspack-blocks' ) },
-	],
 	supports: {
 		html: false,
 		default: '',


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

See https://linear.app/a8c/issue/NPPM-2583/newspack-blocks-iframe-editor-compatibility#comment-189afc4d

I inadvertently re-added the styles config to the author-profile block config while fixing a merge conflict. This PR removes it again. 

### How to test the changes in this Pull Request:

1. Smoke test the author profile block

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
