### PR TITLE
 feat(author-profile): add block variations for layout selection

### DIFF
--- a/src/blocks/author-profile/block.json
+++ b/src/blocks/author-profile/block.json
@@ -68,6 +68,10 @@
 		"avatarHideDefault": {
 			"type": "boolean",
 			"default": false
+		},
+		"variation": {
+			"type": "string",
+			"default": ""
 		}
 	}
 }

--- a/src/blocks/author-profile/edit.js
+++ b/src/blocks/author-profile/edit.js
@@ -16,9 +16,6 @@ import {
 	Button,
 	Card,
 	CardBody,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalConfirmDialog as ConfirmDialog,
-	DropdownMenu,
 	Notice,
 	PanelBody,
 	Placeholder,
@@ -26,8 +23,6 @@ import {
 	Spinner,
 	ToggleControl,
 	Toolbar,
-	ToolbarButton,
-	ToolbarGroup,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalUnitControl as UnitControl,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -41,7 +36,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useEffect, useState, useMemo } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
-import { layout, pencil, postAuthor, pullLeft, pullRight } from '@wordpress/icons';
+import { pencil, postAuthor, pullLeft, pullRight } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -201,19 +196,13 @@ function VariationPlaceholder( { clientId, name, setAttributes } ) {
 	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 	const blockProps = useBlockProps();
 
-	// Use short labels in the picker to avoid layout overflow.
-	const pickerVariations = variations?.map( v => ( {
-		...v,
-		title: v.label || v.title,
-	} ) );
-
 	return (
 		<div { ...blockProps }>
 			<BlockVariationPicker
 				icon={ blockType?.icon?.src }
 				label={ blockType?.title }
-				variations={ pickerVariations }
-				instructions={ __( 'Select a layout to start with.', 'newspack-blocks' ) }
+				variations={ variations }
+				instructions={ __( 'Select a layout to start with:', 'newspack-blocks' ) }
 				onSelect={ ( nextVariation = defaultVariation ) => {
 					setAttributes( { ...nextVariation.attributes, variation: nextVariation.name } );
 					if ( nextVariation.innerBlocks ) {
@@ -222,90 +211,6 @@ function VariationPlaceholder( { clientId, name, setAttributes } ) {
 				} }
 			/>
 		</div>
-	);
-}
-
-/**
- * Toolbar dropdown for switching between layout variations.
- */
-function VariationToolbarDropdown( { clientId, name, currentVariation, setAttributes } ) {
-	const { variations, innerBlocks, activeTemplate } = useSelect(
-		select => {
-			const allVariations = select( blocksStore ).getBlockVariations( name, 'block' );
-			const active = allVariations?.find( v => v.name === currentVariation );
-			return {
-				variations: allVariations,
-				innerBlocks: select( blockEditorStore ).getBlocks( clientId ),
-				activeTemplate: active?.innerBlocks,
-			};
-		},
-		[ name, clientId, currentVariation ]
-	);
-	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
-	const [ pendingVariation, setPendingVariation ] = useState( null );
-
-	const hasCustomEdits = () => {
-		if ( ! activeTemplate ) {
-			return true;
-		}
-		// Compare block structure and attributes, ignoring runtime differences:
-		// - `content`: populated by block bindings (author name, bio, etc.)
-		// - `allowedBlocks`, `templateLock`: structural attrs that evolve with the template
-		// - Inner blocks of dynamic blocks (e.g. social links, populated from author data)
-		const DYNAMIC_BLOCKS = [ 'newspack/author-profile-social' ];
-		const IGNORED_ATTRS = [ 'content', 'allowedBlocks', 'templateLock' ];
-		const fingerprint = blocks =>
-			blocks.map( block => {
-				const attrs = Object.fromEntries( Object.entries( block.attributes ).filter( ( [ key ] ) => ! IGNORED_ATTRS.includes( key ) ) );
-				return {
-					name: block.name,
-					attributes: attrs,
-					innerBlocks: DYNAMIC_BLOCKS.includes( block.name ) ? [] : fingerprint( block.innerBlocks || [] ),
-				};
-			} );
-		const freshBlocks = createBlocksFromInnerBlocksTemplate( activeTemplate );
-		return JSON.stringify( fingerprint( innerBlocks ) ) !== JSON.stringify( fingerprint( freshBlocks ) );
-	};
-
-	const applyVariation = variation => {
-		setAttributes( { ...variation.attributes, variation: variation.name } );
-		if ( variation.innerBlocks ) {
-			replaceInnerBlocks( clientId, createBlocksFromInnerBlocksTemplate( variation.innerBlocks ), false );
-		}
-	};
-
-	const controls = variations?.map( variation => ( {
-		icon: variation.icon?.src || variation.icon,
-		title: variation.label || variation.title,
-		isActive: variation.name === currentVariation,
-		role: 'menuitemradio',
-		onClick: () => {
-			if ( variation.name !== currentVariation ) {
-				if ( hasCustomEdits() ) {
-					setPendingVariation( variation );
-				} else {
-					applyVariation( variation );
-				}
-			}
-		},
-	} ) );
-
-	return (
-		<>
-			<DropdownMenu icon={ layout } label={ __( 'Change layout', 'newspack-blocks' ) } controls={ controls } />
-			{ pendingVariation && (
-				<ConfirmDialog
-					isOpen
-					onConfirm={ () => {
-						applyVariation( pendingVariation );
-						setPendingVariation( null );
-					} }
-					onCancel={ () => setPendingVariation( null ) }
-				>
-					{ __( 'Switching layouts will replace the current block content. Continue?', 'newspack-blocks' ) }
-				</ConfirmDialog>
-			) }
-		</>
 	);
 }
 
@@ -645,12 +550,6 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 	// In nested mode, hide field toggles since publishers control display by adding/removing blocks.
 	const isNestedLayout = layoutVersion === 2;
 
-	const resetLayout = () => {
-		if ( activeVariationTemplate ) {
-			replaceInnerBlocks( clientId, createBlocksFromInnerBlocksTemplate( activeVariationTemplate ), false );
-		}
-	};
-
 	// Inspector controls for display settings
 	const inspectorControls = (
 		<InspectorControls>
@@ -777,19 +676,6 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 					] }
 				/>
 			) }
-			{ isNestedLayout && (
-				<ToolbarGroup>
-					<VariationToolbarDropdown
-						clientId={ clientId }
-						name="newspack-blocks/author-profile"
-						currentVariation={ variation }
-						setAttributes={ setAttributes }
-					/>
-					<ToolbarButton label={ __( 'Reset layout', 'newspack-blocks' ) } onClick={ resetLayout }>
-						{ __( 'Reset', 'newspack-blocks' ) }
-					</ToolbarButton>
-				</ToolbarGroup>
-			) }
 		</BlockControls>
 	);
 
@@ -801,7 +687,7 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 				className="newspack-blocks-author-profile"
 				icon={ postAuthor }
 				label={ __( 'Author Profile', 'newspack-blocks' ) }
-				instructions={ __( 'Select a type to start with.', 'newspack-blocks' ) }
+				instructions={ __( 'Select a type:', 'newspack-blocks' ) }
 			>
 				<Button variant="primary" onClick={ () => setAttributes( { isContextual: true } ) }>
 					{ __( 'Contextual', 'newspack-blocks' ) }

--- a/src/blocks/author-profile/edit.js
+++ b/src/blocks/author-profile/edit.js
@@ -18,7 +18,7 @@ import {
 	CardBody,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalConfirmDialog as ConfirmDialog,
-	Modal,
+	DropdownMenu,
 	Notice,
 	PanelBody,
 	Placeholder,
@@ -28,7 +28,6 @@ import {
 	Toolbar,
 	ToolbarButton,
 	ToolbarGroup,
-	Tooltip,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalUnitControl as UnitControl,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -227,50 +226,86 @@ function VariationPlaceholder( { clientId, name, setAttributes } ) {
 }
 
 /**
- * Modal for switching between layout variations after initial selection.
+ * Toolbar dropdown for switching between layout variations.
  */
-function VariationSwitcherModal( { clientId, name, currentVariation, setAttributes, onClose } ) {
-	const variations = useSelect( select => select( blocksStore ).getBlockVariations( name, 'block' ), [ name ] );
+function VariationToolbarDropdown( { clientId, name, currentVariation, setAttributes } ) {
+	const { variations, innerBlocks, activeTemplate } = useSelect(
+		select => {
+			const allVariations = select( blocksStore ).getBlockVariations( name, 'block' );
+			const active = allVariations?.find( v => v.name === currentVariation );
+			return {
+				variations: allVariations,
+				innerBlocks: select( blockEditorStore ).getBlocks( clientId ),
+				activeTemplate: active?.innerBlocks,
+			};
+		},
+		[ name, clientId, currentVariation ]
+	);
 	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 	const [ pendingVariation, setPendingVariation ] = useState( null );
+
+	const hasCustomEdits = () => {
+		if ( ! activeTemplate ) {
+			return true;
+		}
+		// Compare block structure and attributes, ignoring runtime differences:
+		// - `content`: populated by block bindings (author name, bio, etc.)
+		// - `allowedBlocks`, `templateLock`: structural attrs that evolve with the template
+		// - Inner blocks of dynamic blocks (e.g. social links, populated from author data)
+		const DYNAMIC_BLOCKS = [ 'newspack/author-profile-social' ];
+		const IGNORED_ATTRS = [ 'content', 'allowedBlocks', 'templateLock' ];
+		const fingerprint = blocks =>
+			blocks.map( block => {
+				const attrs = Object.fromEntries( Object.entries( block.attributes ).filter( ( [ key ] ) => ! IGNORED_ATTRS.includes( key ) ) );
+				return {
+					name: block.name,
+					attributes: attrs,
+					innerBlocks: DYNAMIC_BLOCKS.includes( block.name ) ? [] : fingerprint( block.innerBlocks || [] ),
+				};
+			} );
+		const freshBlocks = createBlocksFromInnerBlocksTemplate( activeTemplate );
+		return JSON.stringify( fingerprint( innerBlocks ) ) !== JSON.stringify( fingerprint( freshBlocks ) );
+	};
 
 	const applyVariation = variation => {
 		setAttributes( { variation: variation.name } );
 		if ( variation.innerBlocks ) {
 			replaceInnerBlocks( clientId, createBlocksFromInnerBlocksTemplate( variation.innerBlocks ), false );
 		}
-		onClose();
 	};
 
+	const controls = variations?.map( variation => ( {
+		icon: variation.icon?.src || variation.icon,
+		title: variation.label || variation.title,
+		isActive: variation.name === currentVariation,
+		role: 'menuitemradio',
+		onClick: () => {
+			if ( variation.name !== currentVariation ) {
+				if ( hasCustomEdits() ) {
+					setPendingVariation( variation );
+				} else {
+					applyVariation( variation );
+				}
+			}
+		},
+	} ) );
+
 	return (
-		<Modal title={ __( 'Change layout', 'newspack-blocks' ) } onRequestClose={ onClose }>
-			<div className="newspack-author-profile-variation-switcher">
-				{ variations?.map( variation => (
-					<Tooltip key={ variation.name } text={ variation.description }>
-						<Button
-							className={ `newspack-author-profile-variation-switcher__option${
-								variation.name === currentVariation ? ' is-active' : ''
-							}` }
-							onClick={ () => {
-								if ( variation.name === currentVariation ) {
-									onClose();
-									return;
-								}
-								setPendingVariation( variation );
-							} }
-						>
-							<span className="newspack-author-profile-variation-switcher__icon">{ variation.icon?.src || variation.icon }</span>
-							<span className="newspack-author-profile-variation-switcher__title">{ variation.label || variation.title }</span>
-						</Button>
-					</Tooltip>
-				) ) }
-			</div>
+		<>
+			<DropdownMenu icon={ layout } label={ __( 'Change layout', 'newspack-blocks' ) } controls={ controls } />
 			{ pendingVariation && (
-				<ConfirmDialog isOpen onConfirm={ () => applyVariation( pendingVariation ) } onCancel={ () => setPendingVariation( null ) }>
+				<ConfirmDialog
+					isOpen
+					onConfirm={ () => {
+						applyVariation( pendingVariation );
+						setPendingVariation( null );
+					} }
+					onCancel={ () => setPendingVariation( null ) }
+				>
 					{ __( 'Switching layouts will replace the current block content. Continue?', 'newspack-blocks' ) }
 				</ConfirmDialog>
 			) }
-		</Modal>
+		</>
 	);
 }
 
@@ -326,7 +361,6 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ maxItemsToSuggest, setMaxItemsToSuggest ] = useState( 0 );
 	const [ showSpecificSelector, setShowSpecificSelector ] = useState( false );
-	const [ isVariationSwitcherOpen, setIsVariationSwitcherOpen ] = useState( false );
 	const [ previewAuthorIndex, setPreviewAuthorIndex ] = useState( 0 );
 	const [ socialIconSvgs, setSocialIconSvgs ] = useState( {} );
 
@@ -744,16 +778,15 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 			) }
 			{ isNestedLayout && (
 				<ToolbarGroup>
-					<ToolbarButton
-						icon={ layout }
-						label={ __( 'Change layout', 'newspack-blocks' ) }
-						onClick={ () => setIsVariationSwitcherOpen( true ) }
+					<VariationToolbarDropdown
+						clientId={ clientId }
+						name="newspack-blocks/author-profile"
+						currentVariation={ variation }
+						setAttributes={ setAttributes }
 					/>
-					<Tooltip text={ __( 'Reset layout', 'newspack-blocks' ) }>
-						<ToolbarButton label={ __( 'Reset layout', 'newspack-blocks' ) } onClick={ resetLayout }>
-							{ __( 'Reset', 'newspack-blocks' ) }
-						</ToolbarButton>
-					</Tooltip>
+					<ToolbarButton label={ __( 'Reset layout', 'newspack-blocks' ) } onClick={ resetLayout }>
+						{ __( 'Reset', 'newspack-blocks' ) }
+					</ToolbarButton>
 				</ToolbarGroup>
 			) }
 		</BlockControls>
@@ -953,15 +986,6 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 						templateLock="insert"
 						allowedBlocks={ [ 'core/columns', 'core/group' ] }
 					/>
-					{ isVariationSwitcherOpen && (
-						<VariationSwitcherModal
-							clientId={ clientId }
-							name="newspack-blocks/author-profile"
-							currentVariation={ variation }
-							setAttributes={ setAttributes }
-							onClose={ () => setIsVariationSwitcherOpen( false ) }
-						/>
-					) }
 				</div>
 			</AuthorContext.Provider>
 		);

--- a/src/blocks/author-profile/edit.js
+++ b/src/blocks/author-profile/edit.js
@@ -2,12 +2,23 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { BlockControls, InnerBlocks, InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { createBlocksFromInnerBlocksTemplate, getBlockType, registerBlockBindingsSource } from '@wordpress/blocks';
+import {
+	BlockControls,
+	InnerBlocks,
+	InspectorControls,
+	useBlockProps,
+	store as blockEditorStore,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalBlockVariationPicker as BlockVariationPicker,
+} from '@wordpress/block-editor';
+import { createBlocksFromInnerBlocksTemplate, getBlockType, registerBlockBindingsSource, store as blocksStore } from '@wordpress/blocks';
 import {
 	Button,
 	Card,
 	CardBody,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalConfirmDialog as ConfirmDialog,
+	Modal,
 	Notice,
 	PanelBody,
 	Placeholder,
@@ -31,7 +42,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useEffect, useState, useMemo } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
-import { pencil, postAuthor, pullLeft, pullRight } from '@wordpress/icons';
+import { layout, pencil, postAuthor, pullLeft, pullRight } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -172,151 +183,93 @@ export const avatarSizeOptions = [
 	},
 ];
 
-// Helper to create a bound paragraph block with custom list view name.
-// If wrapInLink is true, the content will be wrapped in an anchor tag for editor preview.
-const createBoundParagraph = ( key, className, name, placeholder, wrapInLink = false ) => {
-	const attributes = {
-		metadata: {
-			name, // Custom name shown in list view.
-			bindings: {
-				content: {
-					source: 'newspack-blocks/author',
-					args: { key },
-				},
-			},
+/**
+ * Variation picker shown when the block has no inner blocks.
+ * Follows the same pattern as the core Columns block.
+ */
+function VariationPlaceholder( { clientId, name, setAttributes } ) {
+	const { blockType, defaultVariation, variations } = useSelect(
+		select => {
+			const { getBlockVariations, getBlockType: _getBlockType, getDefaultBlockVariation } = select( blocksStore );
+			return {
+				blockType: _getBlockType( name ),
+				defaultVariation: getDefaultBlockVariation( name, 'block' ),
+				variations: getBlockVariations( name, 'block' ),
+			};
 		},
-		className,
-		placeholder: placeholder || name,
+		[ name ]
+	);
+	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
+	const blockProps = useBlockProps();
+
+	// Use short labels in the picker to avoid layout overflow.
+	const pickerVariations = variations.map( v => ( {
+		...v,
+		title: v.label || v.title,
+	} ) );
+
+	return (
+		<div { ...blockProps }>
+			<BlockVariationPicker
+				icon={ blockType?.icon?.src }
+				label={ blockType?.title }
+				variations={ pickerVariations }
+				instructions={ __( 'Select a layout to start with.', 'newspack-blocks' ) }
+				onSelect={ ( nextVariation = defaultVariation ) => {
+					setAttributes( { ...nextVariation.attributes, variation: nextVariation.name } );
+					if ( nextVariation.innerBlocks ) {
+						replaceInnerBlocks( clientId, createBlocksFromInnerBlocksTemplate( nextVariation.innerBlocks ), true );
+					}
+				} }
+			/>
+		</div>
+	);
+}
+
+/**
+ * Modal for switching between layout variations after initial selection.
+ */
+function VariationSwitcherModal( { clientId, name, currentVariation, setAttributes, onClose } ) {
+	const variations = useSelect( select => select( blocksStore ).getBlockVariations( name, 'block' ), [ name ] );
+	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
+	const [ pendingVariation, setPendingVariation ] = useState( null );
+
+	const applyVariation = variation => {
+		setAttributes( { variation: variation.name } );
+		if ( variation.innerBlocks ) {
+			replaceInnerBlocks( clientId, createBlocksFromInnerBlocksTemplate( variation.innerBlocks ), false );
+		}
+		onClose();
 	};
 
-	// If wrapInLink is true, set initial content with link wrapper for editor preview.
-	if ( wrapInLink ) {
-		const linkText = placeholder || name;
-		attributes.content = `<a href="#" class="no-op">${ linkText }</a>`;
-	}
-
-	return [ 'core/paragraph', attributes ];
-};
-
-// Template for nested inner blocks.
-// Each author field is a separate block that can be reordered or removed.
-// Block bindings connect core block attributes to author data via 'newspack-blocks/author' source.
-const NESTED_TEMPLATE = [
-	[
-		'core/columns',
-		{ isStackedOnMobile: true, className: 'author-profile-columns', templateLock: 'insert' },
-		[
-			[
-				'core/column',
-				{
-					className: 'author-profile-avatar-column',
-					templateLock: 'insert',
-					allowedBlocks: [ 'newspack/avatar' ],
-				},
-				[ [ 'newspack/avatar', { size: 128 } ] ],
-			],
-			[
-				'core/column',
-				{
-					className: 'author-profile-content-column',
-					templateLock: false,
-					allowedBlocks: [ 'core/heading', 'core/paragraph', 'core/separator', 'core/spacer', 'newspack/author-profile-social' ],
-					style: {
-						spacing: {
-							blockGap: 'var:preset|spacing|20',
-						},
-						elements: {
-							link: {
-								color: {
-									text: 'var:preset|color|contrast-3',
-								},
-							},
-						},
-					},
-					textColor: 'contrast-3',
-					fontSize: 'small',
-				},
-				[
-					[
-						'core/heading',
-						{
-							level: 3,
-							metadata: {
-								name: __( 'Author Name', 'newspack-blocks' ),
-								bindings: {
-									content: {
-										source: 'newspack-blocks/author',
-										args: { key: 'name' },
-									},
-								},
-							},
-							className: 'author-name',
-							placeholder: __( 'Author Name', 'newspack-blocks' ),
-							textColor: 'contrast',
-							fontSize: 'large',
-						},
-					],
-					[
-						'core/paragraph',
-						{
-							metadata: {
-								name: __( 'Job Title', 'newspack-blocks' ),
-								bindings: {
-									content: {
-										source: 'newspack-blocks/author',
-										args: { key: 'newspack_job_title' },
-									},
-								},
-							},
-							className: 'author-job-title',
-							placeholder: __( 'Job Title', 'newspack-blocks' ),
-							style: {
-								typography: {
-									fontStyle: 'normal',
-									fontWeight: '600',
-								},
-								elements: {
-									link: {
-										color: {
-											text: 'var:preset|color|contrast',
-										},
-									},
-								},
-							},
-							textColor: 'contrast',
-						},
-					],
-					createBoundParagraph( 'newspack_role', 'author-role', __( 'Role', 'newspack-blocks' ) ),
-					createBoundParagraph( 'newspack_employer', 'author-employer', __( 'Employer', 'newspack-blocks' ) ),
-					createBoundParagraph( 'bio', 'author-bio', __( 'Biography', 'newspack-blocks' ) ),
-					createBoundParagraph(
-						'archive_link_text',
-						'author-archive-link',
-						sprintf(
-							/* translators: %s: author name. */
-							__( 'More by %s', 'newspack-blocks' ),
-							__( 'Author Name', 'newspack-blocks' )
-						),
-						undefined,
-						true
-					),
-					[
-						'newspack/author-profile-social',
-						{
-							style: {
-								spacing: {
-									padding: {
-										top: 'var:preset|spacing|20',
-									},
-								},
-							},
-						},
-					],
-				],
-			],
-		],
-	],
-];
+	return (
+		<Modal title={ __( 'Change layout', 'newspack-blocks' ) } onRequestClose={ onClose }>
+			<div className="newspack-author-profile-variation-switcher">
+				{ variations.map( variation => (
+					<Button
+						key={ variation.name }
+						className={ `newspack-author-profile-variation-switcher__option${ variation.name === currentVariation ? ' is-active' : '' }` }
+						onClick={ () => {
+							if ( variation.name === currentVariation ) {
+								onClose();
+								return;
+							}
+							setPendingVariation( variation );
+						} }
+					>
+						<span className="newspack-author-profile-variation-switcher__icon">{ variation.icon?.src || variation.icon }</span>
+						<span className="newspack-author-profile-variation-switcher__title">{ variation.label || variation.title }</span>
+					</Button>
+				) ) }
+			</div>
+			{ pendingVariation && (
+				<ConfirmDialog isOpen onConfirm={ () => applyVariation( pendingVariation ) } onCancel={ () => setPendingVariation( null ) }>
+					{ __( 'Switching layouts will replace the current block content. Continue?', 'newspack-blocks' ) }
+				</ConfirmDialog>
+			) }
+		</Modal>
+	);
+}
 
 // Module-level cache for social icon SVGs so multiple block instances share one fetch.
 let socialIconSvgsCache = null;
@@ -370,6 +323,7 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ maxItemsToSuggest, setMaxItemsToSuggest ] = useState( 0 );
 	const [ showSpecificSelector, setShowSpecificSelector ] = useState( false );
+	const [ isVariationSwitcherOpen, setIsVariationSwitcherOpen ] = useState( false );
 	const [ previewAuthorIndex, setPreviewAuthorIndex ] = useState( 0 );
 	const [ socialIconSvgs, setSocialIconSvgs ] = useState( {} );
 
@@ -387,6 +341,7 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 		avatarSize,
 		avatarHideDefault,
 		showEmptyBio,
+		variation,
 	} = attributes;
 	const blockProps = useBlockProps();
 
@@ -435,6 +390,17 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 		return ( theme?.is_block_theme ?? false ) && !! getBlockType( 'newspack/avatar' ) && !! getBlockType( 'newspack/author-profile-social' );
 	}, [] );
 
+	// Check for inner blocks (pattern picker shows when empty).
+	const hasInnerBlocks = useSelect( select => !! select( blockEditorStore ).getBlocks( clientId ).length, [ clientId ] );
+
+	// Look up the active variation's template from the store.
+	const blockVariations = useSelect( select => select( blocksStore ).getBlockVariations( 'newspack-blocks/author-profile', 'block' ), [] );
+	const defaultVariation = useMemo( () => blockVariations?.find( v => v.isDefault ), [ blockVariations ] );
+	const activeVariationTemplate = useMemo( () => {
+		const match = blockVariations?.find( v => v.name === variation );
+		return match?.innerBlocks || defaultVariation?.innerBlocks;
+	}, [ blockVariations, variation, defaultVariation ] );
+
 	// Set layoutVersion to 2 for brand new blocks in block themes.
 	// This persists the mode choice and enables InnerBlocks-based layout.
 	// Only converts unconfigured blocks to preserve existing blocks created in classic themes.
@@ -444,6 +410,16 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 			setAttributes( { layoutVersion: 2 } );
 		}
 	}, [ isNestedMode, layoutVersion, isUnconfiguredBlock, setAttributes ] );
+
+	// Auto-populate inner blocks from variation attribute on mount (e.g., when inserted from a pattern).
+	// Only runs once; subsequent empty states show the variation picker instead of auto-repopulating.
+	const [ didAutoPopulate, setDidAutoPopulate ] = useState( false );
+	useEffect( () => {
+		if ( ! didAutoPopulate && variation && ! hasInnerBlocks && activeVariationTemplate ) {
+			replaceInnerBlocks( clientId, createBlocksFromInnerBlocksTemplate( activeVariationTemplate ), true );
+			setDidAutoPopulate( true );
+		}
+	}, [ didAutoPopulate, variation, hasInnerBlocks, activeVariationTemplate, clientId, replaceInnerBlocks ] );
 
 	// Fetch author for specific mode
 	useEffect( () => {
@@ -632,7 +608,9 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 	const isNestedLayout = layoutVersion === 2;
 
 	const resetLayout = () => {
-		replaceInnerBlocks( clientId, createBlocksFromInnerBlocksTemplate( NESTED_TEMPLATE ), false );
+		if ( activeVariationTemplate ) {
+			replaceInnerBlocks( clientId, createBlocksFromInnerBlocksTemplate( activeVariationTemplate ), false );
+		}
 	};
 
 	// Inspector controls for display settings
@@ -763,6 +741,11 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 			) }
 			{ isNestedLayout && (
 				<ToolbarGroup>
+					<ToolbarButton
+						icon={ layout }
+						label={ __( 'Change layout', 'newspack-blocks' ) }
+						onClick={ () => setIsVariationSwitcherOpen( true ) }
+					/>
 					<Tooltip text={ __( 'Reset layout', 'newspack-blocks' ) }>
 						<ToolbarButton label={ __( 'Reset layout', 'newspack-blocks' ) } onClick={ resetLayout }>
 							{ __( 'Reset', 'newspack-blocks' ) }
@@ -811,6 +794,11 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 					</Placeholder>
 				</div>
 			);
+		}
+
+		// Variation picker: shown when block has no inner blocks.
+		if ( ! hasInnerBlocks ) {
+			return <VariationPlaceholder clientId={ clientId } name="newspack-blocks/author-profile" setAttributes={ setAttributes } />;
 		}
 
 		// Mode selection for new blocks in nested mode
@@ -958,10 +946,19 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 					{ /* Key forces re-render when author changes, which re-evaluates bindings */ }
 					<InnerBlocks
 						key={ `author-${ previewAuthor?.id || 'none' }` }
-						template={ NESTED_TEMPLATE }
+						template={ activeVariationTemplate }
 						templateLock="insert"
-						allowedBlocks={ [ 'core/columns' ] }
+						allowedBlocks={ [ 'core/columns', 'core/group' ] }
 					/>
+					{ isVariationSwitcherOpen && (
+						<VariationSwitcherModal
+							clientId={ clientId }
+							name="newspack-blocks/author-profile"
+							currentVariation={ variation }
+							setAttributes={ setAttributes }
+							onClose={ () => setIsVariationSwitcherOpen( false ) }
+						/>
+					) }
 				</div>
 			</AuthorContext.Provider>
 		);

--- a/src/blocks/author-profile/edit.js
+++ b/src/blocks/author-profile/edit.js
@@ -268,7 +268,7 @@ function VariationToolbarDropdown( { clientId, name, currentVariation, setAttrib
 	};
 
 	const applyVariation = variation => {
-		setAttributes( { variation: variation.name } );
+		setAttributes( { ...variation.attributes, variation: variation.name } );
 		if ( variation.innerBlocks ) {
 			replaceInnerBlocks( clientId, createBlocksFromInnerBlocksTemplate( variation.innerBlocks ), false );
 		}
@@ -450,7 +450,8 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 
 	// Auto-populate inner blocks from variation attribute on mount (e.g., when inserted from a pattern).
 	// Only runs once; subsequent empty states show the variation picker instead of auto-repopulating.
-	const [ didAutoPopulate, setDidAutoPopulate ] = useState( false );
+	// Initialized with hasInnerBlocks so existing blocks (after page reload) don't re-populate.
+	const [ didAutoPopulate, setDidAutoPopulate ] = useState( hasInnerBlocks );
 	useEffect( () => {
 		if ( ! didAutoPopulate && variation && ! hasInnerBlocks && activeVariationTemplate ) {
 			replaceInnerBlocks( clientId, createBlocksFromInnerBlocksTemplate( activeVariationTemplate ), true );

--- a/src/blocks/author-profile/edit.js
+++ b/src/blocks/author-profile/edit.js
@@ -199,11 +199,11 @@ function VariationPlaceholder( { clientId, name, setAttributes } ) {
 		},
 		[ name ]
 	);
-	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
+	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 	const blockProps = useBlockProps();
 
 	// Use short labels in the picker to avoid layout overflow.
-	const pickerVariations = variations.map( v => ( {
+	const pickerVariations = variations?.map( v => ( {
 		...v,
 		title: v.label || v.title,
 	} ) );
@@ -231,7 +231,7 @@ function VariationPlaceholder( { clientId, name, setAttributes } ) {
  */
 function VariationSwitcherModal( { clientId, name, currentVariation, setAttributes, onClose } ) {
 	const variations = useSelect( select => select( blocksStore ).getBlockVariations( name, 'block' ), [ name ] );
-	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
+	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 	const [ pendingVariation, setPendingVariation ] = useState( null );
 
 	const applyVariation = variation => {
@@ -245,7 +245,7 @@ function VariationSwitcherModal( { clientId, name, currentVariation, setAttribut
 	return (
 		<Modal title={ __( 'Change layout', 'newspack-blocks' ) } onRequestClose={ onClose }>
 			<div className="newspack-author-profile-variation-switcher">
-				{ variations.map( variation => (
+				{ variations?.map( variation => (
 					<Button
 						key={ variation.name }
 						className={ `newspack-author-profile-variation-switcher__option${ variation.name === currentVariation ? ' is-active' : '' }` }
@@ -313,7 +313,7 @@ const getPlaceholderAuthor = ( socialIconSvgs = {} ) => {
 };
 
 const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
-	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
+	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 
 	// ALL HOOKS MUST BE CALLED UNCONDITIONALLY (React rules of hooks)
 	const [ author, setAuthor ] = useState( null );

--- a/src/blocks/author-profile/edit.js
+++ b/src/blocks/author-profile/edit.js
@@ -246,20 +246,23 @@ function VariationSwitcherModal( { clientId, name, currentVariation, setAttribut
 		<Modal title={ __( 'Change layout', 'newspack-blocks' ) } onRequestClose={ onClose }>
 			<div className="newspack-author-profile-variation-switcher">
 				{ variations?.map( variation => (
-					<Button
-						key={ variation.name }
-						className={ `newspack-author-profile-variation-switcher__option${ variation.name === currentVariation ? ' is-active' : '' }` }
-						onClick={ () => {
-							if ( variation.name === currentVariation ) {
-								onClose();
-								return;
-							}
-							setPendingVariation( variation );
-						} }
-					>
-						<span className="newspack-author-profile-variation-switcher__icon">{ variation.icon?.src || variation.icon }</span>
-						<span className="newspack-author-profile-variation-switcher__title">{ variation.label || variation.title }</span>
-					</Button>
+					<Tooltip key={ variation.name } text={ variation.description }>
+						<Button
+							className={ `newspack-author-profile-variation-switcher__option${
+								variation.name === currentVariation ? ' is-active' : ''
+							}` }
+							onClick={ () => {
+								if ( variation.name === currentVariation ) {
+									onClose();
+									return;
+								}
+								setPendingVariation( variation );
+							} }
+						>
+							<span className="newspack-author-profile-variation-switcher__icon">{ variation.icon?.src || variation.icon }</span>
+							<span className="newspack-author-profile-variation-switcher__title">{ variation.label || variation.title }</span>
+						</Button>
+					</Tooltip>
 				) ) }
 			</div>
 			{ pendingVariation && (

--- a/src/blocks/author-profile/editor.scss
+++ b/src/blocks/author-profile/editor.scss
@@ -1,3 +1,5 @@
+@use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/variables" as wp-variables;
 @use "../../shared/sass/mixins";
 
 .editor-styles-wrapper {
@@ -57,5 +59,36 @@
 	// Prevent flex layout on the block wrapper (flex is for individual author cards).
 	[data-type="newspack-blocks/author-profile"]:not(.is-nested-mode) {
 		display: block;
+	}
+}
+
+// Variation switcher modal (rendered outside .editor-styles-wrapper).
+.newspack-author-profile-variation-switcher {
+	display: grid;
+	grid-template-columns: repeat( 2, 1fr );
+	gap: wp-variables.$grid-unit-20;
+
+	&__option {
+		display: flex;
+		flex-direction: column;
+		gap: wp-variables.$grid-unit-10;
+		padding: wp-variables.$grid-unit-20;
+		border: 1px solid wp-colors.$gray-300;
+		border-radius: wp-variables.$radius-block-ui;
+		height: auto;
+
+		&:hover,
+		&.is-active {
+			border-color: var(--wp-admin-theme-color);
+		}
+	}
+
+	&__icon svg {
+		width: wp-variables.$grid-unit-60;
+		height: wp-variables.$grid-unit-60;
+	}
+
+	&__title {
+		font-weight: 500;
 	}
 }

--- a/src/blocks/author-profile/editor.scss
+++ b/src/blocks/author-profile/editor.scss
@@ -1,5 +1,3 @@
-@use "~@wordpress/base-styles/colors" as wp-colors;
-@use "~@wordpress/base-styles/variables" as wp-variables;
 @use "../../shared/sass/mixins";
 
 .editor-styles-wrapper {
@@ -59,36 +57,5 @@
 	// Prevent flex layout on the block wrapper (flex is for individual author cards).
 	[data-type="newspack-blocks/author-profile"]:not(.is-nested-mode) {
 		display: block;
-	}
-}
-
-// Variation switcher modal (rendered outside .editor-styles-wrapper).
-.newspack-author-profile-variation-switcher {
-	display: grid;
-	grid-template-columns: repeat( 2, 1fr );
-	gap: wp-variables.$grid-unit-20;
-
-	&__option {
-		display: flex;
-		flex-direction: column;
-		gap: wp-variables.$grid-unit-10;
-		padding: wp-variables.$grid-unit-20;
-		border: 1px solid wp-colors.$gray-300;
-		border-radius: wp-variables.$radius-block-ui;
-		height: auto;
-
-		&:hover,
-		&.is-active {
-			border-color: var(--wp-admin-theme-color);
-		}
-	}
-
-	&__icon svg {
-		width: wp-variables.$grid-unit-60;
-		height: wp-variables.$grid-unit-60;
-	}
-
-	&__title {
-		font-weight: 500;
 	}
 }

--- a/src/blocks/author-profile/index.js
+++ b/src/blocks/author-profile/index.js
@@ -14,6 +14,7 @@ import { postAuthor } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
+import variations from './variations';
 
 /**
  * Style dependencies - will load in editor
@@ -53,6 +54,7 @@ export const settings = {
 		default: '',
 	},
 	edit,
+	variations,
 	// Save inner blocks for nested mode (layoutVersion 2).
 	// For flat mode (layoutVersion 1), return null to use server-side rendering only.
 	save: props => {

--- a/src/blocks/author-profile/templates.js
+++ b/src/blocks/author-profile/templates.js
@@ -1,0 +1,262 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Helper to create a bound paragraph block with custom list view name.
+ * If wrapInLink is true, the content will be wrapped in an anchor tag for editor preview.
+ *
+ * @param {string}  key         Author data key for binding.
+ * @param {string}  className   CSS class for the paragraph.
+ * @param {string}  name        Display name shown in list view.
+ * @param {string}  placeholder Placeholder text (defaults to name).
+ * @param {boolean} wrapInLink  Whether to wrap content in a link.
+ * @return {Array} InnerBlocks template entry for a bound paragraph.
+ */
+const createBoundParagraph = ( key, className, name, placeholder, wrapInLink = false ) => {
+	const attributes = {
+		metadata: {
+			name, // Custom name shown in list view.
+			bindings: {
+				content: {
+					source: 'newspack-blocks/author',
+					args: { key },
+				},
+			},
+		},
+		className,
+		placeholder: placeholder || name,
+	};
+
+	// If wrapInLink is true, set initial content with link wrapper for editor preview.
+	if ( wrapInLink ) {
+		const linkText = placeholder || name;
+		attributes.content = `<a href="#" class="no-op">${ linkText }</a>`;
+	}
+
+	return [ 'core/paragraph', attributes ];
+};
+
+/**
+ * Shared block definition constants.
+ */
+
+// Styles applied to the content column in column-based layouts.
+const CONTENT_COLUMN_ATTRS = Object.freeze( {
+	className: 'author-profile-content-column',
+	templateLock: false,
+	allowedBlocks: [ 'core/heading', 'core/paragraph', 'core/separator', 'core/spacer', 'newspack/author-profile-social' ],
+	style: {
+		spacing: {
+			blockGap: 'var:preset|spacing|20',
+		},
+		elements: {
+			link: {
+				color: {
+					text: 'var:preset|color|contrast-3',
+				},
+			},
+		},
+	},
+	textColor: 'contrast-3',
+	fontSize: 'small',
+} );
+
+// Author name heading block.
+const HEADING_BLOCK = [
+	'core/heading',
+	{
+		level: 3,
+		metadata: {
+			name: __( 'Author Name', 'newspack-blocks' ),
+			bindings: {
+				content: {
+					source: 'newspack-blocks/author',
+					args: { key: 'name' },
+				},
+			},
+		},
+		className: 'author-name',
+		placeholder: __( 'Author Name', 'newspack-blocks' ),
+		textColor: 'contrast',
+		fontSize: 'large',
+	},
+];
+
+// Job title paragraph block with bold styling.
+const JOB_TITLE_BLOCK = [
+	'core/paragraph',
+	{
+		metadata: {
+			name: __( 'Job Title', 'newspack-blocks' ),
+			bindings: {
+				content: {
+					source: 'newspack-blocks/author',
+					args: { key: 'newspack_job_title' },
+				},
+			},
+		},
+		className: 'author-job-title',
+		placeholder: __( 'Job Title', 'newspack-blocks' ),
+		style: {
+			typography: {
+				fontStyle: 'normal',
+				fontWeight: '600',
+			},
+			elements: {
+				link: {
+					color: {
+						text: 'var:preset|color|contrast',
+					},
+				},
+			},
+		},
+		textColor: 'contrast',
+	},
+];
+
+// Bound paragraph blocks for author fields.
+const ROLE_BLOCK = createBoundParagraph( 'newspack_role', 'author-role', __( 'Role', 'newspack-blocks' ) );
+const EMPLOYER_BLOCK = createBoundParagraph( 'newspack_employer', 'author-employer', __( 'Employer', 'newspack-blocks' ) );
+const BIO_BLOCK = createBoundParagraph( 'bio', 'author-bio', __( 'Biography', 'newspack-blocks' ) );
+
+const archiveLinkLabel = sprintf(
+	/* translators: %s: author name. */
+	__( 'More by %s', 'newspack-blocks' ),
+	__( 'Author Name', 'newspack-blocks' )
+);
+const ARCHIVE_LINK_BLOCK = createBoundParagraph( 'archive_link_text', 'author-archive-link', archiveLinkLabel, undefined, true );
+
+// Social icons block with top padding.
+const SOCIAL_BLOCK = [
+	'newspack/author-profile-social',
+	{
+		style: {
+			spacing: {
+				padding: {
+					top: 'var:preset|spacing|20',
+				},
+			},
+		},
+	},
+];
+
+/**
+ * Returns a copy of a block template entry with center alignment added.
+ * Uses `textAlign` for headings, `align` for paragraphs.
+ *
+ * @param {Array}  block   InnerBlocks template entry [blockName, attributes].
+ * @param {string} block.0 Block name.
+ * @param {Object} block.1 Block attributes.
+ * @return {Array} New template entry with center alignment.
+ */
+const centered = ( [ blockName, attrs ] ) => [
+	blockName,
+	{ ...attrs, ...( blockName === 'core/heading' ? { textAlign: 'center' } : { align: 'center' } ) },
+];
+
+// Shared group styles for centered and compact layouts.
+const GROUP_STYLES = Object.freeze( {
+	spacing: {
+		blockGap: 'var:preset|spacing|20',
+	},
+	elements: {
+		link: {
+			color: {
+				text: 'var:preset|color|contrast-3',
+			},
+		},
+	},
+} );
+
+// Content blocks shared across all layouts.
+// Shared references are frozen to prevent accidental mutation across templates.
+const CONTENT_BLOCKS = Object.freeze( [ HEADING_BLOCK, JOB_TITLE_BLOCK, ROLE_BLOCK, EMPLOYER_BLOCK, BIO_BLOCK, ARCHIVE_LINK_BLOCK, SOCIAL_BLOCK ] );
+
+// -- Layout Templates --------------------------------------------------------
+
+/**
+ * Default layout: avatar on the left, content on the right.
+ */
+export const DEFAULT_TEMPLATE = [
+	[
+		'core/columns',
+		{ isStackedOnMobile: true, className: 'author-profile-columns', templateLock: 'insert' },
+		[
+			[
+				'core/column',
+				{
+					className: 'author-profile-avatar-column',
+					templateLock: 'insert',
+					allowedBlocks: [ 'newspack/avatar' ],
+				},
+				[ [ 'newspack/avatar', { size: 128 } ] ],
+			],
+			[ 'core/column', CONTENT_COLUMN_ATTRS, CONTENT_BLOCKS ],
+		],
+	],
+];
+
+/**
+ * Avatar right layout: content on the left, avatar on the right.
+ */
+export const AVATAR_RIGHT_TEMPLATE = [
+	[
+		'core/columns',
+		{ isStackedOnMobile: true, className: 'author-profile-columns', templateLock: 'insert' },
+		[
+			[ 'core/column', CONTENT_COLUMN_ATTRS, CONTENT_BLOCKS ],
+			[
+				'core/column',
+				{
+					className: 'author-profile-avatar-column',
+					templateLock: 'insert',
+					allowedBlocks: [ 'newspack/avatar' ],
+				},
+				[ [ 'newspack/avatar', { size: 128 } ] ],
+			],
+		],
+	],
+];
+
+/**
+ * Centered layout: large centered avatar with center-aligned text.
+ */
+export const CENTERED_TEMPLATE = [
+	[
+		'core/group',
+		{
+			layout: { type: 'flex', orientation: 'vertical', justifyContent: 'center' },
+			style: GROUP_STYLES,
+			textColor: 'contrast-3',
+			fontSize: 'small',
+		},
+		[
+			[ 'newspack/avatar', { size: 200 } ],
+			centered( HEADING_BLOCK ),
+			centered( JOB_TITLE_BLOCK ),
+			centered( ROLE_BLOCK ),
+			centered( EMPLOYER_BLOCK ),
+			centered( BIO_BLOCK ),
+			centered( ARCHIVE_LINK_BLOCK ),
+			SOCIAL_BLOCK,
+		],
+	],
+];
+
+/**
+ * Compact layout: no avatar.
+ */
+export const COMPACT_TEMPLATE = [
+	[
+		'core/group',
+		{
+			layout: { type: 'flex', orientation: 'vertical' },
+			style: GROUP_STYLES,
+			textColor: 'contrast-3',
+			fontSize: 'small',
+		},
+		CONTENT_BLOCKS,
+	],
+];

--- a/src/blocks/author-profile/templates.js
+++ b/src/blocks/author-profile/templates.js
@@ -171,7 +171,7 @@ const GROUP_STYLES = Object.freeze( {
 } );
 
 // Content blocks shared across all layouts.
-// Shared references are frozen to prevent accidental mutation across templates.
+// Shallow-frozen to prevent push/splice; nested block definitions are safe because templates compose via spread.
 const CONTENT_BLOCKS = Object.freeze( [ HEADING_BLOCK, JOB_TITLE_BLOCK, ROLE_BLOCK, EMPLOYER_BLOCK, BIO_BLOCK, ARCHIVE_LINK_BLOCK, SOCIAL_BLOCK ] );
 
 // -- Layout Templates --------------------------------------------------------

--- a/src/blocks/author-profile/templates.js
+++ b/src/blocks/author-profile/templates.js
@@ -177,9 +177,9 @@ const CONTENT_BLOCKS = Object.freeze( [ HEADING_BLOCK, JOB_TITLE_BLOCK, ROLE_BLO
 // -- Layout Templates --------------------------------------------------------
 
 /**
- * Default layout: avatar on the left, content on the right.
+ * Avatar left layout: avatar on the left, content on the right.
  */
-export const DEFAULT_TEMPLATE = [
+export const AVATAR_LEFT_TEMPLATE = [
 	[
 		'core/columns',
 		{ isStackedOnMobile: true, className: 'author-profile-columns', templateLock: 'insert' },

--- a/src/blocks/author-profile/variations.js
+++ b/src/blocks/author-profile/variations.js
@@ -1,0 +1,111 @@
+/**
+ * Newspack dependencies
+ */
+import colors from 'newspack-colors';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { SVG, Circle, Rect } from '@wordpress/primitives';
+
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_TEMPLATE, AVATAR_RIGHT_TEMPLATE, CENTERED_TEMPLATE, COMPACT_TEMPLATE } from './templates';
+
+const ICON_COLOR = colors[ 'primary-400' ];
+
+// Variation icons: abstract layout representations.
+// Circle represents the avatar, rectangles represent text lines.
+
+const iconDefault = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+		<Circle cx="12" cy="24" r="8" />
+		<Rect x="26" y="14" width="16" height="3" rx="1.5" />
+		<Rect x="26" y="20" width="12" height="2" rx="1" />
+		<Rect x="26" y="26" width="16" height="2" rx="1" />
+		<Rect x="26" y="32" width="10" height="2" rx="1" />
+	</SVG>
+);
+
+const iconAvatarRight = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+		<Rect x="6" y="14" width="16" height="3" rx="1.5" />
+		<Rect x="6" y="20" width="12" height="2" rx="1" />
+		<Rect x="6" y="26" width="16" height="2" rx="1" />
+		<Rect x="6" y="32" width="10" height="2" rx="1" />
+		<Circle cx="36" cy="24" r="8" />
+	</SVG>
+);
+
+const iconCentered = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+		<Circle cx="24" cy="14" r="8" />
+		<Rect x="14" y="26" width="20" height="3" rx="1.5" />
+		<Rect x="16" y="32" width="16" height="2" rx="1" />
+		<Rect x="12" y="38" width="24" height="2" rx="1" />
+	</SVG>
+);
+
+const iconCompact = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+		<Rect x="6" y="16" width="20" height="3" rx="1.5" />
+		<Rect x="6" y="23" width="36" height="2" rx="1" />
+		<Rect x="6" y="29" width="30" height="2" rx="1" />
+		<Rect x="6" y="35" width="12" height="2" rx="1" />
+	</SVG>
+);
+
+// `label` is a custom property (not part of the WordPress variation API).
+// It provides a short title for picker UIs, while `title` includes the block
+// name for contexts like the list view and sidebar where extra context helps.
+const variations = [
+	{
+		name: 'default',
+		title: __( 'Author Profile', 'newspack-blocks' ),
+		label: __( 'Default', 'newspack-blocks' ),
+		description: __( 'Avatar on the left, content on the right.', 'newspack-blocks' ),
+		icon: { src: iconDefault, foreground: ICON_COLOR },
+		attributes: { variation: 'default' },
+		innerBlocks: DEFAULT_TEMPLATE,
+		isActive: [ 'variation' ],
+		scope: [ 'block' ],
+		isDefault: true,
+	},
+	{
+		name: 'avatar-right',
+		title: __( 'Author Profile (Avatar right)', 'newspack-blocks' ),
+		label: __( 'Avatar right', 'newspack-blocks' ),
+		description: __( 'Content on the left, avatar on the right.', 'newspack-blocks' ),
+		icon: { src: iconAvatarRight, foreground: ICON_COLOR },
+		attributes: { variation: 'avatar-right' },
+		innerBlocks: AVATAR_RIGHT_TEMPLATE,
+		isActive: [ 'variation' ],
+		scope: [ 'block' ],
+	},
+	{
+		name: 'centered',
+		title: __( 'Author Profile (Centered)', 'newspack-blocks' ),
+		label: __( 'Centered', 'newspack-blocks' ),
+		description: __( 'Large centered avatar with center-aligned text.', 'newspack-blocks' ),
+		icon: { src: iconCentered, foreground: ICON_COLOR },
+		attributes: { variation: 'centered' },
+		innerBlocks: CENTERED_TEMPLATE,
+		isActive: [ 'variation' ],
+		scope: [ 'block' ],
+	},
+	{
+		name: 'compact',
+		title: __( 'Author Profile (Compact)', 'newspack-blocks' ),
+		label: __( 'Compact', 'newspack-blocks' ),
+		description: __( 'No avatar, vertical stack.', 'newspack-blocks' ),
+		icon: { src: iconCompact, foreground: ICON_COLOR },
+		attributes: { variation: 'compact' },
+		innerBlocks: COMPACT_TEMPLATE,
+		isActive: [ 'variation' ],
+		scope: [ 'block' ],
+	},
+];
+
+export default variations;

--- a/src/blocks/author-profile/variations.js
+++ b/src/blocks/author-profile/variations.js
@@ -43,53 +43,42 @@ const iconCompact = (
 	</SVG>
 );
 
-// `label` is a custom property (not part of the WordPress variation API).
-// It provides a short title for picker UIs, while `title` includes the block
-// name for contexts like the list view and sidebar where extra context helps.
 const variations = [
 	{
-		name: 'default',
-		title: __( 'Author Profile', 'newspack-blocks' ),
-		label: __( 'Default', 'newspack-blocks' ),
+		name: 'avatar-left',
+		title: __( 'Avatar left', 'newspack-blocks' ),
 		description: __( 'Avatar on the left, content on the right.', 'newspack-blocks' ),
 		icon: { src: iconAvatarLeft, foreground: ICON_COLOR },
-		attributes: { variation: 'default' },
+		attributes: { variation: 'avatar-left' },
 		innerBlocks: DEFAULT_TEMPLATE,
-		isActive: [ 'variation' ],
 		scope: [ 'block' ],
 		isDefault: true,
 	},
 	{
 		name: 'avatar-right',
-		title: __( 'Author Profile (Avatar right)', 'newspack-blocks' ),
-		label: __( 'Avatar right', 'newspack-blocks' ),
+		title: __( 'Avatar right', 'newspack-blocks' ),
 		description: __( 'Content on the left, avatar on the right.', 'newspack-blocks' ),
 		icon: { src: iconAvatarRight, foreground: ICON_COLOR },
 		attributes: { variation: 'avatar-right' },
 		innerBlocks: AVATAR_RIGHT_TEMPLATE,
-		isActive: [ 'variation' ],
 		scope: [ 'block' ],
 	},
 	{
 		name: 'centered',
-		title: __( 'Author Profile (Centered)', 'newspack-blocks' ),
-		label: __( 'Centered', 'newspack-blocks' ),
+		title: __( 'Centered', 'newspack-blocks' ),
 		description: __( 'Large centered avatar with center-aligned text.', 'newspack-blocks' ),
 		icon: { src: iconCentered, foreground: ICON_COLOR },
 		attributes: { variation: 'centered' },
 		innerBlocks: CENTERED_TEMPLATE,
-		isActive: [ 'variation' ],
 		scope: [ 'block' ],
 	},
 	{
 		name: 'compact',
-		title: __( 'Author Profile (Compact)', 'newspack-blocks' ),
-		label: __( 'Compact', 'newspack-blocks' ),
+		title: __( 'Compact', 'newspack-blocks' ),
 		description: __( 'No avatar, vertical stack.', 'newspack-blocks' ),
 		icon: { src: iconCompact, foreground: ICON_COLOR },
 		attributes: { variation: 'compact' },
 		innerBlocks: COMPACT_TEMPLATE,
-		isActive: [ 'variation' ],
 		scope: [ 'block' ],
 	},
 ];

--- a/src/blocks/author-profile/variations.js
+++ b/src/blocks/author-profile/variations.js
@@ -12,7 +12,7 @@ import { SVG, Path } from '@wordpress/primitives';
 /**
  * Internal dependencies
  */
-import { DEFAULT_TEMPLATE, AVATAR_RIGHT_TEMPLATE, CENTERED_TEMPLATE, COMPACT_TEMPLATE } from './templates';
+import { AVATAR_LEFT_TEMPLATE, AVATAR_RIGHT_TEMPLATE, CENTERED_TEMPLATE, COMPACT_TEMPLATE } from './templates';
 
 const ICON_COLOR = colors[ 'primary-400' ];
 
@@ -50,7 +50,7 @@ const variations = [
 		description: __( 'Avatar on the left, content on the right.', 'newspack-blocks' ),
 		icon: { src: iconAvatarLeft, foreground: ICON_COLOR },
 		attributes: { variation: 'avatar-left' },
-		innerBlocks: DEFAULT_TEMPLATE,
+		innerBlocks: AVATAR_LEFT_TEMPLATE,
 		scope: [ 'block' ],
 		isDefault: true,
 	},

--- a/src/blocks/author-profile/variations.js
+++ b/src/blocks/author-profile/variations.js
@@ -7,7 +7,7 @@ import colors from 'newspack-colors';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { SVG, Circle, Rect } from '@wordpress/primitives';
+import { SVG, Path } from '@wordpress/primitives';
 
 /**
  * Internal dependencies
@@ -19,41 +19,27 @@ const ICON_COLOR = colors[ 'primary-400' ];
 // Variation icons: abstract layout representations.
 // Circle represents the avatar, rectangles represent text lines.
 
-const iconDefault = (
+const iconAvatarLeft = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
-		<Circle cx="12" cy="24" r="8" />
-		<Rect x="26" y="14" width="16" height="3" rx="1.5" />
-		<Rect x="26" y="20" width="12" height="2" rx="1" />
-		<Rect x="26" y="26" width="16" height="2" rx="1" />
-		<Rect x="26" y="32" width="10" height="2" rx="1" />
+		<Path d="M31 33H17V32H31V33ZM39 30H17V29H39V30ZM37 27H17V26H37V27ZM41 24H17V23H41V24ZM11 15C13.2091 15 15 16.7909 15 19C15 21.2091 13.2091 23 11 23C8.79086 23 7 21.2091 7 19C7 16.7909 8.79086 15 11 15ZM37 21H17V20H37V21ZM41 18H17V15H41V18Z" />
 	</SVG>
 );
 
 const iconAvatarRight = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
-		<Rect x="6" y="14" width="16" height="3" rx="1.5" />
-		<Rect x="6" y="20" width="12" height="2" rx="1" />
-		<Rect x="6" y="26" width="16" height="2" rx="1" />
-		<Rect x="6" y="32" width="10" height="2" rx="1" />
-		<Circle cx="36" cy="24" r="8" />
+		<Path d="M21 33H7V32H21V33ZM29 30H7V29H29V30ZM27 27H7V26H27V27ZM31 24H7V23H31V24ZM37 15C39.2091 15 41 16.7909 41 19C41 21.2091 39.2091 23 37 23C34.7909 23 33 21.2091 33 19C33 16.7909 34.7909 15 37 15ZM27 21H7V20H27V21ZM31 18H7V15H31V18Z" />
 	</SVG>
 );
 
 const iconCentered = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
-		<Circle cx="24" cy="14" r="8" />
-		<Rect x="14" y="26" width="20" height="3" rx="1.5" />
-		<Rect x="16" y="32" width="16" height="2" rx="1" />
-		<Rect x="12" y="38" width="24" height="2" rx="1" />
+		<Path d="M36 38H12V37H36V38ZM40 35H8V34H40V35ZM39 32H9V31H39V32ZM41 29H7V28H41V29ZM39 26H9V25H39V26ZM41 23H7V20H41V23ZM24 10C26.2091 10 27.9999 11.791 28 14C28 16.2091 26.2091 18 24 18C21.7909 18 20 16.2091 20 14C20.0001 11.791 21.7909 10 24 10Z" />
 	</SVG>
 );
 
 const iconCompact = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
-		<Rect x="6" y="16" width="20" height="3" rx="1.5" />
-		<Rect x="6" y="23" width="36" height="2" rx="1" />
-		<Rect x="6" y="29" width="30" height="2" rx="1" />
-		<Rect x="6" y="35" width="12" height="2" rx="1" />
+		<Path d="M31 33H7V32H31V33ZM39 30H7V29H39V30ZM37 27H7V26H37V27ZM41 24H7V23H41V24ZM37 21H7V20H37V21ZM41 18H7V15H41V18Z" />
 	</SVG>
 );
 
@@ -66,7 +52,7 @@ const variations = [
 		title: __( 'Author Profile', 'newspack-blocks' ),
 		label: __( 'Default', 'newspack-blocks' ),
 		description: __( 'Avatar on the left, content on the right.', 'newspack-blocks' ),
-		icon: { src: iconDefault, foreground: ICON_COLOR },
+		icon: { src: iconAvatarLeft, foreground: ICON_COLOR },
 		attributes: { variation: 'default' },
 		innerBlocks: DEFAULT_TEMPLATE,
 		isActive: [ 'variation' ],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When inserting the Author Profile block in a block theme, publishers can now choose from four layout variations: Default (avatar left), Avatar right, Centered, and Compact (no avatar). Each variation provides the same set of author fields so publishers can remove what they don't need without worrying about losing fields they can't add back.

After choosing a layout, a "Change layout" button in the toolbar lets publishers switch to a different variation. A confirmation dialog warns that switching will replace the current block content. A "Reset" button restores the current variation's original layout.

Closes NPPD-1221.

### How to test the changes in this Pull Request:

1. Open a post editor in a block theme environment.
2. Insert a new Author Profile block and verify a layout picker appears with 4 options.
3. Select each variation and verify the inner blocks match the expected layout.
4. In the list view and sidebar, verify each variation shows its name (e.g., "Author Profile (Centered)") with a blue icon.
5. Click "Change layout" in the toolbar and verify the currently active variation is highlighted.
6. Click a different variation, confirm the dialog appears, accept it, and verify inner blocks are replaced.
7. Cancel the dialog on a different attempt and verify nothing changes.
8. Remove some inner blocks, then click "Reset" and verify the block resets to the current variation's full template.
9. Add the Author Profile block in the site editor and verify the variation picker and layout switching work correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?