### PR TITLE
fix: ensure buttons pick up all colours, fonts sizes, font class styles

### DIFF
--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -396,7 +396,7 @@ class Newspack_Blocks {
 			$classes = array_merge( $classes, $extra );
 		}
 
-		return implode( ' ', array_filter( $classes ) );
+		return implode( ' ', array_filter( $classes, 'strlen' ) );
 	}
 
 	/**

--- a/includes/class-newspack-blocks.php
+++ b/includes/class-newspack-blocks.php
@@ -396,7 +396,7 @@ class Newspack_Blocks {
 			$classes = array_merge( $classes, $extra );
 		}
 
-		return implode( ' ', $classes );
+		return implode( ' ', array_filter( $classes ) );
 	}
 
 	/**

--- a/src/blocks/checkout-button/view.php
+++ b/src/blocks/checkout-button/view.php
@@ -98,9 +98,9 @@ function render_callback( $attributes ) {
 
 	$button = sprintf(
 		'<button class="%1$s" style="%2$s" type="submit">%3$s</button>',
-		$button_classes,
-		$button_styles,
-		$text
+		esc_attr( $button_classes ),
+		esc_attr( $button_styles ),
+		wp_kses_post( $text )
 	);
 
 	// Generate hidden fields for the form.
@@ -168,7 +168,7 @@ function render_callback( $attributes ) {
 		[
 			'wp-block-button',
 			( $font_size || isset( $style['typography']['fontSize'] ) ) ? 'has-custom-font-size' : '',
-			$width ? ' has-custom-width wp-block-button__width-' . esc_attr( $width ) : '',
+			$width ? 'has-custom-width wp-block-button__width-' . esc_attr( $width ) : '',
 		]
 	);
 	return sprintf(

--- a/src/blocks/checkout-button/view.php
+++ b/src/blocks/checkout-button/view.php
@@ -49,6 +49,7 @@ function render_callback( $attributes ) {
 	$background_color           = $attributes['backgroundColor'] ?? '';
 	$gradient                   = $attributes['gradient'] ?? '';
 	$font_size                  = $attributes['fontSize'] ?? '';
+	$font_family                = $attributes['fontFamily'] ?? '';
 	$style                      = $attributes['style'] ?? [];
 	$text_align                 = $attributes['textAlign'] ?? '';
 	$width                      = $attributes['width'] ?? '';
@@ -74,8 +75,6 @@ function render_callback( $attributes ) {
 	$button_styles = Newspack_Blocks::block_styles(
 		$attributes,
 		[
-			$background_color ? 'background-color:' . esc_attr( $background_color ) . ';' : '',
-			$font_size ? 'font-size:' . esc_attr( $font_size ) . ';' : '',
 			$width ? 'width:' . esc_attr( $width ) . '%;' : '',
 			$button_color ? 'color:' . esc_attr( $button_color ) . ';' : '',
 		]
@@ -86,8 +85,11 @@ function render_callback( $attributes ) {
 		$attributes,
 		[
 			'wp-block-button__link',
-			$background_color ? 'has-background has-' . esc_attr( $background_color ) . '-background-color' : '',
-			$gradient ? 'has-background has-' . esc_attr( $gradient ) . '-gradient-background' : '',
+			( $background_color || $gradient || isset( $style['color']['background'] ) || isset( $style['color']['gradient'] ) ) ? 'has-background' : '',
+			$background_color ? 'has-' . esc_attr( $background_color ) . '-background-color' : '',
+			$gradient ? 'has-' . esc_attr( $gradient ) . '-gradient-background' : '',
+			$font_size ? 'has-' . esc_attr( $font_size ) . '-font-size' : '',
+			$font_family ? 'has-' . esc_attr( $font_family ) . '-font-family' : '',
 			$text_align ? 'has-text-align-' . esc_attr( $text_align ) : '',
 			isset( $style['border']['radius'] ) && $style['border']['radius'] === 0 ? 'no-border-radius' : '',
 			$button_color ? 'has-text-color has-' . esc_attr( $button_color ) . '-color' : '',

--- a/src/blocks/checkout-button/view.php
+++ b/src/blocks/checkout-button/view.php
@@ -92,7 +92,8 @@ function render_callback( $attributes ) {
 			$font_family ? 'has-' . esc_attr( $font_family ) . '-font-family' : '',
 			$text_align ? 'has-text-align-' . esc_attr( $text_align ) : '',
 			isset( $style['border']['radius'] ) && $style['border']['radius'] === 0 ? 'no-border-radius' : '',
-			$button_color ? 'has-text-color has-' . esc_attr( $button_color ) . '-color' : '',
+			( $button_color || isset( $style['color']['text'] ) ) ? 'has-text-color' : '',
+			$button_color ? 'has-' . esc_attr( $button_color ) . '-color' : '',
 		]
 	);
 

--- a/src/blocks/checkout-button/view.php
+++ b/src/blocks/checkout-button/view.php
@@ -76,7 +76,6 @@ function render_callback( $attributes ) {
 		$attributes,
 		[
 			$width ? 'width:' . esc_attr( $width ) . '%;' : '',
-			$button_color ? 'color:' . esc_attr( $button_color ) . ';' : '',
 		]
 	);
 

--- a/src/blocks/checkout-button/view.php
+++ b/src/blocks/checkout-button/view.php
@@ -47,6 +47,7 @@ function render_callback( $attributes ) {
 	\Newspack_Blocks::enqueue_view_assets( 'checkout-button' );
 
 	$background_color           = $attributes['backgroundColor'] ?? '';
+	$text_color                 = $attributes['textColor'] ?? '';
 	$gradient                   = $attributes['gradient'] ?? '';
 	$font_size                  = $attributes['fontSize'] ?? '';
 	$font_family                = $attributes['fontFamily'] ?? '';
@@ -63,13 +64,11 @@ function render_callback( $attributes ) {
 	}
 
 	// Generate the button.
-	$button_color = '';
-	// Get button color from style attribute since style engine doesn't seem to handle this.
-	if ( isset( $style['elements']['link']['color']['text'] ) ) {
-		$color = $style['elements']['link']['color']['text'];
-		$color = explode( '|', $color );
+	// Fall back to the legacy link-color storage path if textColor isn't set.
+	if ( ! $text_color && isset( $style['elements']['link']['color']['text'] ) ) {
+		$color = explode( '|', $style['elements']['link']['color']['text'] );
 		if ( isset( $color[2] ) ) {
-			$button_color = $color[2];
+			$text_color = $color[2];
 		}
 	}
 	$button_styles = Newspack_Blocks::block_styles(
@@ -91,8 +90,8 @@ function render_callback( $attributes ) {
 			$font_family ? 'has-' . esc_attr( $font_family ) . '-font-family' : '',
 			$text_align ? 'has-text-align-' . esc_attr( $text_align ) : '',
 			isset( $style['border']['radius'] ) && $style['border']['radius'] === 0 ? 'no-border-radius' : '',
-			( $button_color || isset( $style['color']['text'] ) ) ? 'has-text-color' : '',
-			$button_color ? 'has-' . esc_attr( $button_color ) . '-color' : '',
+			( $text_color || isset( $style['color']['text'] ) ) ? 'has-text-color' : '',
+			$text_color ? 'has-' . esc_attr( $text_color ) . '-color' : '',
 		]
 	);
 

--- a/tests/test-checkout-button-block.php
+++ b/tests/test-checkout-button-block.php
@@ -1,0 +1,142 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Class CheckoutButtonBlockTest
+ *
+ * @package Newspack_Blocks
+ */
+
+require_once dirname( __DIR__ ) . '/src/blocks/checkout-button/view.php';
+
+/**
+ * Checkout Button Block.
+ */
+class CheckoutButtonBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
+
+	/**
+	 * Render the block with the given attributes merged into a minimal valid set.
+	 *
+	 * @param array $attributes Attributes to override.
+	 * @return string Rendered HTML.
+	 */
+	private function render( $attributes = [] ) {
+		return \Newspack_Blocks\Checkout_Button\render_callback(
+			array_merge(
+				[
+					'product'     => '1',
+					'variation'   => '',
+					'text'        => 'Checkout',
+					'is_variable' => false,
+				],
+				$attributes
+			)
+		);
+	}
+
+	/**
+	 * Extract the class attribute value from the rendered <button> element.
+	 *
+	 * @param string $output Rendered HTML.
+	 * @return string Class attribute value, or empty string if not found.
+	 */
+	private function get_button_class( $output ) {
+		if ( preg_match( '/<button[^>]*class="([^"]*)"/', $output, $matches ) ) {
+			return $matches[1];
+		}
+		return '';
+	}
+
+	/**
+	 * Extract the style attribute value from the rendered <button> element.
+	 *
+	 * @param string $output Rendered HTML.
+	 * @return string Style attribute value, or empty string if not found.
+	 */
+	private function get_button_style( $output ) {
+		if ( preg_match( '/<button[^>]*style="([^"]*)"/', $output, $matches ) ) {
+			return $matches[1];
+		}
+		return '';
+	}
+
+	/**
+	 * Preset slugs (color, font) should emit has-{slug}-* classes and must NOT
+	 * appear as literal CSS values in the inline style attribute.
+	 */
+	public function test_presets_emit_classes_not_inline_values() {
+		$output = $this->render(
+			[
+				'backgroundColor' => 'primary',
+				'textColor'       => 'accent',
+				'fontSize'        => 'large',
+				'fontFamily'      => 'system-sans-serif',
+			]
+		);
+		$class = $this->get_button_class( $output );
+		$style = $this->get_button_style( $output );
+
+		$this->assertStringContainsString( 'has-background', $class );
+		$this->assertStringContainsString( 'has-primary-background-color', $class );
+		$this->assertStringContainsString( 'has-text-color', $class );
+		$this->assertStringContainsString( 'has-accent-color', $class );
+		$this->assertStringContainsString( 'has-large-font-size', $class );
+		$this->assertStringContainsString( 'has-system-sans-serif-font-family', $class );
+
+		$this->assertStringNotContainsString( 'background-color:primary', $style );
+		$this->assertStringNotContainsString( 'color:accent', $style );
+		$this->assertStringNotContainsString( 'font-size:large', $style );
+		$this->assertStringNotContainsString( 'font-family:system-sans-serif', $style );
+	}
+
+	/**
+	 * Custom background color via style.color.background should trigger has-background.
+	 */
+	public function test_custom_background_emits_has_background() {
+		$output = $this->render(
+			[
+				'style' => [ 'color' => [ 'background' => '#ff0000' ] ],
+			]
+		);
+		$this->assertStringContainsString( 'has-background', $this->get_button_class( $output ) );
+	}
+
+	/**
+	 * Custom gradient via style.color.gradient should trigger has-background.
+	 */
+	public function test_custom_gradient_emits_has_background() {
+		$output = $this->render(
+			[
+				'style' => [ 'color' => [ 'gradient' => 'linear-gradient(45deg,red,blue)' ] ],
+			]
+		);
+		$this->assertStringContainsString( 'has-background', $this->get_button_class( $output ) );
+	}
+
+	/**
+	 * Custom text color via style.color.text should trigger has-text-color
+	 * (no slug class is expected for custom hex values).
+	 */
+	public function test_custom_text_color_emits_has_text_color() {
+		$output = $this->render(
+			[
+				'style' => [ 'color' => [ 'text' => '#ff0000' ] ],
+			]
+		);
+		$this->assertStringContainsString( 'has-text-color', $this->get_button_class( $output ) );
+	}
+
+	/**
+	 * Class list should not have leading or trailing whitespace, or any double spaces.
+	 */
+	public function test_class_list_has_no_extra_whitespace() {
+		$output = $this->render(
+			[
+				'backgroundColor' => 'primary',
+				'fontSize'        => 'large',
+			]
+		);
+		$class = $this->get_button_class( $output );
+
+		$this->assertSame( trim( $class ), $class, 'Class list should have no leading or trailing whitespace.' );
+		$this->assertStringNotContainsString( '  ', $class, 'Class list should not contain double spaces.' );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR originated as a way to fix an issue with the new font options coming in WP 7.0, but it also fixes a couple minor issues with button styles:
* It makes sure the theme's baked-in font sizes work on the front-end
* It makes sure WP 7.0's new font face option works on the checkout button block
* It adds a `has-background` CSS class when custom background colours are applied, not just colours from the default palette; ditto `has-text-color`. 
* It cleans up some extra spacing getting added in between CSS classes

**Edited to add:**

This PR updates `block_classes()` in `includes/class-newspack-blocks.php`, which is shared by all server-rendered blocks. The new `array_filter()` on the return value also affects:

* `homepage-articles` (Content Loop)
* `carousel` (Content Carousel)
* `author-profile` (and the `author-profile-card` template)

Closes NEWS-1754 

### How to test the changes in this Pull Request:

1. Test on a site running the latest WP 7.0 RC.
2. Under Appearance > Fonts, click Install Fonts, allow Google Fonts, pick at least one font and install a variant by checking at least one weight/style, and clicking 'Install':

<img width="877" height="544" alt="image" src="https://github.com/user-attachments/assets/3fc34c5b-021f-497f-96d4-22c1c9dced69" />

3. Create a new post or page, and add a few different checkout button blocks. Make sure to include:
* A block using colours from the theme (background and text)
* A block using custom colours
* A block using font sizes from the theme (like 'Large')
* A block using a custom font size
* In the 'Typography' panel, click the `...` menu and select 'Font', then use it to change the font-family on one of the buttons.
4. Publish and view on the front end and note what's not working -- it should be the baked in font sizes, and font family. If you view source, you'll also see some funky styles (like `background-color: primary`)
5. Apply this PR.
6. Refresh the front end and confirm the block styles are all being picked up - the only one that should be a mismatch with the editor is the padding, but this is due to missing editor styles from the theme; that'll be fixed in a separate PR ([here](https://github.com/Automattic/newspack-theme/pull/2686)).
7. Ensure that blocks with custom background and text colours have the `has-background` and `has-text-color` classes, respectively. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
