### PR TITLE
fix(modal-checkout): retrieve order from query vars in thankyou template

### DIFF
--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -34,8 +34,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // When this template replaces global/form-login.php, $order is not provided by WooCommerce.
 // Retrieve it from the URL query vars, the same way WooCommerce does in the order-received endpoint.
 if ( ! isset( $order ) || ! $order ) {
-	global $wp;
-	$order_id = isset( $wp->query_vars['order-received'] ) ? absint( $wp->query_vars['order-received'] ) : 0;
+	$order_id = absint( \get_query_var( 'order-received' ) );
 	$order    = $order_id ? \wc_get_order( $order_id ) : false; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 }
 

--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -31,6 +31,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  * existing customer account.
  * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
  */
+// When this template replaces global/form-login.php, $order is not provided by WooCommerce.
+// Retrieve it from the URL query vars, the same way WooCommerce does in the order-received endpoint.
+if ( ! isset( $order ) || ! $order ) {
+	global $wp;
+	$order_id = isset( $wp->query_vars['order-received'] ) ? absint( $wp->query_vars['order-received'] ) : 0;
+	$order    = $order_id ? \wc_get_order( $order_id ) : false;
+}
+
 $key      = isset( $_GET['key'] ) ? \wc_clean( \sanitize_text_field( \wp_unslash( $_GET['key'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 $is_valid = $order && is_a( $order, 'WC_Order' ) && hash_equals( $order->get_order_key(), $key ); // Validate order key to prevent CSRF.
 

--- a/src/modal-checkout/templates/thankyou.php
+++ b/src/modal-checkout/templates/thankyou.php
@@ -36,7 +36,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! isset( $order ) || ! $order ) {
 	global $wp;
 	$order_id = isset( $wp->query_vars['order-received'] ) ? absint( $wp->query_vars['order-received'] ) : 0;
-	$order    = $order_id ? \wc_get_order( $order_id ) : false;
+	$order    = $order_id ? \wc_get_order( $order_id ) : false; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 }
 
 $key      = isset( $_GET['key'] ) ? \wc_clean( \sanitize_text_field( \wp_unslash( $_GET['key'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When the modal checkout `thankyou.php` template is used as a replacement for `global/form-login.php`, WooCommerce does not provide the `$order` variable. This causes the thank-you page to fail because subsequent code depends on `$order` being set.

This fix retrieves the order from the URL query vars (`order-received`) when `$order` is not available, using the same approach WooCommerce uses in its order-received endpoint.

### How to test the changes in this Pull Request:

1. On `trunk`,
1. Set up a Newspack site with WooCommerce and the modal checkout enabled (donations or memberships).
2. Open the modal checkout
3. Observe the logged warning:

<img width="733" height="461" alt="image" src="https://github.com/user-attachments/assets/12291c57-a98e-42ed-9ad8-7423fe048a56" />

5. Switch to this branch, observe the warning gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?