### PR TITLE
feat: add dedupe option to Carousel block

### DIFF
--- a/src/blocks/carousel/block.json
+++ b/src/blocks/carousel/block.json
@@ -112,6 +112,10 @@
 			"items": {
 				"type": "string"
 			}
+		},
+    "deduplicate": {
+			"type": "boolean",
+			"default": true
 		}
 	}
 }

--- a/src/blocks/carousel/block.json
+++ b/src/blocks/carousel/block.json
@@ -113,7 +113,7 @@
 				"type": "string"
 			}
 		},
-    "deduplicate": {
+		"deduplicate": {
 			"type": "boolean",
 			"default": true
 		}

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -207,6 +207,7 @@ class Edit extends Component {
 				<InspectorControls>
 					<PanelBody title={ __( 'Settings', 'newspack-blocks' ) } className="newspack-block__panel is-content">
 						{ postsToShow && (
+							<>
 							<QueryControls
 								numberOfItems={ postsToShow }
 								onNumberOfItemsChange={ value => setAttributes( { postsToShow: value ? value : 1 } ) }
@@ -229,6 +230,13 @@ class Edit extends Component {
 								onSpecificPostsChange={ _specificPosts => setAttributes( { specificPosts: _specificPosts } ) }
 								postType={ postType }
 							/>
+							<ToggleControl
+								label={ __( 'Allow duplicate content', 'newspack-blocks' ) }
+								help={ __( "Exclude this block from the page's deduplication logic.", 'newspack-blocks' ) }
+								checked={ ! attributes.deduplicate }
+								onChange={ ( value ) => setAttributes( { deduplicate: ! value } ) }
+							/>
+							</>
 						) }
 					</PanelBody>
 					<PanelBody title={ __( 'Display', 'newspack-blocks' ) }>

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -208,34 +208,34 @@ class Edit extends Component {
 					<PanelBody title={ __( 'Settings', 'newspack-blocks' ) } className="newspack-block__panel is-content">
 						{ postsToShow && (
 							<>
-							<QueryControls
-								numberOfItems={ postsToShow }
-								onNumberOfItemsChange={ value => setAttributes( { postsToShow: value ? value : 1 } ) }
-								authors={ authors }
-								onAuthorsChange={ value => setAttributes( { authors: value } ) }
-								categories={ categories }
-								onCategoriesChange={ value => setAttributes( { categories: value } ) }
-								includeSubcategories={ includeSubcategories }
-								onIncludeSubcategoriesChange={ value => setAttributes( { includeSubcategories: value } ) }
-								categoryJoinType={ categoryJoinType }
-								onCategoryJoinTypeChange={ value => setAttributes( { categoryJoinType: value } ) }
-								tags={ tags }
-								onTagsChange={ value => setAttributes( { tags: value } ) }
-								onCustomTaxonomiesChange={ value => setAttributes( { customTaxonomies: value } ) }
-								customTaxonomies={ customTaxonomies }
-								specificMode={ specificMode }
-								onSpecificModeChange={ () => setAttributes( { specificMode: true } ) }
-								onLoopModeChange={ () => setAttributes( { specificMode: false } ) }
-								specificPosts={ specificPosts }
-								onSpecificPostsChange={ _specificPosts => setAttributes( { specificPosts: _specificPosts } ) }
-								postType={ postType }
-							/>
-							<ToggleControl
-								label={ __( 'Allow duplicate content', 'newspack-blocks' ) }
-								help={ __( "Exclude this block from the page's deduplication logic.", 'newspack-blocks' ) }
-								checked={ ! attributes.deduplicate }
-								onChange={ ( value ) => setAttributes( { deduplicate: ! value } ) }
-							/>
+								<QueryControls
+									numberOfItems={ postsToShow }
+									onNumberOfItemsChange={ value => setAttributes( { postsToShow: value ? value : 1 } ) }
+									authors={ authors }
+									onAuthorsChange={ value => setAttributes( { authors: value } ) }
+									categories={ categories }
+									onCategoriesChange={ value => setAttributes( { categories: value } ) }
+									includeSubcategories={ includeSubcategories }
+									onIncludeSubcategoriesChange={ value => setAttributes( { includeSubcategories: value } ) }
+									categoryJoinType={ categoryJoinType }
+									onCategoryJoinTypeChange={ value => setAttributes( { categoryJoinType: value } ) }
+									tags={ tags }
+									onTagsChange={ value => setAttributes( { tags: value } ) }
+									onCustomTaxonomiesChange={ value => setAttributes( { customTaxonomies: value } ) }
+									customTaxonomies={ customTaxonomies }
+									specificMode={ specificMode }
+									onSpecificModeChange={ () => setAttributes( { specificMode: true } ) }
+									onLoopModeChange={ () => setAttributes( { specificMode: false } ) }
+									specificPosts={ specificPosts }
+									onSpecificPostsChange={ _specificPosts => setAttributes( { specificPosts: _specificPosts } ) }
+									postType={ postType }
+								/>
+								<ToggleControl
+									label={ __( 'Allow duplicate content', 'newspack-blocks' ) }
+									help={ __( "Exclude this block from the page's deduplication logic.", 'newspack-blocks' ) }
+									checked={ ! attributes.deduplicate }
+									onChange={ ( value ) => setAttributes( { deduplicate: ! value } ) }
+								/>
 							</>
 						) }
 					</PanelBody>

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -207,32 +207,30 @@ class Edit extends Component {
 				<InspectorControls>
 					<PanelBody title={ __( 'Settings', 'newspack-blocks' ) } className="newspack-block__panel is-content">
 						{ postsToShow && (
-							<>
-								<QueryControls
-									numberOfItems={ postsToShow }
-									onNumberOfItemsChange={ value => setAttributes( { postsToShow: value ? value : 1 } ) }
-									authors={ authors }
-									onAuthorsChange={ value => setAttributes( { authors: value } ) }
-									categories={ categories }
-									onCategoriesChange={ value => setAttributes( { categories: value } ) }
-									includeSubcategories={ includeSubcategories }
-									onIncludeSubcategoriesChange={ value => setAttributes( { includeSubcategories: value } ) }
-									categoryJoinType={ categoryJoinType }
-									onCategoryJoinTypeChange={ value => setAttributes( { categoryJoinType: value } ) }
-									tags={ tags }
-									onTagsChange={ value => setAttributes( { tags: value } ) }
-									onCustomTaxonomiesChange={ value => setAttributes( { customTaxonomies: value } ) }
-									customTaxonomies={ customTaxonomies }
-									specificMode={ specificMode }
-									onSpecificModeChange={ () => setAttributes( { specificMode: true } ) }
-									onLoopModeChange={ () => setAttributes( { specificMode: false } ) }
-									specificPosts={ specificPosts }
-									onSpecificPostsChange={ _specificPosts => setAttributes( { specificPosts: _specificPosts } ) }
-									postType={ postType }
-									allowDedupeCurrentValue={ ! attributes.deduplicate }
-									onAllowDedupeChange={ value => setAttributes( { deduplicate: ! value } ) }
-								/>
-							</>
+							<QueryControls
+								numberOfItems={ postsToShow }
+								onNumberOfItemsChange={ value => setAttributes( { postsToShow: value ? value : 1 } ) }
+								authors={ authors }
+								onAuthorsChange={ value => setAttributes( { authors: value } ) }
+								categories={ categories }
+								onCategoriesChange={ value => setAttributes( { categories: value } ) }
+								includeSubcategories={ includeSubcategories }
+								onIncludeSubcategoriesChange={ value => setAttributes( { includeSubcategories: value } ) }
+								categoryJoinType={ categoryJoinType }
+								onCategoryJoinTypeChange={ value => setAttributes( { categoryJoinType: value } ) }
+								tags={ tags }
+								onTagsChange={ value => setAttributes( { tags: value } ) }
+								onCustomTaxonomiesChange={ value => setAttributes( { customTaxonomies: value } ) }
+								customTaxonomies={ customTaxonomies }
+								specificMode={ specificMode }
+								onSpecificModeChange={ () => setAttributes( { specificMode: true } ) }
+								onLoopModeChange={ () => setAttributes( { specificMode: false } ) }
+								specificPosts={ specificPosts }
+								onSpecificPostsChange={ _specificPosts => setAttributes( { specificPosts: _specificPosts } ) }
+								postType={ postType }
+								allowDedupeCurrentValue={ ! attributes.deduplicate }
+								onAllowDedupeChange={ value => setAttributes( { deduplicate: ! value } ) }
+							/>
 						) }
 					</PanelBody>
 					<PanelBody title={ __( 'Display', 'newspack-blocks' ) }>

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -229,7 +229,7 @@ class Edit extends Component {
 									specificPosts={ specificPosts }
 									onSpecificPostsChange={ _specificPosts => setAttributes( { specificPosts: _specificPosts } ) }
 									postType={ postType }
-									allowDedupeCurrentValue = { ! attributes.deduplicate }
+									allowDedupeCurrentValue={ ! attributes.deduplicate }
 									onAllowDedupeChange={ value => setAttributes( { deduplicate: ! value } ) }
 								/>
 							</>

--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -229,12 +229,8 @@ class Edit extends Component {
 									specificPosts={ specificPosts }
 									onSpecificPostsChange={ _specificPosts => setAttributes( { specificPosts: _specificPosts } ) }
 									postType={ postType }
-								/>
-								<ToggleControl
-									label={ __( 'Allow duplicate content', 'newspack-blocks' ) }
-									help={ __( "Exclude this block from the page's deduplication logic.", 'newspack-blocks' ) }
-									checked={ ! attributes.deduplicate }
-									onChange={ ( value ) => setAttributes( { deduplicate: ! value } ) }
+									allowDedupeCurrentValue = { ! attributes.deduplicate }
+									onAllowDedupeChange={ value => setAttributes( { deduplicate: ! value } ) }
 								/>
 							</>
 						) }

--- a/src/blocks/carousel/view.php
+++ b/src/blocks/carousel/view.php
@@ -51,7 +51,9 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 			$article_query->the_post();
 			$post_id                             = get_the_ID();
 			$authors                             = Newspack_Blocks::prepare_authors();
-			$newspack_blocks_post_id[ $post_id ] = true;
+			if ( Newspack_Blocks::should_deduplicate_block( $attributes ) ) {
+				$newspack_blocks_post_id[ $post_id ] = true;
+			}
 
 			$article_classes = [
 				'post-has-image',

--- a/src/blocks/homepage-articles/edit.tsx
+++ b/src/blocks/homepage-articles/edit.tsx
@@ -285,12 +285,8 @@ class Edit extends Component< HomepageArticlesProps > {
 						customTaxonomyExclusions={ customTaxonomyExclusions }
 						onCustomTaxonomyExclusionsChange={ handleAttributeChange( 'customTaxonomyExclusions' ) }
 						postType={ postType }
-					/>
-					<ToggleControl
-						label={ __( 'Allow duplicate content', 'newspack-blocks' ) }
-						help={ __( "Exclude this block from the page's deduplication logic.", 'newspack-blocks' ) }
-						checked={ ! attributes.deduplicate }
-						onChange={ ( value: boolean ) => setAttributes( { deduplicate: ! value } ) }
+						allowDedupeCurrentValue={ ! attributes.deduplicate }
+						onAllowDedupeChange={ ( value: boolean ) => setAttributes( { deduplicate: ! value } ) }
 					/>
 					{ ! specificMode && isBlogPrivate() ? (
 						/*

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -426,7 +426,7 @@ class QueryControls extends Component {
 								label={ __( 'Allow duplicate content', 'newspack-blocks' ) }
 								help={ __( "Exclude this block from the page's deduplication logic.", 'newspack-blocks' ) }
 								checked={ allowDedupeCurrentValue }
-								onChange={ ( value ) => onAllowDedupeChange( value ) }
+								onChange={ value => onAllowDedupeChange( value ) }
 							/>
 						) }
 					</>

--- a/src/components/query-controls.js
+++ b/src/components/query-controls.js
@@ -8,6 +8,7 @@ import {
 	CheckboxControl,
 	SelectControl,
 	QueryControls as BasicQueryControls,
+	ToggleControl,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -263,6 +264,8 @@ class QueryControls extends Component {
 			customTaxonomyExclusions,
 			onCustomTaxonomyExclusionsChange,
 			enableSpecific,
+			onAllowDedupeChange,
+			allowDedupeCurrentValue,
 		} = this.props;
 
 		const registeredCustomTaxonomies = window.newspack_blocks_data?.custom_taxonomies;
@@ -417,6 +420,15 @@ class QueryControls extends Component {
 									tokens={ getTermsOfCustomTaxonomy( customTaxonomyExclusions, slug ) }
 								/>
 							) ) }
+
+						{ onAllowDedupeChange && (
+							<ToggleControl
+								label={ __( 'Allow duplicate content', 'newspack-blocks' ) }
+								help={ __( "Exclude this block from the page's deduplication logic.", 'newspack-blocks' ) }
+								checked={ allowDedupeCurrentValue }
+								onChange={ ( value ) => onAllowDedupeChange( value ) }
+							/>
+						) }
 					</>
 				) }
 			</>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Up until now, the carousel block was partially included in the duplication logic with content loop block. Posts that appeared in a carousel block would always be counted and excluded from other blocks that were part of the duplication logic. But the carousel block would never exclude posts from its own query based on what appeared in other blocks. 

This pull request will add the same option we have in the content loop block to the carousel block, meaning that you can opt out and allow duplicated posts to be displayed in the carousel block. It also means that if a carousel block is placed after some content loop blocks or other carousel blocks, it will by default exclude posts that have already appeared in the page. 

### How to test the changes in this Pull Request:

1. Start on `trunk`
2. Add a carousel block at the top of a page followed by Content loop block
3. Confirm that the posts that are displayed in the carousel are excluded from the content loop (both in the front end and in the editor)
4. Checkout this branch and build
5. Confirm the behavior is still the same
6. Now edit this page or create a new one. Add a carousel block after a content loop block
7. Confirm that the posts that are displayed in the content loop are not repeated in the carousel
8. Toggle "allow duplicate" in the carousel and confirm it now renders duplicated content
9. Play around with these settings in multiple blocks and confirm they work as expected.
10. Back on `trunk` confirm the behavior we're changing: add a carousel block after a content loop block and see that it renders duplicate content.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
