### PR TITLE
fix: track seen blocks to prevent infinite recursion in cache checks

### DIFF
--- a/includes/class-newspack-blocks-caching.php
+++ b/includes/class-newspack-blocks-caching.php
@@ -20,6 +20,13 @@ class Newspack_Blocks_Caching {
 	private static $can_serve_all_blocks_from_cache = true;
 
 	/**
+	 * Track visited reusable block IDs to spot recursion.
+	 *
+	 * @var int[]
+	 */
+	private static $visited_reusable_blocks = [];
+
+	/**
 	 * Store the current block index. This will be incremented with each cache reading,
 	 * in order to add specificity to the cache key. The cache key consists of the
 	 * hashed block attributes – which may be duplicated on a page – and a unique index.
@@ -73,6 +80,7 @@ class Newspack_Blocks_Caching {
 		if ( is_singular() ) {
 			$post = get_post();
 			if ( $post && property_exists( $post, 'post_content' ) ) {
+				self::$visited_reusable_blocks = [];
 				self::check_block_cache_status( parse_blocks( $post->post_content ) );
 				// Reset the index after initial checks.
 				self::$current_block_index = 0;
@@ -89,11 +97,19 @@ class Newspack_Blocks_Caching {
 		$cacheable_block_names = self::get_cacheable_blocks_names();
 		foreach ( $blocks as $block_data ) {
 			// Special treatment for reusable blocks, which are blocks stored in the posts table.
-			if ( $block_data['blockName'] === 'core/block' ) {
-				$reusable_block_post = get_post( $block_data['attrs']['ref'] );
+			if ( $block_data['blockName'] === 'core/block' && ! empty( $block_data['attrs']['ref'] ) ) {
+				$ref = $block_data['attrs']['ref'];
+				// Skip blocks we've seen before to avoid infinite recursion.
+				// Based on core's render_block_core_block().
+				if ( isset( self::$visited_reusable_blocks[ $ref ] ) ) {
+					continue;
+				}
+				self::$visited_reusable_blocks[ $ref ] = true;
+				$reusable_block_post = get_post( $ref );
 				if ( $reusable_block_post && property_exists( $reusable_block_post, 'post_content' ) ) {
 					self::check_block_cache_status( parse_blocks( $reusable_block_post->post_content ) );
 				}
+				unset( self::$visited_reusable_blocks[ $ref ] );
 			}
 			if ( in_array( $block_data['blockName'], $cacheable_block_names, true ) ) {
 				if ( ! self::get_cached_block_data( $block_data ) ) {

--- a/includes/class-newspack-blocks-caching.php
+++ b/includes/class-newspack-blocks-caching.php
@@ -22,7 +22,7 @@ class Newspack_Blocks_Caching {
 	/**
 	 * Track visited reusable block IDs to spot recursion.
 	 *
-	 * @var int[]
+	 * @var array<int, bool>
 	 */
 	private static $visited_reusable_blocks = [];
 

--- a/tests/test-caching.php
+++ b/tests/test-caching.php
@@ -1,0 +1,164 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Class CachingTest
+ *
+ * @package Newspack_Blocks
+ */
+
+/**
+ * Newspack_Blocks_Caching test case.
+ */
+class CachingTest extends WP_UnitTestCase { // phpcs:ignore
+
+	/**
+	 * A self-referencing synced pattern should not cause infinite recursion
+	 * in check_all_blocks_cache_status().
+	 */
+	public function test_self_referencing_reusable_block_does_not_recurse() {
+		// Create a synced pattern (wp_block) with placeholder content.
+		$pattern_id = self::factory()->post->create(
+			[
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_title'   => 'Recursive Pattern',
+				'post_content' => '<!-- wp:newspack-blocks/homepage-articles /-->',
+			]
+		);
+
+		// Update the pattern to include a reference to itself.
+		wp_update_post(
+			[
+				'ID'           => $pattern_id,
+				'post_content' => sprintf(
+					'<!-- wp:newspack-blocks/homepage-articles /--><!-- wp:block {"ref":%d} /-->',
+					$pattern_id
+				),
+			]
+		);
+
+		// Create a post that embeds the recursive pattern.
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_title'   => 'Test Post',
+				'post_content' => sprintf(
+					'<!-- wp:block {"ref":%d} /-->',
+					$pattern_id
+				),
+			]
+		);
+
+		// Simulate a singular request for this post.
+		$this->go_to( get_permalink( $post_id ) );
+
+		// If the recursion guard is working, this completes without a fatal error.
+		Newspack_Blocks_Caching::check_all_blocks_cache_status();
+
+		// Reaching this assertion means no infinite recursion occurred.
+		$this->assertTrue( true, 'check_all_blocks_cache_status() completed without infinite recursion.' );
+	}
+
+	/**
+	 * Two distinct synced patterns embedded in the same post should both
+	 * be traversed by check_all_blocks_cache_status().
+	 */
+	public function test_non_recursive_reusable_blocks_are_traversed() {
+		$pattern_a = self::factory()->post->create(
+			[
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_title'   => 'Pattern A',
+				'post_content' => '<!-- wp:newspack-blocks/homepage-articles /-->',
+			]
+		);
+		$pattern_b = self::factory()->post->create(
+			[
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_title'   => 'Pattern B',
+				'post_content' => '<!-- wp:newspack-blocks/homepage-articles /-->',
+			]
+		);
+
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_title'   => 'Test Post',
+				'post_content' => sprintf(
+					'<!-- wp:block {"ref":%d} /--><!-- wp:block {"ref":%d} /-->',
+					$pattern_a,
+					$pattern_b
+				),
+			]
+		);
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		// Should complete without error — neither pattern references the other.
+		Newspack_Blocks_Caching::check_all_blocks_cache_status();
+		$this->assertTrue( true, 'Non-recursive patterns traversed without error.' );
+	}
+
+	/**
+	 * A cycle between two synced patterns (A references B, B references A)
+	 * should be caught by the recursion guard.
+	 */
+	public function test_mutual_recursion_between_patterns_is_caught() {
+		// Create two patterns with placeholder content first.
+		$pattern_a = self::factory()->post->create(
+			[
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_title'   => 'Pattern A',
+				'post_content' => '<!-- wp:paragraph --><p>placeholder</p><!-- /wp:paragraph -->',
+			]
+		);
+		$pattern_b = self::factory()->post->create(
+			[
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_title'   => 'Pattern B',
+				'post_content' => '<!-- wp:paragraph --><p>placeholder</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		// Now wire them into a cycle: A includes B, B includes A.
+		wp_update_post(
+			[
+				'ID'           => $pattern_a,
+				'post_content' => sprintf(
+					'<!-- wp:newspack-blocks/homepage-articles /--><!-- wp:block {"ref":%d} /-->',
+					$pattern_b
+				),
+			]
+		);
+		wp_update_post(
+			[
+				'ID'           => $pattern_b,
+				'post_content' => sprintf(
+					'<!-- wp:newspack-blocks/homepage-articles /--><!-- wp:block {"ref":%d} /-->',
+					$pattern_a
+				),
+			]
+		);
+
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_title'   => 'Test Post',
+				'post_content' => sprintf(
+					'<!-- wp:block {"ref":%d} /-->',
+					$pattern_a
+				),
+			]
+		);
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		Newspack_Blocks_Caching::check_all_blocks_cache_status();
+		$this->assertTrue( true, 'Mutual recursion between two patterns was caught.' );
+	}
+}

--- a/tests/test-caching.php
+++ b/tests/test-caching.php
@@ -7,6 +7,8 @@
 
 /**
  * Newspack_Blocks_Caching test case.
+ *
+ * @group caching
  */
 class CachingTest extends WP_UnitTestCase { // phpcs:ignore
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A synced pattern containing a `core/block` reference to itself (or a cycle of patterns referencing each other) causes infinite recursion in `Newspack_Blocks_Caching::check_block_cache_status()`. The method recurses into reusable block content via `get_post()` + `parse_blocks()`, but never checks whether it has already visited a given block ID. This leads to an OOM crash on the front end for logged-out visitors, since logged-in admins bypass the cache path entirely.

This was observed on a live site where a synced pattern accidentally contained a self-referencing `<!-- wp:block {"ref":14406} /-->`, causing 500 errors on any page that embedded it.

This PR adds a static `$visited_reusable_blocks` tracker that mirrors the approach used by WordPress core's `render_block_core_block()` ([source](https://github.com/WordPress/WordPress/blob/master/wp-includes/blocks/block.php)). When a reusable block ID is encountered a second time during the same traversal, it is skipped. The visited set is scoped per top-level call: entries are added before recursing and removed after, so the same block can still appear in unrelated branches of the block tree.

Also adds a guard for empty `ref` attributes to avoid passing a falsy value to `get_post()` (because of course it'll happen!).

Addresses [NPPM-2706](https://linear.app/a8c/issue/NPPM-2706/guard-against-infinite-recursion-in-included-blocks) Guard against infinite recursion in included blocks.

### How to test the changes in this Pull Request:

**Setup:**
```bash
ncd newspack-blocks   # or: cd repos/newspack-blocks
n ci-build
```

**1. Verify existing tests pass:**
```bash
n test-php
```

#### Manual testing (browser)

**2a. Create a recursive synced pattern:**
1. In wp-admin, go to **Appearance → Editor → Patterns** and create a new synced pattern.
2. Add a Homepage Posts block. Publish the pattern and note its post ID (visible in the URL: `post=<ID>`).
3. Edit the same pattern and switch to the Code Editor. Append a self-reference:
   ```
   <!-- wp:block {"ref":<ID>} /-->
   ```
4. Save the pattern.

**3a. Verify the fix:**
1. Create or edit a post and insert the recursive pattern.
2. Publish the post and view it in a logged-out browser (or incognito window).
3. **Before this fix:** PHP fatal error (max nesting depth exceeded), HTTP 500. **After:** the page renders normally; the self-referencing block is silently skipped.

**4a. Confirm non-recursive patterns still render:**
1. Create two separate synced patterns, each containing a Homepage Posts block.
2. Embed both in a post and view it logged-out.
3. Both patterns should render their content normally.

#### Alternative: CLI testing using `newspack-workspace`

**2b. Create a self-referencing synced pattern and verify the fix prevents a crash:**
```bash
# Create a synced pattern containing a Homepage Posts block.
PATTERN_ID=$(docker exec newspack_dev sh -c "wp post create \
  --post_type=wp_block \
  --post_status=publish \
  --post_title='Recursion Test Pattern' \
  --post_content='<!-- wp:newspack-blocks/homepage-articles /-->' \
  --porcelain \
  --allow-root")
echo "Created pattern: $PATTERN_ID"

# Inject a self-reference into the pattern.
docker exec newspack_dev sh -c "wp post update $PATTERN_ID \
  --post_content='<!-- wp:newspack-blocks/homepage-articles /--><!-- wp:block {\"ref\":$PATTERN_ID} /-->' \
  --allow-root"

# Create a published post that embeds the recursive pattern.
TEST_POST_ID=$(docker exec newspack_dev sh -c "wp post create \
  --post_type=post \
  --post_status=publish \
  --post_title='Recursion Guard Test' \
  --post_content='<!-- wp:block {\"ref\":$PATTERN_ID} /-->' \
  --porcelain \
  --allow-root")
TEST_URL=$(docker exec newspack_dev sh -c "wp post list \
  --post__in=$TEST_POST_ID --field=url --allow-root")
echo "Test URL: $TEST_URL"

# Fetch the page as a logged-out visitor and check for a successful response.
# Before this fix: HTTP 500 (PHP fatal from max nesting depth).
# After this fix: HTTP 200 with rendered content.
HTTP_STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$TEST_URL")
echo "HTTP status: $HTTP_STATUS"  # Expect: 200
```

**3b. Confirm non-recursive synced patterns still render normally:**
```bash
# Create two independent synced patterns.
PATTERN_A=$(docker exec newspack_dev sh -c "wp post create \
  --post_type=wp_block \
  --post_status=publish \
  --post_title='Pattern A' \
  --post_content='<!-- wp:newspack-blocks/homepage-articles /-->' \
  --porcelain \
  --allow-root")
PATTERN_B=$(docker exec newspack_dev sh -c "wp post create \
  --post_type=wp_block \
  --post_status=publish \
  --post_title='Pattern B' \
  --post_content='<!-- wp:newspack-blocks/homepage-articles /-->' \
  --porcelain \
  --allow-root")

# Create a post that embeds both (no cycle).
NORMAL_POST_ID=$(docker exec newspack_dev sh -c "wp post create \
  --post_type=post \
  --post_status=publish \
  --post_title='Non-Recursive Test' \
  --post_content='<!-- wp:block {\"ref\":$PATTERN_A} /--><!-- wp:block {\"ref\":$PATTERN_B} /-->' \
  --porcelain \
  --allow-root")
NORMAL_URL=$(docker exec newspack_dev sh -c "wp post list \
  --post__in=$NORMAL_POST_ID --field=url --allow-root")

# Both patterns should render. Check for HTTP 200 and presence of block markup.
HTTP_STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$NORMAL_URL")
echo "HTTP status: $HTTP_STATUS"  # Expect: 200
curl -s "$NORMAL_URL" | grep -q 'wp-block-newspack-blocks-homepage-articles' \
  && echo "Block markup found" || echo "Block markup MISSING"
```

**4. Cleanup (optional):**
```bash
docker exec newspack_dev sh -c "wp post delete $PATTERN_ID $TEST_POST_ID \
  $PATTERN_A $PATTERN_B $NORMAL_POST_ID --force --allow-root"
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?