### PR TITLE
fix(modal-checkout): prevent empty error notices and fix padding

### DIFF
--- a/src/modal-checkout/checkout.scss
+++ b/src/modal-checkout/checkout.scss
@@ -984,6 +984,9 @@
 	.woocommerce .woocommerce-notices-wrapper:not(:empty) {
 		margin-bottom: var(--newspack-ui-spacer-5, 24px);
 		margin-top: 0;
+		/* Prevent duplicated padding and border from Newspack UI notices */
+		padding: 0 !important;
+		border-left: none;
 	}
 
 	.woocommerce .woocommerce-notices-wrapper .woocommerce-error.newspack-ui__notice--error {

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -899,7 +899,7 @@ import { domReady, onCheckoutPlaceOrderProcessing } from './utils';
 		 */
 		$( document.body ).on( 'checkout_error', function () {
 			// Apply newspack styling to default Woo checkout errors.
-			const $errors = $( '.woocommerce-NoticeGroup-checkout, .woocommerce-notices-wrapper' );
+			const $errors = $( '.woocommerce-NoticeGroup-checkout, .woocommerce-notices-wrapper:not(:empty)' );
 			if ( $errors.length ) {
 				$errors.each( ( _, error ) => $( error ).addClass( `${ CLASS_PREFIX }__notice ${ CLASS_PREFIX }__notice--error` ) );
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Prevent empty error notices and fix duplicate styles in the notices wrapper:

| Before | After |
| --- | --- |
| <img width="659" height="625" alt="image" src="https://github.com/user-attachments/assets/d643a9a1-9a0f-4aec-9d82-de61ea89c55f" /> | <img width="658" height="519" alt="image" src="https://github.com/user-attachments/assets/14bc879b-3002-4ab6-8b79-af34b2f32611" /> |

Closes NPPM-2676

### How to test the changes in this Pull Request:

1. Checkout `release` and go through the modal checkout
2. Force an error (either billing fields validation error or empty CC)
3. Confirm you get empty error notices and the style issue
4. Checkout this branch and confirm the notice appear with proper styling and no empty notices appear

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
