### PR TITLE
fix: tweak the payment gateway to include enabled gateways not in get_available_payment_gateways()

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -267,7 +267,7 @@ final class Modal_Checkout {
 	}
 
 	/**
-	 * Whether any available payment gateways are not supported in modal checkout.
+	 * Whether any enabled payment gateways are not supported in modal checkout.
 	 *
 	 * @return bool
 	 */

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -269,7 +269,7 @@ final class Modal_Checkout {
 	/**
 	 * Whether any available payment gateways are not supported in modal checkout.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function has_unsupported_payment_gateway() {
 		if ( ! function_exists( 'WC' ) ) {
@@ -280,7 +280,7 @@ final class Modal_Checkout {
 		$available_gateways = \WC()->payment_gateways->get_available_payment_gateways();
 		$all_gateways       = \WC()->payment_gateways()->payment_gateways();
 
-		foreach ( $available_gateways as $id => $gateway ) {
+		foreach ( array_keys( $available_gateways ) as $id ) {
 			if ( ! in_array( $id, $supported_gateways, true ) ) {
 				return true;
 			}
@@ -304,7 +304,7 @@ final class Modal_Checkout {
 	 * Whether a gateway is explicitly enabled via WooCommerce settings.
 	 *
 	 * @param string $gateway_id Gateway ID.
-	 * @return boolean
+	 * @return bool
 	 */
 	private static function is_gateway_enabled_in_settings( $gateway_id ) {
 		$settings = get_option( 'woocommerce_' . $gateway_id . '_settings', [] );

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -277,38 +277,21 @@ final class Modal_Checkout {
 		}
 
 		$supported_gateways = self::get_supported_payment_gateways();
-		$available_gateways = \WC()->payment_gateways->get_available_payment_gateways();
 		$all_gateways       = \WC()->payment_gateways()->payment_gateways();
 
-		foreach ( array_keys( $available_gateways ) as $id ) {
-			if ( ! in_array( $id, $supported_gateways, true ) ) {
-				return true;
-			}
-		}
-
-		// Some gateways can be enabled in admin settings but omitted from
-		// get_available_payment_gateways() due to runtime constraints, for example Wompi.
+		// Check unsupported gateways directly against admin settings. Some gateways
+		// can be omitted from runtime availability due to constraints (like Wompi).
 		foreach ( array_keys( $all_gateways ) as $id ) {
 			if ( in_array( $id, $supported_gateways, true ) ) {
 				continue;
 			}
-			if ( self::is_gateway_enabled_in_settings( $id ) ) {
+			$settings = get_option( 'woocommerce_' . $id . '_settings', [] );
+			if ( is_array( $settings ) && isset( $settings['enabled'] ) && 'yes' === $settings['enabled'] ) {
 				return true;
 			}
 		}
 
 		return false;
-	}
-
-	/**
-	 * Whether a gateway is explicitly enabled via WooCommerce settings.
-	 *
-	 * @param string $gateway_id Gateway ID.
-	 * @return bool
-	 */
-	private static function is_gateway_enabled_in_settings( $gateway_id ) {
-		$settings = get_option( 'woocommerce_' . $gateway_id . '_settings', [] );
-		return is_array( $settings ) && isset( $settings['enabled'] ) && 'yes' === $settings['enabled'];
 	}
 
 	/**

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -267,21 +267,48 @@ final class Modal_Checkout {
 	}
 
 	/**
-	 * Whether any available payment gateways are not suppored in modal checkout.
+	 * Whether any available payment gateways are not supported in modal checkout.
 	 *
 	 * @return boolean
 	 */
 	public static function has_unsupported_payment_gateway() {
-		$supported_gateways          = self::get_supported_payment_gateways();
-		$available_gateways          = function_exists( 'WC' ) ? \WC()->payment_gateways->get_available_payment_gateways() : [];
-		$unsupported_payment_gateway = false;
+		if ( ! function_exists( 'WC' ) ) {
+			return false;
+		}
+
+		$supported_gateways = self::get_supported_payment_gateways();
+		$available_gateways = \WC()->payment_gateways->get_available_payment_gateways();
+		$all_gateways       = \WC()->payment_gateways()->payment_gateways();
+
 		foreach ( $available_gateways as $id => $gateway ) {
 			if ( ! in_array( $id, $supported_gateways, true ) ) {
-				$unsupported_payment_gateway = true;
-				break;
+				return true;
 			}
 		}
-		return $unsupported_payment_gateway;
+
+		// Some gateways can be enabled in admin settings but omitted from
+		// get_available_payment_gateways() due to runtime constraints, for example Wompi.
+		foreach ( array_keys( $all_gateways ) as $id ) {
+			if ( in_array( $id, $supported_gateways, true ) ) {
+				continue;
+			}
+			if ( self::is_gateway_enabled_in_settings( $id ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Whether a gateway is explicitly enabled via WooCommerce settings.
+	 *
+	 * @param string $gateway_id Gateway ID.
+	 * @return boolean
+	 */
+	private static function is_gateway_enabled_in_settings( $gateway_id ) {
+		$settings = get_option( 'woocommerce_' . $gateway_id . '_settings', [] );
+		return is_array( $settings ) && isset( $settings['enabled'] ) && 'yes' === $settings['enabled'];
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

If you have any unsupported payment gateways enabled, the modal checkout should redirect you to the regular checkout. 

One publisher uses the payment gateway Wompi; it's somehow getting past the supported payment gateway check when it's active. It looks like this is because it's not coming up as "available" when using `get_available_payment_gateways()`

This PR switches the check to see what gateways are enabled in the UI vs. what gateways are available. 

Note that this PR is a hotfix, but it's only for a specific publisher -- if it makes more sense it can be merged into trunk and just added to the one site for now. 

Closes NPPM-2657

### How to test the changes in this Pull Request:

1. Install the copy of the Wompi plugin in the Linear task, and enable it as a payment gateway on your site in test mode.
2. Set up a product and try to purchase it with a Checkout Button block, to trigger the modal checkout. The gateway check should be catching that Wompi is not supported, and passing it to the normal checkout instead but it's not. 
3. Apply this PR.
4. Repeat step 2; confirm that you get redirected to the regular non-modal checkout.
5. Try deactivating Wompi and test some of the supported gateways (Stripe, WooPayments, PayPal payments). They should all open the modal checkout unless you have some of the sub-gateways active (like for WooPayments, if you have Affirm or Afterpay enabled, the modal checkout should be bypassed.
6. Try a combination of allowed and not allowed payment gateways -- confirm that if you have any unsupported gateway active, you get redirected to the regular checkout.

Smoke test Braintree -- this is the one payment gateway a publisher is using that uses a bypass in the wild, and we don't want to break that:
1. Follow the steps [here](https://handbook.newspack.com/newspack-team-resources/technical/newspack-support/woocommerce-for-newspack/setting-up-braintree-for-woocommerce-payment-gateway/) to set up Braintree. 
2. Confirm with those settings (including the gateway filter) that Braintree still opens the modal checkout.
3. Remove the `add_filter(...)` added in step 3 of the Braintree setup steps -- this removes the step that bypasses the payment gateway check for Braintree.
4. Rerun step 7 and confirm that you get redirected to the regular checkout because you're no longer adding an unsupported gateway to the allowed list. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
