### PR TITLE
fix: modal checkout for blocks

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -138,6 +138,7 @@ final class Modal_Checkout {
 		add_action( 'wp', [ __CLASS__, 'process_checkout_request' ] );
 		add_action( 'wp_ajax_abandon_modal_checkout', [ __CLASS__, 'process_abandon_checkout' ] );
 		add_action( 'wp_ajax_nopriv_abandon_modal_checkout', [ __CLASS__, 'process_abandon_checkout' ] );
+		add_action( 'wp_loaded', [ __CLASS__, 'process_checkout_action' ], 21 );
 
 		add_filter( 'wp_redirect', [ __CLASS__, 'pass_url_param_on_redirect' ] );
 		add_filter( 'woocommerce_cart_product_cannot_be_purchased_message', [ __CLASS__, 'woocommerce_cart_product_cannot_be_purchased_message' ], 10, 2 );
@@ -292,6 +293,35 @@ final class Modal_Checkout {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Process checkout after order button is clicked in the modal.
+	 */
+	public static function process_checkout_action() {
+		if ( ! self::is_modal_checkout() ) {
+			return;
+		}
+
+		$nonce = isset( $_POST['newspack_checkout_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['newspack_checkout_nonce'] ) ) : '';
+		if ( ! wp_verify_nonce( $nonce, 'newspack_modal_checkout_nonce' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Invalid nonce.', 'newspack-blocks' ) ] );
+			wp_die();
+		}
+
+		if ( isset( $_POST['newspack_blocks_checkout_action'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			wc_nocache_headers();
+
+			if ( \WC()->cart->is_empty() ) {
+				wp_safe_redirect( wc_get_cart_url() );
+				exit;
+			}
+
+			wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
+			// Generate a fresh WC nonce so process_checkout() passes its internal verification.
+			$_REQUEST['woocommerce-process-checkout-nonce'] = wp_create_nonce( 'woocommerce-process_checkout' );
+			\WC()->checkout()->process_checkout();
+		}
 	}
 
 	/**

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -299,7 +299,7 @@ final class Modal_Checkout {
 	 * Process checkout after order button is clicked in the modal.
 	 */
 	public static function process_checkout_action() {
-		if ( ! self::is_modal_checkout() ) {
+		if ( ! self::is_modal_checkout() || ! isset( $_POST['newspack_blocks_checkout_action'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			return;
 		}
 
@@ -309,19 +309,23 @@ final class Modal_Checkout {
 			wp_die();
 		}
 
-		if ( isset( $_POST['newspack_blocks_checkout_action'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
-			wc_nocache_headers();
+		wc_nocache_headers();
 
-			if ( \WC()->cart->is_empty() ) {
-				wp_safe_redirect( wc_get_cart_url() );
-				exit;
-			}
-
-			wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
-			// Generate a fresh WC nonce so process_checkout() passes its internal verification.
-			$_REQUEST['woocommerce-process-checkout-nonce'] = wp_create_nonce( 'woocommerce-process_checkout' );
-			\WC()->checkout()->process_checkout();
+		if ( \WC()->cart->is_empty() ) {
+			wp_safe_redirect( wc_get_cart_url() );
+			exit;
 		}
+
+		wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
+
+		// If this is a validation-only request, set the flag that tells process_checkout() to only validate the order.
+		if ( isset( $_POST['is_validation_only'] ) ) {
+			$_POST['woocommerce_checkout_update_totals'] = '1';
+		}
+		// Generate a fresh WC nonce so process_checkout() passes its internal verification.
+		$_REQUEST['woocommerce-process-checkout-nonce'] = wp_create_nonce( 'woocommerce-process_checkout' );
+
+		\WC()->checkout()->process_checkout();
 	}
 
 	/**

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -323,12 +323,15 @@ final class Modal_Checkout {
 
 		wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
 
+		// Generate a fresh WC nonce so process_checkout() passes its internal verification.
+		// We take this approach to ensure compatibility with block theme which causes WC to no longer
+		// rely on this checkout nonce requried by process checkout.
+		$_REQUEST['woocommerce-process-checkout-nonce'] = wp_create_nonce( 'woocommerce-process_checkout' );
+
 		// If this is a validation-only request, set the flag that tells process_checkout() to only validate the order.
 		if ( isset( $_POST['is_validation_only'] ) ) {
 			$_POST['woocommerce_checkout_update_totals'] = '1';
 		}
-		// Generate a fresh WC nonce so process_checkout() passes its internal verification.
-		$_REQUEST['woocommerce-process-checkout-nonce'] = wp_create_nonce( 'woocommerce-process_checkout' );
 
 		\WC()->checkout()->process_checkout();
 	}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -316,6 +316,11 @@ final class Modal_Checkout {
 			exit;
 		}
 
+		// If checkout is already defined as being processed, don't run process_checkout().
+		if ( defined( 'WOOCOMMERCE_CHECKOUT' ) && WOOCOMMERCE_CHECKOUT ) {
+			return;
+		}
+
 		wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
 
 		// If this is a validation-only request, set the flag that tells process_checkout() to only validate the order.

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -296,7 +296,7 @@ final class Modal_Checkout {
 	}
 
 	/**
-	 * Process checkout after order button is clicked in the modal.
+	 * Process checkout handler for form validation and order complete.
 	 */
 	public static function process_checkout_action() {
 		if ( ! self::is_modal_checkout() || ! isset( $_POST['newspack_blocks_checkout_action'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing

--- a/src/blocks/donate/styles/editor.scss
+++ b/src/blocks/donate/styles/editor.scss
@@ -35,7 +35,7 @@
 
 	button,
 	.submit-button {
-		font-family: var(--newspack-theme-font-heading);
+		font-family: var(--newspack-theme-font-heading, sans-serif);
 		font-size: variables.$font__size-sm;
 		font-weight: bold;
 		outline: none;

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -6,6 +6,11 @@
 	background: var(--newspack-ui-color-neutral-0, np-colors.$neutral-000);
 	padding: var(--newspack-ui-spacer-5, 24px);
 
+	a,
+	a:hover {
+	  text-decoration: none;
+    }
+
 	form p {
 		margin: 0 0 var(--newspack-ui-spacer-5, 24px);
 
@@ -851,7 +856,7 @@
 
 		td,
 		th {
-			border: 1px solid var(--newspack-ui-color-border);
+			border: 1px solid var(--newspack-ui-color-border, #ddd);
 			border-width: 0 0 1px;
 			word-break: break-all;
 		}

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -856,12 +856,14 @@
 			word-break: break-all;
 		}
 
-		tr:last-child {
-			td,
-			th {
-				border-bottom: 0;
-			}
-		}
+        tfoot {
+          tr:last-child {
+              td,
+              th {
+                  border-bottom: 0;
+              }
+          }
+        }
 	}
 
 	.woocommerce .first-payment-date {

--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -16,6 +16,11 @@
 	}
 
 	table.woocommerce-checkout-review-order-table {
+		tr,
+		th {
+			font-weight: normal;
+		}
+
 		thead > tr > th {
 			font-weight: var(--newspack-ui-font-weight-strong, 600);
 		}
@@ -821,6 +826,8 @@
 
 	// Order review table.
 	.woocommerce-checkout-review-order-table {
+		width: 100%;
+
 		th,
 		td,
 		label,
@@ -839,6 +846,20 @@
 			li,
 			label {
 				margin: 0;
+			}
+		}
+
+		td,
+		th {
+			border: 1px solid var(--newspack-ui-color-border);
+			border-width: 0 0 1px;
+			word-break: break-all;
+		}
+
+		tr:last-child {
+			td,
+			th {
+				border-bottom: 0;
 			}
 		}
 	}

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -685,7 +685,7 @@ import { domReady, onCheckoutPlaceOrderProcessing } from './utils';
 					// Serialize form and remove fields that shouldn't be included for validation.
 					const serializedForm = $form.serializeArray().filter( item => ! removeFromValidation.includes( item.name ) );
 					// Add 'update totals' parameter so it just performs validation.
-					serializedForm.push( { name: 'woocommerce_checkout_update_totals', value: '1' } );
+					serializedForm.push( { name: 'newspack_blocks_checkout_action', value: '1' } );
 					// Ajax request.
 					$.ajax( {
 						type: 'POST',

--- a/src/modal-checkout/templates/form-checkout.php
+++ b/src/modal-checkout/templates/form-checkout.php
@@ -25,6 +25,7 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 ?>
 
 <form name="checkout" method="post" class="checkout woocommerce-checkout" action="<?php echo esc_url( wc_get_checkout_url() ); ?>" enctype="multipart/form-data">
+	<?php wp_nonce_field( 'newspack_modal_checkout_nonce', 'newspack_checkout_nonce' ); ?>
 	<?php if ( $checkout->get_checkout_fields() ) : ?>
 		<?php do_action( 'woocommerce_checkout_before_customer_details' ); ?>
 		<div id="customer_details">

--- a/src/modal-checkout/templates/form-checkout.php
+++ b/src/modal-checkout/templates/form-checkout.php
@@ -35,6 +35,11 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 			<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide" id="checkout_continue" type="submit"><?php esc_html_e( 'Continue', 'newspack-blocks' ); ?></button>
 		</div>
 		<div id="after_customer_details">
+			<?php
+			if ( wp_is_block_theme() && function_exists( 'woocommerce_checkout_payment' ) ) {
+				woocommerce_checkout_payment();
+			}
+			?>
 			<div class="order-review-wrapper hidden">
 				<?php do_action( 'woocommerce_checkout_before_order_review_heading' ); ?>
 				<button id="order_review_heading" aria-expanded="false" aria-controls="order_review_content" class="newspack-ui__button newspack-ui__button--ghost" type="button">
@@ -47,7 +52,13 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 					<div class="transaction-details-content-inner" id="order_review_content">
 						<?php do_action( 'woocommerce_checkout_before_order_review' ); ?>
 						<div id="order_review" class="woocommerce-checkout-review-order newspack-ui__box">
-							<?php do_action( 'woocommerce_checkout_order_review' ); ?>
+							<?php
+							if ( wp_is_block_theme() && function_exists( 'woocommerce_order_review' ) ) {
+								woocommerce_order_review();
+							} else {
+								do_action( 'woocommerce_checkout_order_review' );
+							}
+							?>
 						</div>
 						<?php do_action( 'woocommerce_checkout_after_order_review' ); ?>
 					</div>


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPD-1188/modal-checkout-testing-and-fixes

This PR gets Modal checkout working with the block theme.

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-plugin/pull/4557 for testing instructions

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
