### PR TITLE
hotfix: restore editing tools to Carousel block

### DIFF
--- a/src/blocks/carousel/edit.js
+++ b/src/blocks/carousel/edit.js
@@ -347,7 +347,7 @@ class Edit extends Component {
 					<PostTypesPanel attributes={ attributes } setAttributes={ setAttributes } />
 					<PostStatusesPanel attributes={ attributes } setAttributes={ setAttributes } />
 				</InspectorControls>
-				<div { ...blockProps } className={ classes } ref={ this.props.carouselRef }>
+				<div { ...blockProps } className={ classes }>
 					{ hasNoPosts && (
 						<Placeholder className="component-placeholder__align-center">
 							<div style={ { margin: 'auto' } }>{ __( 'Sorry, no posts were found.' ) }</div>
@@ -460,7 +460,7 @@ class Edit extends Component {
 
 const EditWithBlockProps = props => {
 	const carouselRef = useRef();
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( { ref: carouselRef } );
 	return <Edit { ...props } blockProps={ blockProps } carouselRef={ carouselRef } />;
 };
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixed regression to Carousel block:  editing tools are now available in the Post Editor.

Obsoletes #2315.

### How to test the changes in this Pull Request:

1. Add a Carousel block to your post.  Observe it isn't editable (no tools appear when you interact with it in the post editor).
2. Apply this PR.
3. Try the Carousel block again.  You should see the usual tools appear when you click on it.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
