### PR TITLE
fix: change defaultFrequency approach in the Donate block to match tiered layout

### DIFF
--- a/src/blocks/donate/edit/FrequencyBasedLayout.tsx
+++ b/src/blocks/donate/edit/FrequencyBasedLayout.tsx
@@ -60,12 +60,7 @@ const FrequencyBasedLayout = ( props: { canUseNameYourPrice: boolean; isTiered: 
 
 	// Update selected frequency when the default frequency attribute is updated.
 	useEffect( () => {
-		if ( formRef.current ) {
-			const defaultFrequencyInput = formRef.current.querySelector( `[name="donation_frequency"][value="${ attributes.defaultFrequency }"]` );
-			if ( defaultFrequencyInput instanceof HTMLInputElement ) {
-				defaultFrequencyInput.click();
-			}
-		}
+		setSelectedFrequency( attributes.defaultFrequency );
 	}, [ attributes.defaultFrequency ] );
 
 	const [ selectedFrequency, setSelectedFrequency ] = useState( attributes.defaultFrequency );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In the latest WordPress RC, changing the 'Default Layout' for the Donate Block when using the Frequency layout isn't updating the preview in the editor, though it is working on the front-end. The Tiered Layout works, so this PR switches the regular layout to use the same approach.

Closes NEWS-1758

### How to test the changes in this Pull Request:

1. Start on a test site running the latest WP 7.0 RC.
2. Add a Donate Block, and make sure it's using the Frequency layout.
3. Try changing the Default Tab in the sidebar; note it doesn't update in the editor.
4. Switch the block's layout to the Tiered Layout, and confirm the Default Tab does work.
5. Apply this PR.
6. Repeat testing with the Frequency layout, and ensure the Default tab previews.
7. Test the PR on a site running 6.9 and ensure it still works as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
