### PR TITLE
fix: reinstate WP 7.0 enqueue_block_assets workaround

### DIFF
--- a/newspack-blocks.php
+++ b/newspack-blocks.php
@@ -81,9 +81,9 @@ function newspack_iframe_block_register_rest_routes() { // phpcs:ignore WordPres
 add_action( 'rest_api_init', 'newspack_iframe_block_register_rest_routes' );
 
 Newspack_Blocks::manage_view_scripts();
-add_action( 'enqueue_block_editor_assets', array( 'Newspack_Blocks', 'enqueue_block_assets' ) );
-add_action( 'enqueue_block_editor_assets', array( 'Newspack_Blocks', 'enqueue_placeholder_blocks_assets' ), 9999 );
-add_action( 'wp_enqueue_scripts', array( 'Newspack_Blocks', 'enqueue_block_styles_assets' ) );
+add_action( 'enqueue_block_assets', array( 'Newspack_Blocks', 'enqueue_block_assets' ) );
+add_action( 'enqueue_block_assets', array( 'Newspack_Blocks', 'enqueue_placeholder_blocks_assets' ), 9999 );
+add_action( 'enqueue_block_assets', array( 'Newspack_Blocks', 'enqueue_block_styles_assets' ) );
 
 /**
  * Load language files


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Redoes https://github.com/Automattic/newspack-blocks/pull/2318 as a regular commit, not a hotfix.

Undoes changes in https://github.com/Automattic/newspack-blocks/pull/2314, since the real culprit has been uncovered.

Open question: we had some performance issues also reported yesterday - could the `is_admin()` check be the culprit, and should we be switching all these blocks to load assets using block.json instead?

### How to test the changes in this Pull Request:

1. Following the testing steps in https://github.com/Automattic/newspack-newsletters/pull/2051.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
