### PR TITLE
fix: ensure block option spacing for checkout button block is consistent

### DIFF
--- a/src/blocks/checkout-button/edit.scss
+++ b/src/blocks/checkout-button/edit.scss
@@ -22,7 +22,7 @@
 		.components-base-control {
 			margin: 0 0 8px;
 
-			&:last-child {
+			&:last-of-type {
 				margin-bottom: 0;
 			}
 		}

--- a/src/blocks/checkout-button/edit.scss
+++ b/src/blocks/checkout-button/edit.scss
@@ -20,7 +20,11 @@
 			}
 		}
 		.components-base-control {
-			margin: 0;
+			margin: 0 0 8px;
+
+			&:last-child {
+				margin-bottom: 0;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In WordPress 7.0 the options for product variations end up all smooshed together for the Checkout Button Block.

Closes NEWS-1744

### How to test the changes in this Pull Request:

1. On a site running the latest WordPress 7.0 RC, create a product with variations, and set up a checkout button block to use it.
2. In the editor, select the button, and look in the right sidebar. Note cozy spacing:

<img width="277" height="507" alt="CleanShot 2026-05-01 at 15 17 27" src="https://github.com/user-attachments/assets/5b031d32-1069-4937-82f7-dbc5f55309d5" />

3. Apply the PR; confirm the spacing looks better.
4. Also test the PR on a site running WP 6.9; compare it against trunk and confirm the spacing looks the same. 

<img width="279" height="530" alt="CleanShot 2026-05-01 at 15 16 35" src="https://github.com/user-attachments/assets/bdffa19c-ff28-4ce1-aef6-373626b3e068" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
