### PR TITLE
fix(author-profile): correct avatar-right mobile stacking order

### DIFF
--- a/src/blocks/author-profile/templates.js
+++ b/src/blocks/author-profile/templates.js
@@ -199,14 +199,14 @@ export const AVATAR_LEFT_TEMPLATE = [
 ];
 
 /**
- * Avatar right layout: content on the left, avatar on the right.
+ * Avatar right layout: avatar first in DOM for correct mobile stacking,
+ * CSS reorders content to the left on desktop.
  */
 export const AVATAR_RIGHT_TEMPLATE = [
 	[
 		'core/columns',
-		{ isStackedOnMobile: true, className: 'author-profile-columns', templateLock: 'insert' },
+		{ isStackedOnMobile: true, className: 'author-profile-columns is-style-first-col-to-second', templateLock: 'insert' },
 		[
-			[ 'core/column', CONTENT_COLUMN_ATTRS, CONTENT_BLOCKS ],
 			[
 				'core/column',
 				{
@@ -216,6 +216,7 @@ export const AVATAR_RIGHT_TEMPLATE = [
 				},
 				[ [ 'newspack/avatar', { size: 128 } ] ],
 			],
+			[ 'core/column', CONTENT_COLUMN_ATTRS, CONTENT_BLOCKS ],
 		],
 	],
 ];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In the `avatar-right` variation, the avatar column was second in DOM order. On mobile, columns stack vertically, so the avatar ended up underneath the bio text instead of above it.

This fix places the avatar column first in the DOM (so it naturally stacks on top on mobile) and applies the `is-style-first-col-to-second` block style to visually reorder the content column to the left on desktop via CSS `order`.

Per @laurelfulford's [feedback](https://github.com/Automattic/newspack-blocks/pull/2302#issuecomment-4027702223) on PR #2302.

Closes NPPD-1349.

### How to test the changes in this Pull Request:

1. Use the `newspack-block-theme` and navigate to the Site Editor.
2. Add an Author Profile block and select the "Avatar right" variation.
3. On desktop, confirm the layout shows content on the left and avatar on the right.
4. Resize the browser to a mobile viewport width.
5. Confirm the avatar stacks above the bio/content text, not below it.
6. Add another Author Profile block and select the "Avatar left" variation. Confirm it still works correctly (avatar on the left on desktop, avatar on top on mobile).
7. Test the "Centered" and "Compact" variations to ensure they are unaffected.
8. For existing posts that already use the avatar-right variation, delete the block and re-add it to pick up the new template. Confirm the layout is correct in both desktop and mobile viewports.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?