### PR TITLE
fix(modal-checkout): suppress WooPayments express checkout when Stripe is active

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -530,8 +530,24 @@ final class Modal_Checkout {
 		if ( ! self::is_modal_checkout() ) {
 			return $settings;
 		}
+		// Disable WooPay (Woo's hosted checkout experience) — not supported in the modal.
 		if ( isset( $settings['platform_checkout'] ) ) {
 			$settings['platform_checkout'] = 'no';
+		}
+		// If Stripe's express checkout is active, suppress WooPayments' express checkout
+		// (payment_request) to prevent duplicate Apple Pay / Google Pay buttons in the modal.
+		// Stripe is preferred: Newspack already manages its express checkout behavior (see
+		// class-woocommerce-gateway-stripe.php), and WooPayments is already partially filtered
+		// above (platform_checkout). WooPayments is suppressed, not the reverse.
+		if ( class_exists( 'WC_Stripe' ) ) {
+			$stripe_settings = get_option( 'woocommerce_stripe_settings', [] );
+			if ( isset( $stripe_settings['express_checkout'] ) && 'yes' === $stripe_settings['express_checkout'] ) {
+				if ( isset( $settings['express_checkout_checkout_methods'] ) ) {
+					$settings['express_checkout_checkout_methods'] = array_values(
+						array_diff( $settings['express_checkout_checkout_methods'], [ 'payment_request' ] )
+					);
+				}
+			}
 		}
 		return $settings;
 	}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -593,12 +593,12 @@ final class Modal_Checkout {
 		if ( ! isset( $GLOBALS['wp_filter']['woocommerce_checkout_before_customer_details'] ) ) {
 			return;
 		}
-		$filters = $GLOBALS['wp_filter']['woocommerce_checkout_before_customer_details'];
-		foreach ( $filters as $index => $filter ) {
-			$keys = array_keys( $filter );
-			foreach ( $keys as $key ) {
+		$hook      = $GLOBALS['wp_filter']['woocommerce_checkout_before_customer_details'];
+		$callbacks = $hook instanceof \WP_Hook ? $hook->callbacks : (array) $hook;
+		foreach ( $callbacks as $priority => $priority_callbacks ) {
+			foreach ( array_keys( $priority_callbacks ) as $key ) {
 				if ( strpos( $key, 'display_express_checkout_buttons' ) !== false ) {
-					remove_action( 'woocommerce_checkout_before_customer_details', $key, $index );
+					remove_action( 'woocommerce_checkout_before_customer_details', $key, $priority );
 				}
 			}
 		}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -544,7 +544,7 @@ final class Modal_Checkout {
 			if ( isset( $stripe_settings['express_checkout'] ) && 'yes' === $stripe_settings['express_checkout'] ) {
 				if ( isset( $settings['express_checkout_checkout_methods'] ) ) {
 					$settings['express_checkout_checkout_methods'] = array_values(
-						array_diff( $settings['express_checkout_checkout_methods'], [ 'payment_request' ] )
+						array_diff( (array) $settings['express_checkout_checkout_methods'], [ 'payment_request' ] )
 					);
 				}
 			}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -536,9 +536,9 @@ final class Modal_Checkout {
 		}
 		// If Stripe's express checkout is active, suppress WooPayments' express checkout
 		// (payment_request) to prevent duplicate Apple Pay / Google Pay buttons in the modal.
-		// Stripe is preferred: Newspack already manages its express checkout behavior (see
-		// newspack-plugin/includes/plugins/class-woocommerce-gateway-stripe.php), and WooPayments
-		// is already partially filtered above (platform_checkout). WooPayments is suppressed, not the reverse.
+		// Stripe is preferred here because Newspack already keys this behavior off the Stripe
+		// gateway settings below, while WooPayments is already partially filtered above via
+		// platform_checkout. WooPayments is suppressed, not the reverse.
 		$stripe_settings = get_option( 'woocommerce_stripe_settings', [] );
 		if ( isset( $stripe_settings['enabled'], $stripe_settings['express_checkout'] )
 			&& 'yes' === $stripe_settings['enabled']

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -177,6 +177,7 @@ final class Modal_Checkout {
 		add_action( 'wp_ajax_nopriv_process_name_your_price_request', [ __CLASS__, 'process_name_your_price_request' ] );
 		add_filter( 'option_woocommerce_woocommerce_payments_settings', [ __CLASS__, 'filter_woocommerce_payments_settings' ] );
 		add_action( 'init', [ __CLASS__, 'unhook_woocommerce_payments_update_billing_fields' ] );
+		add_action( 'init', [ __CLASS__, 'unhook_woocommerce_payments_express_checkout_buttons' ], 20 );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'update_password_strength_message' ], 9999 );
 		add_filter( 'woocommerce_enforce_password_strength_meter_on_checkout', '__return_true' );
 
@@ -530,23 +531,8 @@ final class Modal_Checkout {
 		if ( ! self::is_modal_checkout() ) {
 			return $settings;
 		}
-		// Disable WooPay (Woo's hosted checkout experience) — not supported in the modal.
 		if ( isset( $settings['platform_checkout'] ) ) {
 			$settings['platform_checkout'] = 'no';
-		}
-		// If Stripe's express checkout is active, suppress WooPayments' express checkout
-		// (payment_request) to prevent duplicate Apple Pay / Google Pay buttons in the modal.
-		// Stripe is preferred here because Newspack already keys this behavior off the Stripe
-		// gateway settings below, while WooPayments is already partially filtered above via
-		// platform_checkout. WooPayments is suppressed, not the reverse.
-		$stripe_settings = get_option( 'woocommerce_stripe_settings', [] );
-		if ( isset( $stripe_settings['enabled'], $stripe_settings['express_checkout'] )
-			&& 'yes' === $stripe_settings['enabled']
-			&& 'yes' === $stripe_settings['express_checkout'] ) {
-			// Always write the key — if it's absent from the DB, WooPayments falls back to its
-			// hardcoded default (['payment_request', 'woopay', 'amazon_pay']), bypassing this filter.
-			$methods = (array) ( $settings['express_checkout_checkout_methods'] ?? [ 'payment_request', 'woopay', 'amazon_pay' ] );
-			$settings['express_checkout_checkout_methods'] = array_values( array_diff( $methods, [ 'payment_request' ] ) );
 		}
 		return $settings;
 	}
@@ -575,6 +561,44 @@ final class Modal_Checkout {
 			foreach ( $keys as $key ) {
 				if ( strpos( $key, 'checkout_update_email_field_priority' ) !== false ) {
 					remove_filter( 'woocommerce_billing_fields', $key, $index );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Unhook WooCommerce Payments' express checkout buttons during modal checkout.
+	 *
+	 * WooPayments 10.4 split Apple Pay / Google Pay into separate gateways. The display
+	 * handler attaches display_express_checkout_buttons to woocommerce_checkout_before_customer_details
+	 * at init priority 15; when Stripe's express checkout is also active the modal renders
+	 * duplicate Apple Pay / Google Pay rows. Removing the hook here suppresses WooPayments'
+	 * buttons while leaving Stripe's intact. Hooked on init at priority 20 so WooPayments'
+	 * init callback has already attached its actions.
+	 */
+	public static function unhook_woocommerce_payments_express_checkout_buttons() {
+		if ( ! self::is_modal_checkout() ) {
+			return;
+		}
+		if ( ! class_exists( 'WC_Payments' ) ) {
+			return;
+		}
+		// Only suppress WooPayments when Stripe is also providing express checkout. Otherwise
+		// WooPayments is the only source of Apple Pay / Google Pay in the modal and must render.
+		$stripe_settings = get_option( 'woocommerce_stripe_settings', [] );
+		if ( 'yes' !== ( $stripe_settings['enabled'] ?? '' )
+			|| 'yes' !== ( $stripe_settings['express_checkout'] ?? '' ) ) {
+			return;
+		}
+		if ( ! isset( $GLOBALS['wp_filter']['woocommerce_checkout_before_customer_details'] ) ) {
+			return;
+		}
+		$filters = $GLOBALS['wp_filter']['woocommerce_checkout_before_customer_details'];
+		foreach ( $filters as $index => $filter ) {
+			$keys = array_keys( $filter );
+			foreach ( $keys as $key ) {
+				if ( strpos( $key, 'display_express_checkout_buttons' ) !== false ) {
+					remove_action( 'woocommerce_checkout_before_customer_details', $key, $index );
 				}
 			}
 		}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -543,11 +543,10 @@ final class Modal_Checkout {
 		if ( isset( $stripe_settings['enabled'], $stripe_settings['express_checkout'] )
 			&& 'yes' === $stripe_settings['enabled']
 			&& 'yes' === $stripe_settings['express_checkout'] ) {
-			if ( isset( $settings['express_checkout_checkout_methods'] ) ) {
-				$settings['express_checkout_checkout_methods'] = array_values(
-					array_diff( (array) $settings['express_checkout_checkout_methods'], [ 'payment_request' ] )
-				);
-			}
+			// Always write the key — if it's absent from the DB, WooPayments falls back to its
+			// hardcoded default (['payment_request', 'woopay', 'amazon_pay']), bypassing this filter.
+			$methods = (array) ( $settings['express_checkout_checkout_methods'] ?? [ 'payment_request', 'woopay', 'amazon_pay' ] );
+			$settings['express_checkout_checkout_methods'] = array_values( array_diff( $methods, [ 'payment_request' ] ) );
 		}
 		return $settings;
 	}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -539,14 +539,14 @@ final class Modal_Checkout {
 		// Stripe is preferred: Newspack already manages its express checkout behavior (see
 		// newspack-plugin/includes/plugins/class-woocommerce-gateway-stripe.php), and WooPayments
 		// is already partially filtered above (platform_checkout). WooPayments is suppressed, not the reverse.
-		if ( class_exists( 'WC_Stripe' ) ) {
-			$stripe_settings = get_option( 'woocommerce_stripe_settings', [] );
-			if ( isset( $stripe_settings['express_checkout'] ) && 'yes' === $stripe_settings['express_checkout'] ) {
-				if ( isset( $settings['express_checkout_checkout_methods'] ) ) {
-					$settings['express_checkout_checkout_methods'] = array_values(
-						array_diff( (array) $settings['express_checkout_checkout_methods'], [ 'payment_request' ] )
-					);
-				}
+		$stripe_settings = get_option( 'woocommerce_stripe_settings', [] );
+		if ( isset( $stripe_settings['enabled'], $stripe_settings['express_checkout'] )
+			&& 'yes' === $stripe_settings['enabled']
+			&& 'yes' === $stripe_settings['express_checkout'] ) {
+			if ( isset( $settings['express_checkout_checkout_methods'] ) ) {
+				$settings['express_checkout_checkout_methods'] = array_values(
+					array_diff( (array) $settings['express_checkout_checkout_methods'], [ 'payment_request' ] )
+				);
 			}
 		}
 		return $settings;

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -580,7 +580,7 @@ final class Modal_Checkout {
 		if ( ! self::is_modal_checkout() ) {
 			return;
 		}
-		if ( ! class_exists( 'WC_Payments' ) ) {
+		if ( ! class_exists( 'WC_Payments' ) || ! class_exists( 'WC_Stripe' ) ) {
 			return;
 		}
 		// Only suppress WooPayments when Stripe is also providing express checkout. Otherwise
@@ -603,7 +603,6 @@ final class Modal_Checkout {
 			}
 		}
 	}
-
 
 	/**
 	 * Process name your price request for modal.

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -537,8 +537,8 @@ final class Modal_Checkout {
 		// If Stripe's express checkout is active, suppress WooPayments' express checkout
 		// (payment_request) to prevent duplicate Apple Pay / Google Pay buttons in the modal.
 		// Stripe is preferred: Newspack already manages its express checkout behavior (see
-		// class-woocommerce-gateway-stripe.php), and WooPayments is already partially filtered
-		// above (platform_checkout). WooPayments is suppressed, not the reverse.
+		// newspack-plugin/includes/plugins/class-woocommerce-gateway-stripe.php), and WooPayments
+		// is already partially filtered above (platform_checkout). WooPayments is suppressed, not the reverse.
 		if ( class_exists( 'WC_Stripe' ) ) {
 			$stripe_settings = get_option( 'woocommerce_stripe_settings', [] );
 			if ( isset( $stripe_settings['express_checkout'] ) && 'yes' === $stripe_settings['express_checkout'] ) {


### PR DESCRIPTION
### All Submissions:
* [x] Have you followed the Newspack Contributing guideline?
* [x] Does your code follow the WordPress' coding standards and VIP Go coding standards?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Changes proposed in this Pull Request:

When both Stripe and WooPayments are active with express checkout enabled, the modal checkout renders two sets of Apple Pay / Google Pay buttons — one from each gateway.

The fix adds a new `unhook_woocommerce_payments_express_checkout_buttons()` method that runs on `init` priority 20 (after WooPayments attaches its callback at priority 15) and removes WooPayments' `display_express_checkout_buttons` action from `woocommerce_checkout_before_customer_details` during modal checkout. This mirrors the existing `unhook_woocommerce_payments_update_billing_fields()` pattern in the same file.

The unhook is gated on:
1. Being in modal checkout context (`is_modal_checkout()`).
2. WooPayments being installed (`class_exists('WC_Payments')`).
3. Stripe's gateway being enabled AND its express checkout setting being `yes`.

If Stripe isn't providing express checkout, WooPayments remains the only source of Apple Pay / Google Pay in the modal and renders normally.

Also removes now-unused filter code inside `filter_woocommerce_payments_settings()` that targeted `express_checkout_checkout_methods` — WooPayments 10.4+ no longer consults that key for button display (it reads from the new split Apple Pay / Google Pay gateway options instead), so the filter was a silent no-op in modern installs.

Closes NPPM-2652.

### How to test the changes in this Pull Request:

**Reproduce the problem (without this PR):**

1. Activate both `woocommerce-gateway-stripe` and `woocommerce-payments`, with express checkout enabled on each.
2. WooPayments must be in a connected state (`WC_Payments_Features::are_payments_enabled()` returns `true`) — if the gateway hasn't been connected, its display hook won't fire.
3. Open the modal checkout via the Donate block (e.g. on `/support-our-publication/`).
4. You will see two sets of Apple Pay / Google Pay buttons

<img width="601" height="250" alt="download-1" src="https://github.com/user-attachments/assets/0ddd6cbf-4870-4802-8c7a-01733363eb9c" />


**Verify the fix (with this PR):**

5. Reload the page. Confirm only a single row of Apple Pay / Google Pay (Stripe's, with the "Pay with Link" button) appears, followed by one "— Or —" divider and the card form.
   
<img width="604" height="130" alt="download" src="https://github.com/user-attachments/assets/9701b9d6-dfaa-4ad4-a76f-642ffba26d00" />


**Regression Check:**

6. Deactivate Stripe, leaving only WooPayments active. Reload the page and open the modal. Confirm WooPayments' Apple Pay / Google Pay buttons appear normally. The fix should only suppress when both gateways are providing express checkout.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?