### PR TITLE
fix: reinstate enqueue block editor assets for the blocks

### DIFF
--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -83,7 +83,6 @@ add_action( 'rest_api_init', 'newspack_iframe_block_register_rest_routes' );
 Newspack_Blocks::manage_view_scripts();
 add_action( 'enqueue_block_editor_assets', array( 'Newspack_Blocks', 'enqueue_block_assets' ) );
 add_action( 'enqueue_block_editor_assets', array( 'Newspack_Blocks', 'enqueue_placeholder_blocks_assets' ), 9999 );
-add_action( 'enqueue_block_editor_assets', array( 'Newspack_Blocks', 'enqueue_block_styles_assets' ) );
 add_action( 'wp_enqueue_scripts', array( 'Newspack_Blocks', 'enqueue_block_styles_assets' ) );
 
 /**

--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -81,9 +81,10 @@ function newspack_iframe_block_register_rest_routes() { // phpcs:ignore WordPres
 add_action( 'rest_api_init', 'newspack_iframe_block_register_rest_routes' );
 
 Newspack_Blocks::manage_view_scripts();
-add_action( 'enqueue_block_assets', array( 'Newspack_Blocks', 'enqueue_block_assets' ) );
-add_action( 'enqueue_block_assets', array( 'Newspack_Blocks', 'enqueue_placeholder_blocks_assets' ), 9999 );
-add_action( 'enqueue_block_assets', array( 'Newspack_Blocks', 'enqueue_block_styles_assets' ) );
+add_action( 'enqueue_block_editor_assets', array( 'Newspack_Blocks', 'enqueue_block_assets' ) );
+add_action( 'enqueue_block_editor_assets', array( 'Newspack_Blocks', 'enqueue_placeholder_blocks_assets' ), 9999 );
+add_action( 'enqueue_block_editor_assets', array( 'Newspack_Blocks', 'enqueue_block_styles_assets' ) );
+add_action( 'wp_enqueue_scripts', array( 'Newspack_Blocks', 'enqueue_block_styles_assets' ) );
 
 /**
  * Load language files


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR reinstates `enqueue_block_editor_assets` to fix some block asset loading issues in the editor. 

### How to test the changes in this Pull Request:

The issue seems to be inconsistent but we do have a few sites where it's happening that could be used to test. 

1. Apply the PR.
2. Ensure assets are still loading in the block editor. 
3. Ensure assets are still loading on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
