### PR TITLE
fix(recaptcha): bypass on Check Payments path in modal checkout

### DIFF
--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1584,8 +1584,14 @@ final class Modal_Checkout {
 		if ( 'checkout' !== $context ) {
 			return $should_verify;
 		}
-		// Skip captcha verification if we're in the modal checkout and this is a validation-only request,
-		// which happens when the user updates their billing details on the first screen of the modal checkout.
+		// All bypasses below are scoped to the modal checkout context so a
+		// crafted POST to standard /checkout/ can't disable reCAPTCHA via
+		// is_validation_only or payment_method=cheque.
+		if ( ! self::is_modal_checkout() ) {
+			return $should_verify;
+		}
+		// Skip captcha verification on the validation-only request fired when
+		// the user updates billing details on the first screen of the modal.
 		if ( self::is_validation_only() ) {
 			return false;
 		}
@@ -1593,11 +1599,9 @@ final class Modal_Checkout {
 		// client-side tokenization to serialize the submit, so v2 invisible
 		// races with updated_checkout resets and freezes the button (NPPM-2619).
 		// Mirrors the data-skip-recaptcha toggle on the modal checkout form.
-		if ( self::is_modal_checkout() ) {
-			$payment_method = isset( $_POST['payment_method'] ) ? sanitize_text_field( wp_unslash( $_POST['payment_method'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
-			if ( 'cheque' === $payment_method ) {
-				return false;
-			}
+		$payment_method = isset( $_POST['payment_method'] ) ? sanitize_text_field( wp_unslash( $_POST['payment_method'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( 'cheque' === $payment_method ) {
+			return false;
 		}
 		return $should_verify;
 	}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1595,7 +1595,12 @@ final class Modal_Checkout {
 	 * @return bool True if the request is for validation only.
 	 */
 	private static function is_validation_only() {
-		return boolval( filter_input( INPUT_POST, 'is_validation_only', FILTER_SANITIZE_NUMBER_INT ) );
+		// Read $_POST directly (rather than filter_input) so the recaptcha
+		// bypass branch this gates is exercisable from unit tests —
+		// filter_input(INPUT_POST, ...) returns null under PHP CLI. Nonce
+		// verification is owned by Woo's checkout flow upstream of every
+		// call site.
+		return ! empty( $_POST['is_validation_only'] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 	}
 
 	/**

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1584,8 +1584,20 @@ final class Modal_Checkout {
 		if ( 'checkout' !== $context ) {
 			return $should_verify;
 		}
+		// Skip captcha verification if we're in the modal checkout and this is a validation-only request,
+		// which happens when the user updates their billing details on the first screen of the modal checkout.
 		if ( self::is_validation_only() ) {
 			return false;
+		}
+		// Skip captcha on the Check Payments path. The cheque gateway has no
+		// client-side tokenization to serialize the submit, so v2 invisible
+		// races with updated_checkout resets and freezes the button (NPPM-2619).
+		// Mirrors the data-skip-recaptcha toggle on the modal checkout form.
+		if ( self::is_modal_checkout() ) {
+			$payment_method = isset( $_POST['payment_method'] ) ? sanitize_text_field( wp_unslash( $_POST['payment_method'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			if ( 'cheque' === $payment_method ) {
+				return false;
+			}
 		}
 		return $should_verify;
 	}

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -1624,10 +1624,10 @@ final class Modal_Checkout {
 	 * billing-edit step and offline gateways with no client-side tokenization
 	 * (e.g. Check Payments). Also covers AJAX checkout (e.g. Apple Pay).
 	 *
-	 * All bypasses are scoped to the modal checkout context and to logged-in
-	 * readers so a crafted POST to standard /checkout/ — or an unauthenticated
-	 * POST to the modal — can't disable reCAPTCHA to spam the reader/order
-	 * tables.
+	 * All bypasses are scoped to the modal checkout context and gated on a valid
+	 * modal-checkout nonce so a crafted POST to standard /checkout/ — or a blind
+	 * POST to the modal without the nonce — can't disable reCAPTCHA to spam the
+	 * reader/order tables.
 	 *
 	 * @param bool   $should_verify Whether to verify the captcha.
 	 * @param string $url The URL from which the verification request originated.
@@ -1640,10 +1640,16 @@ final class Modal_Checkout {
 		if ( ! self::is_modal_checkout() ) {
 			return $should_verify;
 		}
-		// Require an authenticated reader for any bypass. Reader Activation
-		// auto-registers and logs in the reader when they submit billing on the
-		// first modal screen, so the bypasses still apply on the real flow.
-		if ( ! is_user_logged_in() ) {
+		// Require a valid modal-checkout nonce for any bypass. The nonce is
+		// rendered into the modal checkout form (form-checkout.php) and submitted
+		// with the checkout request, so the real modal flow — including guest
+		// donors converting through the modal (NPPM-2619), who are not yet
+		// registered/logged in at woocommerce_checkout_process time — still hits
+		// the bypass. A crafted POST to standard /checkout/ with modal_checkout=1
+		// but no valid nonce falls through to standard reCAPTCHA verification,
+		// closing the spam vector without locking out unauthenticated readers.
+		$nonce = isset( $_POST['newspack_checkout_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['newspack_checkout_nonce'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( ! wp_verify_nonce( $nonce, 'newspack_modal_checkout_nonce' ) ) {
 			return $should_verify;
 		}
 		// Skip captcha verification on the validation-only request fired when

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -134,6 +134,21 @@ final class Modal_Checkout {
 	];
 
 	/**
+	 * Offline payment gateways with no client-side tokenization. These race with
+	 * Woo's updated_checkout reset under reCAPTCHA v2 invisible and freeze the
+	 * submit button (NPPM-2619), so reCAPTCHA verification is bypassed for them
+	 * inside the modal checkout. Mirrored in JS via the localized
+	 * `newspackBlocksModalCheckout.recaptcha_bypass_gateways` array.
+	 *
+	 * @var string[]
+	 */
+	private static $recaptcha_bypass_gateways = [
+		'bacs', // Direct bank transfer.
+		'cheque',
+		'cod', // Cash on delivery.
+	];
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
@@ -272,6 +287,23 @@ final class Modal_Checkout {
 		 * @param array $supported_gateways
 		 */
 		return apply_filters( 'newspack_blocks_modal_checkout_supported_gateways', self::$supported_gateways );
+	}
+
+	/**
+	 * Get the list of payment gateways for which reCAPTCHA verification should
+	 * be bypassed inside the modal checkout. Filterable via
+	 * `newspack_blocks_modal_checkout_recaptcha_bypass_gateways`.
+	 *
+	 * @return string[] Bypass gateway IDs.
+	 */
+	public static function get_recaptcha_bypass_gateways() {
+		/**
+		 * Filters the list of payment gateways that bypass reCAPTCHA verification
+		 * inside the modal checkout.
+		 *
+		 * @param string[] $bypass_gateways Bypass gateway IDs.
+		 */
+		return apply_filters( 'newspack_blocks_modal_checkout_recaptcha_bypass_gateways', self::$recaptcha_bypass_gateways );
 	}
 
 	/**
@@ -844,14 +876,15 @@ final class Modal_Checkout {
 			'newspack-blocks-modal-checkout',
 			'newspackBlocksModalCheckout',
 			[
-				'ajax_url'              => admin_url( 'admin-ajax.php' ),
-				'nyp_nonce'             => wp_create_nonce( 'newspack_checkout_name_your_price' ),
-				'checkout_nonce'        => wp_create_nonce( 'newspack_modal_checkout_nonce' ),
-				'newspack_class_prefix' => self::get_class_prefix(),
-				'is_checkout_complete'  => function_exists( 'is_order_received_page' ) && is_order_received_page(),
-				'divider_text'          => esc_html__( 'Or', 'newspack-blocks' ),
-				'is_error'              => ! is_checkout() && ! is_order_received_page(),
-				'labels'                => [
+				'ajax_url'                  => admin_url( 'admin-ajax.php' ),
+				'nyp_nonce'                 => wp_create_nonce( 'newspack_checkout_name_your_price' ),
+				'checkout_nonce'            => wp_create_nonce( 'newspack_modal_checkout_nonce' ),
+				'newspack_class_prefix'     => self::get_class_prefix(),
+				'is_checkout_complete'      => function_exists( 'is_order_received_page' ) && is_order_received_page(),
+				'divider_text'              => esc_html__( 'Or', 'newspack-blocks' ),
+				'is_error'                  => ! is_checkout() && ! is_order_received_page(),
+				'recaptcha_bypass_gateways' => array_values( self::get_recaptcha_bypass_gateways() ),
+				'labels'                    => [
 					'billing_details'  => self::get_modal_checkout_labels( 'billing_details' ),
 					'shipping_details' => self::get_modal_checkout_labels( 'shipping_details' ),
 					'gift_recipient'   => self::get_modal_checkout_labels( 'gift_recipient' ),
@@ -1574,7 +1607,15 @@ final class Modal_Checkout {
 	}
 
 	/**
-	 * Prevent reCAPTCHA from being verified for AJAX checkout (e.g. Apple Pay).
+	 * Selectively bypass reCAPTCHA verification in the modal checkout for paths
+	 * that can't safely serialize with the v2 widget — the validation-only
+	 * billing-edit step and offline gateways with no client-side tokenization
+	 * (e.g. Check Payments). Also covers AJAX checkout (e.g. Apple Pay).
+	 *
+	 * All bypasses are scoped to the modal checkout context and to logged-in
+	 * readers so a crafted POST to standard /checkout/ — or an unauthenticated
+	 * POST to the modal — can't disable reCAPTCHA to spam the reader/order
+	 * tables.
 	 *
 	 * @param bool   $should_verify Whether to verify the captcha.
 	 * @param string $url The URL from which the verification request originated.
@@ -1584,10 +1625,13 @@ final class Modal_Checkout {
 		if ( 'checkout' !== $context ) {
 			return $should_verify;
 		}
-		// All bypasses below are scoped to the modal checkout context so a
-		// crafted POST to standard /checkout/ can't disable reCAPTCHA via
-		// is_validation_only or payment_method=cheque.
 		if ( ! self::is_modal_checkout() ) {
+			return $should_verify;
+		}
+		// Require an authenticated reader for any bypass. Reader Activation
+		// auto-registers and logs in the reader when they submit billing on the
+		// first modal screen, so the bypasses still apply on the real flow.
+		if ( ! is_user_logged_in() ) {
 			return $should_verify;
 		}
 		// Skip captcha verification on the validation-only request fired when
@@ -1595,12 +1639,16 @@ final class Modal_Checkout {
 		if ( self::is_validation_only() ) {
 			return false;
 		}
-		// Skip captcha on the Check Payments path. The cheque gateway has no
-		// client-side tokenization to serialize the submit, so v2 invisible
-		// races with updated_checkout resets and freezes the button (NPPM-2619).
-		// Mirrors the data-skip-recaptcha toggle on the modal checkout form.
+		// Skip captcha for offline gateways with no client-side tokenization
+		// (cheque, bacs, cod). v2 invisible races with updated_checkout resets
+		// and freezes the submit on these (NPPM-2619). Mirrors the
+		// data-skip-recaptcha toggle on the modal checkout form.
+		// Read $_POST directly (rather than filter_input) so this branch is
+		// exercisable from unit tests — filter_input(INPUT_POST, ...) returns
+		// null under PHP CLI. Nonce verification is owned by Woo's checkout
+		// flow upstream of this filter.
 		$payment_method = isset( $_POST['payment_method'] ) ? sanitize_text_field( wp_unslash( $_POST['payment_method'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		if ( 'cheque' === $payment_method ) {
+		if ( $payment_method && in_array( $payment_method, self::get_recaptcha_bypass_gateways(), true ) ) {
 			return false;
 		}
 		return $should_verify;

--- a/includes/class-modal-checkout.php
+++ b/includes/class-modal-checkout.php
@@ -446,7 +446,14 @@ final class Modal_Checkout {
 
 		/** Apply NYP custom price */
 		$price = filter_input( INPUT_GET, 'price', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
-		if ( \Newspack_Blocks::can_use_name_your_price() ? \WC_Name_Your_Price_Helpers::is_nyp( $product_id ) : false ) {
+		// can_use_name_your_price() can return true under the NRH donation
+		// platform even when WC_Name_Your_Price_Helpers isn't loaded, so guard
+		// the class call directly. Mirrors process_name_your_price_request().
+		if (
+			\Newspack_Blocks::can_use_name_your_price() &&
+			class_exists( 'WC_Name_Your_Price_Helpers' ) &&
+			\WC_Name_Your_Price_Helpers::is_nyp( $product_id )
+		) {
 			if ( empty( $price ) ) {
 				$price = \WC_Name_Your_Price_Helpers::get_suggested_price( $product_id );
 			}

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -569,6 +569,10 @@ import { domReady, onCheckoutPlaceOrderProcessing } from './utils';
 
 						// Disable 'Place Order' button if Subscription Confirmation is required.
 						handleSubscriptionConfirmation();
+						// Re-apply the payment-method-based reCAPTCHA toggle. validateForm's
+						// custom AJAX doesn't fire updated_checkout, so cheque bypass would
+						// otherwise be lost on return from the edit-billing step.
+						handlePaymentMethodSelect();
 					}
 					$form.triggerHandler( 'editing_details', [ isEditingDetails ] );
 					// Scroll to top.

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -99,29 +99,80 @@ import { domReady, onCheckoutPlaceOrderProcessing } from './utils';
 				const $after_customer_details = $( '#after_customer_details' );
 				const $gift_options = $( '.newspack-wcsg--wrapper' );
 
+				// Mirrored from PHP via Modal_Checkout::get_recaptcha_bypass_gateways().
+				// Filterable on the PHP side via newspack_blocks_modal_checkout_recaptcha_bypass_gateways.
+				const recaptchaBypassGateways = Array.isArray( newspackBlocksModalCheckout.recaptcha_bypass_gateways )
+					? newspackBlocksModalCheckout.recaptcha_bypass_gateways
+					: [];
+
+				// Tracked via the editing_details event below instead of probing the DOM.
+				let isEditingDetails = false;
+
 				/**
 				 * Handle styling update for selected payment method.
+				 *
+				 * Bound to input.change, payment_method_selected, and updated_checkout
+				 * because each fires in distinct scenarios (initial bind, programmatic
+				 * Woo updates, full fragment refresh). The body is idempotent so the
+				 * overlap is intentional and harmless.
 				 */
 				function handlePaymentMethodSelect() {
 					const selected = $( 'input[name="payment_method"]:checked' ).val();
 					$( '.wc_payment_method' ).removeClass( 'selected' );
 					$( '.wc_payment_method.payment_method_' + selected ).addClass( 'selected' );
-					// Skip reCAPTCHA on the Check Payments path. The cheque gateway has no
-					// client-side tokenization to serialize the submit, so v2 invisible
-					// races with updated_checkout resets and freezes the button (NPPM-2619).
-					// Skip while editing billing details — setEditingDetails owns the attr there.
-					if ( ! $form.find( '[name="is_validation_only"]' ).length ) {
-						if ( 'cheque' === selected ) {
-							$form.attr( 'data-skip-recaptcha', '1' );
-						} else {
-							$form.removeAttr( 'data-skip-recaptcha' );
-						}
+					// setEditingDetails owns data-skip-recaptcha during edit mode.
+					if ( isEditingDetails ) {
+						return;
+					}
+					// Bypass reCAPTCHA on offline gateways with no client-side
+					// tokenization (cheque/bacs/cod). v2 invisible races with
+					// updated_checkout resets and freezes the submit button (NPPM-2619).
+					if ( selected && recaptchaBypassGateways.indexOf( selected ) !== -1 ) {
+						$form.attr( 'data-skip-recaptcha', '1' );
+					} else {
+						$form.removeAttr( 'data-skip-recaptcha' );
 					}
 				}
 				$( 'input[name="payment_method"]' ).change( handlePaymentMethodSelect );
 				$( document ).on( 'payment_method_selected', handlePaymentMethodSelect );
 				$( document ).on( 'updated_checkout', handlePaymentMethodSelect );
 				handlePaymentMethodSelect();
+
+				// When v2 invisible is rendered, newspack-plugin's recaptcha attaches a
+				// click handler to #place_order_clone that preventDefaults and runs
+				// handleSubmit. In skip-recaptcha mode that handler clears an attribute
+				// and returns without submitting — the visible button goes dead. Catch
+				// the click on document capture phase (before the clone's element-level
+				// listener) and force a native submit when the bypass is active.
+				document.addEventListener(
+					'click',
+					function ( e ) {
+						const clone = e.target && e.target.closest ? e.target.closest( '#place_order_clone' ) : null;
+						if ( ! clone || ! $form.is( '[data-skip-recaptcha]' ) ) {
+							return;
+						}
+						e.preventDefault();
+						e.stopImmediatePropagation();
+						const formEl = $form.get( 0 );
+						if ( typeof formEl.requestSubmit === 'function' ) {
+							formEl.requestSubmit();
+						} else {
+							formEl.submit();
+						}
+					},
+					true
+				);
+
+				// Mirror setEditingDetails' state so handlePaymentMethodSelect can defer
+				// to it without probing the DOM, and re-apply the payment-method toggle
+				// when leaving edit mode (setEditingDetails(false) clears the attr
+				// unconditionally before this fires).
+				$form.on( 'editing_details', function ( e, editing ) {
+					isEditingDetails = !! editing;
+					if ( ! isEditingDetails ) {
+						handlePaymentMethodSelect();
+					}
+				} );
 
 				/**
 				 * Bubble up checkout place order event.
@@ -503,14 +554,14 @@ import { domReady, onCheckoutPlaceOrderProcessing } from './utils';
 				/**
 				 * Set the checkout state as editing billing/shipping fields or not.
 				 *
-				 * @param {boolean} isEditingDetails
+				 * @param {boolean} editing
 				 */
-				function setEditingDetails( isEditingDetails ) {
+				function setEditingDetails( editing ) {
 					const newspack_grecaptcha = window.newspack_grecaptcha || {};
 					clearNotices();
 					// Clear checkout details.
 					$( '#checkout_details' ).remove();
-					if ( isEditingDetails ) {
+					if ( editing ) {
 						$form.attr( 'data-skip-recaptcha', '1' );
 						$form.append( '<input name="is_validation_only" type="hidden" value="1" />' );
 						// Destroy reCAPTCHA inputs so we don't trigger validation between checkout steps.
@@ -569,12 +620,8 @@ import { domReady, onCheckoutPlaceOrderProcessing } from './utils';
 
 						// Disable 'Place Order' button if Subscription Confirmation is required.
 						handleSubscriptionConfirmation();
-						// Re-apply the payment-method-based reCAPTCHA toggle. validateForm's
-						// custom AJAX doesn't fire updated_checkout, so cheque bypass would
-						// otherwise be lost on return from the edit-billing step.
-						handlePaymentMethodSelect();
 					}
-					$form.triggerHandler( 'editing_details', [ isEditingDetails ] );
+					$form.triggerHandler( 'editing_details', [ editing ] );
 					// Scroll to top.
 					window.scroll( { top: 0, left: 0, behavior: 'smooth' } );
 				}

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -144,6 +144,11 @@ import { domReady, onCheckoutPlaceOrderProcessing } from './utils';
 				// and returns without submitting — the visible button goes dead. Catch
 				// the click on document capture phase (before the clone's element-level
 				// listener) and force a native submit when the bypass is active.
+				// NOTE: this is a deliberate cross-repo monkey-patch of newspack-plugin's
+				// recaptcha handler from newspack-blocks. The cleaner home would be a
+				// data-skip-recaptcha branch in newspack-plugin's recaptcha/index.js
+				// handleSubmit, but the cross-repo coordination isn't worth it for this
+				// one-off fix.
 				document.addEventListener(
 					'click',
 					function ( e ) {

--- a/src/modal-checkout/index.js
+++ b/src/modal-checkout/index.js
@@ -106,6 +106,17 @@ import { domReady, onCheckoutPlaceOrderProcessing } from './utils';
 					const selected = $( 'input[name="payment_method"]:checked' ).val();
 					$( '.wc_payment_method' ).removeClass( 'selected' );
 					$( '.wc_payment_method.payment_method_' + selected ).addClass( 'selected' );
+					// Skip reCAPTCHA on the Check Payments path. The cheque gateway has no
+					// client-side tokenization to serialize the submit, so v2 invisible
+					// races with updated_checkout resets and freezes the button (NPPM-2619).
+					// Skip while editing billing details — setEditingDetails owns the attr there.
+					if ( ! $form.find( '[name="is_validation_only"]' ).length ) {
+						if ( 'cheque' === selected ) {
+							$form.attr( 'data-skip-recaptcha', '1' );
+						} else {
+							$form.removeAttr( 'data-skip-recaptcha' );
+						}
+					}
 				}
 				$( 'input[name="payment_method"]' ).change( handlePaymentMethodSelect );
 				$( document ).on( 'payment_method_selected', handlePaymentMethodSelect );

--- a/tests/test-modal-checkout-recaptcha.php
+++ b/tests/test-modal-checkout-recaptcha.php
@@ -1,0 +1,168 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Class ModalCheckoutRecaptchaTest
+ *
+ * @package Newspack_Blocks
+ */
+
+use Newspack_Blocks\Modal_Checkout;
+
+/**
+ * Modal_Checkout::recaptcha_verify_captcha scoping invariant.
+ *
+ * Locks the gating rules so future edits can't silently widen the bypass:
+ *   - non-checkout context             → unchanged
+ *   - non-modal request                → unchanged
+ *   - modal + logged-out               → unchanged (auth gate)
+ *   - modal + logged-in + validation   → false
+ *   - modal + logged-in + cheque/bacs/cod → false
+ *   - modal + logged-in + other gateway → unchanged
+ *
+ * @group modal-checkout
+ */
+class ModalCheckoutRecaptchaTest extends WP_UnitTestCase { // phpcs:ignore
+
+	/**
+	 * URL passed to the filter — not consulted by the callback, present for signature parity.
+	 */
+	const DUMMY_URL = 'https://example.test/checkout/';
+
+	/**
+	 * Reset superglobals and current user between cases.
+	 */
+	public function tear_down() {
+		unset( $_REQUEST['modal_checkout'], $_REQUEST['post_data'] );
+		unset( $_POST['payment_method'], $_POST['is_validation_only'] );
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Mark the request as a modal-checkout request and authenticate a reader.
+	 *
+	 * @param string $payment_method Payment method to put on $_POST. Empty to leave unset.
+	 */
+	private function set_up_authed_modal_request( $payment_method = '' ) {
+		$_REQUEST['modal_checkout'] = '1';
+		if ( '' !== $payment_method ) {
+			$_POST['payment_method'] = $payment_method;
+		}
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+	}
+
+	/**
+	 * Non-checkout contexts must pass through unchanged.
+	 */
+	public function test_non_checkout_context_passes_through() {
+		$_REQUEST['modal_checkout'] = '1';
+		$_POST['payment_method']    = 'cheque';
+
+		$this->assertTrue( Modal_Checkout::recaptcha_verify_captcha( true, self::DUMMY_URL, 'login' ) );
+		$this->assertFalse( Modal_Checkout::recaptcha_verify_captcha( false, self::DUMMY_URL, 'login' ) );
+	}
+
+	/**
+	 * A crafted POST to standard /checkout/ (no modal_checkout flag) must not
+	 * be able to disable reCAPTCHA via either bypass path.
+	 */
+	public function test_non_modal_request_is_not_bypassed() {
+		$_POST['payment_method']    = 'cheque';
+		$_POST['is_validation_only'] = '1';
+
+		$this->assertTrue( Modal_Checkout::recaptcha_verify_captcha( true, self::DUMMY_URL, 'checkout' ) );
+	}
+
+	/**
+	 * Unauthenticated modal requests must not be able to bypass reCAPTCHA —
+	 * this is the abuse-vector gate that prevents spamming reader/order
+	 * records via crafted POSTs with modal_checkout=1.
+	 */
+	public function test_unauthenticated_modal_request_is_not_bypassed() {
+		$_REQUEST['modal_checkout']  = '1';
+		$_POST['payment_method']     = 'cheque';
+		$_POST['is_validation_only'] = '1';
+
+		$this->assertTrue( Modal_Checkout::recaptcha_verify_captcha( true, self::DUMMY_URL, 'checkout' ) );
+	}
+
+	/**
+	 * Authenticated modal + validation-only request bypasses reCAPTCHA. This
+	 * is the validation step from the first modal screen, which must not
+	 * consume the v2 widget.
+	 */
+	public function test_modal_validation_only_bypasses() {
+		$this->set_up_authed_modal_request();
+		$_POST['is_validation_only'] = '1';
+
+		$this->assertFalse( Modal_Checkout::recaptcha_verify_captcha( true, self::DUMMY_URL, 'checkout' ) );
+	}
+
+	/**
+	 * Each offline gateway in the bypass allowlist must bypass reCAPTCHA when
+	 * a reader is authenticated inside the modal.
+	 *
+	 * @dataProvider provider_bypass_gateways
+	 *
+	 * @param string $gateway Gateway ID.
+	 */
+	public function test_modal_bypass_gateway_bypasses( $gateway ) {
+		$this->set_up_authed_modal_request( $gateway );
+
+		$this->assertFalse(
+			Modal_Checkout::recaptcha_verify_captcha( true, self::DUMMY_URL, 'checkout' ),
+			"Gateway '$gateway' should bypass reCAPTCHA inside the modal."
+		);
+	}
+
+	/**
+	 * Default bypass gateways.
+	 *
+	 * @return array<int, array{0: string}>
+	 */
+	public function provider_bypass_gateways() {
+		return [
+			[ 'cheque' ],
+			[ 'bacs' ],
+			[ 'cod' ],
+		];
+	}
+
+	/**
+	 * A non-bypass gateway must still require reCAPTCHA verification.
+	 */
+	public function test_modal_non_bypass_gateway_still_verifies() {
+		$this->set_up_authed_modal_request( 'stripe' );
+
+		$this->assertTrue( Modal_Checkout::recaptcha_verify_captcha( true, self::DUMMY_URL, 'checkout' ) );
+	}
+
+	/**
+	 * Authenticated modal request with no validation_only and no
+	 * payment_method passes through to the caller's default.
+	 */
+	public function test_modal_with_no_bypass_signals_passes_through() {
+		$this->set_up_authed_modal_request();
+
+		$this->assertTrue( Modal_Checkout::recaptcha_verify_captcha( true, self::DUMMY_URL, 'checkout' ) );
+		$this->assertFalse( Modal_Checkout::recaptcha_verify_captcha( false, self::DUMMY_URL, 'checkout' ) );
+	}
+
+	/**
+	 * The bypass gateway list is filterable so publishers can add/remove
+	 * offline gateways without touching plugin code.
+	 */
+	public function test_bypass_gateway_filter_is_respected() {
+		$filter = function ( $gateways ) {
+			$gateways[] = 'custom_offline';
+			return $gateways;
+		};
+		add_filter( 'newspack_blocks_modal_checkout_recaptcha_bypass_gateways', $filter );
+
+		$this->set_up_authed_modal_request( 'custom_offline' );
+
+		$this->assertFalse( Modal_Checkout::recaptcha_verify_captcha( true, self::DUMMY_URL, 'checkout' ) );
+
+		remove_filter( 'newspack_blocks_modal_checkout_recaptcha_bypass_gateways', $filter );
+	}
+}

--- a/tests/test-modal-checkout-recaptcha.php
+++ b/tests/test-modal-checkout-recaptcha.php
@@ -11,12 +11,12 @@ use Newspack_Blocks\Modal_Checkout;
  * Modal_Checkout::recaptcha_verify_captcha scoping invariant.
  *
  * Locks the gating rules so future edits can't silently widen the bypass:
- *   - non-checkout context             → unchanged
- *   - non-modal request                → unchanged
- *   - modal + logged-out               → unchanged (auth gate)
- *   - modal + logged-in + validation   → false
- *   - modal + logged-in + cheque/bacs/cod → false
- *   - modal + logged-in + other gateway → unchanged
+ *   - non-checkout context                  → unchanged
+ *   - non-modal request                     → unchanged
+ *   - modal + missing/invalid nonce         → unchanged (nonce gate)
+ *   - modal + valid nonce + validation      → false
+ *   - modal + valid nonce + cheque/bacs/cod → false
+ *   - modal + valid nonce + other gateway   → unchanged
  *
  * @group modal-checkout
  */
@@ -28,27 +28,25 @@ class ModalCheckoutRecaptchaTest extends WP_UnitTestCase { // phpcs:ignore
 	const DUMMY_URL = 'https://example.test/checkout/';
 
 	/**
-	 * Reset superglobals and current user between cases.
+	 * Reset superglobals between cases.
 	 */
 	public function tear_down() {
 		unset( $_REQUEST['modal_checkout'], $_REQUEST['post_data'] );
-		unset( $_POST['payment_method'], $_POST['is_validation_only'] );
-		wp_set_current_user( 0 );
+		unset( $_POST['payment_method'], $_POST['is_validation_only'], $_POST['newspack_checkout_nonce'] );
 		parent::tear_down();
 	}
 
 	/**
-	 * Mark the request as a modal-checkout request and authenticate a reader.
+	 * Mark the request as a modal-checkout request carrying a valid modal nonce.
 	 *
 	 * @param string $payment_method Payment method to put on $_POST. Empty to leave unset.
 	 */
-	private function set_up_authed_modal_request( $payment_method = '' ) {
-		$_REQUEST['modal_checkout'] = '1';
+	private function set_up_nonced_modal_request( $payment_method = '' ) {
+		$_REQUEST['modal_checkout']          = '1';
+		$_POST['newspack_checkout_nonce']    = wp_create_nonce( 'newspack_modal_checkout_nonce' );
 		if ( '' !== $payment_method ) {
 			$_POST['payment_method'] = $payment_method;
 		}
-		$user_id = self::factory()->user->create();
-		wp_set_current_user( $user_id );
 	}
 
 	/**
@@ -74,40 +72,45 @@ class ModalCheckoutRecaptchaTest extends WP_UnitTestCase { // phpcs:ignore
 	}
 
 	/**
-	 * Unauthenticated modal requests must not be able to bypass reCAPTCHA —
-	 * this is the abuse-vector gate that prevents spamming reader/order
-	 * records via crafted POSTs with modal_checkout=1.
+	 * Modal requests without a valid modal-checkout nonce must not be able to
+	 * bypass reCAPTCHA — this is the abuse-vector gate that prevents spamming
+	 * reader/order records via crafted POSTs with modal_checkout=1.
 	 */
-	public function test_unauthenticated_modal_request_is_not_bypassed() {
+	public function test_modal_request_without_valid_nonce_is_not_bypassed() {
 		$_REQUEST['modal_checkout']  = '1';
 		$_POST['payment_method']     = 'cheque';
 		$_POST['is_validation_only'] = '1';
 
+		// No nonce at all.
+		$this->assertTrue( Modal_Checkout::recaptcha_verify_captcha( true, self::DUMMY_URL, 'checkout' ) );
+
+		// Garbage nonce.
+		$_POST['newspack_checkout_nonce'] = 'not-a-real-nonce';
 		$this->assertTrue( Modal_Checkout::recaptcha_verify_captcha( true, self::DUMMY_URL, 'checkout' ) );
 	}
 
 	/**
-	 * Authenticated modal + validation-only request bypasses reCAPTCHA. This
-	 * is the validation step from the first modal screen, which must not
-	 * consume the v2 widget.
+	 * Nonced modal + validation-only request bypasses reCAPTCHA. This is the
+	 * validation step from the first modal screen, which must not consume the
+	 * v2 widget.
 	 */
 	public function test_modal_validation_only_bypasses() {
-		$this->set_up_authed_modal_request();
+		$this->set_up_nonced_modal_request();
 		$_POST['is_validation_only'] = '1';
 
 		$this->assertFalse( Modal_Checkout::recaptcha_verify_captcha( true, self::DUMMY_URL, 'checkout' ) );
 	}
 
 	/**
-	 * Each offline gateway in the bypass allowlist must bypass reCAPTCHA when
-	 * a reader is authenticated inside the modal.
+	 * Each offline gateway in the bypass allowlist must bypass reCAPTCHA on a
+	 * nonced modal request.
 	 *
 	 * @dataProvider provider_bypass_gateways
 	 *
 	 * @param string $gateway Gateway ID.
 	 */
 	public function test_modal_bypass_gateway_bypasses( $gateway ) {
-		$this->set_up_authed_modal_request( $gateway );
+		$this->set_up_nonced_modal_request( $gateway );
 
 		$this->assertFalse(
 			Modal_Checkout::recaptcha_verify_captcha( true, self::DUMMY_URL, 'checkout' ),
@@ -132,17 +135,17 @@ class ModalCheckoutRecaptchaTest extends WP_UnitTestCase { // phpcs:ignore
 	 * A non-bypass gateway must still require reCAPTCHA verification.
 	 */
 	public function test_modal_non_bypass_gateway_still_verifies() {
-		$this->set_up_authed_modal_request( 'stripe' );
+		$this->set_up_nonced_modal_request( 'stripe' );
 
 		$this->assertTrue( Modal_Checkout::recaptcha_verify_captcha( true, self::DUMMY_URL, 'checkout' ) );
 	}
 
 	/**
-	 * Authenticated modal request with no validation_only and no
-	 * payment_method passes through to the caller's default.
+	 * Nonced modal request with no validation_only and no payment_method
+	 * passes through to the caller's default.
 	 */
 	public function test_modal_with_no_bypass_signals_passes_through() {
-		$this->set_up_authed_modal_request();
+		$this->set_up_nonced_modal_request();
 
 		$this->assertTrue( Modal_Checkout::recaptcha_verify_captcha( true, self::DUMMY_URL, 'checkout' ) );
 		$this->assertFalse( Modal_Checkout::recaptcha_verify_captcha( false, self::DUMMY_URL, 'checkout' ) );
@@ -159,7 +162,7 @@ class ModalCheckoutRecaptchaTest extends WP_UnitTestCase { // phpcs:ignore
 		};
 		add_filter( 'newspack_blocks_modal_checkout_recaptcha_bypass_gateways', $filter );
 
-		$this->set_up_authed_modal_request( 'custom_offline' );
+		$this->set_up_nonced_modal_request( 'custom_offline' );
 
 		$this->assertFalse( Modal_Checkout::recaptcha_verify_captcha( true, self::DUMMY_URL, 'checkout' ) );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When a reader chooses **Check Payments** in the modal checkout, the "Complete payment" button could freeze indefinitely on sites running reCAPTCHA v2 invisible. The cheque gateway has no client-side tokenization to serialize the submit, so the v2 widget could race with checkout fragment refreshes and never produce a token — leaving the form stuck.

This change bypasses reCAPTCHA on the cheque path in the modal checkout, both client-side (the widget is never executed) and server-side (token verification is skipped). Other gateways are unaffected and continue to be protected by reCAPTCHA. The cheque path remains low-risk: no charge is processed, orders are created on hold, and reader account creation/sign-in remain protected by their own captcha layers.

Closes NPPM-2619.

### How to test the changes in this Pull Request:

1. On a site with reCAPTCHA v2 invisible enabled and the Check Payments WooCommerce gateway active, open a modal checkout for any product (donation, subscription, or one-time purchase).
2. Fill in billing details and proceed to the payment step.
3. Select **Check Payments** as the payment method. Inspect the `form.checkout` element in DevTools and confirm `data-skip-recaptcha="1"` is present.
4. Click **Complete payment**. The order should submit immediately and land on the thank-you screen with a new on-hold order in WooCommerce.
5. On the same modal, switch back to a card gateway (Stripe / WooPayments). Confirm `data-skip-recaptcha` is removed from the form.
6. Submit a card order and verify reCAPTCHA still fires (no regression for card paths).
7. Toggle "Edit billing details" mid-checkout. Confirm `data-skip-recaptcha` stays set during the edit step regardless of the previously selected payment method, then resolves to the correct value when returning to the payment step.
8. Outside modal checkout (standard `/checkout/` page), submit a cheque order and confirm reCAPTCHA still fires — the bypass is scoped to modal checkout only.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?