### PR TITLE
fix: update payment gateway check to make more specific

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -123,8 +123,6 @@ final class Modal_Checkout {
 		'cheque',
 		'cod', // Cash on delivery.
 		'ppcp-gateway', // PayPal Payments.
-		'ppcp-googlepay', // PayPal Google Pay.
-		'ppcp-applepay', // PayPal Apple Pay.
 		'stripe',
 		'stripe_link', // Stripe Link.
 		'stripe_amazon_pay', // Stripe Amazon Pay.

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -123,9 +123,16 @@ final class Modal_Checkout {
 		'cheque',
 		'cod', // Cash on delivery.
 		'ppcp-gateway', // PayPal Payments.
+		'ppcp-googlepay', // PayPal Google Pay.
+		'ppcp-applepay', // PayPal Apple Pay.
 		'stripe',
-		'stripe-link',
+		'stripe_link', // Stripe Link.
+		'stripe_amazon_pay', // Stripe Amazon Pay.
 		'woocommerce_payments',
+		'woocommerce_payments_apple_pay', // WooPayments Apple Pay.
+		'woocommerce_payments_google_pay', // WooPayments Google Pay.
+		'ppcp-axo-gateway', // PayPal Accelerated Checkout, used by WooPayments.
+
 	];
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Changes in https://github.com/Automattic/newspack-blocks/pull/2306 made our payment gateway check a little too specific 💀 Rather than trying to do some weird dance that could be vague, but still properly check for Wompi, I made a much more explicit list for what should be supported. 

### How to test the changes in this Pull Request:

1. Apply this PR.
2. Check the following gateways and combinations of express payments with the checkout button block, and opens the modal checkout
3. Stripe
    a. Make sure stripe alone works
    b. Stripe + Stripe Link
    c. Stripe + Apple Pay & Google Pay
    d. Stripe + Amazon Pay
4. PayPal (note: I didn't explicitly add support for PayPal's Advanced Card Processing because it looks pretty borked and doesn't seem to work -- we would've heard if someone was trying and failing to use it. Both Apple Pay and Google Pay in this plugin require the Advanced Card option to be enabled; we want to support that + PP Google Pay and Apple Pay in the future, we can address them separately). 
     a. PayPal button alone
     b. PayPal + Venmo
5. WooPayments (the WooPay express payment is not supported because it doesn't work in iframes)
     a. WooPayments alone
     b. WooPayments + Stripe Link
     c. WooPayments +  Apple Pay and Google Pay
6. Random combinations of the above (multiple express payment gateways from one or more provider).
7. Repeat the testing steps in [this issue](https://github.com/Automattic/newspack-blocks/pull/2306) to confirm there are no regressions with how Wompi and Braintree can be worked around. For both, make sure they initially redirect to the normal /checkout page until the bypass code is added. The code to bypass Wompi is similar to Braintree, just with a different gateway:

```
add_filter(
	'newspack_blocks_modal_checkout_supported_gateways',
	function( $gateways ) {
		if ( ! in_array( 'wompi', $gateways, true ) ) {
			$gateways[] = 'wompi';
		}
		return $gateways;
	}
);
```
8. Smoke test any other payment combination you can think of (supported and unsupported). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
